### PR TITLE
remove templated c'tors from Alignment classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ option(DD4HEP_USE_LCIO    "Build lcio extensions"    OFF)
 option(BUILD_TESTING      "Enable and build tests"   ON)
 option(DD4HEP_USE_CXX11   "Build DD4hep using c++11" OFF)
 option(DD4HEP_USE_CXX14   "Build DD4hep using c++14" OFF)
+option(CMAKE_MACOSX_RPATH "Build with rpath on macos" ON)
+ 
 #
 #-----------------------------------------------------------------------------------------------------
 #
@@ -134,6 +136,7 @@ ENDIF()
 # ----for APPLE scripts have to set the DYLD_LIBRARY_PATH 
 if( APPLE ) 
   set( USE_DYLD 1)
+  set(CMAKE_MACOSX_RPATH 1)
 endif()
 
 configure_file(cmake/thisdd4hep.csh bin/thisdd4hep.csh @ONLY)

--- a/DDCore/include/DD4hep/Alignments.h
+++ b/DDCore/include/DD4hep/Alignments.h
@@ -87,7 +87,8 @@ namespace DD4hep {
       /// Constructor to be used when reading the already parsed object
       template <typename Q> Alignment(const Handle<Q>& e) : Handle<Object>(e)  {}
       /// Object constructor for pure alignment objects
-      template <typename Q=Interna::AlignmentNamedObject> Alignment(const std::string& name);
+      //      template <typename Q=Interna::AlignmentNamedObject> Alignment(const std::string& name);
+      Alignment(const std::string& name) ;
 
       /// Hash code generation from input string
       static key_type hashCode(const char* value);
@@ -147,7 +148,8 @@ namespace DD4hep {
       /// Constructor to be used when reading the already parsed object
       template <typename Q> AlignmentCondition(const Handle<Q>& e) : Handle<Object>(e) {}
       /// Object constructor for pure alignment objects
-      template <typename Q=Object> AlignmentCondition(const std::string& name);
+      //      template <typename Q=Object> AlignmentCondition(const std::string& name);
+      AlignmentCondition(const std::string& name) ;
 
       /** Interval of validity            */
       /// Access the IOV type

--- a/DDCore/src/Alignments.cpp
+++ b/DDCore/src/Alignments.cpp
@@ -26,24 +26,32 @@ using namespace DD4hep::Alignments;
 
 /// Namespace for the AIDA detector description toolkit
 namespace DD4hep {
-
+  
   /// Namespace for the alignment part of the AIDA detector description toolkit
   namespace Alignments {
-
+    
+    // // /// Initializing constructor to create a new object (Specialized for AlignmentNamedObject)
+    // // template <> Alignment::Alignment<Alignment::Object>(const string& nam) {
+    // //   assign(new Alignment::Object(), nam, "alignment");
+    // // }
+    
+    // // /// Initializing constructor to create a new object (Specialized for AlignmentNamedObject)
+    // // template <> Alignment::Alignment<Interna::AlignmentNamedObject>(const string& nam) {
+    // //   assign(new Interna::AlignmentNamedObject(nam, "alignment"), nam, "alignment");
+    // // }
     /// Initializing constructor to create a new object (Specialized for AlignmentNamedObject)
-    template <> Alignment::Alignment<Alignment::Object>(const string& nam) {
-      assign(new Alignment::Object(), nam, "alignment");
-    }
-
-    /// Initializing constructor to create a new object (Specialized for AlignmentNamedObject)
-    template <> Alignment::Alignment<Interna::AlignmentNamedObject>(const string& nam) {
+    Alignment::Alignment(const string& nam) {
       assign(new Interna::AlignmentNamedObject(nam, "alignment"), nam, "alignment");
     }
-
+    
     /// Initializing constructor to create a new object (Specialized for AlignmentConditionObject)
-    template <> AlignmentCondition::AlignmentCondition<AlignmentCondition::Object>(const string& nam) {
-      assign(new Object(nam, "alignment"), nam, "alignment");
+    AlignmentCondition::AlignmentCondition(const string& nam) {
+      assign(new AlignmentCondition::Object(nam, "alignment"), nam, "alignment");
     }
+    // // /// Initializing constructor to create a new object (Specialized for AlignmentConditionObject)
+    // // template <> AlignmentCondition::AlignmentCondition<AlignmentCondition::Object>(const string& nam) {
+    // //   assign(new Object(nam, "alignment"), nam, "alignment");
+    // // }
   } /* End namespace Aligments                  */
 } /* End namespace DD4hep                       */
 


### PR DESCRIPTION
this is needed to get it compiling under clang - and as only one specialization was used (so far) we do not really need templates here ...