### PR TITLE
Fix DDEve header files.

### DIFF
--- a/DDEve/include/DDEve/Dictionary.h
+++ b/DDEve/include/DDEve/Dictionary.h
@@ -40,10 +40,10 @@
 #include "DDEve/DDG4EventHandler.h"
 
 namespace DD4hep {
-  void EveDisplay(const char* xmlFile);
+  void EveDisplay(const char* xmlFile, const char* eventFileName);
   struct DDEve {
     static void run(const char* xmlFile)  {
-      EveDisplay(xmlFile);
+      EveDisplay(xmlFile, nullptr);
     }
   };
 }
@@ -55,7 +55,7 @@ namespace DD4hep {
 
 #pragma link C++ namespace DD4hep;
 
-#pragma link C++ function DD4hep::EveDisplay(const char* xmlFile);
+#pragma link C++ function DD4hep::EveDisplay(const char* xmlFile, const char* eventFileName);
 
 
 #pragma link C++ class DD4hep::DDEve;


### PR DESCRIPTION
Some of my recent changes to DDEve did not make it to the header Dictionary.h, which resulted in a broken `run()` method. This should fix it.  See https://sft.its.cern.ch/jira/projects/DDFORHEP/issues/DDFORHEP-23 for background/discussion. This issue and 22 can then be closed.