### PR TITLE
Initialise field values, this fixes an issue in MarlinTrk where wrong…

### DIFF
--- a/DDCore/include/DD4hep/Fields.h
+++ b/DDCore/include/DD4hep/Fields.h
@@ -204,6 +204,7 @@ namespace DD4hep {
 
       /// Returns the 3 electric field components (x, y, z).
       void electricField(const double* pos, double* field) const {
+	field[0] = field[1] = field[2] = 0.0;
         CartesianField f = data<Object>()->electric;
         f.isValid() ? f.value(pos, field) : combinedElectric(pos, field);
       }
@@ -220,6 +221,7 @@ namespace DD4hep {
 
       /// Returns the 3  magnetic field components (x, y, z).
       void magneticField(const double* pos, double* field) const {
+	field[0] = field[1] = field[2] = 0.0;
         CartesianField f = data<Object>()->magnetic;
         f.isValid() ? f.value(pos, field) : combinedMagnetic(pos, field);
       }


### PR DESCRIPTION
… magnetic fields were assigned to surfaces because the field array was uninitialised

valgrind showed "Conditional jump or move depends on uninitialised value"