### PR TITLE
Remove minimum required cmake version from DD4hepBuild, this interfer…

### DIFF
--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -9,7 +9,7 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 #=================================================================================
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+
 ###set(DD4HEP_DEBUG_CMAKE 1)
 message ( STATUS "INCLUDING DD4hepBuild.... c++11:${DD4HEP_USE_CXX11} c++14:${DD4HEP_USE_CXX14}" )
 


### PR DESCRIPTION
…es with other packages depending on DD4hep causing CMP0033 errors in some ilcsoft packages (that should be fixed at some later date as well)