### PR TITLE
graphicalMaterialScan: fix CMakeLists and axis labels

### DIFF
--- a/UtilityApps/CMakeLists.txt
+++ b/UtilityApps/CMakeLists.txt
@@ -1,4 +1,3 @@
-# $Id: $
 #==========================================================================
 #  AIDA Detector description implementation for LCD
 #--------------------------------------------------------------------------
@@ -24,7 +23,7 @@ dd4hep_add_executable( print_materials src/print_materials.cpp USES DDRec )
 #-----------------------------------------------------------------------------------
 dd4hep_add_executable( materialScan    src/materialScan.cpp USES DDRec )
 #-----------------------------------------------------------------------------------
-dd4hep_add_executable( graphicalMaterialScan src/graphicalMaterialScan.cpp USES DDRec )
+dd4hep_add_executable( graphicalMaterialScan src/graphicalMaterialScan.cpp USES DDRec ROOT )
 #-----------------------------------------------------------------------------------
 #dd4hep_add_executable( pydd4hep     
 #  USES        [ROOT   REQUIRED COMPONENTS PyROOT]

--- a/UtilityApps/src/graphicalMaterialScan.cpp
+++ b/UtilityApps/src/graphicalMaterialScan.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv)   {
     index[1] = 2;
     index[2] = 0;
     labx="Z [cm]";
-    laby="Z [cm]";
+    laby="X [cm]";
   } else if ( XYZ=="z" || XYZ=="Z" ) {
     index[0] = 2;
     index[1] = 0;


### PR DESCRIPTION
Fix a histogram axis label in graphicalMaterialScan
Fixed issues pointed out by Marko in my last update of CMakeLists.txt (they don't seem to have made it into the master)