### PR TITLE
use DD4HEP_LIBRARY_PATH and full lib path on mac

### DIFF
--- a/GaudiPluginService/src/PluginService.cpp
+++ b/GaudiPluginService/src/PluginService.cpp
@@ -162,7 +162,9 @@ namespace Gaudi { namespace PluginService {
       const char sep = ';';
 #else
 #ifdef APPLE
-      const char* envVar = "DYLD_LIBRARY_PATH";
+      //fg: on macos >10.11 we cannot rely on DYLD_LIBRARY_PATH any more
+      //    and therefore use consistently DD4HEP_LIBRARY_PATH instead
+      const char* envVar = "DD4HEP_LIBRARY_PATH";
       const char sep = ':';
 #else
       const char* envVar = "LD_LIBRARY_PATH";
@@ -224,9 +226,18 @@ namespace Gaudi { namespace PluginService {
                     logger().warning(o.str());
                     continue;
                   }
+
                   const std::string lib(line, 0, other_pos);
                   const std::string fact(line, other_pos+1);
+
+#ifdef APPLE
+		  //fg: on macos >10.11 we cannot rely on DYLD_LIBRARY_PATH any more
+		  //    and therefore store the complete path to the lib for the dlopen call
+                  m_factories.insert(std::make_pair(fact, FactoryInfo(  std::string(dirName + "/" + lib ) )));
+#else
                   m_factories.insert(std::make_pair(fact, FactoryInfo(lib)));
+#endif
+
 #ifdef GAUDI_REFLEX_COMPONENT_ALIASES
                   // add an alias for the factory using the Reflex convention
                   std::string old_name = old_style_name(fact);

--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -45,9 +45,11 @@ dd4hep_add_library_path()    {
     if [ @USE_DYLD@ ];
     then
         if [ ${DYLD_LIBRARY_PATH} ]; then
-	    export DYLD_LIBRARY_PATH=${path_prefix}:$DYLD_LIBRARY_PATH;
+            export DYLD_LIBRARY_PATH=${path_prefix}:$DYLD_LIBRARY_PATH;
+            export DD4HEP_LIBRARY_PATH=${path_prefix}:$DD4HEP_LIBRARY_PATH;
         else
             export DYLD_LIBRARY_PATH=${path_prefix};
+            export DD4HEP_LIBRARY_PATH=${path_prefix};
         fi;
     else
         if [ ${LD_LIBRARY_PATH} ]; then
@@ -63,6 +65,10 @@ dd4hep_parse_this ${BASH_ARGV[0]} DD4hep;
 #
 # These 3 are the main configuration variables: ROOT, Geant4 and XercesC
 # --> LCIO & Co. are handled elsewhere!
+
+if [ -z $ROOTSYS ]; then
+    export ROOTSYS=`dirname @ROOT_DIR@`
+fi;
 export Geant4_DIR=@Geant4_DIR@;
 export XERCESCINSTALL=@XERCESC_ROOT_DIR@;
 #


### PR DESCRIPTION
This fixes running python simulation programs with plugins on macos 10.12.