### PR TITLE
SurfaceHelper/IDDecoder: avoid multiple instantiations of the VolumeManager

### DIFF
--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -461,6 +461,7 @@ DECLARE_APPLY(DD4hepXMLProcessor,process_xml_doc)
  *  \date    01/04/2014
  */
 static long load_volmgr(LCDD& lcdd, int, char**) {
+  printout(INFO,"DD4hepVolumeManager","**** running plugin DD4hepVolumeManager ! " );
   try {
     LCDDImp* imp = dynamic_cast<LCDDImp*>(&lcdd);
     if ( imp )  {

--- a/DDRec/src/IDDecoder.cpp
+++ b/DDRec/src/IDDecoder.cpp
@@ -34,7 +34,8 @@ IDDecoder::IDDecoder() {
 	LCDD& lcdd = LCDD::getInstance();
 	_volumeManager = lcdd.volumeManager();
 	if (not _volumeManager.isValid()) {
-		_volumeManager = VolumeManager(lcdd, "volman", lcdd.world(), Readout(), VolumeManager::TREE);
+		lcdd.apply("DD4hepVolumeManager",0,0);
+		_volumeManager = lcdd.volumeManager();
 	}
 	_tgeoMgr = lcdd.world().volume()->GetGeoManager();
 }

--- a/DDRec/src/SurfaceHelper.cpp
+++ b/DDRec/src/SurfaceHelper.cpp
@@ -27,7 +27,13 @@ namespace DD4hep {
       // have to populate the volume manager once in order to have 
       // the volumeIDs attached to the DetElements
       LCDD& lcdd = LCDD::getInstance();
-      static VolumeManager volMgr( lcdd  , "volMan" , lcdd.world() ) ;
+      VolumeManager volMgr = lcdd.volumeManager();
+      if(not volMgr.isValid()) {
+	// VolumeManager initialised by DD4hepVolumeManager plugin
+	lcdd.apply("DD4hepVolumeManager",0,0);
+	volMgr = lcdd.volumeManager();
+      }
+
 
  
       //------------------ breadth first tree traversal ---------


### PR DESCRIPTION

Pick the VolumeManager from lcdd, and create it if necessary instead of creating a static one in SurfaceHelper
This is necessary in case someone needs a volumemanager before surfaceHelper is called, otherwise one has to be patient more than once.