### PR TITLE
Fixed tests and CLHEP linking error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,6 @@ add_subdirectory(DDCond)
 add_subdirectory(DDAlign)
 add_subdirectory(DDEve)
 add_subdirectory(DDDB)
-add_subdirectory(DDTest)
 
 dd4hep_enable_tests( DDTest )
 add_subdirectory(UtilityApps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,6 @@ endif()
 ##checks for xercesc or not and sets up the include_directories
 include(DD4hep_XML_setup)
 
-#---Packages------------------------------------------------------------------------
-add_subdirectory(DDSegmentation)
-add_subdirectory(DDCore)
-add_subdirectory(DDSurfaces)
-add_subdirectory(DDRec)
-add_subdirectory(DDDetectors)
-
 if(DD4HEP_USE_GEANT4)
 
   #--- create a geant4 variables for the thisdd4hep.sh script
@@ -103,6 +96,13 @@ if(DD4HEP_USE_GEANT4)
   #----- End of treatment for Geant4 10.2.1 or before
 endif()
 
+#---Packages------------------------------------------------------------------------
+add_subdirectory(DDSegmentation)
+add_subdirectory(DDCore)
+add_subdirectory(DDSurfaces)
+add_subdirectory(DDRec)
+add_subdirectory(DDDetectors)
+
 #------- now configure DDG4 -------
 add_subdirectory(DDG4)
 
@@ -110,6 +110,7 @@ add_subdirectory(DDCond)
 add_subdirectory(DDAlign)
 add_subdirectory(DDEve)
 add_subdirectory(DDDB)
+add_subdirectory(DDTest)
 
 dd4hep_enable_tests( DDTest )
 add_subdirectory(UtilityApps)


### PR DESCRIPTION
This could be due to using a system-wide CLHEP instead of the built-in geant4 version.