### PR TITLE
Fixed installation destinations of cmake and doxygen files.

### DIFF
--- a/cmake/DD4hepDoxygen.cmake
+++ b/cmake/DD4hepDoxygen.cmake
@@ -10,7 +10,7 @@ if(DOXYGEN_FOUND)
                     COMMENT "Generating API documentation with Doxygen" VERBATIM)
 
   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html
-    DESTINATION doc
+    DESTINATION share/DD4hep/doc
     )
 
 else()

--- a/cmake/DD4hepMacros.cmake
+++ b/cmake/DD4hepMacros.cmake
@@ -76,7 +76,7 @@ MACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
                 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                                 "${PROJECT_BINARY_DIR}/${arg}" @ONLY
                 )
-                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION cmake )
                 #IF( EXISTS "${_current_dir}/MacroCheckPackageLibs.cmake" )
                 #    INSTALL( FILES "${_current_dir}/MacroCheckPackageLibs.cmake" DESTINATION cmake )
                 #ENDIF()


### PR DESCRIPTION
The cmake file goes in `${CMAKE_INSTALL_PREFIX}/cmake`
rather than polluting the installation prefix.

The documentation goes into `${CMAKE_INSTALL_PREFIX}/share/DD4hep`
I was not sure if it should be `share/DD4hep/doc/html` or
`share/DD4hep/html`, but I thought the former was more clear since the
`share/DD4hep` directory can hold other things beyond documentation.
For example, "examples" would go into `share/DD4hep/examples`, hence the extra `doc` directory.