### PR TITLE
Fixed small bug in TSystem::Load call

### DIFF
--- a/DDG4/python/DD4hep.py
+++ b/DDG4/python/DD4hep.py
@@ -46,7 +46,7 @@ def loadDD4hep():
     gSystem.SetDynamicPath(os.environ['DD4HEP_LIBRARY_PATH'])
 
   result = gSystem.Load("libDDCore")
-  if 0 != result:
+  if result < 0:
     raise Exception('DD4hep.py: Failed to load the DD4hep library libDDCore: '+gSystem.GetErrorStr())
   from ROOT import DD4hep as module
   return module


### PR DESCRIPTION
TSystem::Load return > 0 if the library is already loaded. This is not an error. For some reason it was already loaded when I run ddsim in a singularity container. I have no idea why.