### PR TITLE
Add possibility to remove the production cut from region

### DIFF
--- a/DDCore/include/DD4hep/Objects.h
+++ b/DDCore/include/DD4hep/Objects.h
@@ -556,6 +556,10 @@ namespace DD4hep {
       double threshold() const;
       /// Access secondaries flag
       bool storeSecondaries() const;
+      /// Access use_default_cut flag
+      bool useDefaultCut() const;
+      /// Access was_threshold_set flag
+      bool wasThresholdSet() const;
     };
 
   } /* End namespace Geometry           */

--- a/DDCore/include/DD4hep/objects/ObjectsInterna.h
+++ b/DDCore/include/DD4hep/objects/ObjectsInterna.h
@@ -112,6 +112,8 @@ namespace DD4hep {
       double threshold;
       double cut;
       bool store_secondaries;
+      bool use_default_cut;
+      bool was_threshold_set;
       std::vector<std::string> user_limits;
       /// Standard constructor
       RegionObject();

--- a/DDCore/src/Objects.cpp
+++ b/DDCore/src/Objects.cpp
@@ -444,6 +444,8 @@ Region::Region(const string& nam) {
   p->store_secondaries = false;
   p->threshold = 10.0;
   p->cut = 10.0;
+  p->use_default_cut = true;
+  p->was_threshold_set = false;
 }
 
 Region& Region::setStoreSecondaries(bool value) {
@@ -453,11 +455,13 @@ Region& Region::setStoreSecondaries(bool value) {
 
 Region& Region::setThreshold(double value) {
   object<Object>().threshold = value;
+  object<Object>().was_threshold_set = true;
   return *this;
 }
 
 Region& Region::setCut(double value) {
   object<Object>().cut = value;
+  object<Object>().use_default_cut = false;
   return *this;
 }
 
@@ -479,6 +483,14 @@ double Region::threshold() const {
 /// Access secondaries flag
 bool Region::storeSecondaries() const {
   return object<Object>().store_secondaries;
+}
+
+bool Region::useDefaultCut() const {
+  return object<Object>().use_default_cut;
+}
+
+bool Region::wasThresholdSet() const {
+  return object<Object>().was_threshold_set;
 }
 
 #undef setAttr

--- a/DDCore/src/ObjectsInterna.cpp
+++ b/DDCore/src/ObjectsInterna.cpp
@@ -66,7 +66,8 @@ DD4HEP_INSTANTIATE_HANDLE_NAMED(RegionObject);
 
 /// Standard constructor
 RegionObject::RegionObject()
-  : magic(magic_word()), threshold(10.0), cut(10.0), store_secondaries(false)
+  : magic(magic_word()), threshold(10.0), cut(10.0), store_secondaries(false),
+    use_default_cut(true), was_threshold_set(false)
 {
   InstanceCount::increment(this);
 }

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -772,11 +772,16 @@ void* Geant4Converter::handleRegion(Region region, const set<const TGeoVolume*>&
     Region r = Ref_t(region);
     g4 = new G4Region(r.name());
     // set production cut
-    G4ProductionCuts* cuts = new G4ProductionCuts();
-    cuts->SetProductionCut(r.cut()*CLHEP::mm/dd4hep::mm);
-    g4->SetProductionCuts(cuts);
+    if( not r.useDefaultCut() ) {
+      G4ProductionCuts* cuts = new G4ProductionCuts();
+      cuts->SetProductionCut(r.cut()*CLHEP::mm/dd4hep::mm);
+      g4->SetProductionCuts(cuts);
+    }
 
     // create region info with storeSecondaries flag
+    if( not r.wasThresholdSet() and r.storeSecondaries() ) {
+      throw runtime_error("G4Region: StoreSecondaries is True, but no explicit threshold set:");
+    }
     G4UserRegionInformation* info = new G4UserRegionInformation();
     info->region = r;
     info->threshold = r.threshold()*CLHEP::MeV/dd4hep::MeV;


### PR DESCRIPTION
 so that it uses the Global Range Cut instead of the default set for Regions

Geant4 will print a warning about regions without thresholds, but that is what we need. This allows one to keep regions for e.g., creating material scan with out manually having to set range cuts
As far as I can tell the threshold is only used when store_secondaries is true (which is ignored), so we are now throwing an exception if someone specifies store_secondaries without setting a threshold.
However, it seems that store_secondaries is actually never used anywhere else?

The global range cut is 0.7 mm, but Regions set the default to 10cm.
Implemented together with @simoniel 