### PR TITLE
Add static accessor for volumeManager

### DIFF
--- a/DDCore/include/DD4hep/VolumeManager.h
+++ b/DDCore/include/DD4hep/VolumeManager.h
@@ -123,6 +123,9 @@ namespace DD4hep {
       /// Initializing constructor for subdetector volume managers.
       VolumeManager(DetElement subdetector, Readout ro);
 
+      /// static accessor calling DD4hepVolumeManagerPlugin if necessary
+      static VolumeManager getVolumeManager(LCDD& lcdd);
+
       /// Assignment operator
       VolumeManager& operator=(const VolumeManager& m)  {
         if ( this != &m ) m_element = m.m_element;

--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -470,6 +470,13 @@ VolumeManager::VolumeManager(DetElement sub_detector, Readout ro)  {
   assign(obj_ptr, sub_detector.name(), "VolumeManager");
 }
 
+VolumeManager VolumeManager::getVolumeManager(LCDD& lcdd) {
+  if( not lcdd.volumeManager().isValid() ) {
+    lcdd.apply("DD4hepVolumeManager", 0, 0);
+  }
+  return lcdd.volumeManager();
+}
+
 /// Add a new Volume manager section according to a new subdetector
 VolumeManager VolumeManager::addSubdetector(DetElement det, Readout ro) {
   if (isValid()) {

--- a/DDG4/scripts/dumpDDG4.C
+++ b/DDG4/scripts/dumpDDG4.C
@@ -216,7 +216,7 @@ int dumpddg4_load_geometry(const char* fname)   {
     gSystem->Load("libDDG4Plugins");
     LCDD& lcdd = LCDD::getInstance();
     lcdd.fromXML(fname);
-    lcdd.apply("DD4hepVolumeManager",0,(char**)0);
+    VolumeManager::getVolumeManager();
   }
   return 1;
 }

--- a/DDRec/src/IDDecoder.cpp
+++ b/DDRec/src/IDDecoder.cpp
@@ -32,12 +32,7 @@ IDDecoder& IDDecoder::getInstance() {
 /// Default constructor
 IDDecoder::IDDecoder() {
 	LCDD& lcdd = LCDD::getInstance();
-	_volumeManager = lcdd.volumeManager();
-	if (not _volumeManager.isValid()) {
-		lcdd.apply("DD4hepVolumeManager",0,0);
-		_volumeManager = lcdd.volumeManager();
-	}
-	_tgeoMgr = lcdd.world().volume()->GetGeoManager();
+	_volumeManager = VolumeManager::getVolumeManager(lcdd);
 }
 
 /**

--- a/DDRec/src/SurfaceHelper.cpp
+++ b/DDRec/src/SurfaceHelper.cpp
@@ -27,15 +27,8 @@ namespace DD4hep {
       // have to populate the volume manager once in order to have 
       // the volumeIDs attached to the DetElements
       LCDD& lcdd = LCDD::getInstance();
-      VolumeManager volMgr = lcdd.volumeManager();
-      if(not volMgr.isValid()) {
-	// VolumeManager initialised by DD4hepVolumeManager plugin
-	lcdd.apply("DD4hepVolumeManager",0,0);
-	volMgr = lcdd.volumeManager();
-      }
+      VolumeManager volMgr = VolumeManager::getVolumeManager(lcdd);
 
-
- 
       //------------------ breadth first tree traversal ---------
       std::list< DetElement > dets ;
       std::list< DetElement > daugs ; 


### PR DESCRIPTION
 and replace calling of DD4hepVolumeManager with it

I didn't change this
https://github.com/AIDASoft/DD4hep/blob/master/DDG4/plugins/Geant4DetectorGeometryConstruction.cpp#L96
because I don't understand how the Geant4VolumeManager and the DD4hepVolumeManager are related and why the DD4hepVolumeManager plugin is called even though this is about the Geant4VolumeManager