### PR TITLE
Fix coverity defects in DDRec

### DIFF
--- a/DDRec/CMakeLists.txt
+++ b/DDRec/CMakeLists.txt
@@ -12,7 +12,7 @@
 #
 #==========================================================================
 dd4hep_package(DDRec
-  USES             DDCore DDSurfaces
+  USES             DDCore DDSurfaces boost
                   [ROOT REQUIRED COMPONENTS Geom]
   INCLUDE_DIRS     include
   INSTALL_INCLUDES include/DDRec)

--- a/DDRec/include/DDRec/Surface.h
+++ b/DDRec/include/DDRec/Surface.h
@@ -699,11 +699,11 @@ namespace DD4hep {
       SurfaceList(const SurfaceList& other ) : std::list< ISurface* >( other ), _isOwner( false ){}
 
       /// required c'tor for extension mechanism
-      SurfaceList(const Geometry::DetElement& ){
+      SurfaceList(const Geometry::DetElement& ) : _isOwner( false ) {
         // anything to do here  ?
       }
       /// required c'tor for extension mechanism
-      SurfaceList(const SurfaceList& ,const Geometry::DetElement& ){
+      SurfaceList(const SurfaceList& ,const Geometry::DetElement& ) : _isOwner( false ) {
         // anything to do here  ?
       }
     

--- a/DDRec/src/DetectorData.cpp
+++ b/DDRec/src/DetectorData.cpp
@@ -1,10 +1,14 @@
 #include "DDRec/DetectorData.h"
 
+#include <boost/io/ios_state.hpp>
+
 namespace DD4hep {
   namespace DDRec {
 
 
     std::ostream& operator<<( std::ostream& io , const FixedPadSizeTPCData& d ){
+      boost::io::ios_base_all_saver ifs(io);
+
       io <<  " --FixedPadSizeTPCData: "  << std::scientific << std::endl ; 
       io <<  "   zHalf : "              <<  d.zHalf  << std::endl ; 
       io <<  "   rMin : "               <<  d.rMin << std::endl ; 
@@ -25,6 +29,7 @@ namespace DD4hep {
 
 
     std::ostream& operator<<( std::ostream& io , const ZPlanarData& d ) {
+      boost::io::ios_base_all_saver ifs(io);
 
       io <<  " -- ZPlanarData: "  << std::scientific << std::endl ; 
       io <<  " zHalfShell  : " <<  d.zHalfShell  << std::endl ; 
@@ -68,6 +73,7 @@ namespace DD4hep {
     }
 
     std::ostream& operator<<( std::ostream& io , const ZDiskPetalsData& d ) {
+      boost::io::ios_base_all_saver ifs(io);
 
       io <<  " -- ZDiskPetalsData: "  << std::scientific << std::endl ; 
       io <<  "  widthStrip : " <<  d.widthStrip  << std::endl ; 
@@ -116,6 +122,7 @@ namespace DD4hep {
 
     
     std::ostream& operator<<( std::ostream& io , const ConicalSupportData& d ) {
+      boost::io::ios_base_all_saver ifs(io);
 
       io <<  " -- ConicalSupportData : "  << std::scientific << std::endl ; 
       io <<  "  isSymmetricInZ : " <<  d.isSymmetricInZ  << std::endl ; 
@@ -139,6 +146,7 @@ namespace DD4hep {
 
     
     std::ostream& operator<<( std::ostream& io , const LayeredCalorimeterData& d ) {
+      boost::io::ios_base_all_saver ifs(io);
 
       io <<  " -- LayeredCalorimeterData : "  << std::scientific << std::endl ; 
       io <<  "  LayoutType : " <<  ( d.layoutType == LayeredCalorimeterStruct::BarrelLayout ?
@@ -180,6 +188,8 @@ namespace DD4hep {
 
 
     std::ostream& operator<<( std::ostream& io , const NeighbourSurfacesData& d ){
+      boost::io::ios_base_all_saver ifs(io);
+
       io <<  " --NeighbourSurfacesData: "  << std::scientific << std::endl ; 
       io <<  "   sameLayer.size() : " << d.sameLayer.size() << std::endl ; 
       return io ;

--- a/DDRec/src/LayeringExtensionImpl.cpp
+++ b/DDRec/src/LayeringExtensionImpl.cpp
@@ -171,7 +171,9 @@ void LayeringExtensionImpl::checkMap(int layerIndex) const {
 	map<int, LayerAttributes>::iterator it;
 	it = _layerMap.find(layerIndex);
 	if (it == _layerMap.end()) {
-		// TODO throw exception
+	  std::stringstream err;
+	  err << "No entry found for layer" << layerIndex;
+	  throw std::out_of_range(err.str());
 	}
 	if (not it->second.isCalculated) {
 		it->second.calculate();

--- a/DDRec/src/SubdetectorExtensionImpl.cpp
+++ b/DDRec/src/SubdetectorExtensionImpl.cpp
@@ -24,6 +24,7 @@ SubdetectorExtensionImpl::SubdetectorExtensionImpl(const Geometry::DetElement& d
 
 /// Copy constructor
 SubdetectorExtensionImpl::SubdetectorExtensionImpl(const SubdetectorExtensionImpl& e, const Geometry::DetElement& d) {
+	this->resetAll();
 	this->det = d;
 	if (e._setIsBarrel) {
 		this->setIsBarrel(e.isBarrel());

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -30,9 +30,9 @@ namespace DD4hep {
     long64 VolSurfaceBase::id() const  { return _id ; } 
 
     const SurfaceType& VolSurfaceBase::type() const { return _type ; }
-    Vector3D VolSurfaceBase::u( const Vector3D& point ) const {  point.x() ; return _u ; }
-    Vector3D VolSurfaceBase::v(const Vector3D& point  ) const { point.x() ;  return _v ; }
-    Vector3D VolSurfaceBase::normal(const Vector3D& point ) const {  point.x() ; return _n ; }
+    Vector3D VolSurfaceBase::u(const Vector3D& /*point*/) const { return _u ; }
+    Vector3D VolSurfaceBase::v(const Vector3D& /*point*/) const { return _v ; }
+    Vector3D VolSurfaceBase::normal(const Vector3D& /*point*/) const { return _n ; }
     const Vector3D& VolSurfaceBase::origin() const { return _o ;}
 
     Vector2D VolSurfaceBase::globalToLocal( const Vector3D& point) const {
@@ -190,7 +190,7 @@ namespace DD4hep {
     }
     
 
-    double VolSurfaceBase::distance(const Vector3D& point ) const  {  point.x() ; return 1.e99 ; }
+    double VolSurfaceBase::distance(const Vector3D& /*point*/ ) const { return 1.e99 ; }
 
     /// Checks if the given point lies within the surface
     bool VolSurfaceBase::insideBounds(const Vector3D& point, double epsilon) const {
@@ -604,9 +604,9 @@ namespace DD4hep {
 
     const SurfaceType& Surface::type() const { return _type ; }
 
-    Vector3D Surface::u( const Vector3D& point ) const { point.x() ; return _u ; }
-    Vector3D Surface::v(const Vector3D& point ) const {  point.x() ; return _v ; }
-    Vector3D Surface::normal(const Vector3D& point ) const {  point.x() ; return _n ; }
+    Vector3D Surface::u(const Vector3D& /*point*/) const { return _u ; }
+    Vector3D Surface::v(const Vector3D& /*point*/) const { return _v ; }
+    Vector3D Surface::normal(const Vector3D& /*point*/) const { return _n ; }
     const Vector3D& Surface::origin() const { return _o ;}
     double Surface::innerThickness() const { return _volSurf.innerThickness() ; }
     double Surface::outerThickness() const { return _volSurf.outerThickness() ; }


### PR DESCRIPTION
Note: using boost class to restore the ostream state, DDRec now depends on boost