### PR TITLE
Added a NoSegmentation  segmentation

### DIFF
--- a/DDCore/include/DD4hep/Dictionary.h
+++ b/DDCore/include/DD4hep/Dictionary.h
@@ -380,6 +380,7 @@ template vector<pair<string, int> >::iterator;
 // -------------------------------------------------------------------------
 #ifdef __HAVE_DDSEGMENTATION__
 #include "DDSegmentation/Segmentation.h"
+#include "DDSegmentation/NoSegmentation.h"
 #include "DDSegmentation/CartesianGrid.h"
 #include "DDSegmentation/CartesianGridXY.h"
 #include "DDSegmentation/CartesianGridXYZ.h"
@@ -408,6 +409,7 @@ typedef DD4hep::DDSegmentation::CellID CellID;
 #endif
 
 #pragma link C++ class DD4hep::DDSegmentation::Segmentation+;
+#pragma link C++ class DD4hep::DDSegmentation::NoSegmentation+;
 #pragma link C++ class DD4hep::DDSegmentation::CartesianGrid+;
 #pragma link C++ class DD4hep::DDSegmentation::CartesianGridXY+;
 #pragma link C++ class DD4hep::DDSegmentation::CartesianGridXYZ+;

--- a/DDCore/include/DD4hep/NoSegmentation.h
+++ b/DDCore/include/DD4hep/NoSegmentation.h
@@ -1,0 +1,67 @@
+//==========================================================================
+//  AIDA Detector description implementation for LCD
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//  \author   Markus Frank
+//  \date     2016-10-18
+//  \version  1.0
+//
+//==========================================================================
+#ifndef DD4HEP_DDCORE_NoSegmentation_H 
+#define DD4HEP_DDCORE_NoSegmentation_H 1
+
+// Framework include files
+#include "DD4hep/Segmentations.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace DD4hep {
+
+  /// Namespace for base segmentations
+  namespace DDSegmentation  {    class NoSegmentation;  }
+  
+  /// Namespace for the geometry part of the AIDA detector description toolkit
+  namespace Geometry {
+
+    // Forward declarations
+    class Segmentation;
+    template <typename T> class SegmentationWrapper;
+    
+    /// We need some abbreviation to make the code more readable.
+    typedef Handle<SegmentationWrapper<DDSegmentation::NoSegmentation> > NoSegmentationHandle;
+
+    /// Implementation class for the grid XY segmentation.
+    /**
+     *
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_GEOMETRY
+     */
+    class NoSegmentation : public NoSegmentationHandle  {
+    public:
+      /// Defintiion of the basic handled object
+      typedef NoSegmentationHandle::Implementation Object;
+
+    public:
+      NoSegmentation() = default;
+      NoSegmentation(const NoSegmentation& e) = default;
+      NoSegmentation(const Segmentation& e) : Handle<Object>(e) { }
+      NoSegmentation(const Handle<Object>& e) : Handle<Object>(e) { }
+      template <typename Q>
+      NoSegmentation(const Handle<Q>& e) : Handle<Object>(e) { }
+      NoSegmentation& operator=(const NoSegmentation& seg) = default;
+      bool operator==(const NoSegmentation& seg) const {
+        return m_element == seg.m_element;
+      }
+
+      Position position(const CellID& cellID) const;
+      CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const;
+    };
+
+  } /* End namespace Geometry              */
+} /* End namespace DD4hep                */
+#endif // DD4HEP_DDCORE_NoSegmentation_H

--- a/DDCore/python/lcdd.py
+++ b/DDCore/python/lcdd.py
@@ -36,6 +36,7 @@ Readout    = DD4hep.Geometry.Readout
 GridXYZ = DD4hep.Geometry.GridXYZ
 GlobalGridXY = DD4hep.Geometry.GlobalGridXY
 CartesianGridXY = DD4hep.Geometry.CartesianGridXY
+NoSegmentation = DD4hep.Geometry.NoSegmentation
 ProjectiveCylinder = DD4hep.Geometry.ProjectiveCylinder
 NonProjectiveCylinder = DD4hep.Geometry.NonProjectiveCylinder
 ProjectiveZPlane = DD4hep.Geometry.ProjectiveZPlane
@@ -364,6 +365,10 @@ def create_CartesianGridXY(lcdd, elem) :
   obj = CartesianGridXY()
   if 'gridSizeX' in elem.keys() : obj.setGridSizeX(elem.getF('gridSizeX'))
   if 'gridSizeY' in elem.keys() : obj.setGridSizeY(elem.getF('gridSizeY'))
+  return obj
+
+def create_NoSegmentation(lcdd, elem) :
+  obj = NoSegmentation()
   return obj
 
 def create_ProjectiveCylinder(lcdd, elem) :

--- a/DDCore/src/NoSegmentation.cpp
+++ b/DDCore/src/NoSegmentation.cpp
@@ -1,0 +1,35 @@
+//==========================================================================
+//  AIDA Detector description implementation for LCD
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/NoSegmentation.h"
+#include "DD4hep/objects/SegmentationsInterna.h"
+#include "DDSegmentation/NoSegmentation.h"
+
+// C/C++ include files
+
+using namespace std;
+using namespace DD4hep::Geometry;
+
+Position NoSegmentation::position(const CellID& id) const   {
+  return Position(access()->implementation->position(id));
+}
+
+/// determine the cell ID based on the position
+DD4hep::CellID NoSegmentation::cellID(const Position& local,
+                                       const Position& global,
+                                       const VolumeID& volID) const
+{
+  return access()->implementation->cellID(local, global, volID);
+}
+

--- a/DDCore/src/Segmentations.cpp
+++ b/DDCore/src/Segmentations.cpp
@@ -120,6 +120,9 @@ Handle<SensitiveDetectorObject> Segmentation::sensitive() const  {
 #define IMPLEMENT_SEGMENTATION_HANDLE(X)                                \
   DD4HEP_INSTANTIATE_HANDLE_UNNAMED(SegmentationWrapper<DDSegmentation::X>);
 
+#include "DDSegmentation/NoSegmentation.h"
+IMPLEMENT_SEGMENTATION_HANDLE(NoSegmentation)
+
 #include "DDSegmentation/CartesianGrid.h"
 IMPLEMENT_SEGMENTATION_HANDLE(CartesianGrid)
 

--- a/DDCore/src/plugins/LCDDSegmentations.cpp
+++ b/DDCore/src/plugins/LCDDSegmentations.cpp
@@ -25,6 +25,9 @@ namespace {
   }
 }
 
+#include "DDSegmentation/NoSegmentation.h"
+DECLARE_SEGMENTATION(NoSegmentation,create_segmentation<DD4hep::DDSegmentation::NoSegmentation>)
+
 #include "DDSegmentation/CartesianGridXY.h"
 DECLARE_SEGMENTATION(CartesianGridXY,create_segmentation<DD4hep::DDSegmentation::CartesianGridXY>)
 

--- a/DDSegmentation/include/DDSegmentation/NoSegmentation.h
+++ b/DDSegmentation/include/DDSegmentation/NoSegmentation.h
@@ -1,0 +1,33 @@
+/*
+ * NoSegmentation.h
+ *
+ *  Created on: Feb. 13 2017
+ *      Author: Whitney Armstrong, ANL
+ */
+
+#ifndef DDSegmentation_NoSegmentation_H_
+#define DDSegmentation_NoSegmentation_H_
+
+#include "DDSegmentation/Segmentation.h"
+
+namespace DD4hep {
+  namespace DDSegmentation {
+
+    /** This class exists to provide a segmenation when it is need but doesn't exist. */
+    class NoSegmentation: public Segmentation {
+      public:
+        
+        virtual ~NoSegmentation();
+
+        NoSegmentation(const std::string& cellEncoding = "");
+        NoSegmentation(BitField64* decoder);
+	
+        virtual Vector3D position(const CellID& cellID) const;
+        virtual CellID cellID(const Vector3D& localPosition, const Vector3D& globalPosition, const VolumeID& volumeID) const;
+
+    };
+
+
+  } /* namespace DDSegmentation */
+} /* namespace DD4hep */
+#endif /* DDSegmentation_NoSegmentation */

--- a/DDSegmentation/src/NoSegmentation.cpp
+++ b/DDSegmentation/src/NoSegmentation.cpp
@@ -1,0 +1,42 @@
+/*
+ * NoSegmentation.cpp
+ *
+ *  Created on: Jun 28, 2013
+ *      Author: Christian Grefe, CERN
+ */
+
+#include "DDSegmentation/NoSegmentation.h"
+
+namespace DD4hep {
+  namespace DDSegmentation {
+
+    NoSegmentation::NoSegmentation(const std::string& cellEncoding) :
+      Segmentation(cellEncoding)
+    {
+      _type = "NoSegmentation";
+      _description = "None Segmentation";
+    }
+
+    NoSegmentation::NoSegmentation(BitField64* decode) : Segmentation(decode)
+    { 
+      _type = "NoSegmentation";
+      _description = "None Segmentation";
+    }
+
+    NoSegmentation::~NoSegmentation()
+    { }
+
+    Vector3D NoSegmentation::position(const CellID& cID) const
+    {
+      Vector3D cellPosition{0,0,0};
+      return cellPosition;
+    }
+
+    CellID NoSegmentation::cellID(const Vector3D& /*localPosition*/, const Vector3D& /* globalPosition */, const VolumeID& vID) const {
+      return vID;
+    }
+
+REGISTER_SEGMENTATION(NoSegmentation)
+
+  } /* namespace DDSegmentation */
+} /* namespace DD4hep */


### PR DESCRIPTION
NoSegmentation is useful because it defaults to the volumeID and allows IDDecoder to be used.

	modified:   DDCore/include/DD4hep/Dictionary.h
	new file:   DDCore/include/DD4hep/NoSegmentation.h
	modified:   DDCore/python/lcdd.py
	new file:   DDCore/src/NoSegmentation.cpp
	modified:   DDCore/src/Segmentations.cpp
	modified:   DDCore/src/plugins/LCDDSegmentations.cpp
	new file:   DDSegmentation/include/DDSegmentation/NoSegmentation.h
	new file:   DDSegmentation/src/NoSegmentation.cpp