### PR TITLE
InputAction: Add parameter map property

### DIFF
--- a/DDG4/include/DDG4/Geant4InputAction.h
+++ b/DDG4/include/DDG4/Geant4InputAction.h
@@ -18,6 +18,7 @@
 #include "DDG4/Geant4Vertex.h"
 #include "DDG4/Geant4Particle.h"
 #include "DDG4/Geant4GeneratorAction.h"
+#include "DD4hep/Parsers.h"
 
 // C/C++ include files
 #include <vector>
@@ -64,6 +65,24 @@ namespace DD4hep  {
       bool m_directAccess;
       /// Current event number
       int  m_currEvent;
+
+      /// transform the string parameter value into the type of parameter
+      /**
+       * removes parameter from the parameters map
+       */
+      template <typename T>
+      void _getParameterValue( std::map< std::string, std::string > & parameters,
+			       std::string const& parameterName,
+			       T& parameter, T defaultValue ) {
+
+	if( parameters.find( parameterName ) != parameters.end() ) {
+	  DD4hep::Parsers::parse( parameter, parameters.at( parameterName ) );
+	  parameters.erase( parameterName );
+	} else {
+	  parameter = defaultValue;
+	}
+      }
+
     public:
       /// Initializing constructor
       Geant4EventReader(const std::string& nam);
@@ -92,6 +111,12 @@ namespace DD4hep  {
       virtual EventReaderStatus readParticles(int event_number, 
                                               Vertices&  vertices,
                                               Particles& particles) = 0;
+
+      /// pass parameters to the event reader object
+      virtual EventReaderStatus setParameters( std::map< std::string, std::string > & ) {return EVENT_READER_OK; }
+
+      /// make sure that all parameters have been processed, otherwise throw exceptions
+      virtual void checkParameters( std::map< std::string, std::string >& );
     };
 
     /// Generic input action capable of using the Geant4EventReader class.
@@ -126,6 +151,8 @@ namespace DD4hep  {
       int m_currentEventNumber;
       /// Flag to call abortEvent in case of failure (default: true)
       bool m_abort;
+      /// Property: named parameters to configure file readers or input actions
+      std::map< std::string, std::string> m_parameters;
 
     public:
       /// Read an event and return a LCCollectionVec of MCParticles.

--- a/DDG4/src/Geant4InputAction.cpp
+++ b/DDG4/src/Geant4InputAction.cpp
@@ -52,6 +52,21 @@ Geant4EventReader::EventReaderStatus Geant4EventReader::skipEvent()  {
   return sc;
 }
 
+/// check if all parameters have been consumed by the reader, otherwise throws exception
+void Geant4EventReader::checkParameters(std::map< std::string, std::string > &parameters) {
+
+  if( parameters.empty() ) {
+    return;
+  }
+  for (auto const& pairNV : parameters ) {
+    printout(FATAL,"EventReader::checkParameters","Unknown parameter name: %s with value %s",
+	     pairNV.first.c_str(),
+	     pairNV.second.c_str());
+  }
+  throw std::runtime_error("Unknown parameter for event reader");
+
+}
+
 /// Move to the indicated event number.
 Geant4EventReader::EventReaderStatus
 Geant4EventReader::moveToEvent(int event_number)   {
@@ -87,6 +102,7 @@ Geant4InputAction::Geant4InputAction(Geant4Context* ctxt, const string& nam)
   declareProperty("Mask",           m_mask = 0);
   declareProperty("MomentumScale",  m_momScale = 1.0);
   declareProperty("HaveAbort",      m_abort = true);
+  declareProperty("Parameters",     m_parameters = {});
   m_needsControl = true;
 }
 
@@ -123,6 +139,8 @@ int Geant4InputAction::readParticles(int evt_number,
                  tn.first.c_str(),tn.second.c_str());
         return Geant4EventReader::EVENT_READER_NO_FACTORY;
       }
+      m_reader->setParameters( m_parameters );
+      m_reader->checkParameters( m_parameters );
     }
     catch(const exception& e)  {
       err = e.what();


### PR DESCRIPTION
Add parameter map property to pass arbitrary parameters to event readers if necessary

Then we can do something like this in an eventReader class
``` C++
Geant4EventReaderGuineaPig::setParameters( std::map< std::string, std::string > & parameters ) {
  // int m_part_num
  _getParameterValue( parameters, "ParticlesPerEvent", m_part_num, -1);
}
```