### PR TITLE
Set verbose true for G4EmSaturation to printout Birks coefficient.

### DIFF
--- a/DDG4/src/Geant4StepHandler.cpp
+++ b/DDG4/src/Geant4StepHandler.cpp
@@ -114,9 +114,10 @@ G4ThreeVector Geant4StepHandler::globalToLocalG4(const G4ThreeVector& global)  c
 /// Apply BirksLaw
 double Geant4StepHandler::birkAttenuation() const    {
 #if G4VERSION_NUMBER >= 1001
-  static G4EmSaturation s_emSaturation(0);
+  static G4EmSaturation s_emSaturation(1);
 #else
   static G4EmSaturation s_emSaturation();
+  s_emSaturation.SetVerbose(1);
 #endif
 
   double energyDeposition = step->GetTotalEnergyDeposit();


### PR DESCRIPTION
Added printout information for user to check the Birks Law usage at ddsim/Geant4 runtime.
It will printout only once in the first event like this.
### G4EmSaturation::FindBirksCoefficient Birks coefficient for G4_POLYSTYRENE  0.07943 mm/MeV

BEGINRELEASENOTES
- Set verbose true for G4EmSaturation to printout Birks coefficient.

ENDRELEASENOTES
