### PR TITLE
Remove the Parrot Connector and mount cvmfs directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,37 @@ dist: trusty
 services:
   - docker
 
+env:
+  matrix:
+    - COMPILER=gcc
+
+before_install:
+  - wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+  - sudo dpkg -i cvmfs-release-latest_all.deb
+  - sudo apt-get update
+  - sudo apt-get install cvmfs cvmfs-config-default
+  - rm -f cvmfs-release-latest_all.deb
+  - wget https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
+  - sudo mkdir -p /etc/cvmfs
+  - sudo mv default.local /etc/cvmfs/default.local
+  - sudo /etc/init.d/autofs stop
+  - sudo cvmfs_config setup
+  - sudo mkdir -p /cvmfs/clicdp.cern.ch
+  - sudo mount -t cvmfs clicdp.cern.ch /cvmfs/clicdp.cern.ch
+  - ls /cvmfs/clicdp.cern.ch
+
 # command to install dependencies
 install:
   - shopt -s extglob dotglob
-  - mkdir DD4hep
-  - mv !(DD4hep) DD4hep
+  - mkdir Package
+  - mv !(Package) Package
   - shopt -u dotglob
-  - export DD4hepDIR=${PWD}/DD4hep
-  - cat $DD4hepDIR/.dd4hep-ci.d/compile_and_test.sh
-  - curl -O https://lcd-data.web.cern.ch/lcd-data/CernVM/cernvm3-docker-latest.tar
-  - cat cernvm3-docker-latest.tar | docker import - cernvm
+  - export PKGDIR=${PWD}/Package
 
 # command to run tests
 script:
-  - docker run -t -v $DD4hepDIR:/DD4hep cernvm /init /DD4hep/.dd4hep-ci.d/compile_and_test.sh
+  - docker run -t --name CI_container -v $PKGDIR:/Package -e COMPILER=$COMPILER -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch -d clicdp/slc6-build /bin/bash
+  - docker exec CI_container /bin/bash -c "./Package/.dd4hep-ci.d/compile_and_test.sh"
 
 # Don't send e-mail notifications
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ install:
 
 # command to run tests
 script:
-  - docker run -ti --name CI_container -v $PKGDIR:/Package -e COMPILER=$COMPILER -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch -d clicdp/slc6-build /bin/bash
-  - docker exec -ti CI_container /bin/bash -c "./Package/.dd4hep-ci.d/compile_and_test.sh"
+  - docker run -ti --name CI_container -v $PKGDIR:/DD4hep -e COMPILER=$COMPILER -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch -d clicdp/slc6-build /bin/bash
+  - docker exec -ti CI_container /bin/bash -c "./DD4hep/.dd4hep-ci.d/compile_and_test.sh"
 
 # Don't send e-mail notifications
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ install:
 
 # command to run tests
 script:
-  - docker run -t --name CI_container -v $PKGDIR:/Package -e COMPILER=$COMPILER -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch -d clicdp/slc6-build /bin/bash
-  - docker exec CI_container /bin/bash -c "./Package/.dd4hep-ci.d/compile_and_test.sh"
+  - docker run -ti --name CI_container -v $PKGDIR:/Package -e COMPILER=$COMPILER -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch -d clicdp/slc6-build /bin/bash
+  - docker exec -ti CI_container /bin/bash -c "./Package/.dd4hep-ci.d/compile_and_test.sh"
 
 # Don't send e-mail notifications
 notifications:


### PR DESCRIPTION
BEGINRELEASENOTES
- Update to the CI system:
  - Install directly cvmfs on base system, which removes the need for the parrot connector 
  - Replace CernVM docker with plain docker
  - This reduces the build run time from 50 min to 25 min

ENDRELEASENOTES