### PR TITLE
LCIO: Add setting of ProducedBySecondary bit for SimTrackerHits

### DIFF
--- a/DDG4/include/DDG4/Geant4Particle.h
+++ b/DDG4/include/DDG4/Geant4Particle.h
@@ -105,7 +105,9 @@ namespace DD4hep {
       typedef std::set<int> Particles;
       /// Reference counter
       int ref = 0;           //! not persistent
-      int id  = 0, originalG4ID = 0, g4Parent = 0, reason = 0, mask = 0;
+      int id  = 0;
+      int originalG4ID = 0;  //! not persistent
+      int g4Parent = 0, reason = 0, mask = 0;
       int steps  = 0, secondaries = 0, pdgID = 0;
       int status = 0, colorFlow[2] {0,0};
       char charge = 0, _spare[3] {0,0,0};

--- a/DDG4/include/DDG4/Geant4Particle.h
+++ b/DDG4/include/DDG4/Geant4Particle.h
@@ -105,7 +105,7 @@ namespace DD4hep {
       typedef std::set<int> Particles;
       /// Reference counter
       int ref = 0;           //! not persistent
-      int id  = 0, g4Parent = 0, reason = 0, mask = 0;
+      int id  = 0, originalG4ID = 0, g4Parent = 0, reason = 0, mask = 0;
       int steps  = 0, secondaries = 0, pdgID = 0;
       int status = 0, colorFlow[2] {0,0};
       char charge = 0, _spare[3] {0,0,0};

--- a/DDG4/lcio/LCIOConversions.cpp
+++ b/DDG4/lcio/LCIOConversions.cpp
@@ -137,6 +137,17 @@ namespace DD4hep {
         lc_hit->setMCParticle(lc_mcp);
         lc_hit->setPosition(pos);
         lc_hit->setMomentum(hit->momentum.x()/CLHEP::GeV,hit->momentum.y()/CLHEP::GeV,hit->momentum.z()/CLHEP::GeV);
+
+#if LCIO_VERSION_GE( 2, 8 )
+        auto particleIt = pm->particles().find(trackID);
+        if( ( particleIt != pm->particles().end()) ){
+	  // if the original track ID of the particle is not the same as the
+	  // original track ID of the hit it was produced by an MCParticle that
+	  // is no longer stored
+	  lc_hit->setProducedBySecondary( (particleIt->second->originalG4ID != t.trackID) );
+        }
+#endif
+
         lc_coll->addElement(lc_hit);
       }
       return lc_coll;

--- a/DDG4/src/Geant4Particle.cpp
+++ b/DDG4/src/Geant4Particle.cpp
@@ -36,7 +36,7 @@ ParticleExtension::~ParticleExtension() {
 
 /// Copy constructor
 Geant4Particle::Geant4Particle(const Geant4Particle& c)
-: ref(1), id(c.id), g4Parent(c.g4Parent), reason(c.reason), mask(c.mask),
+: ref(1), id(c.id), originalG4ID(c.originalG4ID), g4Parent(c.g4Parent), reason(c.reason), mask(c.mask),
   steps(c.steps), secondaries(c.secondaries), pdgID(c.pdgID),
   status(c.status), charge(0),
   vsx(c.vsx), vsy(c.vsy), vsz(c.vsz),
@@ -57,7 +57,7 @@ Geant4Particle::Geant4Particle(const Geant4Particle& c)
 
 /// Default constructor
 Geant4Particle::Geant4Particle()
-: ref(1), id(0), g4Parent(0), reason(0), mask(0),
+: ref(1), id(0), originalG4ID(0), g4Parent(0), reason(0), mask(0),
   steps(0), secondaries(0), pdgID(0),
   status(0), charge(0),
   vsx(0.0), vsy(0.0), vsz(0.0),
@@ -74,7 +74,7 @@ Geant4Particle::Geant4Particle()
 
 /// Constructor with ID initialization
 Geant4Particle::Geant4Particle(int part_id)
-: ref(1), id(part_id), g4Parent(0), reason(0), mask(0),
+: ref(1), id(part_id), originalG4ID(part_id), g4Parent(0), reason(0), mask(0),
   steps(0), secondaries(0), pdgID(0),
   status(0), charge(0),
   vsx(0.0), vsy(0.0), vsz(0.0),
@@ -106,6 +106,7 @@ void Geant4Particle::release()  {
 Geant4Particle& Geant4Particle::get_data(Geant4Particle& c)   {
   if ( this != &c )  {
     id = c.id;
+    originalG4ID = c.originalG4ID;
     g4Parent    = c.g4Parent;
     reason      = c.reason;
     mask        = c.mask;

--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -255,6 +255,7 @@ void Geant4ParticleHandler::begin(const G4Track* track)   {
   m_currTrack.steps       = 0;
   m_currTrack.secondaries = 0;
   m_currTrack.g4Parent    = h.parent();
+  m_currTrack.originalG4ID= h.id();
   m_currTrack.process     = h.creatorProcess();
   m_currTrack.time        = h.globalTime();
   m_currTrack.vsx         = v.x();


### PR DESCRIPTION
if the hit is produced by a particle that is not kept in the MCParticle history we set the bit

added oid (original ID) to Geant4Particle class for faster lookup, as this ID is stored with the hit
Otherwise we need a complicated and time-consuming logic to parse the equivalent map if this hit really belonged to that track

Needs ilcsoft/lcio#21 to work, but compiles also against older LCIO versions


BEGINRELEASENOTES
- LCIOOutput: Add setting of ProducedBySecondary bit for SimTrackerHits if the hit is produced by a particle that is not stored in the MCParticle collection, needs lcio 2.8

ENDRELEASENOTES