### PR TITLE
Fix to create paramphysvol3D volumes

### DIFF
--- a/DDDB/include/DDDB/DDDBTags.h
+++ b/DDDB/include/DDDB/DDDBTags.h
@@ -92,6 +92,7 @@ namespace DD4hep {
 
     UNICODE(paramphysvol);
     UNICODE(paramphysvol2D);
+    UNICODE(paramphysvol3D);
     UNICODE(phiAngle);
     UNICODE(paramVector);
     UNICODE(posXYZ);

--- a/DDDB/src/CondDB2DDDB.cpp
+++ b/DDDB/src/CondDB2DDDB.cpp
@@ -1213,6 +1213,7 @@ namespace DD4hep {
           xml_coll_t(element, _U(physvol)).for_each(Conv<PhysVol>(lcdd,context,vol));
           xml_coll_t(element, _LBU(paramphysvol)).for_each(Conv<ParamPhysVol>(lcdd,context,vol));
           xml_coll_t(element, _LBU(paramphysvol2D)).for_each(Conv<ParamPhysVol2D>(lcdd,context,vol));
+          xml_coll_t(element, _LBU(paramphysvol3D)).for_each(Conv<ParamPhysVol3D>(lcdd,context,vol));
         }
       }
     }


### PR DESCRIPTION
BEGINRELEASENOTES
* Trivial fix for the DDDB converter to create paramphysvol3D volumes, which are otherwise ignored.

ENDRELEASENOTES