### PR TITLE
CMake: add creation of DD4hepConfigVersion.cmake file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build/
 
 # CMake config files
 *Config.cmake
+*ConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ display_std_variables()
 
 ##############################################################################
 # generate and install following configuration files
-generate_package_configuration_files( DD4hepConfig.cmake )
+dd4hep_generate_package_configuration_files( DD4hepConfig.cmake )
 if(APPLE)
   SET ( ENV{DD4HEP_LIBRARY_PATH} $ENV{DYLD_LIBRARY_PATH} )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ display_std_variables()
 
 ##############################################################################
 # generate and install following configuration files
-generate_package_configuration_files( DD4hepConfig.cmake DD4hepConfigVersion.cmake )
+generate_package_configuration_files( DD4hepConfig.cmake )
 if(APPLE)
   SET ( ENV{DD4HEP_LIBRARY_PATH} $ENV{DYLD_LIBRARY_PATH} )
 else()

--- a/cmake/DD4hepMacros.cmake
+++ b/cmake/DD4hepMacros.cmake
@@ -67,7 +67,7 @@ ENDMACRO( DISPLAY_STD_VARIABLES )
 
 #---------------------------------------------------------------------------
 # helper macro for generating project configuration file
-MACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
+MACRO( DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES )
 #---------------------------------------------------------------------------
 
     FOREACH( arg ${ARGN} )
@@ -98,7 +98,7 @@ MACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
                                       VERSION ${DD4hep_VERSION}
                                       COMPATIBILITY AnyNewerVersion )
 
-ENDMACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
+ENDMACRO( DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES )
 
 
 ##############################################################################

--- a/cmake/DD4hepMacros.cmake
+++ b/cmake/DD4hepMacros.cmake
@@ -83,6 +83,7 @@ MACRO( DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES )
                 #IF( EXISTS "${_current_dir}/MacroExportPackageDeps.cmake" )
                 #    INSTALL( FILES "${_current_dir}/MacroExportPackageDeps.cmake" DESTINATION cmake )
                 #ENDIF()
+                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION ./cmake )
             ENDIF()
         ENDIF()
 
@@ -94,9 +95,11 @@ MACRO( DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES )
     ENDFOREACH()
 
     INCLUDE( CMakePackageConfigHelpers )
-    WRITE_BASIC_PACKAGE_VERSION_FILE( ${CMAKE_INSTALL_PREFIX}/DD4hepConfigVersion.cmake
+    WRITE_BASIC_PACKAGE_VERSION_FILE( DD4hepConfigVersion.cmake
                                       VERSION ${DD4hep_VERSION}
                                       COMPATIBILITY AnyNewerVersion )
+    INSTALL( FILES "${PROJECT_BINARY_DIR}/DD4hepConfigVersion.cmake" DESTINATION . )
+    INSTALL( FILES "${PROJECT_BINARY_DIR}/DD4hepConfigVersion.cmake" DESTINATION ./cmake )
 
 ENDMACRO( DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES )
 

--- a/cmake/DD4hepMacros.cmake
+++ b/cmake/DD4hepMacros.cmake
@@ -86,26 +86,17 @@ MACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
             ENDIF()
         ENDIF()
 
-
-        IF( ${arg} MATCHES "ConfigVersion.cmake" )
-            # version configuration file
-            IF( EXISTS "${PROJECT_SOURCE_DIR}/cmake/${arg}.in" )
-                CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
-                                "${PROJECT_BINARY_DIR}/${arg}" @ONLY
-                )
-                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
-                #IF( EXISTS "${_current_dir}/MacroCheckPackageVersion.cmake" )
-                #    INSTALL( FILES "${_current_dir}/MacroCheckPackageVersion.cmake" DESTINATION cmake )
-                #ENDIF()
-            ENDIF( EXISTS "${PROJECT_SOURCE_DIR}/cmake/${arg}.in" )
-        ENDIF()
-
         IF( ${arg} MATCHES "LibDeps.cmake" )
             EXPORT_LIBRARY_DEPENDENCIES( "${arg}" )
             INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake )
         ENDIF()
 
     ENDFOREACH()
+
+    INCLUDE( CMakePackageConfigHelpers )
+    WRITE_BASIC_PACKAGE_VERSION_FILE( ${CMAKE_INSTALL_PREFIX}/DD4hepConfigVersion.cmake
+                                      VERSION ${DD4hep_VERSION}
+                                      COMPATIBILITY AnyNewerVersion )
 
 ENDMACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
 

--- a/cmake/DD4hepMacros.cmake
+++ b/cmake/DD4hepMacros.cmake
@@ -77,21 +77,9 @@ MACRO( DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES )
                                 "${PROJECT_BINARY_DIR}/${arg}" @ONLY
                 )
                 INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
-                #IF( EXISTS "${_current_dir}/MacroCheckPackageLibs.cmake" )
-                #    INSTALL( FILES "${_current_dir}/MacroCheckPackageLibs.cmake" DESTINATION cmake )
-                #ENDIF()
-                #IF( EXISTS "${_current_dir}/MacroExportPackageDeps.cmake" )
-                #    INSTALL( FILES "${_current_dir}/MacroExportPackageDeps.cmake" DESTINATION cmake )
-                #ENDIF()
                 INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION ./cmake )
             ENDIF()
         ENDIF()
-
-        IF( ${arg} MATCHES "LibDeps.cmake" )
-            EXPORT_LIBRARY_DEPENDENCIES( "${arg}" )
-            INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake )
-        ENDIF()
-
     ENDFOREACH()
 
     INCLUDE( CMakePackageConfigHelpers )


### PR DESCRIPTION
Fixes #149 , #49 

BEGINRELEASENOTES
- Always create DD4hepConfigVersion.cmake in CMAKE_INSTALL_PREFIX and cmake folder
- Create DD4hepConfig.cmake also in cmake folder
- renamed Cmake Macro GENERATE_PACKAGE_CONFIGURATION_FILES to DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES so it does not clash with the macro of the same name in ilcutil/cmakemodules

ENDRELEASENOTES