### PR TITLE
Use standard cmake way of defining package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ build/
 # CMake config files
 *Config.cmake
 *ConfigVersion.cmake
+Version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,24 @@ option(CMAKE_MACOSX_RPATH "Build with rpath on macos" ON)
 #  project version (Major,minor,patch)
 #  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #  !! Use the same version numbers in DDSegmentation/CMakeLists.txt    !!
-#  !! and make also sure to change in DDCore/include/DD4hep/LCDD.h     !!
 #  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #
-dd4hep_set_version(DD4hep MAJOR 0 MINOR 20 PATCH 0)
+# project version
+SET( DD4hep_VERSION_MAJOR 0  )
+SET( DD4hep_VERSION_MINOR 22 )
+SET( DD4hep_VERSION_PATCH 0  )
+
+dd4hep_set_version(DD4hep
+  MAJOR ${DD4hep_VERSION_MAJOR}
+  MINOR ${DD4hep_VERSION_MINOR}
+  PATCH ${DD4hep_VERSION_PATCH} )
+
+configure_file (
+  "${PROJECT_SOURCE_DIR}/cmake/Version.h.in"
+  "${PROJECT_SOURCE_DIR}/DDCore/include/DD4hep/Version.h"
+  )
+
+
 dd4hep_configure_output( OUTPUT "${PROJECT_BINARY_DIR}" INSTALL "${CMAKE_INSTALL_PREFIX}" )
 #
 # Include ROOT

--- a/DDCore/include/DD4hep/LCDD.h
+++ b/DDCore/include/DD4hep/LCDD.h
@@ -13,18 +13,7 @@
 #ifndef DD4HEP_LCDD_LCDD_H
 #define DD4HEP_LCDD_LCDD_H
 
-// define version macros for DD4hep
-#define DD4HEP_MAJOR_VERSION 0
-#define DD4HEP_MINOR_VERSION 19
-
-#define DD4HEP_VERSION_GE(MAJV,MINV)  ( (  DD4HEP_MAJOR_VERSION  > MAJV ) || \
-                                        ( (DD4HEP_MAJOR_VERSION == MAJV ) && \
-                                          (DD4HEP_MINOR_VERSION >= MINV ) ) )
-
-#define DD4HEP_VERSION_GT(MAJV,MINV)  ( (  DD4HEP_MAJOR_VERSION  > MAJV ) || \
-                                        ( (DD4HEP_MAJOR_VERSION == MAJV ) && \
-                                          (DD4HEP_MINOR_VERSION >  MINV ) ) )
-
+#include "DD4hep/Version.h"
 
 // Framework includes
 #include "DD4hep/Handle.h"

--- a/DDSegmentation/CMakeLists.txt
+++ b/DDSegmentation/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 project(DDSegmentation)
  #fg: version number must be the same as DD4hep !!
 set(DDSegmentation_MAJOR_VERSION 0)
-set(DDSegmentation_MINOR_VERSION 20)
+set(DDSegmentation_MINOR_VERSION 19)
 set(DDSegmentation_PATCH_VERSION 0)
 set(DDSegmentation_VERSION "${DDSegmentation_MAJOR_VERSION}.${DDSegmentation_MINOR_VERSION}" )
 set(DDSegmentation_SOVERSION "${DDSegmentation_MAJOR_VERSION}.${DDSegmentation_MINOR_VERSION}")

--- a/DDSegmentation/CMakeLists.txt
+++ b/DDSegmentation/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 project(DDSegmentation)
  #fg: version number must be the same as DD4hep !!
-set(DDSegmentation_MAJOR_VERSION 0)
-set(DDSegmentation_MINOR_VERSION 19)
-set(DDSegmentation_PATCH_VERSION 0)
-set(DDSegmentation_VERSION "${DDSegmentation_MAJOR_VERSION}.${DDSegmentation_MINOR_VERSION}" )
-set(DDSegmentation_SOVERSION "${DDSegmentation_MAJOR_VERSION}.${DDSegmentation_MINOR_VERSION}")
+set(DDSegmentation_VERSION_MAJOR 0)
+set(DDSegmentation_VERSION_MINOR 19)
+set(DDSegmentation_VERSION_PATCH 0)
+set(DDSegmentation_VERSION "${DDSegmentation_VERSION_MAJOR}.${DDSegmentation_VERSION_MINOR}" )
+set(DDSegmentation_SOVERSION "${DDSegmentation_VERSION_MAJOR}.${DDSegmentation_VERSION_MINOR}")
 
 #------------- set the default installation directory to be the source directory
 

--- a/cmake/Version.h.in
+++ b/cmake/Version.h.in
@@ -1,0 +1,29 @@
+//==========================================================================
+//  AIDA Detector description implementation for LCD
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : A.Sailer
+//
+//==========================================================================
+#ifndef DD4HEP_VERSION_H
+#define DD4HEP_VERSION_H 1
+
+// define version macros for DD4hep
+#define DD4HEP_MAJOR_VERSION @DD4hep_VERSION_MAJOR@
+#define DD4HEP_MINOR_VERSION @DD4hep_VERSION_MINOR@
+
+#define DD4HEP_VERSION_GE(MAJV,MINV)  ( (  DD4HEP_MAJOR_VERSION  > MAJV ) || \
+                                        ( (DD4HEP_MAJOR_VERSION == MAJV ) && \
+                                          (DD4HEP_MINOR_VERSION >= MINV ) ) )
+
+#define DD4HEP_VERSION_GT(MAJV,MINV)  ( (  DD4HEP_MAJOR_VERSION  > MAJV ) || \
+                                        ( (DD4HEP_MAJOR_VERSION == MAJV ) && \
+                                          (DD4HEP_MINOR_VERSION >  MINV ) ) )
+
+
+#endif // DD4HEP_VERSION_H


### PR DESCRIPTION
These changes simplify the setting of the package version, so that the version only has to be defined in one place. This allows more automatic tagging of dd4hep, which needs to have the `PACKAGE_VERSION_*` variables be set in the main CMakeLists file.

Also change the variables in DDSegmentation to cmake like PACKAGE_VERSION_* (Will adapt tagging scripts to modify this file automatically as well and change ddsegmentation version via tagging script when making the tag on Monday...)

BEGINRELEASENOTES
- Use cmake to create Version.h file to contain DD4hep version information and macros
- Change the way DD4hep package version is defined and set standard cmake variables for this purpose

ENDRELEASENOTES