### PR TITLE
[WIP] add CellIDPositionConverter

### DIFF
--- a/DDCore/include/DD4hep/objects/VolumeManagerInterna.h
+++ b/DDCore/include/DD4hep/objects/VolumeManagerInterna.h
@@ -66,9 +66,11 @@ namespace DD4hep {
       DetElement   element;
       /// The transformation of space-points to the world corrdinate system
       TGeoHMatrix  toWorld;
-      /// The transformation of space-points to the corrdinate system of the closests detector element
+      /// The transformation of space-points to the coordinate system of the detector element
       [[gnu::deprecated("This member variable might get axed if it is not used, please tell us if you do")]]
       TGeoHMatrix toDetector;
+      /// The transformation of space-points to the coordinate system of the closests detector element
+      TGeoHMatrix toElement;
     public:
       /// Default constructor
       VolumeManagerContext();

--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -251,6 +251,7 @@ namespace DD4hep {
             }
             //            context->volID      = ids;
             //            context->path       = nodes;
+            context->toElement = context->toWorld;
             context->toDetector = context->toWorld;
             context->toDetector.MultiplyLeft(nodes[0]->GetMatrix());
             context->toWorld.MultiplyLeft(&e.nominal().worldTransformation());

--- a/DDRec/include/DDRec/CellIDPositionConverter.h
+++ b/DDRec/include/DDRec/CellIDPositionConverter.h
@@ -17,13 +17,10 @@ namespace DD4hep {
     typedef DDSegmentation::CellID CellID;
     typedef DDSegmentation::VolumeID VolumeID;
 
-    /** CellIDPositionConverter - utility class that
-     *  combines functionality of the VolumeManager and Segmentation classes to provide a
-     *  high level interface for position to cell ID and cell ID to position conversions
-     *  and related information.
+    /** Utility for position to cell ID and cell ID to position conversions.
+     *  (Correctly re-implements some of the functionality of the deprecated IDDecoder).
      *
-     *
-     * @author F.Gaede, DESY ( based on IDDecoder by C.Grefe, CERN)
+     * @author F.Gaede, DESY
      * @date May 2017
      */
 
@@ -35,75 +32,51 @@ namespace DD4hep {
       
     public:
       
-      /// Default constructor
+      /// The constructor - takes the main lcdd object.
       CellIDPositionConverter( Geometry::LCDD& lcdd ) {
 	_volumeManager = Geometry::VolumeManager::getVolumeManager(lcdd);
-
-	std::cout << " VolumeManager: \n"  << _volumeManager << std::endl ;
       }
 
       /// Destructor
       virtual ~CellIDPositionConverter(){} ;
       
-      /// Returns the cell ID from the local position in the given volume ID.
-      CellID cellIDFromLocal(const Geometry::Position& local, const VolumeID volumeID) const;
-      
-      /// Returns the global cell ID from a given global position
+      /// returns the global cell ID from a given global position
       CellID cellID(const Geometry::Position& global) const;
       
-      /// Returns the global position from a given cell ID
+      /** Return the nominal global position for a given cellID of a sensitive volume.
+       *  No Alignment corrections are applied.
+       *  If no sensitive volume is found, (0,0,0) is returned.
+       */
+      Geometry::Position positionNominal(const CellID& cellID) const;
+      
+      /** Return the global position for a given cellID of a sensitive volume.
+       *  Alignment corrections are applied (TO BE DONE).
+       *  If no sensitive volume is found, (0,0,0) is returned.
+       */
       Geometry::Position position(const CellID& cellID) const;
-      
-      /// Returns the local position from a given cell ID
-      Geometry::Position localPosition(const CellID& cellID) const;
-      
-      /// Returns the volume ID of a given cell ID
-      VolumeID volumeID(const CellID& cellID) const;
-      
-      /// Returns the volume ID of a given global position
-      VolumeID volumeID(const Geometry::Position& global) const;
-      
-      /// Returns the placement for a given cell ID
-      Geometry::PlacedVolume placement(const CellID& cellID) const;
 
-      /// Returns the placement for a given global position
-      Geometry::PlacedVolume placement(const Geometry::Position& global) const;
+      /** Find the context with DetElement, placements etc for a given cellID of a sensitive volume.
+       *  Returns NULL if not found (e.g. if the cellID does not correspond to a sensitive volume).
+       */
+      const Geometry::VolumeManagerContext* findContext(const CellID& cellID) const;
 
-      /// Returns the subdetector for a given cell ID
-      Geometry::DetElement subDetector(const CellID& cellID) const;
 
-      /// Returns the subdetector for a given global position
-      Geometry::DetElement subDetector(const Geometry::Position& global) const;
-
-      /// Returns the closest detector element in the hierarchy for a given cell ID
-      Geometry::DetElement detectorElement(const CellID& cellID) const;
-
-      /// Returns the closest detector element in the hierarchy for a given global position
-      Geometry::DetElement detectorElement(const Geometry::Position& global) const;
-
-      /// Access to the Readout object for a given cell ID
-      Geometry::Readout readout(const CellID& cellID) const;
-
-      /// Access to the Readout object for a given global position
-      Geometry::Readout readout(const Geometry::Position& global) const;
-
-      /// Calculates the neighbours of the given cell ID and adds them to the list of neighbours
-      void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const;
-
-      /// Checks if the given cell IDs are neighbours
-      bool areNeighbours(const CellID& cellID, const CellID& otherCellID) const;
-
-      /// find the context with DetElement, placements etc for a given cellID of a sensitive volume.
-      DD4hep::Geometry::VolumeManagerContext* findContext(const CellID& cellID) const;
-
-      
-    protected:
-      Geometry::VolumeManager _volumeManager{} ;
-
+      /** Find the readout object for the given DetElement. If the DetElement is sensitive the corresondig 
+       *  Readout is returned, else a recursive search in the daughter volumes (nodes) of this DetElement's
+       *  volume is performed and the first Readout object is returned. 
+       *  
+       */
       Geometry::Readout findReadout(const Geometry::DetElement& det) const ;
-      Geometry::DetElement getClosestDaughter(const Geometry:: DetElement& det, const Geometry::Position& position) const ;
+
+
+      /** Return this PlacedVolume's Readout or, if the volume is not sensitive, recursively search for 
+       * a Readout object in the daughter nodes (volumes).
+       */
       Geometry::Readout findReadout(const Geometry::PlacedVolume& pv) const ;
 
+
+    protected:
+      Geometry::VolumeManager _volumeManager{} ;
 
     };
 

--- a/DDRec/include/DDRec/CellIDPositionConverter.h
+++ b/DDRec/include/DDRec/CellIDPositionConverter.h
@@ -33,7 +33,7 @@ namespace DD4hep {
     public:
       
       /// The constructor - takes the main lcdd object.
-      CellIDPositionConverter( Geometry::LCDD& lcdd ) {
+      CellIDPositionConverter( Geometry::LCDD& lcdd ) : _lcdd( &lcdd )  {
 	_volumeManager = Geometry::VolumeManager::getVolumeManager(lcdd);
       }
 
@@ -61,6 +61,21 @@ namespace DD4hep {
       const Geometry::VolumeManagerContext* findContext(const CellID& cellID) const;
 
 
+
+      /** Find the DetElement that contains the given point - if no DetElement is found, an
+       *  invalid DetElement is returned. Uses the optionally given DetElement as start for the search.
+       */ 
+      Geometry::DetElement findDetElement(const Geometry::Position& global,
+					  const Geometry::DetElement& det=Geometry::DetElement() ) const; 
+
+
+      /** Find the lowest daughter Placement in the Placement that
+       *  contains the point (in the coordinate system of the mother placement) the local coordintates 
+       *  in this placement are also returned.
+       */
+      Geometry::PlacedVolume findPlacement(const Geometry::Position& point, const  Geometry::PlacedVolume& mother, double locPos[3]) const ; 
+
+
       /** Find the readout object for the given DetElement. If the DetElement is sensitive the corresondig 
        *  Readout is returned, else a recursive search in the daughter volumes (nodes) of this DetElement's
        *  volume is performed and the first Readout object is returned. 
@@ -77,6 +92,7 @@ namespace DD4hep {
 
     protected:
       Geometry::VolumeManager _volumeManager{} ;
+      const Geometry::LCDD* _lcdd ;
 
     };
 

--- a/DDRec/include/DDRec/CellIDPositionConverter.h
+++ b/DDRec/include/DDRec/CellIDPositionConverter.h
@@ -69,11 +69,12 @@ namespace DD4hep {
 					  const Geometry::DetElement& det=Geometry::DetElement() ) const; 
 
 
-      /** Find the lowest daughter Placement in the Placement that
-       *  contains the point (in the coordinate system of the mother placement) the local coordintates 
-       *  in this placement are also returned.
+      /** Find the lowest daughter Placement in the given Placement that
+       *  contains the point (in the coordinate system of the mother placement).
+       *  Return the local coordinates in this daughter Placement and collect all volIDs 
+       *  on the way.
        */
-      Geometry::PlacedVolume findPlacement(const Geometry::Position& point, const  Geometry::PlacedVolume& mother, double locPos[3]) const ; 
+      Geometry::PlacedVolume findPlacement(const Geometry::Position& point, const  Geometry::PlacedVolume& mother, double locPos[3], Geometry::PlacedVolume::VolIDs& volIDs) const ; 
 
 
       /** Find the readout object for the given DetElement. If the DetElement is sensitive the corresondig 

--- a/DDRec/include/DDRec/CellIDPositionConverter.h
+++ b/DDRec/include/DDRec/CellIDPositionConverter.h
@@ -38,6 +38,8 @@ namespace DD4hep {
       /// Default constructor
       CellIDPositionConverter( Geometry::LCDD& lcdd ) {
 	_volumeManager = Geometry::VolumeManager::getVolumeManager(lcdd);
+
+	std::cout << " VolumeManager: \n"  << _volumeManager << std::endl ;
       }
 
       /// Destructor
@@ -91,13 +93,17 @@ namespace DD4hep {
       /// Checks if the given cell IDs are neighbours
       bool areNeighbours(const CellID& cellID, const CellID& otherCellID) const;
 
+      /// find the context with DetElement, placements etc for a given cellID of a sensitive volume.
+      DD4hep::Geometry::VolumeManagerContext* findContext(const CellID& cellID) const;
 
+      
     protected:
       Geometry::VolumeManager _volumeManager{} ;
 
       Geometry::Readout findReadout(const Geometry::DetElement& det) const ;
       Geometry::DetElement getClosestDaughter(const Geometry:: DetElement& det, const Geometry::Position& position) const ;
       Geometry::Readout findReadout(const Geometry::PlacedVolume& pv) const ;
+
 
     };
 

--- a/DDRec/include/DDRec/CellIDPositionConverter.h
+++ b/DDRec/include/DDRec/CellIDPositionConverter.h
@@ -1,0 +1,106 @@
+#ifndef CellIDPositionConverter_H_
+#define CellIDPositionConverter_H_
+
+#include "DD4hep/Readout.h"
+#include "DD4hep/VolumeManager.h"
+
+#include "DDSegmentation/Segmentation.h"
+
+#include <set>
+#include <string>
+
+class TGeoManager;
+
+namespace DD4hep {
+  namespace DDRec {
+
+    typedef DDSegmentation::CellID CellID;
+    typedef DDSegmentation::VolumeID VolumeID;
+
+    /** CellIDPositionConverter - utility class that
+     *  combines functionality of the VolumeManager and Segmentation classes to provide a
+     *  high level interface for position to cell ID and cell ID to position conversions
+     *  and related information.
+     *
+     *
+     * @author F.Gaede, DESY ( based on IDDecoder by C.Grefe, CERN)
+     * @date May 2017
+     */
+
+    class CellIDPositionConverter {
+      
+      CellIDPositionConverter() = delete ;
+      CellIDPositionConverter(const CellIDPositionConverter&) = delete ;
+      void operator=(const CellIDPositionConverter&) = delete ;
+      
+    public:
+      
+      /// Default constructor
+      CellIDPositionConverter( Geometry::LCDD& lcdd ) {
+	_volumeManager = Geometry::VolumeManager::getVolumeManager(lcdd);
+      }
+
+      /// Destructor
+      virtual ~CellIDPositionConverter(){} ;
+      
+      /// Returns the cell ID from the local position in the given volume ID.
+      CellID cellIDFromLocal(const Geometry::Position& local, const VolumeID volumeID) const;
+      
+      /// Returns the global cell ID from a given global position
+      CellID cellID(const Geometry::Position& global) const;
+      
+      /// Returns the global position from a given cell ID
+      Geometry::Position position(const CellID& cellID) const;
+      
+      /// Returns the local position from a given cell ID
+      Geometry::Position localPosition(const CellID& cellID) const;
+      
+      /// Returns the volume ID of a given cell ID
+      VolumeID volumeID(const CellID& cellID) const;
+      
+      /// Returns the volume ID of a given global position
+      VolumeID volumeID(const Geometry::Position& global) const;
+      
+      /// Returns the placement for a given cell ID
+      Geometry::PlacedVolume placement(const CellID& cellID) const;
+
+      /// Returns the placement for a given global position
+      Geometry::PlacedVolume placement(const Geometry::Position& global) const;
+
+      /// Returns the subdetector for a given cell ID
+      Geometry::DetElement subDetector(const CellID& cellID) const;
+
+      /// Returns the subdetector for a given global position
+      Geometry::DetElement subDetector(const Geometry::Position& global) const;
+
+      /// Returns the closest detector element in the hierarchy for a given cell ID
+      Geometry::DetElement detectorElement(const CellID& cellID) const;
+
+      /// Returns the closest detector element in the hierarchy for a given global position
+      Geometry::DetElement detectorElement(const Geometry::Position& global) const;
+
+      /// Access to the Readout object for a given cell ID
+      Geometry::Readout readout(const CellID& cellID) const;
+
+      /// Access to the Readout object for a given global position
+      Geometry::Readout readout(const Geometry::Position& global) const;
+
+      /// Calculates the neighbours of the given cell ID and adds them to the list of neighbours
+      void neighbours(const CellID& cellID, std::set<CellID>& neighbours) const;
+
+      /// Checks if the given cell IDs are neighbours
+      bool areNeighbours(const CellID& cellID, const CellID& otherCellID) const;
+
+
+    protected:
+      Geometry::VolumeManager _volumeManager{} ;
+
+      Geometry::Readout findReadout(const Geometry::DetElement& det) const ;
+      Geometry::DetElement getClosestDaughter(const Geometry:: DetElement& det, const Geometry::Position& position) const ;
+      Geometry::Readout findReadout(const Geometry::PlacedVolume& pv) const ;
+
+    };
+
+  } /* namespace DDRec */
+} /* namespace DD4hep */
+#endif /* CellIDPositionConverter_H_ */

--- a/DDRec/src/CellIDPositionConverter.cpp
+++ b/DDRec/src/CellIDPositionConverter.cpp
@@ -83,6 +83,7 @@ namespace DD4hep {
 
 
 
+
     CellID CellIDPositionConverter::cellID(const Position& global) const {
 
       CellID result(0) ;

--- a/DDRec/src/CellIDPositionConverter.cpp
+++ b/DDRec/src/CellIDPositionConverter.cpp
@@ -1,0 +1,289 @@
+
+#include "DDRec/CellIDPositionConverter.h"
+#include "DDRec/API/Exceptions.h"
+
+#include "DD4hep/LCDD.h"
+#include "DD4hep/VolumeManager.h"
+
+namespace DD4hep {
+  namespace DDRec {
+
+    using Geometry::DetElement;
+    using Geometry::LCDD;
+    using Geometry::PlacedVolume;
+    using Geometry::Readout;
+    using Geometry::Solid;
+    using Geometry::VolumeManager;
+    using Geometry::Volume;
+    using Geometry::SensitiveDetector;
+    using Geometry::Position;
+    using std::set;
+
+
+
+    CellID CellIDPositionConverter::cellIDFromLocal(const Position& local, const VolumeID volID) const {
+      double l[3];
+      double g[3];
+      local.GetCoordinates(l);
+
+      // DetElement det = this->detectorElement(volID);
+      // const TGeoMatrix& localToGlobal = det.nominal().worldTransformation();
+      // localToGlobal.LocalToMaster(l, g);
+      // Position global(g[0], g[1], g[2]);
+      // return this->findReadout(det).segmentation().cellID(local, global, volID);
+      
+      PlacedVolume pv = placement( volID ) ;
+      Volume v = pv.volume() ;
+      SensitiveDetector sens = v.sensitiveDetector() ;
+      Readout r = sens.readout() ;
+
+      return r.segmentation().cellID( local, Position(), volID ) ;
+    }
+
+    /**
+     * Returns the global cell ID from a given global position
+     */
+    CellID CellIDPositionConverter::cellID(const Position& global) const {
+      VolumeID volID = volumeID(global);
+      double l[3];
+      double g[3];
+      global.GetCoordinates(g);
+      DetElement det = this->detectorElement(volID);
+      const TGeoMatrix& localToGlobal = det.nominal().worldTransformation();
+      localToGlobal.MasterToLocal(g, l);
+      Position local(l[0], l[1], l[2]);
+      return this->findReadout(det).segmentation().cellID(local, global, volID);
+    }
+
+    /**
+     * Returns the global position from a given cell ID
+     */
+    Position CellIDPositionConverter::position(const CellID& cell) const {
+      double l[3];
+      double g[3];
+      DetElement det = this->detectorElement(cell);
+      Position local = this->findReadout(det).segmentation().position(cell);
+      local.GetCoordinates(l);
+      // FIXME: direct lookup of transformations seems to be broken
+      //const TGeoMatrix& localToGlobal = _volumeManager.worldTransformation(cell);
+      const TGeoMatrix& localToGlobal = det.nominal().worldTransformation();
+      localToGlobal.LocalToMaster(l, g);
+      return Position(g[0], g[1], g[2]);
+    }
+
+    /*
+     * Returns the local position from a given cell ID
+     */
+    Position CellIDPositionConverter::localPosition(const CellID& cell) const {
+      DetElement det = this->detectorElement(cell);
+      return this->findReadout(det).segmentation().position(cell);
+    }
+
+    /*
+     * Returns the volume ID of a given cell ID
+     */
+    VolumeID CellIDPositionConverter::volumeID(const CellID& cell) const {
+      DetElement det = this->detectorElement(cell);
+      return this->findReadout(det).segmentation().volumeID(cell);
+    }
+
+    /*
+     * Returns the volume ID of a given global position
+     */
+    VolumeID CellIDPositionConverter::volumeID(const Position& pos) const {
+      DetElement det = this->detectorElement(pos);
+      return det.volumeID();
+    }
+
+    /*
+     * Returns the placement for a given cell ID
+     */
+    PlacedVolume CellIDPositionConverter::placement(const CellID& cell) const {
+      return _volumeManager.lookupPlacement(cell);
+    }
+
+    /*
+     * Returns the placement for a given global position
+     */
+    PlacedVolume CellIDPositionConverter::placement(const Position& pos) const {
+      return placement(volumeID(pos));
+    }
+
+    /*
+     * Returns the subdetector for a given cell ID
+     */
+    DetElement CellIDPositionConverter::subDetector(const CellID& cell) const {
+      return _volumeManager.lookupDetector(cell);
+    }
+
+    /*
+     * Returns the subdetector for a given global position
+     */
+    DetElement CellIDPositionConverter::subDetector(const Position& pos) const {
+      return subDetector(volumeID(pos));
+    }
+
+    /*
+     * Returns the closest detector element in the hierarchy for a given cell ID
+     */
+    DetElement CellIDPositionConverter::detectorElement(const CellID& cell) const {
+      return _volumeManager.lookupDetElement(cell);
+    }
+
+    /*
+     * Returns the closest detector element in the hierarchy for a given global position
+     */
+    DetElement CellIDPositionConverter::detectorElement(const Position& pos) const {
+      DetElement world = Geometry::LCDD::getInstance().world();
+      DetElement det = getClosestDaughter(world, pos);
+      if (not det.isValid()) {
+	throw invalid_position("DD4hep::DDRec::CellIDPositionConverter::detectorElement", pos);
+      }
+      std::cout << det.name() << std::endl;
+      return det;
+    }
+
+    /// Access to the Readout object for a given cell ID
+    Geometry::Readout CellIDPositionConverter::readout(const CellID& cell) const {
+      DetElement det = this->detectorElement(cell);
+      return this->findReadout(det);
+    }
+
+    /// Access to the Readout object for a given global position
+    Geometry::Readout CellIDPositionConverter::readout(const Position& global) const {
+      DetElement det = this->detectorElement(global);
+      return this->findReadout(det);
+    }
+
+    /*
+     * Calculates the neighbours of the given cell ID and adds them to the list of neighbours
+     */
+    void CellIDPositionConverter::neighbours(const CellID& cell, set<CellID>& neighbour_cells) const {
+      DetElement det = this->detectorElement(cell);
+      this->findReadout(det).segmentation().neighbours(cell, neighbour_cells);
+    }
+
+    /*
+     * Checks if the given cell IDs are neighbours
+     */
+    bool CellIDPositionConverter::areNeighbours(const CellID& cell, const CellID& otherCellID) const {
+      set<CellID> neighbour_cells;
+      DetElement det = this->detectorElement(cell);
+      this->findReadout(det).segmentation().neighbours(cell, neighbour_cells);
+      return neighbour_cells.count(otherCellID) != 0;
+    }
+
+    //    long int CellIDPositionConverter::layerIndex(const CellID& cell) const {
+    //   Readout r = this->readout(cell);
+    //   return r.idSpec().field(this->layerIdentifier())->value(cell);
+    // }
+
+    // /// Access to the system index
+    // long int CellIDPositionConverter::systemIndex(const CellID& cell) const {
+    //   Readout r = this->readout(cell);
+    //   return r.idSpec().field(this->systemIdentifier())->value(cell);
+    // }
+
+    // helper method to find the corresponding Readout object to a DetElement
+
+    Readout CellIDPositionConverter::findReadout(const Geometry::DetElement& det) const {
+
+      // first check if top level is a sensitive detector
+      if (det.volume().isValid() and det.volume().isSensitive()) {
+	Geometry::SensitiveDetector sd = det.volume().sensitiveDetector();
+	if (sd.isValid() and sd.readout().isValid()) {
+	  return sd.readout();
+	}
+      }
+      // then return the first sensitive daughter volume's readout
+
+      Readout r = findReadout( det.placement() ) ;
+      if( r.isValid() )
+	return r ;
+
+      // nothing found !?
+      return Readout();
+    }
+
+    // Readout CellIDPositionConverter::findReadout(const Geometry::DetElement& det) const {
+
+    //   // first check if top level is a sensitive detector
+    //   if (det.volume().isValid() and det.volume().isSensitive()) {
+    // 	Geometry::SensitiveDetector sd = det.volume().sensitiveDetector();
+    // 	if (sd.isValid() and sd.readout().isValid()) {
+    // 	  return sd.readout();
+    // 	}
+    //   }
+
+    //   // check all children recursively for the first valid Readout object
+    //   const DetElement::Children& children = det.children();
+    //   DetElement::Children::const_iterator it = children.begin();
+    //   while (it != children.end()) {
+    // 	Readout r = findReadout(it->second);
+    // 	if (r.isValid()) {
+    // 	  return r;
+    // 	}
+    // 	++it;
+    //   }
+
+    //   // neither this or any daughter is sensitive
+    //   return Readout();
+    // }
+
+    Readout CellIDPositionConverter::findReadout(const Geometry::PlacedVolume& pv) const {
+      
+      // first check if we are in a sensitive volume
+      if( pv.volume().isSensitive() ){
+	Geometry::SensitiveDetector sd = pv.volume().sensitiveDetector();
+      	if (sd.isValid() and sd.readout().isValid()) {
+	  return sd.readout();
+	}
+      }
+
+      // traverse the daughter nodes:
+      const TGeoNode* node = pv.ptr();
+      
+      for (Int_t idau = 0, ndau = node->GetNdaughters(); idau < ndau; ++idau) {
+	  
+	TGeoNode* daughter = node->GetDaughter(idau);
+	PlacedVolume dpv( daughter );
+	Readout r = findReadout( dpv ) ;
+	if( r.isValid() )
+	  return r ;
+      }
+
+      return Readout() ;
+    }
+
+      // helper method to get the closest daughter DetElement to the position starting from the given DetElement
+    DetElement CellIDPositionConverter::getClosestDaughter(const DetElement& det, const Position& position) const {
+      DetElement result;
+
+      // check if we have a shape and see if we are inside
+      if (det.volume().isValid() and det.volume().solid().isValid()) {
+	double globalPosition[3] = { position.x(), position.y(), position.z() };
+	double localPosition[3] = { 0., 0., 0. };
+	det.nominal().worldTransformation().MasterToLocal(globalPosition, localPosition);
+	if (det.volume().solid()->Contains(localPosition)) {
+	  result = det;
+	} else {
+	  // assuming that any daughter shape would be inside this shape
+	  return DetElement();
+	}
+      }
+
+      const DetElement::Children& children = det.children();
+      DetElement::Children::const_iterator it = children.begin();
+      while (it != children.end()) {
+	DetElement daughterDet = getClosestDaughter(it->second, position);
+	if (daughterDet.isValid()) {
+	  result = daughterDet;
+	  break;
+	}
+	++it;
+      }
+      return result;
+    }
+
+  } /* namespace DDRec */
+} /* namespace DD4hep */

--- a/DDRec/src/CellIDPositionConverter.cpp
+++ b/DDRec/src/CellIDPositionConverter.cpp
@@ -1,6 +1,5 @@
 
 #include "DDRec/CellIDPositionConverter.h"
-#include "DDRec/API/Exceptions.h"
 
 #include "DD4hep/LCDD.h"
 #include "DD4hep/objects/VolumeManagerInterna.h"
@@ -22,67 +21,51 @@ namespace DD4hep {
 
 
 
-    DD4hep::Geometry::VolumeManagerContext* CellIDPositionConverter::findContext(const CellID& cellID) const{
+    const DD4hep::Geometry::VolumeManagerContext*
+    CellIDPositionConverter::findContext(const CellID& cellID) const {
       return _volumeManager.lookupContext( cellID ) ;
     }
     
 
-    CellID CellIDPositionConverter::cellIDFromLocal(const Position& local, const VolumeID volID) const {
-      double l[3];
-      double g[3];
-      local.GetCoordinates(l);
-
-      // DetElement det = this->detectorElement(volID);
-      // const TGeoMatrix& localToGlobal = det.nominal().worldTransformation();
-      // localToGlobal.LocalToMaster(l, g);
-      // Position global(g[0], g[1], g[2]);
-      // return this->findReadout(det).segmentation().cellID(local, global, volID);
-      
-      PlacedVolume pv = placement( volID ) ;
-      Volume v = pv.volume() ;
-      SensitiveDetector sens = v.sensitiveDetector() ;
-      Readout r = sens.readout() ;
-
-      return r.segmentation().cellID( local, Position(), volID ) ;
-    }
-
-    /**
-     * Returns the global cell ID from a given global position
-     */
-    CellID CellIDPositionConverter::cellID(const Position& global) const {
-      VolumeID volID = volumeID(global);
-      double l[3];
-      double g[3];
-      global.GetCoordinates(g);
-      DetElement det = this->detectorElement(volID);
-      const TGeoMatrix& localToGlobal = det.nominal().worldTransformation();
-      localToGlobal.MasterToLocal(g, l);
-      Position local(l[0], l[1], l[2]);
-      return this->findReadout(det).segmentation().cellID(local, global, volID);
-    }
-
-    /**
-     * Returns the global position from a given cell ID
-     */
     Position CellIDPositionConverter::position(const CellID& cell) const {
+
+      // untill we have the alignment map object, we return the nominal position
+
+      return positionNominal( cell ) ;
+    }
+
+    Position CellIDPositionConverter::positionNominal(const CellID& cell) const {
 
       double l[3], e[3], g[3];
 
-      DD4hep::Geometry::VolumeManagerContext* context = findContext( cell ) ;
+      const Geometry::VolumeManagerContext* context = findContext( cell ) ;
 
       if( context == NULL)
 	return Position() ;
 
       DetElement det = context->element ;
+      
+
+#if 0  // this uses the deprected VolumeManagerContext::placement
+      
       PlacedVolume pv = context->placement ;
 
       if( ! pv.volume().isSensitive() )
 	return Position() ;
 	
-      
       Geometry::SensitiveDetector sd = pv.volume().sensitiveDetector();
       Readout r = sd.readout() ;
+
+#else
+
+      // use a recursive search for the Readout
       
+      Readout r = findReadout( det ) ;
+
+#endif
+
+
+
       Segmentation seg = r.segmentation() ;
       Position local = seg.position(cell);
       
@@ -95,130 +78,18 @@ namespace DD4hep {
       elementToGlobal.LocalToMaster(e, g);
 
 
-      // std::cout << " local " << local << " , " 
-      //  		<< "cellid: " << cell 
-      // 		<< " : " << r.idSpec().str( cell )
-      // 		<< " pv: " << pv.name() 
-      // 		<< std::endl ; 
-
-
       return Position(g[0], g[1], g[2]);
     }
 
-    /*
-     * Returns the local position from a given cell ID
-     */
-    Position CellIDPositionConverter::localPosition(const CellID& cell) const {
-      DetElement det = this->detectorElement(cell);
-      return this->findReadout(det).segmentation().position(cell);
+
+
+    CellID CellIDPositionConverter::cellID(const Position& global) const {
+
+      //FIXME: how to best implement this ?
+
+      return 0 ;
     }
 
-    /*
-     * Returns the volume ID of a given cell ID
-     */
-    VolumeID CellIDPositionConverter::volumeID(const CellID& cell) const {
-      DetElement det = this->detectorElement(cell);
-      return this->findReadout(det).segmentation().volumeID(cell);
-    }
-
-    /*
-     * Returns the volume ID of a given global position
-     */
-    VolumeID CellIDPositionConverter::volumeID(const Position& pos) const {
-      DetElement det = this->detectorElement(pos);
-      return det.volumeID();
-    }
-
-    /*
-     * Returns the placement for a given cell ID
-     */
-    PlacedVolume CellIDPositionConverter::placement(const CellID& cell) const {
-      return _volumeManager.lookupPlacement(cell);
-    }
-
-    /*
-     * Returns the placement for a given global position
-     */
-    PlacedVolume CellIDPositionConverter::placement(const Position& pos) const {
-      return placement(volumeID(pos));
-    }
-
-    /*
-     * Returns the subdetector for a given cell ID
-     */
-    DetElement CellIDPositionConverter::subDetector(const CellID& cell) const {
-      return _volumeManager.lookupDetector(cell);
-    }
-
-    /*
-     * Returns the subdetector for a given global position
-     */
-    DetElement CellIDPositionConverter::subDetector(const Position& pos) const {
-      return subDetector(volumeID(pos));
-    }
-
-    /*
-     * Returns the closest detector element in the hierarchy for a given cell ID
-     */
-    DetElement CellIDPositionConverter::detectorElement(const CellID& cell) const {
-      return _volumeManager.lookupDetElement(cell);
-    }
-
-    /*
-     * Returns the closest detector element in the hierarchy for a given global position
-     */
-    DetElement CellIDPositionConverter::detectorElement(const Position& pos) const {
-      DetElement world = Geometry::LCDD::getInstance().world();
-      DetElement det = getClosestDaughter(world, pos);
-      if (not det.isValid()) {
-	throw invalid_position("DD4hep::DDRec::CellIDPositionConverter::detectorElement", pos);
-      }
-      std::cout << det.name() << std::endl;
-      return det;
-    }
-
-    /// Access to the Readout object for a given cell ID
-    Geometry::Readout CellIDPositionConverter::readout(const CellID& cell) const {
-      DetElement det = this->detectorElement(cell);
-      return this->findReadout(det);
-    }
-
-    /// Access to the Readout object for a given global position
-    Geometry::Readout CellIDPositionConverter::readout(const Position& global) const {
-      DetElement det = this->detectorElement(global);
-      return this->findReadout(det);
-    }
-
-    /*
-     * Calculates the neighbours of the given cell ID and adds them to the list of neighbours
-     */
-    void CellIDPositionConverter::neighbours(const CellID& cell, set<CellID>& neighbour_cells) const {
-      DetElement det = this->detectorElement(cell);
-      this->findReadout(det).segmentation().neighbours(cell, neighbour_cells);
-    }
-
-    /*
-     * Checks if the given cell IDs are neighbours
-     */
-    bool CellIDPositionConverter::areNeighbours(const CellID& cell, const CellID& otherCellID) const {
-      set<CellID> neighbour_cells;
-      DetElement det = this->detectorElement(cell);
-      this->findReadout(det).segmentation().neighbours(cell, neighbour_cells);
-      return neighbour_cells.count(otherCellID) != 0;
-    }
-
-    //    long int CellIDPositionConverter::layerIndex(const CellID& cell) const {
-    //   Readout r = this->readout(cell);
-    //   return r.idSpec().field(this->layerIdentifier())->value(cell);
-    // }
-
-    // /// Access to the system index
-    // long int CellIDPositionConverter::systemIndex(const CellID& cell) const {
-    //   Readout r = this->readout(cell);
-    //   return r.idSpec().field(this->systemIdentifier())->value(cell);
-    // }
-
-    // helper method to find the corresponding Readout object to a DetElement
 
     Readout CellIDPositionConverter::findReadout(const Geometry::DetElement& det) const {
 
@@ -238,31 +109,6 @@ namespace DD4hep {
       // nothing found !?
       return Readout();
     }
-
-    // Readout CellIDPositionConverter::findReadout(const Geometry::DetElement& det) const {
-
-    //   // first check if top level is a sensitive detector
-    //   if (det.volume().isValid() and det.volume().isSensitive()) {
-    // 	Geometry::SensitiveDetector sd = det.volume().sensitiveDetector();
-    // 	if (sd.isValid() and sd.readout().isValid()) {
-    // 	  return sd.readout();
-    // 	}
-    //   }
-
-    //   // check all children recursively for the first valid Readout object
-    //   const DetElement::Children& children = det.children();
-    //   DetElement::Children::const_iterator it = children.begin();
-    //   while (it != children.end()) {
-    // 	Readout r = findReadout(it->second);
-    // 	if (r.isValid()) {
-    // 	  return r;
-    // 	}
-    // 	++it;
-    //   }
-
-    //   // neither this or any daughter is sensitive
-    //   return Readout();
-    // }
 
     Readout CellIDPositionConverter::findReadout(const Geometry::PlacedVolume& pv) const {
       
@@ -289,35 +135,8 @@ namespace DD4hep {
       return Readout() ;
     }
 
-      // helper method to get the closest daughter DetElement to the position starting from the given DetElement
-    DetElement CellIDPositionConverter::getClosestDaughter(const DetElement& det, const Position& position) const {
-      DetElement result;
 
-      // check if we have a shape and see if we are inside
-      if (det.volume().isValid() and det.volume().solid().isValid()) {
-	double globalPosition[3] = { position.x(), position.y(), position.z() };
-	double localPosition[3] = { 0., 0., 0. };
-	det.nominal().worldTransformation().MasterToLocal(globalPosition, localPosition);
-	if (det.volume().solid()->Contains(localPosition)) {
-	  result = det;
-	} else {
-	  // assuming that any daughter shape would be inside this shape
-	  return DetElement();
-	}
-      }
 
-      const DetElement::Children& children = det.children();
-      DetElement::Children::const_iterator it = children.begin();
-      while (it != children.end()) {
-	DetElement daughterDet = getClosestDaughter(it->second, position);
-	if (daughterDet.isValid()) {
-	  result = daughterDet;
-	  break;
-	}
-	++it;
-      }
-      return result;
-    }
 
   } /* namespace DDRec */
 } /* namespace DD4hep */

--- a/DDRec/src/CellIDPositionConverter.cpp
+++ b/DDRec/src/CellIDPositionConverter.cpp
@@ -23,10 +23,9 @@ namespace DD4hep {
 
 
     DD4hep::Geometry::VolumeManagerContext* CellIDPositionConverter::findContext(const CellID& cellID) const{
-
       return _volumeManager.lookupContext( cellID ) ;
     }
-
+    
 
     CellID CellIDPositionConverter::cellIDFromLocal(const Position& local, const VolumeID volID) const {
       double l[3];
@@ -96,51 +95,15 @@ namespace DD4hep {
       elementToGlobal.LocalToMaster(e, g);
 
 
+      // std::cout << " local " << local << " , " 
+      //  		<< "cellid: " << cell 
+      // 		<< " : " << r.idSpec().str( cell )
+      // 		<< " pv: " << pv.name() 
+      // 		<< std::endl ; 
 
-      std::cout << " local " << local << std::endl 
-		<< "cellid: " << std::hex << cell << std::dec
-		<< "\n  ---- volToElement: \n"  ;
-
-      volToElement.Print() ;
-
-      std::cout << "\n elementToGlobal : \n" ;
-      
-      elementToGlobal.Print() ;
-      
-
-      const TGeoMatrix& volToWorld = context->toWorld ;
-
-      std::cout << "\n volToWorld : \n" ;
-      volToWorld.Print() ;
-
-
-      //      volToWorld.LocalToMaster( l, g ) ;
-      
-
-      TGeoHMatrix myWorld = elementToGlobal ;
-      myWorld.Multiply( &volToElement ) ;
-
-      
-      std::cout << "\n myWorld : \n" ;
-      myWorld.Print() ;
-
-
-      
 
       return Position(g[0], g[1], g[2]);
     }
-    // Position CellIDPositionConverter::position(const CellID& cell) const {
-    //   double l[3];
-    //   double g[3];
-    //   DetElement det = this->detectorElement(cell);
-    //   Position local = this->findReadout(det).segmentation().position(cell);
-    //   local.GetCoordinates(l);
-    //   // FIXME: direct lookup of transformations seems to be broken
-    //   //const TGeoMatrix& localToGlobal = _volumeManager.worldTransformation(cell);
-    //   const TGeoMatrix& localToGlobal = det.nominal().worldTransformation();
-    //   localToGlobal.LocalToMaster(l, g);
-    //   return Position(g[0], g[1], g[2]);
-    // }
 
     /*
      * Returns the local position from a given cell ID

--- a/UtilityApps/CMakeLists.txt
+++ b/UtilityApps/CMakeLists.txt
@@ -39,6 +39,10 @@ dd4hep_add_executable(test_surfaces
   USES     DDRec DDTest
   OPTIONAL [LCIO REQUIRED SOURCES src/test_surfaces.cpp])
 #-----------------------------------------------------------------------------------
+dd4hep_add_executable(test_iddecoder
+  USES     DDRec DDTest
+  OPTIONAL [LCIO REQUIRED SOURCES src/test_iddecoder.cpp])
+#-----------------------------------------------------------------------------------
 dd4hep_add_dictionary( G__eve
   SOURCES src/EvNavHandler.h
   LINKDEF src/LinkDef.h )

--- a/UtilityApps/CMakeLists.txt
+++ b/UtilityApps/CMakeLists.txt
@@ -39,9 +39,9 @@ dd4hep_add_executable(test_surfaces
   USES     DDRec DDTest
   OPTIONAL [LCIO REQUIRED SOURCES src/test_surfaces.cpp])
 #-----------------------------------------------------------------------------------
-dd4hep_add_executable(test_iddecoder
+dd4hep_add_executable(test_cellid_position_converter
   USES     DDRec DDTest
-  OPTIONAL [LCIO REQUIRED SOURCES src/test_iddecoder.cpp])
+  OPTIONAL [LCIO REQUIRED SOURCES src/test_cellid_position_converter.cpp])
 #-----------------------------------------------------------------------------------
 dd4hep_add_dictionary( G__eve
   SOURCES src/EvNavHandler.h

--- a/UtilityApps/src/test_cellid_position_converter.cpp
+++ b/UtilityApps/src/test_cellid_position_converter.cpp
@@ -1,0 +1,150 @@
+//==========================================================================
+//  AIDA Detector description implementation for LCD
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// @author F.Gaede, DESY
+// @date May, 2017
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/LCDD.h"
+#include "DD4hep/DDTest.h"
+
+#include "DD4hep/DD4hepUnits.h"
+#include "DD4hep/BitField64.h"
+#include "DDRec/CellIDPositionConverter.h"
+
+#include "lcio.h"
+#include "IO/LCReader.h"
+#include "EVENT/LCEvent.h"
+#include "EVENT/LCCollection.h"
+#include "EVENT/SimCalorimeterHit.h"
+
+#include <sstream>
+
+using namespace std ;
+using namespace DD4hep ;
+using namespace DD4hep::Geometry;
+using namespace DD4hep::DDRec ;
+
+using namespace lcio;
+
+
+static DDTest test( "cellid_position_converter" ) ; 
+
+//=============================================================================
+
+const double epsilon = dd4hep::micrometer ;
+
+double dist( const Position& p0, const Position& p1 ){
+  Position p2 = p1 - p0 ;
+  return p2.r() ;
+} 
+
+
+int main_wrapper(int argc, char** argv ){
+
+  if( argc < 3 ) {
+    std::cout << " usage: test_cellid_position_converter compact.xml lcio_file.slcio" << std::endl ;
+    exit(1) ;
+  }
+  
+  std::string inFile =  argv[1] ;
+
+  LCDD& lcdd = LCDD::getInstance();
+
+  lcdd.fromCompact( inFile );
+
+  CellIDPositionConverter idposConv( lcdd )  ;
+
+  
+  //---------------------------------------------------------------------
+  //    open lcio file with SimCalorimeterHits
+  //---------------------------------------------------------------------
+
+  std::string lcioFileName = argv[2] ;
+
+  LCReader* rdr = LCFactory::getInstance()->createLCReader() ;
+  rdr->open( lcioFileName ) ;
+
+  LCEvent* evt = 0 ;
+
+
+  // use only hits from these collections
+  std::set< std::string > subset = {} ;
+  //{"BeamCalCollection" } ; //EcalBarrelCollection" } ; //"HcalBarrelRegCollection"} ; 
+
+
+  // ignore all hits from these collections
+  std::set< std::string > subsetIgnore = {} ;
+  //{"HCalBarrelRPCHits","HCalECRingRPCHits","HCalEndcapRPCHits" } ;
+  
+  while( ( evt = rdr->readNextEvent() ) != 0 ){
+
+    const std::vector< std::string >& colNames = *evt->getCollectionNames() ;
+
+    for(unsigned icol=0, ncol = colNames.size() ; icol < ncol ; ++icol ){
+
+      LCCollection* col =  evt->getCollection( colNames[ icol ] ) ;
+
+      std::string typeName = col->getTypeName() ;
+
+      if( typeName != lcio::LCIO::SIMCALORIMETERHIT )
+        continue ;
+
+      if( !subset.empty() && subset.find( colNames[icol] ) ==  subset.end()  ) 
+	continue ;
+
+      if( !subsetIgnore.empty() && subsetIgnore.find( colNames[icol] ) !=  subsetIgnore.end()  ) 
+       	continue ;
+
+      std::cout << "  -- testing collection : " <<  colNames[ icol ] << std::endl ;
+
+      std::string cellIDEcoding = col->getParameters().getStringVal("CellIDEncoding") ;
+      
+      DD4hep::BitField64 idDecoder( cellIDEcoding ) ;
+
+      int nHit = col->getNumberOfElements() ;
+      
+      for(int i=0 ; i< nHit ; ++i){
+	
+        SimCalorimeterHit* sHit = (SimCalorimeterHit*) col->getElementAt(i) ;
+	
+        DD4hep::long64 id0 = sHit->getCellID0() ;
+        DD4hep::long64 id1 = sHit->getCellID1() ;
+	DD4hep::long64 id = ( id1 << 32 | id0 ) ;
+	
+        idDecoder.setValue( id ) ;
+	
+
+	Position point( sHit->getPosition()[0]* dd4hep::mm , sHit->getPosition()[1]* dd4hep::mm ,  sHit->getPosition()[2]* dd4hep::mm ) ;
+	
+
+	// ====== test cellID to position and positio to cellID conversion  ================================
+	
+	//	CellID idFromDecoder = idposConv.cellID( point ) ;
+
+	Position pointFromDecoder = idposConv.position( id ) ;
+
+	//	test( idFromDecoder , id  , " compare ids:  " ) ;
+
+	double d = dist(pointFromDecoder, point)  ;
+	std::stringstream sst ;
+	sst << " dist " << d << " ( " <<  pointFromDecoder << " ) - ( " << point << " )" ;
+
+	test( d < epsilon , true  , sst.str()  ) ;
+	
+      }
+    }
+    
+  }
+  return 0;
+}
+
+//=============================================================================
+#include "main.h"


### PR DESCRIPTION
Do not merge this PR yet !

For discussion:
 - I implemented the cellID to position conversion based in the discussions at the
   DD4hep mini-workshop w/o using any of the deprecated members in the VolumeManager
     - however the VolumeManagerContext::placement would be useful, as otherwise the Readout has to be searched recursively every time, see:
https://github.com/gaede/DD4hep/blob/cellid_position_converter/DDRec/src/CellIDPositionConverter.cpp#L49-L65
            - any good reason to not keep the placement ?
- now also implemented a first version of the cellID(position) lookup that seems to (mostly work) 

BEGINRELEASENOTES
- add new class DDRec::CellIDPositionConverter
      - replaces DDRec::IDDecoder
      - implement positionNominal(CellID id) and cellID(postion)
     - prepare for using alignment map by separating transforms to DetElement and daughter volume
     - don not use deprecated methods/members in VolumeManager
- add test_cellid_position_converter.cpp
- add VolumeManagerContext::toElement
     - transform from sensitive volume to next DetElement
ENDRELEASENOTES