### PR TITLE
Add AlignmentsNominalMap to fake alignment conditions access.

### DIFF
--- a/DDAlign/src/AlignmentsCalib.cpp
+++ b/DDAlign/src/AlignmentsCalib.cpp
@@ -86,7 +86,7 @@ AlignmentsCalib::_set(DetElement detector, const Delta& delta)   {
     if ( !src_cond.isValid() )   {
       except("AlignmentsCalib",
              "++ The SOURCE alignment condition [%016llX]: %s#%s is invalid.",
-             key.hash, detector.path().c_str(), Keys::deltaName);
+             key.hash, detector.path().c_str(), Keys::deltaName.c_str());
     }
   }
   // Add the entry the usual way. This should also check everything again.

--- a/DDCore/include/DD4hep/Alignments.h
+++ b/DDCore/include/DD4hep/Alignments.h
@@ -26,8 +26,8 @@ namespace DD4hep {
 
   /// Namespace for the conditions part of the AIDA detector description toolkit
   namespace Conditions   {
-    class Condition;
-    class ConditionsKey;
+
+    /// Forward declarations
     class ConditionsMap;
     
     /// Conditions internal namespace
@@ -54,12 +54,30 @@ namespace DD4hep {
     class Alignment;
     class Delta;
 
+    /// Alignment and Delta item key 
+    /**
+     *
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_ALIGN
+     */
+    class Keys  {
+    public:
+      /// Key name  of a delta condition "alignment_delta".
+      static const std::string                         deltaName;
+      /// Key value of a delta condition "alignment_delta".
+      static const Conditions::Condition::itemkey_type deltaKey;
+      /// Key name  of an alignment condition object "alignment".
+      static const std::string                         alignmentName;
+      /// Key value of an alignment condition object "alignment".
+      static const Conditions::Condition::itemkey_type alignmentKey;
+    };
+    
     /// Main handle class to hold an alignment conditions object
     /**
      *
      *  \author  M.Frank
      *  \version 1.0
-     *  \ingroup DD4HEP_GEOMETRY
      *  \ingroup DD4HEP_ALIGN
      */
     class AlignmentCondition : public Handle<Interna::AlignmentObject>   {

--- a/DDCore/include/DD4hep/Alignments.h
+++ b/DDCore/include/DD4hep/Alignments.h
@@ -115,6 +115,8 @@ namespace DD4hep {
       AlignmentData& data();
       /// Data accessor for the use of decorators
       const AlignmentData& data() const;
+      /// Access the delta value of the object
+      const Delta& delta() const;
       /// Create cached matrix to transform to world coordinates
       const TGeoHMatrix& worldTransformation()  const;
       /// Access the alignment/placement matrix with respect to the world
@@ -169,6 +171,8 @@ namespace DD4hep {
       AlignmentData& data();
       /// Data accessor for the use of decorators
       const AlignmentData& data() const;
+      /// Access the delta value of the object
+      const Delta& delta() const;
       /// Create cached matrix to transform to world coordinates
       const TGeoHMatrix& worldTransformation()  const;
       /// Access the alignment/placement matrix with respect to the world

--- a/DDCore/include/DD4hep/AlignmentsCalculator.h
+++ b/DDCore/include/DD4hep/AlignmentsCalculator.h
@@ -66,10 +66,6 @@ namespace DD4hep {
       AlignmentsCalculator(const AlignmentsCalculator& copy) = delete;
       /// Assignment operator
       AlignmentsCalculator& operator=(const AlignmentsCalculator& mgr) = delete;
-      /// Access the default alignment name
-      static unsigned int alignment_item_key();
-      /// Access the default alignment name
-      static unsigned int alignment_delta_item_key();
       /// Compute all alignment conditions of the internal dependency list
       Result compute(const Deltas& deltas, Alignments& alignments)  const;
     };

--- a/DDCore/include/DD4hep/AlignmentsNominalMap.h
+++ b/DDCore/include/DD4hep/AlignmentsNominalMap.h
@@ -1,0 +1,94 @@
+//==========================================================================
+//  AIDA Detector description implementation for LCD
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_GEOMETRY_ALIGNMENTSNOMINALMAP_H
+#define DD4HEP_GEOMETRY_ALIGNMENTSNOMINALMAP_H
+
+// Framework include files
+#include "DD4hep/ConditionsMap.h"
+
+// C/C++ include files
+
+/// Namespace for the AIDA detector description toolkit
+namespace DD4hep {
+
+  /// Namespace for the conditions part of the AIDA detector description toolkit
+  namespace Conditions   {
+
+    /// An implementation of the ConditionsMap interface to fall back to nominal alignment.
+    /**
+     *  The AlignmentsNominalMap is not a conditions cache per se. This implementation 
+     *  behaves like a conditionsmap, but it shall not return real conditions to the user,
+     *  but rather return the default alignment objects (which at the basis are conditions 
+     *  as well) to the user. These alignments are taken from the DetElement in question
+     *  Alignment DetElement::nominal().
+     *
+     *  The basic idea is to enable users to write code "as if" there would be conditions
+     *  present. This is important to ease in the lifetime of the experiment the step from
+     *  the design phase (where obviously no conditions are taken into account) to a more
+     *  mature phase, where alignment studies etc. actually are part of the 
+     *  "bread and butter work".
+     *
+     *  See DD4hep/ConditionsMap.h for further information.
+     *
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_CONDITIONS
+     */
+    class AlignmentsNominalMap : public ConditionsMap   {
+    public:
+      /// Reference to the top detector element
+      DetElement  world;
+    public:
+      /// Standard constructor
+      AlignmentsNominalMap(DetElement wrld);
+      /// Standard destructor
+      virtual ~AlignmentsNominalMap() = default;
+      /// Insert a new entry to the map. The detector element key and the item key make a unique global alignments key
+      virtual bool insert(DetElement detector, itemkey_type key, Condition condition)  override;
+      /// Interface to access alignments by hash value. The detector element key and the item key make a unique global alignments key
+      virtual Condition get(DetElement detector, itemkey_type key) const  override;
+      /// Interface to scan data content of the alignments mapping
+      virtual void scan(const Processor& processor) const  override;
+
+      /** Partial implementations for utilities accessing DetElement alignments      */
+
+      /// No AlignmentsMap overload: Access all alignments within a key range in the interval [lower,upper]
+      /** Note: This default implementation uses 
+       *        std::vector<Condition> get(DetElement detector,
+       *                                  itemkey_type lower,
+       *                                  itemkey_type upper)
+       *        The performance depends on the concrete implementation of the scan method!
+       */
+      virtual std::vector<Condition> get(DetElement detector,
+                                         itemkey_type lower,
+                                         itemkey_type upper)  const  override
+      {  return this->ConditionsMap::get(detector, lower, upper);                   }
+      
+      /// Interface to partially scan data content of the alignments mapping
+      /** Note: This default implementation assumes unordered containers and hence is
+       *        not the most efficient implementation!
+       *        Internally it uses "scan(Processor& processor)"
+       *        the subselection hence is linearly depending of the number of elements.
+       *        
+       *        Using ordered maps with "lower_bound(key)" this can be greatly improved.
+       *        See the concrete implementations below.
+       */
+      virtual void scan(DetElement       detector,
+                        itemkey_type     lower,
+                        itemkey_type     upper,
+                        const Processor& processor) const  override;
+    };
+
+  }       /* End namespace Conditions               */
+}         /* End namespace DD4hep                   */
+#endif    /* DD4HEP_GEOMETRY_ALIGNMENTSNOMINALMAP_H        */

--- a/DDCore/include/DD4hep/AlignmentsPrinter.h
+++ b/DDCore/include/DD4hep/AlignmentsPrinter.h
@@ -35,7 +35,7 @@ namespace DD4hep {
      *   \date    31/03/2016
      *   \ingroup DD4HEP_DDDB
      */
-    class AlignmentsPrinter /* : public Alignment::Processor , public DetElement::Processor  */ {
+    class AlignmentsPrinter {
     public:
       /// Conditionsmap to resolve things
       ConditionsMap* mapping;
@@ -64,8 +64,6 @@ namespace DD4hep {
       virtual int operator()(DetElement de, int level) const;
       /// Callback to output alignments information
       virtual int operator()(Alignment alignment)  const;
-      /// Processing callback to print alignments of a detector element
-      //virtual int processElement(DetElement de)  override;
     };
 
     
@@ -81,18 +79,6 @@ namespace DD4hep {
      *   \ingroup DD4HEP_DDDB
      */
     class AlignedVolumePrinter : public AlignmentsPrinter {
-#if 0
-    public:
-      /// Printer name. Want to know who is printing what
-      std::string   name;
-      /// Printout prefix
-      std::string   prefix;
-      /// Printout level
-      PrintLevel    printLevel;
-    protected:
-      /// Printout processing and customization flag
-      int           m_flag;
-#endif
     public:
       /// No default constructor
       AlignedVolumePrinter() = delete;
@@ -100,17 +86,11 @@ namespace DD4hep {
       AlignedVolumePrinter(ConditionsMap* map, const std::string& prefix="",int flags=0);
       /// Default destructor
       virtual ~AlignedVolumePrinter() = default;
-      /// Set name for printouts
-      //void setName(const std::string& value)    {  name = value;   }
-      /// Set prefix for printouts
-      //void setPrefix(const std::string& value)  {  prefix = value; }
       /// Callback to output alignments information of an entire DetElement
       virtual int operator()(DetElement de, int level) const override
       { return this->AlignmentsPrinter::operator()(de,level);        }
       /// Callback to output alignments information
       virtual int operator()(Alignment cond)  const  override;
-      /// Callback to output alignments information of an entire DetElement
-      //virtual int processElement(DetElement de)  override;
     };
 
     /// Default printout of an alignment entry

--- a/DDCore/include/DD4hep/ConditionsMap.h
+++ b/DDCore/include/DD4hep/ConditionsMap.h
@@ -29,12 +29,32 @@ namespace DD4hep {
 
     /// ConditionsMap class.
     /**
+     *  Access mechanisms of DD4hep conditions for utilities
+     *  ===================================================
+     *
      *  The conditions map class is the basic interface to manage/access conditions
      *  in DD4hep. It's main use is to provide a common interface to utilities using
      *  DD4hep conditions, such as scanners, selectors, printers etc.
      *  Such utilities often require access to conditions sets based on individual 
      *  DetElement instances.
      *  
+     *  Access to conditions is solely supported using this interface
+     *  -- All utilities must use this interface.
+     *  -- Any concrete implementation using conditions/alignment utilities
+     *     must implement this interface
+     *  -- Basic implmentation using STL map, multimap and unordered_map are provided.
+     *  -- A special no-op implementation of this interface shall be provided to access
+     *     "default" alignment conditions.
+     *     This implementation shall fall-back internally to the DetElement::nominal() alignment.
+     *     Known clients: VolumeManager (hence: DDG4, DDRec, etc.)
+     *
+     *  Though this sounds like a trivial change, the consequences concern the entire conditions
+     *  and alignment handling. This interface decouples entirely the core part of DD4hep
+     *  from the conditons cache handling and the alignment handling.
+     *
+     *  Based on this interface most utilities used to handle conditions, detectors scans
+     *  to visit DetElement related condition sets, alignment and conditions printers etc.
+     *
      *  \author  M.Frank
      *  \version 1.0
      *  \ingroup DD4HEP_CONDITIONS

--- a/DDCore/src/AlignmentNominalMap.cpp
+++ b/DDCore/src/AlignmentNominalMap.cpp
@@ -1,0 +1,80 @@
+//==========================================================================
+//  AIDA Detector description implementation for LCD
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/Printout.h"
+#include "DD4hep/DetectorProcessor.h"
+#include "DD4hep/AlignmentsNominalMap.h"
+#include "DD4hep/detail/AlignmentsInterna.h"
+#include "DD4hep/detail/ConditionsInterna.h"
+
+using namespace DD4hep;
+using namespace Conditions;
+using Alignments::Keys;
+
+/// Standard constructor
+AlignmentsNominalMap::AlignmentsNominalMap(DetElement wrld) : world(wrld) {
+}
+
+/// Insert a new entry to the map
+bool AlignmentsNominalMap::insert(DetElement   /* detector  */,
+                                  unsigned int /* key       */,
+                                  Condition    /* condition */)   {
+  return false;
+}
+
+/// Interface to access conditions by hash value
+Condition AlignmentsNominalMap::get(DetElement detector, unsigned int key) const   {
+  if ( key == Keys::alignmentKey )  {
+    return Condition(detector.nominal().ptr());
+  }
+  return Condition();
+}
+
+/// Interface to scan data content of the conditions mapping
+void AlignmentsNominalMap::scan(const Processor& processor) const  {
+  /// Heklper to implement partial scans.
+  struct Scanner  {
+    const Processor& proc;
+    /// Constructor
+    Scanner(const Processor& p) : proc(p){}
+    /// Conditions callback for object processing
+    int operator()(DetElement de, int /* level */)  const  {
+      Condition c = de.nominal();
+      return proc(c);
+    }
+  } scanner(processor);
+  // We emulate here a full detector scan, access the nominal alignments and process them by the processor.
+  if ( world.isValid() )  {
+    Geometry::DetectorScanner().scan(scanner,world,0,true);
+    return;
+  }
+  DD4hep::except("AlignmentsNominalMap",
+                 "Cannot scan conditions map for conditions of an invalid top level detector element!");
+}
+
+/// Interface to partially scan data content of the conditions mapping
+void AlignmentsNominalMap::scan(DetElement   detector,
+                                itemkey_type lower,
+                                itemkey_type upper,
+                                const Processor&   processor) const   {
+  if ( detector.isValid() )   {
+    if ( lower <= Keys::alignmentKey && upper >= Keys::alignmentKey )  {
+      Condition c(detector.nominal().ptr());
+      processor(c);
+    }
+    return;
+  }
+  DD4hep::except("AlignmentsNominalMap",
+                 "Cannot scan conditions map for conditions of an invalid detector element!");
+}

--- a/DDCore/src/Alignments.cpp
+++ b/DDCore/src/Alignments.cpp
@@ -61,6 +61,11 @@ const AlignmentData& Alignment::data() const  {
   return access()->values();
 }
 
+/// Access the delta value of the object
+const Delta& Alignment::delta() const   {
+  return access()->values().delta;
+}
+
 /// Create cached matrix to transform to world coordinates
 const TGeoHMatrix& Alignment::worldTransformation()  const  {
   return access()->values().worldTransformation();
@@ -160,6 +165,12 @@ AlignmentData& AlignmentCondition::data()              {
 const AlignmentData& AlignmentCondition::data() const  {
   Object* o = access();
   return o->alignment_data ? *o->alignment_data : o->values();
+}
+
+/// Access the delta value of the object
+const Delta& AlignmentCondition::delta() const   {
+  Object* o = access();
+  return (o->alignment_data ? *o->alignment_data : o->values()).delta;
 }
 
 /// Check if object is already bound....

--- a/DDCore/src/Alignments.cpp
+++ b/DDCore/src/Alignments.cpp
@@ -19,8 +19,17 @@
 // C/C++ include files
 #include <sstream>
 
+
 using namespace std;
 using namespace DD4hep::Alignments;
+
+const std::string DD4hep::Alignments::Keys::deltaName("alignment_delta");
+const DD4hep::Conditions::Condition::itemkey_type  DD4hep::Alignments::Keys::deltaKey =
+  DD4hep::Conditions::ConditionKey::itemCode("alignment_delta");
+
+const std::string DD4hep::Alignments::Keys::alignmentName("alignment");
+const DD4hep::Conditions::Condition::itemkey_type DD4hep::Alignments::Keys::alignmentKey =
+  DD4hep::Conditions::ConditionKey::itemCode("alignment");
 
 /// Default constructor
 Alignment::Processor::Processor() {

--- a/DDCore/src/AlignmentsCalculator.cpp
+++ b/DDCore/src/AlignmentsCalculator.cpp
@@ -33,8 +33,6 @@ namespace DD4hep {
 
     /// Anonymous implementation classes
     namespace {
-      static unsigned int alignment_hash = 0;
-      static unsigned int alignment_delta_hash = 0;
       static Delta        identity_delta;
 
       /// Alignment calculator.
@@ -147,7 +145,7 @@ Result Calculator::to_world(Context&      context,
     // Mapping update mode:
     // Check if there is already a transformation in the cache. If yes, take it.
     // We assume it is a good one, because higher level changes are already processed.
-    AlignmentCondition cond = context.mapping.get(par,alignment_hash);
+    AlignmentCondition cond = context.mapping.get(par,Keys::alignmentKey);
     if ( cond.isValid() )  {
       AlignmentData&     align(cond.data());
       if ( s_PRINT <= INFO )  {
@@ -216,7 +214,7 @@ Result Calculator::compute(Context& context, Entry& e)   const  {
     printout(DEBUG,"ComputeAlignment","================ IGNORE %s (already valid)",det.path().c_str());
     return result;
   }
-  AlignmentCondition c = context.mapping.get(e.det, alignment_hash);
+  AlignmentCondition c = context.mapping.get(e.det, Keys::alignmentKey);
   AlignmentCondition cond = c.isValid() ? c : AlignmentCondition("alignment");
   AlignmentData&     align = cond.data();
   const Delta*       delta = e.delta ? e.delta : &identity_delta;
@@ -236,8 +234,8 @@ Result Calculator::compute(Context& context, Entry& e)   const  {
   // Update mapping if the condition is freshly created
   if ( !c.isValid() )  {
     e.created = 1;
-    cond->hash = ConditionKey(e.det,alignment_hash).hash;
-    context.mapping.insert(e.det, alignment_hash, cond);
+    cond->hash = ConditionKey(e.det,Keys::alignmentKey).hash;
+    context.mapping.insert(e.det, Keys::alignmentKey, cond);
   }
   if ( s_PRINT <= INFO )  {
     printout(INFO,"ComputeAlignment","Level:%d Path:%s DetKey:%08X: Cond:%s key:%16llX",
@@ -264,33 +262,11 @@ void Calculator::resolve(Context& context, DetElement detector) const   {
     resolve(context, c.second);
 }
 
-/// Access the default alignment name
-unsigned int AlignmentsCalculator::alignment_item_key()   {
-  if ( 0 == alignment_hash )  {
-    Conditions::ConditionKey k(0,"alignment");
-    alignment_hash = k.item_key();
-  }
-  return alignment_hash;
-}
-
-/// Access the default alignment name
-unsigned int AlignmentsCalculator::alignment_delta_item_key()   {
-  if ( 0 == alignment_delta_hash )  {
-    Conditions::ConditionKey k(0,"alignment_delta");
-    alignment_delta_hash = k.item_key();
-  }
-  return alignment_delta_hash;
-}
-
 /// Compute all alignment conditions of the internal dependency list
 Result AlignmentsCalculator::compute(const Deltas& deltas, Alignments& alignments)  const  {
   Result  result;
   Calculator obj;
   Calculator::Context context(alignments);
-  if ( 0 == alignment_hash )  {
-    Conditions::ConditionKey k(0,"alignment");
-    alignment_hash = k.item_key();
-  }
   for( const auto& i : deltas )
     context.insert(i.first, &(i.second));
   for( const auto& i : deltas )

--- a/DDCore/src/AlignmentsPrinter.cpp
+++ b/DDCore/src/AlignmentsPrinter.cpp
@@ -58,7 +58,7 @@ int AlignmentsPrinter::operator()(DetElement de, int level)  const   {
 AlignedVolumePrinter::AlignedVolumePrinter(ConditionsMap* m, const string& pref,int flg)
   : AlignmentsPrinter(m, pref, flg)
 {
-  name = "Alignmant";
+  name = "Alignment";
 }
 
 /// Callback to output alignments information

--- a/DDCore/src/ConditionsInterna.cpp
+++ b/DDCore/src/ConditionsInterna.cpp
@@ -46,8 +46,12 @@ Interna::ConditionObject::~ConditionObject()  {
 
 /// Data offset from the opaque data block pointer to the condition
 size_t Interna::ConditionObject::offset()   {
-  ConditionObject* o = (ConditionObject*)(0x1000);
-  size_t off = ((char*)&o->data.grammar) - ((char*)o) + sizeof(o->data.grammar);
+  union  _P {
+    const char* c; const void* v; const ConditionObject* o;
+    _P(const void* val) { v = val; }
+  };
+  static _P p((void*)0x1000), q(&p.o->data.grammar);
+  static size_t off = q.c - p.c + sizeof(p.o->data.grammar);
   return off;
 }
 

--- a/DDCore/src/ConditionsMap.cpp
+++ b/DDCore/src/ConditionsMap.cpp
@@ -116,6 +116,7 @@ void ConditionsMapping<T>::scan(DetElement   detector,
     typename T::const_iterator first = data.lower_bound(low);
     for(; first != data.end() && (*first).first <= up; ++first )
       processor((*first).second);
+    return;
   }
   DD4hep::except("ConditionsMap","Cannot scan conditions map for conditions of an invalid detector element!");
 }

--- a/DDDB/src/plugins/CondDB2DDDB.cpp
+++ b/DDDB/src/plugins/CondDB2DDDB.cpp
@@ -623,7 +623,7 @@ namespace DD4hep {
           AlignmentDelta&  align = block.second.bind<AlignmentDelta>();
           d.clientData = doc->addRef();
           d.classID    = cls_id;
-          block.first  = "alignment_delta";
+          block.first  = Alignments::Keys::deltaName;
 
           Conv<AlignmentDelta> conv(lcdd,context,&align);
           xml_coll_t(element,_LBU(paramVector)).for_each(conv);

--- a/DDDB/src/plugins/DDDB2Objects.cpp
+++ b/DDDB/src/plugins/DDDB2Objects.cpp
@@ -903,7 +903,7 @@ namespace DD4hep {
         ::snprintf(text,sizeof(text),"              %%%lds -> %%s",long(object->condition.length()));
         printout(DEBUG,"DDDB","+ Match Align %s -> %s",object->condition.c_str(), object->path.c_str());
         printout(DEBUG,"DDDB",text,"",det.path().c_str());
-        res = context->helper->addConditionEntry(object->condition,det,"alignment_delta");
+        res = context->helper->addConditionEntry(object->condition,det,Alignments::Keys::deltaName);
         if ( !res )  {
           printout(DEBUG,"DDDB","++ Conditions entry with key:%s already exists!",
                    object->condition.c_str());

--- a/DDDB/src/plugins/DDDBAlignmentTest.cpp
+++ b/DDDB/src/plugins/DDDBAlignmentTest.cpp
@@ -58,11 +58,10 @@ namespace  {
     LCDD&                lcdd;
     string               name;
     PrintLevel           printLevel     = INFO;
-    unsigned int         alignmentKey   = 0;
-    unsigned int         alignDeltaKey  = 0;
     TStatistic           load_stat, comp_stat;
     Content              content;
     ConditionsPrinter    printer;
+
     /// Initializing constructor
     AlignmentSelector(LCDD& l, PrintLevel p)
       : lcdd(l), name("DDDBAlignments"), printLevel(p),
@@ -70,8 +69,6 @@ namespace  {
     {
       printer.printLevel = DEBUG;
       content.reset(new ConditionsContent());
-      alignmentKey  = ConditionKey::itemCode("alignment");
-      alignDeltaKey = ConditionKey::itemCode("alignment_delta");
     }
 
     /// Default destructor
@@ -120,7 +117,7 @@ namespace  {
       if ( access )   {
         set<DetElement> detectors;
         for ( const auto& e : align_deltas )  {
-          Condition               c = slice->get(e.first,alignmentKey);
+          Condition               c = slice->get(e.first,Alignments::Keys::alignmentKey);
           Alignment               a = c;
           const Delta&            D = a.data().delta;
           printout(PrintLevel(printLevel+1),"Alignment",

--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -105,12 +105,30 @@ dd4hep_add_test_reg( AlignDet_Telescope_align_new
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
+#---Testing: Load Telescope geometry and read and print alignments --------
+dd4hep_add_test_reg( AlignDet_Telescope_align_nominal
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
+  EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_nominal
+     -input  file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml 
+  REGEX_PASS "Printed 20, scanned 20 and computed a total of 20 alignments \\(C:20,M:0\\)"
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
 #---Testing: Extended stress: Load CLICSiD geometry and have multiple runs on IOVs
 dd4hep_add_test_reg( AlignDet_CLICSiD_stress_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_AlignmentExample_stress 
       -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 10 -runs 100
   REGEX_PASS "Summary: Total 7352100 conditions used \\(S:7352100,L:0,C:0,M:0\\) \\(A:350100,M:0\\)"
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
+#---Testing: Load Telescope geometry and read and print alignments --------
+dd4hep_add_test_reg( AlignDet_CLICSiD_align_nominal
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
+  EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_nominal
+     -input  file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml
+  REGEX_PASS "Printed 35011, scanned 35011 and computed a total of 35011 alignments \\(C:35011,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #

--- a/examples/AlignDet/src/AlignmentExampleObjects.cpp
+++ b/examples/AlignDet/src/AlignmentExampleObjects.cpp
@@ -52,9 +52,9 @@ int AlignmentDataAccess::operator()(DetElement de, int) const {
 /// Callback to process a single detector element
 int AlignmentCreator::operator()(DetElement de, int)  const  {
   if ( de.ptr() != de.world().ptr() )  {
-    Condition     cond(de.path()+"#alignment_delta", "alignment_delta");
-    Delta&        delta = cond.bind<Delta>();
-    cond->hash = ConditionKey::hashCode(de,"alignment_delta");
+    Condition cond(de.path()+"#"+Alignments::Keys::deltaName,Alignments::Keys::deltaName);
+    Delta&    delta = cond.bind<Delta>();
+    cond->hash = Alignments::Keys::deltaKey;
     cond->setFlag(Condition::ACTIVE|Condition::ALIGNMENT_DELTA);
     /// Simply move everything by 1 mm in z. Not physical, but this is just an example...
     delta.translation.SetZ(delta.translation.Z()+0.1*dd4hep::cm);

--- a/examples/AlignDet/src/AlignmentExampleObjects.cpp
+++ b/examples/AlignDet/src/AlignmentExampleObjects.cpp
@@ -54,14 +54,16 @@ int AlignmentCreator::operator()(DetElement de, int)  const  {
   if ( de.ptr() != de.world().ptr() )  {
     Condition cond(de.path()+"#"+Alignments::Keys::deltaName,Alignments::Keys::deltaName);
     Delta&    delta = cond.bind<Delta>();
-    cond->hash = Alignments::Keys::deltaKey;
+    cond->hash = ConditionKey(de.key(),Alignments::Keys::deltaKey).hash;
     cond->setFlag(Condition::ACTIVE|Condition::ALIGNMENT_DELTA);
     /// Simply move everything by 1 mm in z. Not physical, but this is just an example...
     delta.translation.SetZ(delta.translation.Z()+0.1*dd4hep::cm);
     delta.rotation = RotationZYX(0.999,1.001,0.999);
     delta.flags |= Delta::HAVE_TRANSLATION|Delta::HAVE_ROTATION;
-    manager.registerUnlocked(pool, cond);
-    printout(printLevel,"Example","++ Adding manually alignments for %s",de.path().c_str());
+    if ( !manager.registerUnlocked(pool, cond) )   {
+      printout(WARNING,"Example","++ Failed to register condition %s.",cond.name());
+    }
+    printout(printLevel,"Example","++ Adding manually alignments for %s",cond.name());
   }
   return 1;
 }

--- a/examples/AlignDet/src/AlignmentExampleObjects.h
+++ b/examples/AlignDet/src/AlignmentExampleObjects.h
@@ -49,6 +49,7 @@ namespace DD4hep {
     using Alignments::Delta;
     using Alignments::Alignment;
     using Alignments::AlignmentData;
+    using Alignments::AlignmentsPrinter;
     using Alignments::AlignmentsCalculator;
     using Alignments::AlignedVolumePrinter;
     using Alignments::DeltaCollector;

--- a/examples/AlignDet/src/AlignmentExample_align_telescope.cpp
+++ b/examples/AlignDet/src/AlignmentExample_align_telescope.cpp
@@ -45,7 +45,7 @@ using Geometry::Position;
 
 static void print_world_trafo(AlignmentsCalib& calib, const std::string& path)  {
   DetElement d(calib.detector(path));
-  Alignment  a = calib.slice.get(d,AlignmentsCalculator::alignment_item_key());
+  Alignment  a = calib.slice.get(d,Alignments::Keys::alignmentKey);
   if ( a.isValid() )  {
     const double* tr = a.worldTransformation().GetTranslation();
     printout(INFO,"Example","++ World transformation of: %-32s  Tr:(%8.2g,%8.2g,%8.2g [cm])",
@@ -53,7 +53,7 @@ static void print_world_trafo(AlignmentsCalib& calib, const std::string& path)  
     a.worldTransformation().Print();
     return;
   }
-  Condition c = calib.slice.get(d,AlignmentsCalculator::alignment_delta_item_key());
+  Condition c = calib.slice.get(d,Alignments::Keys::deltaKey);
   printout(WARNING,"Example",
            "++ Detector element:%s No alignment conditions present. Delta:%s",
            path.c_str(), c.isValid() ? "Present" : "Not availible");

--- a/examples/AlignDet/src/AlignmentExample_nominal.cpp
+++ b/examples/AlignDet/src/AlignmentExample_nominal.cpp
@@ -1,0 +1,127 @@
+//==========================================================================
+//  AIDA Detector description implementation for LCD
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+/* 
+   Plugin invocation:
+   ==================
+   This plugin behaves like a main program.
+   Invoke the plugin with something like this:
+
+   geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_nominal \
+   -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
+
+   Access the DetElement nominal conditions using the AlignmentNominalMap
+
+*/
+// Framework include files
+#include "AlignmentExampleObjects.h"
+#include "DD4hep/AlignmentsNominalMap.h"
+#include "DD4hep/Factories.h"
+
+using namespace std;
+using namespace DD4hep;
+using namespace DD4hep::AlignmentExamples;
+
+/// Plugin function: Alignment program example
+/**
+ *  Factory: DD4hep_AlignmentExample_nominal
+ *
+ *  \author  M.Frank
+ *  \version 1.0
+ *  \date    01/12/2016
+ */
+static int alignment_example (Geometry::LCDD& lcdd, int argc, char** argv)  {
+  class Collector  {
+  public:
+    AlignmentsCalculator::Deltas& deltas;
+    Collector(AlignmentsCalculator::Deltas& d) : deltas(d) {}
+    int operator()(DetElement de, int )  const    {
+      Alignment a = de.nominal();
+      deltas.insert(make_pair(de,a.delta()));
+      return 1;
+    }
+  };
+  string input;
+  int    num_iov = 10;
+  bool   arg_error = false;
+  for(int i=0; i<argc && argv[i]; ++i)  {
+    if ( 0 == ::strncmp("-input",argv[i],4) )
+      input = argv[++i];
+    else if ( 0 == ::strncmp("-iovs",argv[i],4) )
+      num_iov = ::atol(argv[++i]);
+    else
+      arg_error = true;
+  }
+  if ( arg_error || input.empty() )   {
+    /// Help printout describing the basic command line interface
+    cout <<
+      "Usage: -plugin <name> -arg [-arg]                                             \n"
+      "     name:   factory name     DD4hep_AlignmentExample1                        \n"
+      "     -input   <string>        Geometry file                                   \n"
+      "     -iovs    <number>        Number of parallel IOV slots for processing.    \n"
+      "\tArguments given: " << arguments(argc,argv) << endl << flush;
+    ::exit(EINVAL);
+  }
+
+  // First we load the geometry
+  lcdd.fromXML(input);
+
+  /******************** Initialize the conditions manager *****************/
+  ConditionsManager manager = installManager(lcdd);
+  const IOVType*    iov_typ = manager.registerIOVType(0,"run").second;
+  if ( 0 == iov_typ )
+    except("ConditionsPrepare","++ Unknown IOV type supplied.");
+
+  /******************** Now as usual: create the slice ********************/
+  shared_ptr<ConditionsContent> content(new ConditionsContent());
+  shared_ptr<ConditionsSlice>   slice(new ConditionsSlice(manager,content));
+  shared_ptr<ConditionsMap>     nominal(new Conditions::AlignmentsNominalMap(lcdd.world()));
+
+  // Collect all the delta conditions and make proper alignment conditions out of them
+  AlignmentsCalculator::Deltas deltas;
+  Scanner(Collector(deltas),lcdd.world());
+  printout(INFO,"Prepare","Got a total of %ld Deltas",deltas.size());
+
+  // ++++++++++++++++++++++++ Now compute the alignments for each of these IOVs
+  ConditionsManager::Result cond_total;
+  AlignmentsCalculator::Result align_total;
+  for(int i=0; i<num_iov; ++i)  {
+    IOV req_iov(iov_typ,i*10+5);
+    shared_ptr<ConditionsSlice> sl(new ConditionsSlice(manager,content));
+    // Attach the proper set of conditions to the user pool
+    ConditionsManager::Result cres = manager.prepare(req_iov,*sl);
+    sl->pool->flags |= Conditions::UserPool::PRINT_INSERT;
+    cond_total += cres;
+    // Now compute the tranformation matrices
+    AlignmentsCalculator calculator;
+    AlignmentsCalculator::Result ares = calculator.compute(deltas,*sl);
+    printout(INFO,"Prepare","Total %ld/%ld conditions (S:%ld,L:%ld,C:%ld,M:%ld) of type %s. Alignments:(C:%ld,M:%ld)",
+             slice->conditions().size(), cres.total(), cres.selected, cres.loaded,
+             cres.computed, cres.missing, iov_typ->str().c_str(), ares.computed, ares.missing);
+    align_total += ares;
+    if ( ares.missing > 0 ) {
+      printout(ERROR,"Compute","Failed tro compute %ld alignments of type %s.",
+               ares.missing, iov_typ->str().c_str());
+    }
+  }
+  // What else ? let's access/print the current selection
+  Scanner(AlignedVolumePrinter(slice.get(),"Example"),lcdd.world());
+  printout(INFO,"Summary","Processed a total %ld conditions (S:%ld,L:%ld,C:%ld,M:%ld) and (C:%ld,M:%ld) alignments.",
+           cond_total.total(), cond_total.selected, cond_total.loaded, cond_total.computed, cond_total.missing,
+           align_total.computed, align_total.missing);
+   
+  // All done.
+  return 1;
+}
+
+// first argument is the type from the xml file
+DECLARE_APPLY(DD4hep_AlignmentExample_nominal,alignment_example)

--- a/examples/AlignDet/src/AlignmentExample_populate.cpp
+++ b/examples/AlignDet/src/AlignmentExample_populate.cpp
@@ -123,9 +123,11 @@ static int alignment_example (Geometry::LCDD& lcdd, int argc, char** argv)  {
       printout(ERROR,"Compute","Failed tro compute %ld alignments of type %s.",
                ares.missing, iov_typ->str().c_str());
     }
+    if ( i == 0 )  {
+      // What else ? let's access/print the current selection
+      Scanner(AlignedVolumePrinter(sl.get(),"Example"),lcdd.world());
+    }
   }
-  // What else ? let's access/print the current selection
-  Scanner(AlignedVolumePrinter(slice.get(),"Example"),lcdd.world());
   printout(INFO,"Summary","Processed a total %ld conditions (S:%ld,L:%ld,C:%ld,M:%ld) and (C:%ld,M:%ld) alignments. Created:%ld.",
            cond_total.total(), cond_total.selected, cond_total.loaded, cond_total.computed, cond_total.missing,
            align_total.computed, align_total.missing, total_created);


### PR DESCRIPTION

BEGINRELEASENOTES
Add a new class AlignmentsNominalMap, which behaves like a ConditionsMap and handles alignment entries. 
The AlignmentsNominalMap is not a conditions cache per se. This implementation 
behaves like a conditionsmap, but it shall not return real conditions to the user,
but rather return the default alignment objects (which at the basis are conditions 
as well) to the user. These alignments are taken from the DetElement in question
Alignment DetElement::nominal().

The basic idea is to enable users to write code "as if" there would be conditions
present. This is important to ease in the lifetime of the experiment the step from
the design phase (where obviously no conditions are taken into account) to a more
mature phase, where alignment studies etc. actually are part of the 
"bread and butter work".

Added a corresponding example in examples/AlignDet:
$>   geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_nominal \
         -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml

   Access the DetElement nominal conditions using the AlignmentNominalMap.
   Any use of DDCond is inhibited.
   1) We use the generic printer, which during the detector element scan accesses the
      conditions map.
   2) We use a delta scanner to extract the nominal deltas from the DetElement's 
      nominal alignments
   3) We use a ConditionsTreeMap to perform the alignments re-computation.

===> Coming next on this channel: 
Update the Volume manager to use ConditionsMap objects to resolve position computations.

ENDRELEASENOTES