### PR TITLE
Add namespace dd4hep

### DIFF
--- a/DDCore/include/DD4hep/dd4hep.h
+++ b/DDCore/include/DD4hep/dd4hep.h
@@ -1,0 +1,90 @@
+// -*- C++ -*-
+//==========================================================================
+//  AIDA Detector description implementation for LCD
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// @author F.Gaede, DESY
+// @date June, 2017
+//==========================================================================
+#ifndef dd4hep_NAMESPACE_H
+#define dd4hep_NAMESPACE_H 1
+
+
+#include "DD4hep/LCDD.h"
+#include "DD4hep/DD4hepUnits.h"
+
+
+
+/// The top level namespace in DD4hep 
+namespace DD4hep{
+
+  /// holds all classes relevant for the geometry description
+  namespace Geometry{}
+
+  /// simulation classes
+  namespace Simulation{}
+  
+  /// dedicated view into the geometry for reconstruction
+  namespace DDRec{}
+  
+  /// alignment module
+  namespace DDAlign{}
+
+  /// alignment classes 
+  namespace Alignments{}
+  
+  /// condition handling
+  namespace Conditions{}
+
+  /// segmentations
+  namespace DDSegmentation{}
+
+  /// utilities for boost::spirit
+  namespace Utils{}
+
+  /// general utilities
+  namespace Utilities{}
+  
+  /// xml stuff
+  namespace XML{}
+
+}
+
+
+namespace DDSurfaces{}
+
+
+
+/** 
+ * Convenient namespace that combines all public namespaces in DD4hep into one global namespace.
+ */
+
+namespace dd4hep {
+  
+  using namespace DD4hep ;
+  using namespace DDSurfaces ;
+  
+  using namespace DD4hep::Geometry ;
+  using namespace DD4hep::DDRec ;
+  using namespace DD4hep::Alignments ;
+  using namespace DD4hep::Conditions ;
+  using namespace DD4hep::DDSegmentation ;
+  using namespace DD4hep::DDAlign ;
+  using namespace DD4hep::Utils ;
+  using namespace DD4hep::Utilities ;
+  using namespace DD4hep::Simulation ;
+  using namespace DD4hep::XML ;
+
+
+  /// define a better type name for the main detector description class
+  typedef LCDD DetDescription ;
+
+}
+
+
+#endif

--- a/UtilityApps/src/test_cellid_position_converter.cpp
+++ b/UtilityApps/src/test_cellid_position_converter.cpp
@@ -12,10 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/LCDD.h"
+#include "DD4hep/dd4hep.h"
 #include "DD4hep/DDTest.h"
 
-#include "DD4hep/DD4hepUnits.h"
 #include "DD4hep/BitField64.h"
 #include "DDRec/CellIDPositionConverter.h"
 
@@ -28,11 +27,8 @@
 #include <sstream>
 
 using namespace std ;
-using namespace DD4hep ;
-using namespace DD4hep::Geometry;
-using namespace DD4hep::DDRec ;
-
 using namespace lcio;
+using namespace dd4hep ;
 
 
 static DDTest test( "cellid_position_converter" ) ; 
@@ -72,11 +68,11 @@ int main_wrapper(int argc, char** argv ){
   
   std::string inFile =  argv[1] ;
 
-  LCDD& lcdd = LCDD::getInstance();
+  dd4hep::DetDescription& detDesc = dd4hep::DetDescription::getInstance();
 
-  lcdd.fromCompact( inFile );
+  detDesc.fromCompact( inFile );
 
-  CellIDPositionConverter idposConv( lcdd )  ;
+  CellIDPositionConverter idposConv( detDesc )  ;
 
   
   //---------------------------------------------------------------------
@@ -124,8 +120,8 @@ int main_wrapper(int argc, char** argv ){
 
       std::string cellIDEcoding = col->getParameters().getStringVal("CellIDEncoding") ;
       
-      DD4hep::BitField64 idDecoder0( cellIDEcoding ) ;
-      DD4hep::BitField64 idDecoder1( cellIDEcoding ) ;
+      BitField64 idDecoder0( cellIDEcoding ) ;
+      BitField64 idDecoder1( cellIDEcoding ) ;
 
       int nHit = std::min( col->getNumberOfElements(), maxHit )  ;
      
@@ -134,12 +130,12 @@ int main_wrapper(int argc, char** argv ){
 	
         SimCalorimeterHit* sHit = (SimCalorimeterHit*) col->getElementAt(i) ;
 	
-        DD4hep::long64 id0 = sHit->getCellID0() ;
-        DD4hep::long64 id1 = sHit->getCellID1() ;
+        long64 id0 = sHit->getCellID0() ;
+        long64 id1 = sHit->getCellID1() ;
 
 	idDecoder0.setValue( id0 , id1 ) ;
 
-	DD4hep::long64 id = idDecoder0.getValue() ;
+	long64 id = idDecoder0.getValue() ;
 	
 
 	Position point( sHit->getPosition()[0]* dd4hep::mm , sHit->getPosition()[1]* dd4hep::mm ,  sHit->getPosition()[2]* dd4hep::mm ) ;


### PR DESCRIPTION

BEGINRELEASENOTES
- add header file DD4hep/dd4hep.h
      - define  a convenient namespace dd4hep containing all public namespaces in DDh4ep
            - all DD4hep classes can be called as ```dd4hep::AClass```
      - define a typedef for the LCDD class ```DetDescription```
- use dd4hep.h in test_cellid_position_converter

ENDRELEASENOTES