### PR TITLE
Cleanup ddrec

### DIFF
--- a/DDRec/include/DDRec/API/Calorimeter.h
+++ b/DDRec/include/DDRec/API/Calorimeter.h
@@ -16,7 +16,7 @@
 namespace DD4hep {
 namespace DDRec {
 
-class Calorimeter: public LayeredSubdetector, public Subdetector {
+class  [[gnu::deprecated(" unmaintained code ")]] Calorimeter: public LayeredSubdetector, public Subdetector {
 public:
 	Calorimeter(const Geometry::DetElement& det) :
 		Geometry::DetElement(det), LayeredSubdetector(det), Subdetector(det) {

--- a/DDRec/include/DDRec/API/Exceptions.h
+++ b/DDRec/include/DDRec/API/Exceptions.h
@@ -22,7 +22,7 @@
 namespace DD4hep {
 namespace DDRec {
 
-class invalid_cell_id: public std::invalid_argument {
+class  [[gnu::deprecated(" unmaintained code ")]] invalid_cell_id: public std::invalid_argument {
 public:
 	invalid_cell_id(const std::string& msg, const DDSegmentation::CellID& cellID = 0) :
 			std::invalid_argument(createMsg(msg, cellID)) {
@@ -37,7 +37,7 @@ private:
 	}
 };
 
-class invalid_position: public std::invalid_argument {
+class  [[gnu::deprecated(" unmaintained code ")]] invalid_position: public std::invalid_argument {
 public:
 	invalid_position(const std::string& msg, const Geometry::Position& position) :
 			std::invalid_argument(createMsg(msg, position)) {
@@ -50,7 +50,7 @@ private:
 	}
 };
 
-class invalid_detector_element: public std::invalid_argument {
+class  [[gnu::deprecated(" unmaintained code ")]] invalid_detector_element: public std::invalid_argument {
 public:
 	invalid_detector_element(const std::string& msg, const Geometry::DetElement& det) :
 			std::invalid_argument(createMsg(msg, det)) {

--- a/DDRec/include/DDRec/API/IDDecoder.h
+++ b/DDRec/include/DDRec/API/IDDecoder.h
@@ -29,8 +29,10 @@ typedef DDSegmentation::VolumeID VolumeID;
  * high level interface for position to cell ID and cell ID to position conversions
  * and related information.
  */
-class IDDecoder {
-public:
+  
+  class [[gnu::deprecated(" replaced with CellIDPositionConverter ")]]  IDDecoder{
+     
+  public:
 	class BarrelEndcapFlag {
 	public:
 		enum BarrelEncapID {

--- a/DDRec/include/DDRec/API/LayeredSubdetector.h
+++ b/DDRec/include/DDRec/API/LayeredSubdetector.h
@@ -18,7 +18,7 @@
 namespace DD4hep {
 namespace DDRec {
 
-class LayeredSubdetector: public virtual Geometry::DetElement, public LayeringExtension {
+class [[gnu::deprecated(" unmaintained code ")]] LayeredSubdetector: public virtual Geometry::DetElement, public LayeringExtension {
 public:
 	/// Default constructor
 	LayeredSubdetector(const Geometry::DetElement& det) :

--- a/DDRec/include/DDRec/API/Subdetector.h
+++ b/DDRec/include/DDRec/API/Subdetector.h
@@ -16,7 +16,7 @@
 namespace DD4hep {
 namespace DDRec {
 
-class Subdetector: public virtual Geometry::DetElement {
+class  [[gnu::deprecated(" unmaintained code ")]] Subdetector: public virtual Geometry::DetElement {
 public:
 	/// Default constructor
 	Subdetector(const Geometry::DetElement& det) :

--- a/DDRec/include/DDRec/API/Tracker.h
+++ b/DDRec/include/DDRec/API/Tracker.h
@@ -17,7 +17,7 @@
 namespace DD4hep {
 namespace DDRec {
 
-class Tracker: public LayeredSubdetector {
+class  [[gnu::deprecated(" unmaintained code ")]] Tracker: public LayeredSubdetector {
 public:
 	Tracker(const Geometry::DetElement& det) :
 	Geometry::DetElement(det) {

--- a/DDRec/include/DDRec/Extensions/CalorimeterExtension.h
+++ b/DDRec/include/DDRec/Extensions/CalorimeterExtension.h
@@ -13,7 +13,7 @@
 namespace DD4hep {
 namespace DDRec {
 
-class CalorimeterExtension {
+class  [[gnu::deprecated(" unmaintained code ")]] CalorimeterExtension {
 public:
 	CalorimeterExtension();
 	virtual ~CalorimeterExtension();

--- a/DDRec/include/DDRec/Extensions/LayeringExtension.h
+++ b/DDRec/include/DDRec/Extensions/LayeringExtension.h
@@ -20,7 +20,7 @@ namespace DDRec {
  * The information for one layer corresponds to a typical module
  * if, for example, a layer consists of multiple modules.
  */
-class LayeringExtension {
+class  [[gnu::deprecated(" unmaintained code ")]] LayeringExtension {
 public:
 	/// Destructor
 	virtual ~LayeringExtension() {

--- a/DDRec/include/DDRec/Extensions/LayeringExtensionImpl.h
+++ b/DDRec/include/DDRec/Extensions/LayeringExtensionImpl.h
@@ -25,7 +25,7 @@ class TGeoManager;
 namespace DD4hep {
 namespace DDRec {
 
-class LayeringExtensionImpl: public LayeringExtension {
+class  [[gnu::deprecated(" unmaintained code ")]] LayeringExtensionImpl: public LayeringExtension {
 public:
   /// Shortcut to use geometrical positions
   typedef Geometry::Position Position;

--- a/DDRec/include/DDRec/Extensions/SubdetectorExtension.h
+++ b/DDRec/include/DDRec/Extensions/SubdetectorExtension.h
@@ -18,7 +18,7 @@ namespace DDRec {
 /**
  * Class describing general parameters of a subdetector.
  */
-class SubdetectorExtension {
+class  [[gnu::deprecated(" unmaintained code ")]] SubdetectorExtension {
 public:
 	/// Destructor
 	virtual ~SubdetectorExtension() {

--- a/DDRec/include/DDRec/Extensions/SubdetectorExtensionImpl.h
+++ b/DDRec/include/DDRec/Extensions/SubdetectorExtensionImpl.h
@@ -22,7 +22,7 @@ namespace DDRec {
  * Values can be set manually which will superseed the information from
  * the DetElement.
  */
-class SubdetectorExtensionImpl: public SubdetectorExtension {
+class  [[gnu::deprecated(" unmaintained code ")]] SubdetectorExtensionImpl: public SubdetectorExtension {
 public:
 	/// Default constructor using a top level DetElement
 	SubdetectorExtensionImpl(const Geometry::DetElement& det);

--- a/DDRec/include/DDRec/Extensions/TrackerExtension.h
+++ b/DDRec/include/DDRec/Extensions/TrackerExtension.h
@@ -13,7 +13,7 @@
 namespace DD4hep {
 namespace DDRec {
 
-class TrackerExtension {
+class  [[gnu::deprecated(" unmaintained code ")]] TrackerExtension {
 public:
 	TrackerExtension();
 	virtual ~TrackerExtension();

--- a/DDRec/include/DDRec/MaterialManager.h
+++ b/DDRec/include/DDRec/MaterialManager.h
@@ -5,6 +5,7 @@
 #include "DDSurfaces/Vector3D.h"
 #include "DDRec/Material.h"
 #include "DD4hep/DD4hepUnits.h"
+#include "DD4hep/Volumes.h"
 
 #include <vector>
 
@@ -31,6 +32,11 @@ namespace DD4hep {
 
     public:
 
+      /// Instantiate the MaterialManager for this (world) volume
+      MaterialManager(DD4hep::Geometry::Volume world);
+
+      /// default c'tor
+      [[gnu::deprecated("use MaterialManager(Volume world) instead")]]
       MaterialManager();
       
       ~MaterialManager();

--- a/DDRec/include/DDRec/SurfaceManager.h
+++ b/DDRec/include/DDRec/SurfaceManager.h
@@ -6,6 +6,11 @@
 #include <map>
 
 namespace DD4hep {
+
+  namespace Geometry{
+    class LCDD ;
+  }
+
   namespace DDRec {
 
     /// typedef for surface maps, keyed by the cellID 
@@ -24,8 +29,11 @@ namespace DD4hep {
       typedef std::map< std::string,  SurfaceMap > SurfaceMapsMap ;
 
     public:
-      /// Default constructor
-      SurfaceManager();
+      /// The constructor
+      SurfaceManager(DD4hep::Geometry::LCDD& theDetector);
+
+      /// No default constructor
+      SurfaceManager() = delete ;
 
       /// No copy constructor
       SurfaceManager(const SurfaceManager& copy) = delete;
@@ -50,7 +58,7 @@ namespace DD4hep {
 
 
       /// initialize all known surface maps
-      void initialize() ;
+      void initialize(DD4hep::Geometry::LCDD& theDetector) ;
 
       SurfaceMapsMap _map ;
     };

--- a/DDRec/src/MaterialManager.cpp
+++ b/DDRec/src/MaterialManager.cpp
@@ -13,6 +13,12 @@ namespace DD4hep {
   namespace DDRec {
 
 
+    MaterialManager::MaterialManager(DD4hep::Geometry::Volume world) : _mV(0), _m( Material() ), _p0(),_p1(),_pos() {
+
+      _tgeoMgr = world->GetGeoManager();
+    }
+
+
     MaterialManager::MaterialManager() : _mV(0), _m( Material() ), _p0(),_p1(),_pos() {
 
       _tgeoMgr = Geometry::LCDD::getInstance().world().volume()->GetGeoManager();

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -621,7 +621,7 @@ namespace DD4hep {
       
       if( ! ( mat.Z() > 0 ) ) {
 	
-        MaterialManager matMgr ;
+        MaterialManager matMgr( _det.volume() )  ;
         
 	Vector3D p = _o - innerThickness() * _n  ;
 
@@ -640,7 +640,7 @@ namespace DD4hep {
       
       if( ! ( mat.Z() > 0 ) ) {
 	
-        MaterialManager matMgr ;
+        MaterialManager matMgr( _det.volume() ) ;
         
 	Vector3D p = _o + outerThickness() * _n  ;
 

--- a/DDRec/src/SurfaceHelper.cpp
+++ b/DDRec/src/SurfaceHelper.cpp
@@ -3,7 +3,6 @@
 #include "DDRec/DetectorSurfaces.h"
 #include "DD4hep/Detector.h"
 #include "DD4hep/LCDD.h"
-#include "DD4hep/VolumeManager.h"
 
 namespace DD4hep {
   
@@ -20,14 +19,9 @@ namespace DD4hep {
     SurfaceHelper::~SurfaceHelper(){
       // nothing to do
     }
-    
-    
+
+
     void SurfaceHelper::initialize() {
-      
-      // have to populate the volume manager once in order to have 
-      // the volumeIDs attached to the DetElements
-      LCDD& lcdd = LCDD::getInstance();
-      /* VolumeManager volMgr = */ VolumeManager::getVolumeManager(lcdd);
 
       //------------------ breadth first tree traversal ---------
       std::list< DetElement > dets ;

--- a/DDRec/src/SurfaceManager.cpp
+++ b/DDRec/src/SurfaceManager.cpp
@@ -2,6 +2,7 @@
 
 #include "DDRec/SurfaceHelper.h"
 #include "DD4hep/LCDD.h"
+#include "DD4hep/VolumeManager.h"
 
 #include <sstream>
 
@@ -13,9 +14,15 @@ namespace DD4hep {
   namespace DDRec {
     
 
-    SurfaceManager::SurfaceManager(){
 
-      initialize() ;
+    SurfaceManager::SurfaceManager(DD4hep::Geometry::LCDD& theDetector){
+
+      // have to make sure the volume manager is populated once in order to have
+      // the volumeIDs attached to the DetElements
+
+      VolumeManager::getVolumeManager(theDetector);
+
+      initialize(theDetector) ;
     }
     
     SurfaceManager::~SurfaceManager(){
@@ -35,15 +42,13 @@ namespace DD4hep {
       return 0 ;
     }
 
-    void SurfaceManager::initialize() {
+    void SurfaceManager::initialize(DD4hep::Geometry::LCDD& theDetector) {
       
-      LCDD& lcdd = LCDD::getInstance();
-
-      const std::vector<std::string>& types = lcdd.detectorTypes() ;
+      const std::vector<std::string>& types = theDetector.detectorTypes() ;
 
       for(unsigned i=0,N=types.size();i<N;++i){
 
-	const std::vector<DetElement>& dets = lcdd.detectors( types[i] ) ;  
+	const std::vector<DetElement>& dets = theDetector.detectors( types[i] ) ;  
 
 	for(unsigned j=0,M=dets.size();j<M;++j){
 

--- a/DDRec/src/plugins/createSurfaceManager.cpp
+++ b/DDRec/src/plugins/createSurfaceManager.cpp
@@ -25,13 +25,13 @@ namespace DD4hep{
     */
 
 
-    static long createSurfaceManager(LCDD& lcdd, int /*argc*/, char** /*argv*/) {
+    static long createSurfaceManager(LCDD& theDetector, int /*argc*/, char** /*argv*/) {
 
       printout(INFO,"InstallSurfaceManager","**** running plugin InstallSurfaceManager ! " );
 
-      lcdd.addExtension<SurfaceManager>(  new SurfaceManager() ) ;
+      theDetector.addExtension<SurfaceManager>(  new SurfaceManager(theDetector) ) ;
 
-      printout(INFO,"InstallSurfaceManager","%s" , lcdd.extension<SurfaceManager>()->toString().c_str() );
+      printout(INFO,"InstallSurfaceManager","%s" , theDetector.extension<SurfaceManager>()->toString().c_str() );
 
       return 1;
     }

--- a/UtilityApps/src/graphicalMaterialScan.cpp
+++ b/UtilityApps/src/graphicalMaterialScan.cpp
@@ -138,7 +138,7 @@ int main_wrapper(int argc, char** argv)   {
 
   Vector3D p0, p1; // the two points between which material is calculated
 
-  MaterialManager matMgr;
+  MaterialManager matMgr( lcdd.world().volume() ) ;
 
   for (unsigned int isl=0; isl<nslice; isl++) { // loop over slices
 

--- a/UtilityApps/src/materialScan.cpp
+++ b/UtilityApps/src/materialScan.cpp
@@ -58,7 +58,7 @@ int main_wrapper(int argc, char** argv)   {
   lcdd.fromCompact(inFile);
   direction = (p1-p0).unit();
 
-  MaterialManager matMgr;
+  MaterialManager matMgr( lcdd.world().volume() ) ;
   const MaterialVec& materials = matMgr.materialsBetween(p0, p1);
   double sum_x0 = 0;
   double sum_lambda = 0;

--- a/UtilityApps/src/print_materials.cpp
+++ b/UtilityApps/src/print_materials.cpp
@@ -59,7 +59,7 @@ int main_wrapper(int argc, char** argv ){
   Vector3D p0( x0, y0, z0 ) ;
   Vector3D p1( x1, y1, z1 ) ;
 
-  MaterialManager matMgr ;
+  MaterialManager matMgr( lcdd.world().volume() ) ;
 
   const MaterialVec& materials = matMgr.materialsBetween( p0 , p1  ) ;
 	


### PR DESCRIPTION

BEGINRELEASENOTES
- started to cleanup DDRec
      - don't use  LCDD::getInstance() in SurfaceManager and SurfaceHelper
      -  deprecate unused(?) classes in DDRec/API and DDRec/Extensions
      -  deprecate MaterialManager() using LCDD::getInstance()

ENDRELEASENOTES