### PR TITLE
Warn about using namespace directive in global context in header

### DIFF
--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -41,7 +41,7 @@ macro(dd4hep_set_compiler_flags)
 
   # AppleClang/Clang specific warning flags
   if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
-    set ( COMPILER_FLAGS ${COMPILER_FLAGS} -Winconsistent-missing-override -Wno-c++1z-extensions)
+    set ( COMPILER_FLAGS ${COMPILER_FLAGS} -Winconsistent-missing-override -Wno-c++1z-extensions -Wheader-hygiene )
   endif()
 
   FOREACH( FLAG ${COMPILER_FLAGS} )


### PR DESCRIPTION

BEGINRELEASENOTES
- Add clang flag to warn about using namespace directive in global context in header

ENDRELEASENOTES