### PR TITLE
fix bwd compatibility for DDRec/DetectorData.h

### DIFF
--- a/DDRec/include/DDRec/DetectorData.h
+++ b/DDRec/include/DDRec/DetectorData.h
@@ -481,4 +481,7 @@ namespace dd4hep {
   } /* namespace rec */
 } /* namespace dd4hep */
 
+
+namespace DD4hep { namespace DDRec { using namespace dd4hep::rec  ; } }  // bwd compatibility for old namsepaces
+
 #endif // DDRec_DetectorData_H_


### PR DESCRIPTION

BEGINRELEASENOTES
- fix for the backward compatibility of classes in DDRec/DetectorData.h wrt. namespace change

ENDRELEASENOTES