### PR TITLE
Fix memory leaks

### DIFF
--- a/DDCore/include/XML/Layering.h
+++ b/DDCore/include/XML/Layering.h
@@ -121,7 +121,7 @@ namespace dd4hep {
     /// Initializing constructor
     Layering(xml::Element element);
     /// Default destructor
-    ~Layering() = default;
+    ~Layering();
 
     std::vector<Layer*>& layers() {
       return _stack.layers();

--- a/DDCore/src/XML/Layering.cpp
+++ b/DDCore/src/XML/Layering.cpp
@@ -123,3 +123,9 @@ void Layering::sensitivePositionsInLayer(xml::Element e, std::vector<double>& se
 }
 
 
+Layering::~Layering(){
+  vector<Layer*>& layers = this->layers();
+  for_each(layers.begin(), layers.end(), detail::deletePtr<Layer>);
+  layers.clear();
+}
+

--- a/DDRec/include/DDRec/Surface.h
+++ b/DDRec/include/DDRec/Surface.h
@@ -512,7 +512,7 @@ namespace dd4hep {
       
       DetElement _det ;
       mutable VolSurface _volSurf ;
-      TGeoMatrix* _wtM ; // matrix for world transformation of surface
+      std::unique_ptr<TGeoMatrix> _wtM ; // matrix for world transformation of surface
       
       long64 _id ;
       
@@ -522,8 +522,10 @@ namespace dd4hep {
       Vector3D _n ;
       Vector3D _o ;
 
-      /// default c'tor
-      Surface() :_det( DetElement() ), _volSurf( VolSurface() ), _wtM( 0 ) , _id( 0)  { }
+      /// default c'tor etc. removed
+      Surface() = delete;
+      Surface( Surface const& ) = delete;
+      Surface& operator=( Surface const& ) = delete;
 
     public:
     

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -595,7 +595,7 @@ namespace dd4hep {
     //======================================================================================================================
 
     Surface::Surface( DetElement det, VolSurface volSurf ) : _det( det) , _volSurf( volSurf ), 
-                                                                       _wtM(0) , _id( 0) , _type( _volSurf.type() )  {
+                                                                       _wtM() , _id( 0) , _type( _volSurf.type() )  {
 
       initialize() ;
     }      
@@ -738,7 +738,7 @@ namespace dd4hep {
       // need to get the inverse transformation ( see Detector.cpp )
       // std::auto_ptr<TGeoHMatrix> wtI( new TGeoHMatrix( wm.Inverse() ) ) ;
       // has been fixed now, no need to get the inverse anymore:
-      dd4hep_ptr<TGeoHMatrix> wtI( new TGeoHMatrix( wm ) ) ;
+      std::unique_ptr<TGeoHMatrix> wtI( new TGeoHMatrix( wm ) ) ;
 
       //---- if the volSurface is not in the DetElement's volume, we need to mutliply the path to the volume to the
       // DetElements world transform
@@ -759,11 +759,11 @@ namespace dd4hep {
       dd4hep_ptr<TGeoHMatrix> wt( new TGeoHMatrix( wtI->Inverse() ) ) ;
       wt->Print() ;
       // cache the world transform for the surface
-      _wtM = wt.release()  ;
+      _wtM = std::move(wtI);
 #else
       //      wtI->Print() ;
       // cache the world transform for the surface
-      _wtM = wtI.release()  ;
+      _wtM = std::move(wtI);
 #endif
 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Surface: fix memory leak of transformation matrix
- XML::Layering: fix memory leak of contained layers in the object

ENDRELEASENOTES