### PR TITLE
Fix surface

### DIFF
--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -621,7 +621,7 @@ namespace dd4hep {
       
       if( ! ( mat.Z() > 0 ) ) {
 	
-        MaterialManager matMgr ;
+        MaterialManager matMgr( _det.placement().volume() )  ;
         
 	Vector3D p = _o - innerThickness() * _n  ;
 
@@ -640,7 +640,7 @@ namespace dd4hep {
       
       if( ! ( mat.Z() > 0 ) ) {
 	
-        MaterialManager matMgr ;
+        MaterialManager matMgr( _det.placement().volume() ) ;
         
 	Vector3D p = _o + outerThickness() * _n  ;
 

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -572,8 +572,8 @@ namespace dd4hep {
                                      +" [Internal error -- bad detector constructor]");
           }
 	  
-          PlacedVolume pv_dau = Ref_t(daughter); // why use a Ref_t here  ???
-	  
+	  PlacedVolume pv_dau( daughter );
+
           if( findVolume(  pv_dau , theVol , volList ) ) {
 	    
             //	    std::cout << "  ----- found in daughter volume !!!  " << std::hex << pv_dau.volume().ptr() << std::endl ;


### PR DESCRIPTION

BEGINRELEASENOTES
- fix crash in `dd4hep::rec::Surface` after changes in Handle assignment (PR #193)
- fix use of deprecated `dd4hep::rec::MaterialManager` c'tor in Surface

ENDRELEASENOTES