### PR TITLE
Ensure linker flags and other CMake issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+
+PROJECT( DD4hep )
+
 set ( CMAKE_MODULE_PATH      ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake ) 
 #
 include ( DD4hepBuild )

--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -87,7 +87,7 @@ macro(dd4hep_set_compiler_flags)
   if ( THREADS_HAVE_PTHREAD_ARG )
     set ( CMAKE_CXX_FLAGS           "${CMAKE_CXX_FLAGS} -pthread")
     SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pthread")
-  elif ( CMAKE_THREAD_LIBS_INIT )
+  elseif ( CMAKE_THREAD_LIBS_INIT )
     SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_THREAD_LIBS_INIT}")
   endif()
 

--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -91,12 +91,12 @@ macro(dd4hep_set_compiler_flags)
     SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_THREAD_LIBS_INIT}")
   endif()
 
-  if( ("${CMAKE_CXX_COMPILER_ID}" EQUAL "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" EQUAL "GNU") )
-    SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
-  endif()
-
-  if("${CMAKE_CXX_COMPILER_ID}" EQUAL "AppleClang")
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error")
+  elseif ( ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" ))
+    SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+  else()
+    MESSAGE( WARNING "We do not test with the ${CMAKE_CXX_COMPILER_ID} compiler, use at your own discretion" )
   endif()
 
  #rpath treatment

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,6 +22,9 @@
 # M.Frank, CERN, 2015:  Adapt to new cmake scripts
 #==========================================================================
 cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+
+project( DD4hep_Examples )
+
 option(BUILD_TESTING "Enable and build tests" ON)
 option(CMAKE_MACOSX_RPATH "Build with rpath on macos" ON)
 #


### PR DESCRIPTION

BEGINRELEASENOTES
- CMake: add `Project( DD4hep )`, needed to get the correct CMAKE_CXX_COMPILER_ID on macs due to CMP0025 (cmake policy)
- CMake: fix treatment of linker flags, they are now properly set for Linux and Macs to error when undefined functions are encountered at link time
- CMake: fix elif --> elseif when checking threading libraries

ENDRELEASENOTES