### PR TITLE
Fix memory leaks in some shapes

### DIFF
--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -250,7 +250,7 @@ namespace dd4hep {
   /// Intermediate class to overcome drawing probles with the TGeoTubeSeg
   class MyConeSeg: public TGeoConeSeg {
   public:
-    MyConeSeg() : TGeoConeSeg() { }
+    MyConeSeg() : TGeoConeSeg(0.0,0.0,0.0,0.0,0.0,0.0,0.0) { }
     virtual ~MyConeSeg() { }
     double GetRmin() const {        return GetRmin1();      }
     double GetRmax() const {        return GetRmax1();      }

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -294,15 +294,7 @@ Tube& Tube::setDimensions(double rmin, double rmax, double z, double startPhi, d
 
 /// Constructor to be used when creating a new object with attribute initialization
 void EllipticalTube::make(double a, double b, double dz) {
-  _assign(new TGeoEltu(), "", "elliptic_tube", true);
-  setDimensions(a, b, dz);
-}
-
-/// Set the tube dimensions
-EllipticalTube& EllipticalTube::setDimensions(double a, double b, double dz) {
-  double params[] = { a, b, dz };
-  _setDimensions(params);
-  return *this;
+  _assign(new TGeoEltu("", a, b, dz), "", "elliptic_tube", true);
 }
 
 /// Constructor to be used when creating a new object with attribute initialization

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -399,15 +399,15 @@ Trap& Trap::setDimensions(double z, double theta, double phi, double y1, double 
   return *this;
 }
 
-/// Helper function to create holy hedron
+/// Helper function to create poly hedron
 void PolyhedraRegular::_create(int nsides, double rmin, double rmax, double zpos, double zneg, double start, double delta) {
   if (rmin < 0e0 || rmin > rmax)
     throw runtime_error("dd4hep: PolyhedraRegular: Illegal argument rmin:<" + _toString(rmin) + "> is invalid!");
   else if (rmax < 0e0)
     throw runtime_error("dd4hep: PolyhedraRegular: Illegal argument rmax:<" + _toString(rmax) + "> is invalid!");
-  _assign(new TGeoPgon(), "", "polyhedra", false);
   double params[] = { start, delta, double(nsides), 2e0, zpos, rmin, rmax, zneg, rmin, rmax };
-  _setDimensions(&params[0]);
+  _assign(new TGeoPgon(params), "", "polyhedra", false);
+  //_setDimensions(&params[0]);
 }
 
 /// Constructor to be used when creating a new object


### PR DESCRIPTION
Using the default constructors for TGeoShapes does not register them to the geoManager.

BEGINRELEASENOTES
- Fix memory leaks for Tube, EllipticalTube and Polyhedron

ENDRELEASENOTES
