### PR TITLE
set flag=true in VolumeManager_Populator::add_entry

### DIFF
--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -268,7 +268,7 @@ namespace dd4hep {
             context->element    = e;
             if ( nodes.size() > 0 )  {
               ContextExtension* ext = new(_getExtension(context)) ContextExtension();
-	      context->flag=true ;
+              context->flag=1;
               ext->placement  = PlacedVolume(n);
               for (size_t i = nodes.size(); i > 1; --i) {   // Omit the placement of the parent DetElement
                 TGeoMatrix* m = nodes[i-1]->GetMatrix();

--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -268,6 +268,7 @@ namespace dd4hep {
             context->element    = e;
             if ( nodes.size() > 0 )  {
               ContextExtension* ext = new(_getExtension(context)) ContextExtension();
+	      context->flag=true ;
               ext->placement  = PlacedVolume(n);
               for (size_t i = nodes.size(); i > 1; --i) {   // Omit the placement of the parent DetElement
                 TGeoMatrix* m = nodes[i-1]->GetMatrix();


### PR DESCRIPTION

BEGINRELEASENOTES
- bug fix for VolumeManagerContext::toElement() and VolumeManagerContext::placement() 
      - set flag=true in VolumeManager_Populator::add_entry when 
         a ContextExtension is needed, i.e. sensitive volume is not DetElement's volume
- fixes problems in CellIDPositionConverter

ENDRELEASENOTES