### PR TITLE
MegatileLayerGridXY segmentation: add segmentation parameters

### DIFF
--- a/DDCore/include/DDSegmentation/MegatileLayerGridXY.h
+++ b/DDCore/include/DDSegmentation/MegatileLayerGridXY.h
@@ -107,8 +107,6 @@ namespace dd4hep {
       int getUnifNCellsY() {return _unif_nCellsY;}
 
       
-    protected:
-
       struct segInfo {
         double megaTileSizeX = 0;
         double megaTileSizeY = 0;
@@ -118,6 +116,9 @@ namespace dd4hep {
         unsigned int nCellsY = 0;
         segInfo() = default;
       };
+
+    protected:
+
 
       mutable segInfo _currentSegInfo;
 

--- a/DDCore/include/DDSegmentation/MegatileLayerGridXY.h
+++ b/DDCore/include/DDSegmentation/MegatileLayerGridXY.h
@@ -12,8 +12,6 @@
 
 #include <cassert>
 
-#define MAX_LAYERS 100
-
 /*
 
   a megatile is a rectangule in x-y, split into a grid along x and y, with an exactly integer number of cells in x and y.
@@ -27,6 +25,11 @@
   - complications due to end-of-slab moved to higher level detector drivers.
 
   D. Jeans - Nov 2016
+
+  July 2017 - DJeans
+  some changes for easier use of multi-layer segmentations
+  - for uniform segmentation, allow setting of ncellsx/y via parameter
+  - use std::vector, rather than fixed array to store ncells values
 
 */
 
@@ -65,9 +68,13 @@ namespace dd4hep {
       }
 
       void setMegaTileCellsXY( unsigned int layer, int ix, int iy ) {
-        assert ( layer < MAX_LAYERS );
-        _nCellsX[layer] = ix;
-        _nCellsY[layer] = iy;
+	while ( _nCellsX.size()<=layer ) {
+	  _nCellsX.push_back(0);
+	  _nCellsY.push_back(0);
+	}
+	_nCellsX[layer] = ix;
+	_nCellsY[layer] = iy;
+
       }
 
       void setSpecialMegaTile( unsigned int layer, unsigned int tile, 
@@ -96,6 +103,12 @@ namespace dd4hep {
       virtual std::vector<double> cellDimensions(const CellID& cellID) const;
       virtual std::vector<double> cellDimensions(const unsigned int ilayer, const unsigned int iwafer) const;
 
+      int getUnifNCellsX() {return _unif_nCellsX;}
+      int getUnifNCellsY() {return _unif_nCellsY;}
+
+      
+    protected:
+
       struct segInfo {
         double megaTileSizeX = 0;
         double megaTileSizeY = 0;
@@ -105,9 +118,6 @@ namespace dd4hep {
         unsigned int nCellsY = 0;
         segInfo() = default;
       };
-
-      
-    protected:
 
       mutable segInfo _currentSegInfo;
 
@@ -125,8 +135,11 @@ namespace dd4hep {
       double  _megaTileOffsetY = 0;
 
       // number of cells per megatile in X, Y
-      unsigned int _nCellsX[MAX_LAYERS];
-      unsigned int _nCellsY[MAX_LAYERS];
+      std::vector < int > _nCellsX;
+      std::vector < int > _nCellsY;
+
+      int _unif_nCellsX;
+      int _unif_nCellsY;
 
       std::map < std::pair < unsigned int, unsigned int > , segInfo > specialMegaTiles_layerWafer;
 

--- a/DDCore/src/segmentations/MegatileLayerGridXY.cpp
+++ b/DDCore/src/segmentations/MegatileLayerGridXY.cpp
@@ -50,10 +50,11 @@ namespace dd4hep {
       registerParameter("identifier_module", "Cell encoding identifier for module", _identifierModule, std::string("module"),
                         SegmentationParameter::NoUnit, true);
 
-      for (int i=0; i<MAX_LAYERS; i++) {
-        _nCellsX[i]=0;
-        _nCellsY[i]=0;
-      }
+      registerParameter("common_nCellsX", "ncells in x (uniform)",  _unif_nCellsX, int(0), SegmentationParameter::NoUnit, true);
+      registerParameter("common_nCellsY", "ncells in y (uniform)",  _unif_nCellsY, int(0), SegmentationParameter::NoUnit, true);
+
+      _nCellsX.clear();
+      _nCellsY.clear();
     }
 
 
@@ -144,16 +145,22 @@ namespace dd4hep {
 
     void MegatileLayerGridXY::getSegInfo( unsigned int layerIndex, unsigned int waferIndex) const {
 
-      assert ( layerIndex < MAX_LAYERS && "layer index too high" );
-
       std::pair < unsigned int, unsigned int > tileid(layerIndex, waferIndex);
       if ( specialMegaTiles_layerWafer.find( tileid ) == specialMegaTiles_layerWafer.end() ) { // standard megatile
         _currentSegInfo.megaTileSizeX   = _megaTileSizeX;
         _currentSegInfo.megaTileSizeY   = _megaTileSizeY;
         _currentSegInfo.megaTileOffsetX = _megaTileOffsetX;
         _currentSegInfo.megaTileOffsetY = _megaTileOffsetY;
-        _currentSegInfo.nCellsX         = _nCellsX[layerIndex];
-        _currentSegInfo.nCellsY         = _nCellsY[layerIndex];
+
+	if ( _unif_nCellsX>0 && _unif_nCellsY>0 ) {
+	  _currentSegInfo.nCellsX         = _unif_nCellsX;
+	  _currentSegInfo.nCellsY         = _unif_nCellsY;
+	} else {
+	  assert ( layerIndex<_nCellsX.size() && "MegatileLayerGridXY ERROR: too high layer index?" );
+	  _currentSegInfo.nCellsX         = _nCellsX[layerIndex];
+	  _currentSegInfo.nCellsY         = _nCellsY[layerIndex];
+	}
+
       } else { // special megatile
         _currentSegInfo = specialMegaTiles_layerWafer.find( tileid )->second;
       }


### PR DESCRIPTION

BEGINRELEASENOTES
- add ncellsX/Y as a "parameter", allowing it to be set in compact description. This change is for easier use in the case of a MultiSegmentation. (Only a uniform segmentation can be defined in this way: for more complex cases, must set by driver.) 
- change from array to std::vector to store ncells information
ENDRELEASENOTES