### PR TITLE
include <memory> for the smart pointers.

### DIFF
--- a/DDCore/src/DD4hepRootPersistency.cpp
+++ b/DDCore/src/DD4hepRootPersistency.cpp
@@ -20,6 +20,7 @@
 // ROOT include files
 #include "TFile.h"
 #include "TTimeStamp.h"
+#include <memory>
 
 ClassImp(DD4hepRootPersistency)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- added "#include <memory>" for the smart pointers to DD4hepRootPersistency.cpp

ENDRELEASENOTES