### PR TITLE
Implement ROOT persistency mechanism for the conditions

### DIFF
--- a/DDCond/CMakeLists.txt
+++ b/DDCond/CMakeLists.txt
@@ -13,8 +13,17 @@ dd4hep_package(    DDCond
   INCLUDE_DIRS     include
   INSTALL_INCLUDES include/DDCond)
 
+#---Generate ROOT dictionary-----------------------------------------------------
+dd4hep_add_dictionary( G__DDCond
+  SOURCES include/ROOT/Warnings.h
+  src/ConditionsDictionary.h
+  LINKDEF include/ROOT/LinkDef.h )
+
 #---DDCond library --------------------------------------------------------------
-dd4hep_add_package_library(DDCond SOURCES src/*.cpp )
+dd4hep_add_package_library(DDCond
+  SOURCES        src/*.cpp
+  GENERATED      G__DDCond.cxx 
+  )
 
 #---DDCond components -----------------------------------------------------------
 dd4hep_add_plugin(DDCondPlugins  SOURCES  src/plugins/*.cpp src/Type1/*.cpp )

--- a/DDCond/include/DDCond/ConditionsIOVPool.h
+++ b/DDCond/include/DDCond/ConditionsIOVPool.h
@@ -37,12 +37,15 @@ namespace dd4hep {
      */
     class ConditionsIOVPool  {
     public:
+      /// Shortcut name for the actual container elements
       typedef std::shared_ptr<ConditionsPool> Element;
+      /// Shortcut name for the actual conditions container
       typedef std::map<IOV::Key, Element >    Elements;      
 
       /// Container of IOV dependent conditions pools
-      Elements elements;
-      const IOVType* type;
+      Elements elements;     //! Not ROOT persistent
+      /// Reference to the IOV container
+      const IOVType* type;   //! Not ROOT persistent
       
     public:
       /// Default constructor

--- a/DDCond/include/DDCond/ConditionsPool.h
+++ b/DDCond/include/DDCond/ConditionsPool.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DDCOND_CONDITIONSPOOL_H
-#define DDCOND_CONDITIONSPOOL_H
+#ifndef DDCOND_CONDITIONS_CONDITIONSPOOL_H
+#define DDCOND_CONDITIONS_CONDITIONSPOOL_H
 
 // Framework include files
 #include "DD4hep/NamedObject.h"
@@ -217,6 +217,6 @@ namespace dd4hep {
                              void* user_param,
                              bool force) = 0;
     };
-  }        /* End namespace cond               */
+  }        /* End namespace cond                     */
 }          /* End namespace dd4hep                   */
-#endif     /* DDCOND_CONDITIONSPOOL_H                */
+#endif     /* DDCOND_CONDITIONS_CONDITIONSPOOL_H     */

--- a/DDCond/include/DDCond/ConditionsRootPersistency.h
+++ b/DDCond/include/DDCond/ConditionsRootPersistency.h
@@ -1,0 +1,114 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_CONDITIONS_CONDITIONSROOTPERSISTENCY_H
+#define DD4HEP_CONDITIONS_CONDITIONSROOTPERSISTENCY_H
+
+// Framework/ROOT include files
+#include "DDCond/ConditionsPool.h"
+
+#include "TNamed.h"
+class TFile;
+
+// C/C++ include files
+#include <map>
+#include <list>
+#include <vector>
+#include <memory>
+
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for implementation details of the AIDA detector description toolkit
+  namespace cond {
+
+    /// Forward declarations
+    class ConditionsSlice;
+    class ConditionsIOVPool;
+
+    /// Helper to save conditions pools to ROOT
+    /** 
+     *  \author  M.Frank
+     *  \version 1.0
+     */
+    class ConditionsRootPersistency : public TNamed  {
+    public:
+      typedef std::vector<Condition>                                  pool_type;
+      typedef std::pair<std::string, pool_type>                       named_pool_type;
+      typedef std::pair<std::string,std::pair<std::pair<std::string,int>,IOV::Key> > iov_key_type;
+      typedef std::list<std::pair<iov_key_type, pool_type> >          persistent_type;
+      persistent_type conditionPools;
+      persistent_type userPools;
+      persistent_type iovPools;
+      float           duration;
+      
+      /// Load ConditionsIOVPool and populate conditions manager
+      size_t _import(persistent_type& pers,
+                     const std::string& id,
+                     const std::string& iov_type,
+                     ConditionsManager mgr);
+
+      /// Clear object content and release allocated memory
+      void _clear(persistent_type& pool);
+      
+    public:
+      /// No copy constructor
+      ConditionsRootPersistency(const ConditionsRootPersistency& copy) = delete;
+      /// Initializing constructor
+      ConditionsRootPersistency(const std::string& name, const std::string& title="DD4hep conditions container");
+      /// Default constructor
+      ConditionsRootPersistency();
+      /// Default destructor
+      virtual ~ConditionsRootPersistency();
+      /// No assignment
+      ConditionsRootPersistency& operator=(const ConditionsRootPersistency& copy) = delete;
+
+      /// Clear object content and release allocated memory
+      void clear();
+      /// Open ROOT file in read mode
+      static TFile* openFile(const std::string& fname);      
+      
+      /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+      size_t add(const std::string& identifier, ConditionsPool& pool);
+      /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+      size_t add(const std::string& identifier, const UserPool& pool);
+      /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+      size_t add(const std::string& identifier, const ConditionsIOVPool& pool);
+
+      /// Load conditions content from file.
+      static std::unique_ptr<ConditionsRootPersistency> load(TFile* file,const std::string& object);
+      
+      /// Load conditions content from file.
+      static std::unique_ptr<ConditionsRootPersistency> load(const std::string& file,const std::string& object)  {
+        return load(openFile(file), object);
+      }
+      
+      /// Load conditions IOV pool and populate conditions manager
+      size_t importIOVPool(const std::string& id,const std::string& iov_type,ConditionsManager mgr);
+      /// Load conditions user pool and populate conditions manager
+      size_t importUserPool(const std::string& id,const std::string& iov_type,ConditionsManager mgr);
+      /// Load conditions pool and populate conditions manager
+      size_t importConditionsPool(const std::string& id,const std::string& iov_type,ConditionsManager mgr);
+
+      /// Save the data content to a root file
+      int save(TFile* file);
+      /// Save the data content to a root file
+      int save(const std::string& file_name);
+
+      /// ROOT object ClassDef
+      ClassDef(ConditionsRootPersistency,1);
+    };
+    
+  }        /* End namespace cond                            */
+}          /* End namespace dd4hep                          */
+#endif     /* DD4HEP_CONDITIONS_CONDITIONSROOTPERSISTENCY_H */

--- a/DDCond/include/DDCond/ConditionsRootPersistency.h
+++ b/DDCond/include/DDCond/ConditionsRootPersistency.h
@@ -51,12 +51,23 @@ namespace dd4hep {
       persistent_type userPools;
       persistent_type iovPools;
       float           duration;
-      
+      enum ImportStrategy  {
+        IMPORT_ALL             = 1<<0,
+        IMPORT_EXACT           = 1<<1,
+        IMPORT_CONTAINED       = 1<<2,
+        IMPORT_CONTAINED_LOWER = 1<<3,
+        IMPORT_CONTAINED_UPPER = 1<<4,
+        IMPORT_EDGE_LOWER      = 1<<5,
+        IMPORT_EDGE_UPPER      = 1<<6,
+        LAST
+      };
       /// Load ConditionsIOVPool and populate conditions manager
-      size_t _import(persistent_type& pers,
+      size_t _import(ImportStrategy     strategy,
+                     persistent_type&   pers,
                      const std::string& id,
                      const std::string& iov_type,
-                     ConditionsManager mgr);
+                     const IOV::Key&    iov_key,
+                     ConditionsManager  mgr);
 
       /// Clear object content and release allocated memory
       void _clear(persistent_type& pool);
@@ -78,11 +89,13 @@ namespace dd4hep {
       /// Open ROOT file in read mode
       static TFile* openFile(const std::string& fname);      
       
-      /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+      /// Add conditions content to be saved. Note, that dependent conditions shall not be saved!
+      size_t add(const std::string& identifier, const IOV& iov, std::vector<Condition>& conditions);
+      /// Add conditions content to be saved. Note, that dependent conditions shall not be saved!
       size_t add(const std::string& identifier, ConditionsPool& pool);
-      /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+      /// Add conditions content to be saved. Note, that dependent conditions shall not be saved!
       size_t add(const std::string& identifier, const UserPool& pool);
-      /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+      /// Add conditions content to be saved. Note, that dependent conditions shall not be saved!
       size_t add(const std::string& identifier, const ConditionsIOVPool& pool);
 
       /// Load conditions content from file.
@@ -94,11 +107,18 @@ namespace dd4hep {
       }
       
       /// Load conditions IOV pool and populate conditions manager
-      size_t importIOVPool(const std::string& id,const std::string& iov_type,ConditionsManager mgr);
+      size_t importIOVPool(const std::string& id, const std::string& iov_type, ConditionsManager mgr);
       /// Load conditions user pool and populate conditions manager
-      size_t importUserPool(const std::string& id,const std::string& iov_type,ConditionsManager mgr);
+      size_t importUserPool(const std::string& id, const std::string& iov_type, ConditionsManager mgr);
       /// Load conditions pool and populate conditions manager
-      size_t importConditionsPool(const std::string& id,const std::string& iov_type,ConditionsManager mgr);
+      size_t importConditionsPool(const std::string& id, const std::string& iov_type, ConditionsManager mgr);
+
+      /// Load conditions pool and populate conditions manager. Allow tro be selective also for the key
+      size_t importConditionsPool(ImportStrategy     strategy,
+                                  const std::string& id,
+                                  const std::string& iov_type,
+                                  const IOV::Key&    key,
+                                  ConditionsManager  mgr);
 
       /// Save the data content to a root file
       int save(TFile* file);

--- a/DDCond/src/ConditionsDictionary.h
+++ b/DDCond/src/ConditionsDictionary.h
@@ -1,0 +1,69 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_CONDITIONS_CONDITIONSDICTIONARY_H
+#define DD4HEP_CONDITIONS_CONDITIONSDICTIONARY_H
+
+// Framework include files
+#include "DDCond/ConditionsPool.h"
+#include "DDCond/ConditionsSlice.h"
+#include "DDCond/ConditionsIOVPool.h"
+#include "DDCond/ConditionsContent.h"
+#include "DDCond/ConditionsManager.h"
+#include "DDCond/ConditionsManagerObject.h"
+#include "DDCond/ConditionsRootPersistency.h"
+
+// -------------------------------------------------------------------------
+// Regular dd4hep dictionaries
+// -------------------------------------------------------------------------
+#if defined(__CINT__) || defined(__MAKECINT__) || defined(__CLING__) || defined(__ROOTCLING__)
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ namespace dd4hep;
+#pragma link C++ namespace dd4hep::detail;
+#pragma link C++ namespace dd4hep::cond;
+
+using namespace dd4hep;
+
+// These are necessary to support interactivity
+#pragma link C++ class cond::UserPool-;
+#pragma link C++ class cond::UpdatePool-;
+#pragma link C++ class cond::ConditionsPool-;
+#pragma link C++ class cond::ConditionsManager-;
+#pragma link C++ class cond::ConditionsManagerObject-;
+#pragma link C++ class cond::ConditionsIOVPool-;
+#pragma link C++ class cond::ConditionsContent-;
+#pragma link C++ class cond::ConditionsLoadInfo-;
+#pragma link C++ class cond::ConditionsContent::LoadInfo<std::string>-;
+#pragma link C++ class std::map<Condition::key_type,cond::ConditionsLoadInfo* >-;
+#pragma link C++ class std::map<Condition::key_type,cond::ConditionDependency* >-;
+
+// std::shared_ptr<T> is not yet supported by ROOT!
+//#pragma link C++ class std::shared_ptr<cond::ConditionsPool>-;
+//#pragma link C++ class std::map<IOV::Key,std::shared_ptr<cond::ConditionsPool> >-;
+
+// This one we need to save conditions pool to file
+#pragma link C++ class std::pair<std::string,IOV::Key>+;
+#pragma link C++ class std::pair<std::pair<std::string,int>, IOV::Key>+;
+#pragma link C++ class std::pair<std::string,std::pair<std::pair<std::string,int>,IOV::Key> >+;
+#pragma link C++ class std::list<std::pair<std::pair<std::string,std::pair<std::pair<std::string,int>,IOV::Key> >, std::vector<Condition> >+;
+
+//#pragma link C++ class std::list<cond::ConditionsRootPersistency::Pool>+;
+//#pragma link C++ class std::list<cond::ConditionsRootPersistency::IOVPool>+;
+
+#pragma link C++ class cond::ConditionsRootPersistency+;
+
+#endif
+
+#endif /* DD4HEP_CONDITIONS_CONDITIONSDICTIONARY_H  */

--- a/DDCond/src/ConditionsRootPersistency.cpp
+++ b/DDCond/src/ConditionsRootPersistency.cpp
@@ -1,0 +1,255 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/Printout.h"
+#include "DDCond/ConditionsSlice.h"
+#include "DDCond/ConditionsIOVPool.h"
+#include "DDCond/ConditionsRootPersistency.h"
+
+#include "TFile.h"
+#include "TTimeStamp.h"
+
+typedef dd4hep::cond::ConditionsRootPersistency __ConditionsRootPersistency;
+ClassImp(__ConditionsRootPersistency)
+
+
+using namespace std;
+using namespace dd4hep;
+using namespace dd4hep::cond;
+
+namespace  {
+  /// Helper to select conditions
+  /*
+   *  \author  M.Frank
+   *  \version 1.0
+   *  \ingroup DD4HEP_CONDITIONS
+   */
+  struct Scanner : public Condition::Processor   {
+    ConditionsRootPersistency::pool_type& pool;
+    /// Constructor
+    Scanner(ConditionsRootPersistency::pool_type& p) : pool(p) {}
+    /// Conditions callback for object processing
+    virtual int process(Condition c)  const override  {
+      pool.push_back(c.ptr());
+      return 1;
+    }
+  };
+  struct DurationStamp  {
+    TTimeStamp start;
+    ConditionsRootPersistency* object = 0;
+    DurationStamp(ConditionsRootPersistency* obj) : object(obj)  {
+    }
+    ~DurationStamp()  {
+      TTimeStamp stop;
+      object->duration = stop.AsDouble()-start.AsDouble();
+    }
+  };
+}
+
+/// Default constructor
+ConditionsRootPersistency::ConditionsRootPersistency() : TNamed()   {
+}
+
+/// Initializing constructor
+ConditionsRootPersistency::ConditionsRootPersistency(const string& name, const string& title)
+  : TNamed(name.c_str(), title.c_str())
+{
+}
+
+/// Default destructor
+ConditionsRootPersistency::~ConditionsRootPersistency()    {
+  clear();
+}
+
+/// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+size_t ConditionsRootPersistency::add(const string& identifier, ConditionsPool& pool)    {
+  DurationStamp stamp(this);
+  conditionPools.push_back(pair<iov_key_type, pool_type>());
+  pool_type&    ent = conditionPools.back().second;
+  iov_key_type& key = conditionPools.back().first;
+  const IOV*    iov = pool.iov;
+  key.first         = identifier;
+  key.second.first  = make_pair(iov->iovType->name,iov->type);
+  key.second.second = iov->key();
+  pool.select_all(ent);
+  for(auto c : ent) c.ptr()->addRef();
+  return ent.size();
+}
+
+/// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+size_t ConditionsRootPersistency::add(const string& identifier, const ConditionsIOVPool& pool)    {
+  size_t count = 0;
+  DurationStamp stamp(this);
+  for( const auto& p : pool.elements )  {
+    iovPools.push_back(pair<iov_key_type, pool_type>());
+    pool_type&    ent = iovPools.back().second;
+    iov_key_type& key = iovPools.back().first;
+    const IOV*    iov = p.second->iov;
+    key.first         = identifier;
+    key.second.first  = make_pair(iov->iovType->name,iov->type);
+    key.second.second = p.first;
+    p.second->select_all(ent);
+    for(auto c : ent) c.ptr()->addRef();
+    count += ent.size();
+  }
+  return count;
+}
+
+/// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+size_t ConditionsRootPersistency::add(const string& identifier, const UserPool& pool)    {
+  DurationStamp stamp(this);
+  userPools.push_back(pair<iov_key_type, pool_type>());
+  pool_type&    ent = userPools.back().second;
+  iov_key_type& key = userPools.back().first;
+  const IOV&    iov = pool.validity();
+  key.first         = identifier;
+  key.second.first  = make_pair(iov.iovType->name,iov.type);
+  key.second.second = iov.key();
+  pool.scan(Scanner(ent));
+  for(auto c : ent) c.ptr()->addRef();
+  return ent.size();
+}
+
+/// Open ROOT file in read mode
+TFile* ConditionsRootPersistency::openFile(const string& fname)     {
+  TDirectory::TContext context;
+  TFile* file = TFile::Open(fname.c_str());
+  if ( file && !file->IsZombie()) return file;
+  except("ConditionsRootPersistency","+++ FAILED to open ROOT file %s in read-mode.",fname.c_str());
+  return 0;
+}
+
+/// Clear object content and release allocated memory
+void ConditionsRootPersistency::_clear(persistent_type& pool)  {
+  /// Cleanup all the stuff not useful....
+  for (auto& p : pool )  {
+    for(Condition c : p.second )
+      c.ptr()->release();
+    p.second.clear();
+  }
+  pool.clear();
+}
+
+/// Clear object content and release allocated memory
+void ConditionsRootPersistency::clear()  {
+  /// Cleanup all the stuff not useful....
+  _clear(conditionPools);
+  _clear(userPools);
+  _clear(iovPools);
+}
+
+/// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
+std::unique_ptr<ConditionsRootPersistency>
+ConditionsRootPersistency::load(TFile* file,const string& obj)   {
+  std::unique_ptr<ConditionsRootPersistency> p;
+  if ( file && !file->IsZombie())    {
+    TTimeStamp start;
+    p.reset((ConditionsRootPersistency*)file->Get(obj.c_str()));
+    TTimeStamp stop;
+    if ( p.get() )    {
+      p->duration = stop.AsDouble()-start.AsDouble();
+      return p;
+    }
+    except("ConditionsRootPersistency",
+           "+++ FAILED to load object %s from file %s",
+           obj.c_str(), file->GetName());
+  }
+  except("ConditionsRootPersistency",
+         "+++ FAILED to load object %s from file [Invalid file]",obj.c_str());
+  return p;
+}
+
+/// Load ConditionsPool(s) and populate conditions manager
+size_t ConditionsRootPersistency::_import(persistent_type&   persistent_pools,
+                                          const std::string& id,
+                                          const std::string& iov_type,
+                                          ConditionsManager mgr)   {
+  size_t count = 0;
+  std::pair<bool,const IOVType*> iovTyp(false,0);
+  for (auto& iovp : persistent_pools )   {
+    const iov_key_type& key = iovp.first;
+    if ( !(id.empty() || id=="*" || key.first == id) )
+      continue;
+    if ( !(iov_type.empty() || iov_type == "*" || key.second.first.first == iov_type) )
+      continue;
+    iovTyp = mgr.registerIOVType(key.second.first.second,key.second.first.first);
+    if ( iovTyp.second )   {
+      ConditionsPool* pool = mgr.registerIOV(*iovTyp.second, key.second.second);
+      for (Condition c : iovp.second)   {
+        Condition::Object* o = c.ptr();
+        o->iov = pool->iov;
+        if ( pool->insert(o->addRef()) )    {
+          //printout(WARNING,"ConditionsRootPersistency","%p: [%016llX] %s -> %s",
+          //         o, o->hash,o->GetName(),o->data.str().c_str());
+          ++count;
+        }
+        else   {
+          printout(WARNING,"ConditionsRootPersistency",
+                   "+++ Ignore condition %s from %s iov:%s [Already present]",
+                   c.name(),id.c_str(), iov_type.c_str());
+        }
+      }
+    }
+  }
+  return count;
+}
+
+/// Load ConditionsIOVPool and populate conditions manager
+size_t ConditionsRootPersistency::importIOVPool(const std::string& identifier,
+                                                const std::string& iov_type,
+                                                ConditionsManager  mgr)
+{
+  DurationStamp stamp(this);
+  return _import(iovPools,identifier,iov_type,mgr);
+}
+
+/// Load ConditionsIOVPool and populate conditions manager
+size_t ConditionsRootPersistency::importUserPool(const std::string& identifier,
+                                                 const std::string& iov_type,
+                                                 ConditionsManager  mgr)
+{
+  DurationStamp stamp(this);
+  return _import(userPools,identifier,iov_type,mgr);
+}
+
+/// Load ConditionsIOVPool and populate conditions manager
+size_t ConditionsRootPersistency::importConditionsPool(const std::string& identifier,
+                                                       const std::string& iov_type,
+                                                       ConditionsManager  mgr)
+{
+  DurationStamp stamp(this);
+  return _import(conditionPools,identifier,iov_type,mgr);
+}
+
+/// Save the data content to a root file
+int ConditionsRootPersistency::save(TFile* file)    {
+  DurationStamp stamp(this);
+  //TDirectory::TContext context;
+  int nBytes = file->WriteTObject(this,GetName());
+  return nBytes;
+}
+
+/// Save the data content to a root file
+int ConditionsRootPersistency::save(const string& fname)    {
+  DurationStamp stamp(this);
+  //TDirectory::TContext context;
+  TFile* file = TFile::Open(fname.c_str(),"RECREATE");
+  if ( file && !file->IsZombie())   {
+    int nBytes = save(file);
+    file->Close();
+    delete file;
+    return nBytes;
+  }
+  return -1;
+}

--- a/DDCond/src/plugins/ConditionsUserPool.cpp
+++ b/DDCond/src/plugins/ConditionsUserPool.cpp
@@ -437,10 +437,10 @@ size_t ConditionsMappedUserPool<MAPPING>::compute(const Dependencies& deps,
 
 namespace {
   struct COMP {
-    typedef pair<Condition::key_type,const ConditionDependency*> Dep;
-    typedef pair<const Condition::key_type,detail::ConditionObject*>   Cond;
-    typedef pair<const Condition::key_type,ConditionsLoadInfo* >   Info;
-    typedef pair<const Condition::key_type,Condition>   Cond2;
+    typedef pair<Condition::key_type,const ConditionDependency*>     Dep;
+    typedef pair<const Condition::key_type,detail::ConditionObject*> Cond;
+    typedef pair<const Condition::key_type,ConditionsLoadInfo* >     Info;
+    typedef pair<const Condition::key_type,Condition>                Cond2;
     
     bool operator()(const Dep& a,const Cond& b) const { return a.first < b.first; }
     bool operator()(const Cond& a,const Dep& b) const { return a.first < b.first; }
@@ -498,7 +498,12 @@ ConditionsMappedUserPool<MAPPING>::prepare(const IOV&              required,
   printout(num_calc_miss==0 ? DEBUG : INFO,"UserPool",
            "Found %ld missing derived conditions out of %ld conditions.",
            num_calc_miss, slice_calc.size());
-
+#if 0
+  auto iter = begin(calc_missing);
+  for(auto i=0; i<num_calc_miss; ++i, ++iter)   {
+    printout(INFO,""," Missing derived: %016llX -> %s",(*iter).first,(*iter).second->target.name.c_str());
+  }
+#endif
   result.loaded   = 0;
   result.computed = 0;
   result.selected = m_conditions.size();

--- a/DDCore/CMakeLists.txt
+++ b/DDCore/CMakeLists.txt
@@ -23,6 +23,7 @@ dd4hep_add_dictionary( G__DD4hep
   include/DD4hep/detail/*.h
   include/XML/*.h
   src/DetectorImp.h
+  src/RootDictionary.h
   EXCLUDE include/DD4hep/DetFactoryHelper.h
   include/DD4hep/Factories.h
   include/DD4hep/Plugins.h
@@ -34,11 +35,32 @@ dd4hep_add_dictionary( G__DD4hep
   include/XML/tinystring.h
   LINKDEF include/ROOT/LinkDef.h )
 
+#---Generate ROOT dictionary------------------------------------------------------
+dd4hep_add_dictionary( G__DD4hepGeo
+  SOURCES include/ROOT/Warnings.h
+  src/GeoDictionary.h
+  LINKDEF include/ROOT/LinkDef.h )
+
+#---Generate ROOT dictionary------------------------------------------------------
+dd4hep_add_dictionary( G__DD4hepProperties
+  SOURCES include/ROOT/Warnings.h
+  src/PropertyDictionary.h
+  LINKDEF include/ROOT/LinkDef.h )
+
+#---Generate ROOT dictionary------------------------------------------------------
+dd4hep_add_dictionary( G__DD4hepSegmentations
+  SOURCES include/ROOT/Warnings.h
+  src/SegmentationDictionary.h
+  LINKDEF include/ROOT/LinkDef.h )
+
 #---Generate DDCore Library-------------------------------------------------------
 dd4hep_add_package_library ( DDCore
   SOURCES        src/*.cpp src/segmentations/*.cpp src/XML/*.cpp
   OPTIONAL       [BOOST SOURCES src/JSON/*.cpp]
-  GENERATED      G__DD4hep.cxx 
+  GENERATED      G__DD4hep.cxx
+  G__DD4hepProperties.cxx
+  G__DD4hepSegmentations.cxx
+  G__DD4hepGeo.cxx
   INCLUDE_DIRS   ${GaudiPluginService_INCLUDE_DIRS}
   LINK_LIBRARIES DDParsers ${GaudiPluginService_LIBRARIES}
   )

--- a/DDCore/include/DD4hep/ComponentProperties.h
+++ b/DDCore/include/DD4hep/ComponentProperties.h
@@ -10,7 +10,6 @@
 // Author     : M.Frank
 //
 //==========================================================================
-
 #ifndef DD4HEP_DDG4_COMPONENTPROPERTIES_H
 #define DD4HEP_DDG4_COMPONENTPROPERTIES_H
 
@@ -36,7 +35,7 @@ namespace dd4hep {
    *
    *  \author  M.Frank
    *  \version 1.0
-   *  \ingroup DD4HEP_SIMULATION
+   *  \ingroup DD4HEP_CORE
    */
   class PropertyConfigurator {
   protected:
@@ -49,14 +48,16 @@ namespace dd4hep {
 
   /// Class describing the grammar representation of a given data type
   /**
+   *  Note: This class cannot be saved to a ROOT file!
+   *
    *  \author  M.Frank
    *  \version 1.0
-   *  \ingroup DD4HEP_SIMULATION
+   *  \ingroup DD4HEP_CORE
    */
   class PropertyGrammar {
   protected:
     friend class Property;
-    const BasicGrammar& m_grammar;
+    const BasicGrammar& m_grammar;  //! This member is not ROOT persistent as the entire class is not.
   public:
     /// Default constructor
     PropertyGrammar(const BasicGrammar& g);
@@ -82,9 +83,11 @@ namespace dd4hep {
    *   between types, which are initially unrelated such as
    *   e.g. vector<int> and list<short>.
    *
+   *  Note: This class cannot be saved to a ROOT file!
+   *
    *  \author  M.Frank
    *  \version 1.0
-   *  \ingroup DD4HEP_SIMULATION
+   *  \ingroup DD4HEP_CORE
    */
   class Property {
   protected:
@@ -138,9 +141,11 @@ namespace dd4hep {
 
   /// Concrete template instantiation of a combined property value pair.
   /**
+   *  Note: This class cannot be saved to a ROOT file!
+   *
    *  \author  M.Frank
    *  \version 1.0
-   *  \ingroup DD4HEP_SIMULATION
+   *  \ingroup DD4HEP_CORE
    */
   template <class TYPE> class PropertyValue : private Property {
   public:
@@ -170,9 +175,11 @@ namespace dd4hep {
 
   /// Manager to ease the handling of groups of properties.
   /**
+   *  Note: This class cannot be saved to a ROOT file!
+   *
    *  \author  M.Frank
    *  \version 1.0
-   *  \ingroup DD4HEP_SIMULATION
+   *  \ingroup DD4HEP_CORE
    */
   class PropertyManager {
   public:
@@ -230,6 +237,8 @@ namespace dd4hep {
 
   /// Property object as base class for all objects supporting properties
   /** 
+   *  Note: This class cannot be saved to a ROOT file!
+   *
    *  \author  M.Frank
    *  \version 1.0
    */

--- a/DDCore/include/DD4hep/ConditionDerived.h
+++ b/DDCore/include/DD4hep/ConditionDerived.h
@@ -71,6 +71,8 @@ namespace dd4hep {
                              const ConditionDependency& d,
                              void* parameter,
                              IOV& iov);
+      /// Throw exception on conditions access failure
+      void accessFailure(const ConditionKey& key_value)  const;
       /// Access to dependency keys
       const ConditionKey& key(size_t which)  const;
       /// Access to condition object by dependency index
@@ -90,7 +92,8 @@ namespace dd4hep {
           iov->iov_intersection(cond.iov());
           return data;
         }
-        throw std::runtime_error("ConditionUpdateCall: Failed to access non-existing item:"+key_value.name);
+        accessFailure(key_value);
+        throw std::runtime_error("ConditionUpdateCall");
       }
       /// Access of other conditions data from the resolver
       template<typename T> const T& get(const ConditionKey& key_value)  const {
@@ -101,7 +104,8 @@ namespace dd4hep {
           iov->iov_intersection(cond.iov());
           return data;
         }
-        throw std::runtime_error("ConditionUpdateCall: Failed to access non-existing item:"+key_value.name);
+        accessFailure(key_value);
+        throw std::runtime_error("ConditionUpdateCall");
       }
       /// Access of other conditions data from the resolver
       template<typename T> T& get(size_t key_id)  {

--- a/DDCore/include/DD4hep/Conditions.h
+++ b/DDCore/include/DD4hep/Conditions.h
@@ -408,7 +408,6 @@ namespace dd4hep {
 
   // Utility type definitions
   typedef std::vector<Condition>          RangeConditions;
-  typedef std::pair<RangeConditions,bool> RangeStatus;
-
+  
 }          /* End namespace dd4hep                   */
-#endif     /* DD4HEP_DDCORE_CONDITIONS_H         */
+#endif     /* DD4HEP_DDCORE_CONDITIONS_H             */

--- a/DDCore/include/DD4hep/detail/ConditionsInterna.h
+++ b/DDCore/include/DD4hep/detail/ConditionsInterna.h
@@ -58,29 +58,33 @@ namespace dd4hep {
     class ConditionObject : public NamedObject {
     public:
       /// Condition value (in string form)
-      std::string     value;
+      std::string          value;
       /// Condition validity (in string form)
-      std::string     validity;
+      std::string          validity;
       /// Condition address
-      std::string     address;
+      std::string          address;
       /// Comment string
-      std::string     comment;
+      std::string          comment;
       /// Data block
-      OpaqueDataBlock data;
+      OpaqueDataBlock      data;
       /// Interval of validity
-      const IOV* iov   = 0;     //! No ROOT persistency
+      const IOV*           iov   = 0;     //! No ROOT persistency
       /// Hash value of the name
       Condition::key_type  hash  = 0;
       /// Flags
       Condition::mask_type flags = 0;
       /// Reference count
-      int             refCount = 0;
+      int                  refCount = 1;
       /// Default constructor
       ConditionObject();
       /// Standard constructor
       ConditionObject(const std::string& nam,const std::string& tit="");
       /// Standard Destructor
       virtual ~ConditionObject();
+      /// Increase reference counter (Used by persistency mechanism)
+      ConditionObject* addRef()  {  ++refCount; return this;         }
+      /// Release object (Used by persistency mechanism)
+      void release();
       /// Data offset from the opaque data block pointer to the condition
       static size_t offset();
       /// Move data content: 'from' will be reset to NULL

--- a/DDCore/include/ROOT/Warnings.h
+++ b/DDCore/include/ROOT/Warnings.h
@@ -28,3 +28,12 @@
 #pragma clang diagnostic ignored "-Wunused"
 #pragma clang diagnostic ignored "-Woverlength-strings"
 #endif
+
+#if defined(__CINT__) || defined(__MAKECINT__) || defined(__CLANG__) || defined(__ROOTCLING__)
+#define  DD4HEP_DICTIONARY_MODE 1
+#endif
+
+#if defined(G__DICTIONARY) && defined(G__ROOT)
+#define  DD4HEP_DICTIONARY_CODE 1
+#endif
+

--- a/DDCore/src/ConditionDerived.cpp
+++ b/DDCore/src/ConditionDerived.cpp
@@ -35,6 +35,13 @@ ConditionUpdateCall::~ConditionUpdateCall()  {
 ConditionResolver::~ConditionResolver()  {
 }
 
+/// Throw exception on conditions access failure
+void ConditionUpdateContext::accessFailure(const ConditionKey& key_value)  const   {
+  except("ConditionUpdateCall",
+         "%s [%016llX]: FAILED to access non-existing item:%s [%016llX]",
+         dependency.target.name, dependency.target.hash, key_value.name, key_value.hash);
+}
+
 /// Initializing constructor
 ConditionDependency::ConditionDependency(DetElement de,
                                          unsigned int         item_key,

--- a/DDCore/src/ConditionDerived.cpp
+++ b/DDCore/src/ConditionDerived.cpp
@@ -39,7 +39,8 @@ ConditionResolver::~ConditionResolver()  {
 void ConditionUpdateContext::accessFailure(const ConditionKey& key_value)  const   {
   except("ConditionUpdateCall",
          "%s [%016llX]: FAILED to access non-existing item:%s [%016llX]",
-         dependency.target.name, dependency.target.hash, key_value.name, key_value.hash);
+         dependency.target.name.c_str(), dependency.target.hash,
+         key_value.name.c_str(), key_value.hash);
 }
 
 /// Initializing constructor

--- a/DDCore/src/ConditionsInterna.cpp
+++ b/DDCore/src/ConditionsInterna.cpp
@@ -52,6 +52,11 @@ detail::ConditionObject::~ConditionObject()  {
   InstanceCount::decrement(this);
 }
 
+/// Release object (Used by persistency mechanism)
+void detail::ConditionObject::release()  {
+  if ( --refCount <= 0 ) delete this;
+}
+
 /// Data offset from the opaque data block pointer to the condition
 size_t detail::ConditionObject::offset()   {
   static _P p((void*)0x1000);

--- a/DDCore/src/GeoDictionary.h
+++ b/DDCore/src/GeoDictionary.h
@@ -1,0 +1,126 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//  RootDictionary.h
+//
+//
+//  M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_DDCORE_ROOTDICTIONARY_H
+#define DD4HEP_DDCORE_ROOTDICTIONARY_H
+
+// Framework include files
+#include "DD4hep/Volumes.h"
+#include "DD4hep/Shapes.h"
+
+// C/C++ include files
+#include <vector>
+#include <map>
+#include <string>
+
+// -------------------------------------------------------------------------
+// Regular dd4hep dictionaries
+// -------------------------------------------------------------------------
+#ifdef DD4HEP_DICTIONARY_MODE
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+using namespace std;
+
+#pragma link C++ namespace dd4hep;
+
+// Volume.h
+#pragma link C++ class dd4hep::Volume+;
+#pragma link C++ class dd4hep::VolumeExtension+;
+#pragma link C++ class vector<dd4hep::Volume>+;
+#pragma link C++ class dd4hep::Handle<TGeoVolume>+;
+
+#pragma link C++ class dd4hep::PlacedVolume+;
+#ifndef __ROOTCLING__
+template vector<pair<string, int> >;
+template vector<pair<string, int> >::iterator;
+#endif
+#pragma link C++ class vector<pair<string, int> >+;
+#pragma link C++ class vector<pair<string, int> >::iterator;
+#pragma link C++ class dd4hep::PlacedVolumeExtension::VolIDs+;
+#pragma link C++ class dd4hep::PlacedVolumeExtension+;
+#pragma link C++ class vector<dd4hep::PlacedVolume>+;
+#pragma link C++ class dd4hep::Handle<TGeoNode>+;
+#pragma link C++ class vector<TGeoNode*>+;
+#pragma link C++ class vector<TGeoVolume*>+;
+
+
+// Shapes.h
+#pragma link C++ class dd4hep::Handle<TGeoShape>+;
+#pragma link C++ class dd4hep::Solid_type<TGeoShape>+;
+
+#pragma link C++ class dd4hep::Polycone+;
+#pragma link C++ class dd4hep::Solid_type<TGeoPcon>+;
+#pragma link C++ class dd4hep::Handle<TGeoPcon>+;
+
+#pragma link C++ class dd4hep::ConeSegment+;
+#pragma link C++ class dd4hep::Solid_type<TGeoConeSeg>+;
+#pragma link C++ class dd4hep::Handle<TGeoConeSeg>+;
+
+#pragma link C++ class dd4hep::Box+;
+#pragma link C++ class dd4hep::Solid_type<TGeoBBox>+;
+#pragma link C++ class dd4hep::Handle<TGeoBBox>+;
+
+#pragma link C++ class dd4hep::Torus+;
+#pragma link C++ class dd4hep::Solid_type<TGeoTorus>+;
+#pragma link C++ class dd4hep::Handle<TGeoTorus>+;
+
+#pragma link C++ class dd4hep::Cone+;
+#pragma link C++ class dd4hep::Solid_type<TGeoCone>+;
+#pragma link C++ class dd4hep::Handle<TGeoCone>+;
+
+#pragma link C++ class dd4hep::Tube+;
+#pragma link C++ class dd4hep::Solid_type<TGeoTubeSeg>+;
+#pragma link C++ class dd4hep::Handle<TGeoTubeSeg>+;
+
+#pragma link C++ class dd4hep::EllipticalTube+;
+#pragma link C++ class dd4hep::Solid_type<TGeoEltu>+;
+#pragma link C++ class dd4hep::Handle<TGeoEltu>+;
+
+#pragma link C++ class dd4hep::Trap+;
+#pragma link C++ class dd4hep::Solid_type<TGeoTrap>+;
+#pragma link C++ class dd4hep::Handle<TGeoTrap>+;
+
+#pragma link C++ class dd4hep::Trapezoid+;
+#pragma link C++ class dd4hep::Solid_type<TGeoTrd2>+;
+#pragma link C++ class dd4hep::Handle<TGeoTrd2>+;
+
+#pragma link C++ class dd4hep::Sphere+;
+#pragma link C++ class dd4hep::Solid_type<TGeoSphere>+;
+#pragma link C++ class dd4hep::Handle<TGeoSphere>+;
+
+#pragma link C++ class dd4hep::Paraboloid+;
+#pragma link C++ class dd4hep::Solid_type<TGeoParaboloid>+;
+#pragma link C++ class dd4hep::Handle<TGeoParaboloid>+;
+
+#pragma link C++ class dd4hep::Hyperboloid+;
+#pragma link C++ class dd4hep::Solid_type<TGeoHype>+;
+#pragma link C++ class dd4hep::Handle<TGeoHype>+;
+
+#pragma link C++ class dd4hep::PolyhedraRegular+;
+#pragma link C++ class dd4hep::Solid_type<TGeoPgon>+;
+#pragma link C++ class dd4hep::Handle<TGeoPgon>+;
+
+#pragma link C++ class dd4hep::BooleanSolid+;
+#pragma link C++ class dd4hep::Solid_type<TGeoCompositeShape>+;
+#pragma link C++ class dd4hep::Handle<TGeoCompositeShape>+;
+
+#pragma link C++ class dd4hep::SubtractionSolid+;
+#pragma link C++ class dd4hep::UnionSolid+;
+#pragma link C++ class dd4hep::IntersectionSolid+;
+
+#endif  // __CINT__
+#endif  /* DD4HEP_DDCORE_ROOTDICTIONARY_H  */

--- a/DDCore/src/PropertyDictionary.h
+++ b/DDCore/src/PropertyDictionary.h
@@ -1,0 +1,104 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// PropertyDictionary.h
+//
+//
+// M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_DDCORE_PROPERTYDICTIONARY_H
+#define DD4HEP_DDCORE_PROPERTYDICTIONARY_H
+
+// Framework include files
+#include "DD4hep/ComponentProperties.h"
+
+// C/C++ include files
+#include <vector>
+#include <map>
+#include <string>
+
+#include "TRint.h"
+namespace dd4hep {
+  namespace detail {}
+}
+
+// -------------------------------------------------------------------------
+// Regular dd4hep dictionaries
+// -------------------------------------------------------------------------
+#ifdef DD4HEP_DICTIONARY_MODE
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+using namespace std;
+
+#pragma link C++ class dd4hep::Property;
+#if defined(DD4HEP_HAVE_ALL_PARSERS)
+#pragma link C++ class dd4hep::PropertyValue<char>-;
+#pragma link C++ class dd4hep::PropertyValue<unsigned char>-;
+#pragma link C++ class dd4hep::PropertyValue<short>-;
+#pragma link C++ class dd4hep::PropertyValue<unsigned short>-;
+#pragma link C++ class dd4hep::PropertyValue<unsigned int>-;
+#pragma link C++ class dd4hep::PropertyValue<long>-;
+#pragma link C++ class dd4hep::PropertyValue<unsigned long>-;
+
+#pragma link C++ class dd4hep::PropertyValue<std::vector<char> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::vector<unsigned char> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::vector<short> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::vector<unsigned short> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::vector<unsigned int> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::vector<long> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::vector<unsigned long> >-;
+
+#pragma link C++ class dd4hep::PropertyValue<std::list<char> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::list<unsigned char> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::list<short> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::list<unsigned short> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::list<unsigned int> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::list<long> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::list<unsigned long> >-;
+
+#pragma link C++ class dd4hep::PropertyValue<std::set<char> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::set<unsigned char> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::set<short> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::set<unsigned short> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::set<unsigned int> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::set<long> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::set<unsigned long> >-;
+#endif
+
+#pragma link C++ class dd4hep::PropertyValue<int>-;
+#pragma link C++ class dd4hep::PropertyValue<float>-;
+#pragma link C++ class dd4hep::PropertyValue<double>-;
+#pragma link C++ class dd4hep::PropertyValue<std::string>-;
+
+#pragma link C++ class dd4hep::PropertyValue<std::vector<int> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::vector<float> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::vector<double> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::vector<std::string> >-;
+
+#pragma link C++ class dd4hep::PropertyValue<std::list<int> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::list<float> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::list<double> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::list<std::string> >-;
+
+#pragma link C++ class dd4hep::PropertyValue<std::set<int> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::set<float> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::set<double> >-;
+#pragma link C++ class dd4hep::PropertyValue<std::set<std::string> >-;
+
+#pragma link C++ class std::map<std::string, dd4hep::Property>-;
+#pragma link C++ class PropertyManager-;
+#pragma link C++ class PropertyConfigurable-;
+#pragma link C++ class dd4hep::PropertyConfigurator-;
+#pragma link C++ class dd4hep::PropertyGrammar-;
+
+#endif  // __CINT__
+#endif  /* DD4HEP_DDCORE_PROPERTYDICTIONARY_H  */

--- a/DDCore/src/RootDictionary.h
+++ b/DDCore/src/RootDictionary.h
@@ -7,14 +7,14 @@
 // For the licensing terms see $DD4hepINSTALL/LICENSE.
 // For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 //
-//  LinkDef.h
+//  RootDictionary.h
 //
 //
-//  Created by Pere Mato on 22/1/12.
+//  M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_DICTIONARY_H
-#define DD4HEP_DDCORE_DICTIONARY_H
+#ifndef DD4HEP_DDCORE_ROOTDICTIONARY_H
+#define DD4HEP_DDCORE_ROOTDICTIONARY_H
 
 // Framework include files
 #include "DDParsers/Evaluator.h"
@@ -33,6 +33,7 @@
 #include "DD4hep/Conditions.h"
 #include "DD4hep/Alignments.h"
 #include "DD4hep/FieldTypes.h"
+#include "DD4hep/ComponentProperties.h"
 
 // C/C++ include files
 #include <vector>
@@ -61,7 +62,7 @@ namespace dd4hep   {   namespace Parsers   {
 // -------------------------------------------------------------------------
 // Regular dd4hep dictionaries
 // -------------------------------------------------------------------------
-#if defined(__CINT__) || defined(__MAKECINT__) || defined(__CLING__) || defined(__ROOTCLING__)
+#ifdef DD4HEP_DICTIONARY_MODE
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
@@ -263,93 +264,6 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::Handle<dd4hep::SensitiveDetectorObject>+;
 #pragma link C++ class vector<dd4hep::SensitiveDetector>+;
 
-// Volume.h
-#pragma link C++ class dd4hep::Volume+;
-#pragma link C++ class dd4hep::VolumeExtension+;
-#pragma link C++ class vector<dd4hep::Volume>+;
-#pragma link C++ class dd4hep::Handle<TGeoVolume>+;
-
-#pragma link C++ class dd4hep::PlacedVolume+;
-#ifndef __ROOTCLING__
-template vector<pair<string, int> >;
-template vector<pair<string, int> >::iterator;
-#endif
-#pragma link C++ class vector<pair<string, int> >+;
-#pragma link C++ class vector<pair<string, int> >::iterator;
-#pragma link C++ class dd4hep::PlacedVolumeExtension::VolIDs+;
-#pragma link C++ class dd4hep::PlacedVolumeExtension+;
-#pragma link C++ class vector<dd4hep::PlacedVolume>+;
-#pragma link C++ class dd4hep::Handle<TGeoNode>+;
-#pragma link C++ class vector<TGeoNode*>+;
-#pragma link C++ class vector<TGeoVolume*>+;
-
-
-// Shapes.h
-#pragma link C++ class dd4hep::Handle<TGeoShape>+;
-#pragma link C++ class dd4hep::Solid_type<TGeoShape>+;
-
-#pragma link C++ class dd4hep::Polycone+;
-#pragma link C++ class dd4hep::Solid_type<TGeoPcon>+;
-#pragma link C++ class dd4hep::Handle<TGeoPcon>+;
-
-#pragma link C++ class dd4hep::ConeSegment+;
-#pragma link C++ class dd4hep::Solid_type<TGeoConeSeg>+;
-#pragma link C++ class dd4hep::Handle<TGeoConeSeg>+;
-
-#pragma link C++ class dd4hep::Box+;
-#pragma link C++ class dd4hep::Solid_type<TGeoBBox>+;
-#pragma link C++ class dd4hep::Handle<TGeoBBox>+;
-
-#pragma link C++ class dd4hep::Torus+;
-#pragma link C++ class dd4hep::Solid_type<TGeoTorus>+;
-#pragma link C++ class dd4hep::Handle<TGeoTorus>+;
-
-#pragma link C++ class dd4hep::Cone+;
-#pragma link C++ class dd4hep::Solid_type<TGeoCone>+;
-#pragma link C++ class dd4hep::Handle<TGeoCone>+;
-
-#pragma link C++ class dd4hep::Tube+;
-#pragma link C++ class dd4hep::Solid_type<TGeoTubeSeg>+;
-#pragma link C++ class dd4hep::Handle<TGeoTubeSeg>+;
-
-#pragma link C++ class dd4hep::EllipticalTube+;
-#pragma link C++ class dd4hep::Solid_type<TGeoEltu>+;
-#pragma link C++ class dd4hep::Handle<TGeoEltu>+;
-
-#pragma link C++ class dd4hep::Trap+;
-#pragma link C++ class dd4hep::Solid_type<TGeoTrap>+;
-#pragma link C++ class dd4hep::Handle<TGeoTrap>+;
-
-#pragma link C++ class dd4hep::Trapezoid+;
-#pragma link C++ class dd4hep::Solid_type<TGeoTrd2>+;
-#pragma link C++ class dd4hep::Handle<TGeoTrd2>+;
-
-#pragma link C++ class dd4hep::Sphere+;
-#pragma link C++ class dd4hep::Solid_type<TGeoSphere>+;
-#pragma link C++ class dd4hep::Handle<TGeoSphere>+;
-
-#pragma link C++ class dd4hep::Paraboloid+;
-#pragma link C++ class dd4hep::Solid_type<TGeoParaboloid>+;
-#pragma link C++ class dd4hep::Handle<TGeoParaboloid>+;
-
-#pragma link C++ class dd4hep::Hyperboloid+;
-#pragma link C++ class dd4hep::Solid_type<TGeoHype>+;
-#pragma link C++ class dd4hep::Handle<TGeoHype>+;
-
-#pragma link C++ class dd4hep::PolyhedraRegular+;
-#pragma link C++ class dd4hep::Solid_type<TGeoPgon>+;
-#pragma link C++ class dd4hep::Handle<TGeoPgon>+;
-
-#pragma link C++ class dd4hep::BooleanSolid+;
-#pragma link C++ class dd4hep::Solid_type<TGeoCompositeShape>+;
-#pragma link C++ class dd4hep::Handle<TGeoCompositeShape>+;
-
-#pragma link C++ class dd4hep::SubtractionSolid+;
-#pragma link C++ class dd4hep::UnionSolid+;
-#pragma link C++ class dd4hep::IntersectionSolid+;
-
-
-
 #pragma link C++ class pair<string, string>+;
 #pragma link C++ class map<string, string>+;
 #pragma link C++ class map<string, string>::iterator;
@@ -383,79 +297,4 @@ template vector<pair<string, int> >::iterator;
 #pragma link C++ class dd4hep::cond::AbstractMap::Params+;
 
 #endif  // __CINT__
-
-
-// -------------------------------------------------------------------------
-// DDSegmentation dictionaries
-#define __HAVE_DDSEGMENTATION__
-// -------------------------------------------------------------------------
-#ifdef __HAVE_DDSEGMENTATION__
-#include "DDSegmentation/Segmentation.h"
-#include "DDSegmentation/NoSegmentation.h"
-#include "DDSegmentation/CartesianGrid.h"
-#include "DDSegmentation/CartesianGridXY.h"
-#include "DDSegmentation/CartesianGridXYZ.h"
-#include "DDSegmentation/CartesianGridXZ.h"
-#include "DDSegmentation/CartesianGridYZ.h"
-#include "DDSegmentation/CylindricalSegmentation.h"
-#include "DDSegmentation/GridPhiEta.h"
-#include "DDSegmentation/GridRPhiEta.h"
-#include "DDSegmentation/MegatileLayerGridXY.h"
-#include "DDSegmentation/MultiSegmentation.h"
-#include "DDSegmentation/NoSegmentation.h"
-#include "DDSegmentation/PolarGrid.h"
-#include "DDSegmentation/PolarGridRPhi2.h"
-#include "DDSegmentation/PolarGridRPhi.h"
-#include "DDSegmentation/ProjectiveCylinder.h"
-
-#include "DDSegmentation/SegmentationParameter.h"
-#include "DDSegmentation/TiledLayerGridXY.h"
-#include "DDSegmentation/TiledLayerSegmentation.h"
-#include "DDSegmentation/WaferGridXY.h"
-typedef dd4hep::DDSegmentation::VolumeID VolumeID;
-typedef dd4hep::DDSegmentation::CellID CellID;
-
-#if defined(__CINT__) || defined(__MAKECINT__) || defined(__CLANG__) || defined(__ROOTCLING__)
-#pragma link C++ class dd4hep::DDSegmentation::SegmentationParameter+;
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<int>+;
-
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<float>+;
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<double>+;
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<string>+;
-#pragma link C++ class map<string,dd4hep::DDSegmentation::TypedSegmentationParameter<string>* >+;
-#pragma link C++ class map<string,dd4hep::DDSegmentation::TypedSegmentationParameter<double>* >+;
-#pragma link C++ class map<string,dd4hep::DDSegmentation::TypedSegmentationParameter<float>* >+;
-
-/// Severe problem due to template specialization!
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<int> >+;
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<float> >+;
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<double> >+;
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<string> >+;
-
-#pragma link C++ class dd4hep::DDSegmentation::Segmentation+;
-#pragma link C++ class dd4hep::DDSegmentation::CartesianGrid+;
-#pragma link C++ class dd4hep::DDSegmentation::CartesianGridXY+;
-#pragma link C++ class dd4hep::DDSegmentation::CartesianGridXYZ+;
-#pragma link C++ class dd4hep::DDSegmentation::CartesianGridXZ+;
-#pragma link C++ class dd4hep::DDSegmentation::CartesianGridYZ+;
-#pragma link C++ class dd4hep::DDSegmentation::CylindricalSegmentation+;
-#pragma link C++ class dd4hep::DDSegmentation::GridPhiEta+;
-#pragma link C++ class dd4hep::DDSegmentation::GridRPhiEta+;
-#pragma link C++ class dd4hep::DDSegmentation::MegatileLayerGridXY+;
-#pragma link C++ class dd4hep::DDSegmentation::MultiSegmentation+;
-#pragma link C++ class dd4hep::DDSegmentation::NoSegmentation+;
-#pragma link C++ class dd4hep::DDSegmentation::PolarGrid+;
-#pragma link C++ class dd4hep::DDSegmentation::PolarGridRPhi2+;
-#pragma link C++ class dd4hep::DDSegmentation::PolarGridRPhi+;
-#pragma link C++ class dd4hep::DDSegmentation::ProjectiveCylinder+;
-#pragma link C++ class dd4hep::DDSegmentation::TiledLayerGridXY+;
-#pragma link C++ class dd4hep::DDSegmentation::TiledLayerSegmentation+;
-#pragma link C++ class dd4hep::DDSegmentation::WaferGridXY+;
-
-#pragma link C++ class dd4hep::DDSegmentation::BitFieldValue+;
-#pragma link C++ class dd4hep::DDSegmentation::BitField64+;
-
-#endif  // __CINT__
-#endif  // __HAVE_DDSEGMENTATION__
-
-#endif  /* DD4HEP_DDCORE_DICTIONARY_H  */
+#endif  /* DD4HEP_DDCORE_ROOTDICTIONARY_H  */

--- a/DDCore/src/SegmentationDictionary.h
+++ b/DDCore/src/SegmentationDictionary.h
@@ -1,0 +1,93 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//  RootDictionary.h
+//
+//
+//  M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_DDCORE_ROOTDICTIONARY_H
+#define DD4HEP_DDCORE_ROOTDICTIONARY_H
+
+// Framework include files
+#define __HAVE_DDSEGMENTATION__
+// -------------------------------------------------------------------------
+#ifdef __HAVE_DDSEGMENTATION__
+#include "DDSegmentation/Segmentation.h"
+#include "DDSegmentation/NoSegmentation.h"
+#include "DDSegmentation/CartesianGrid.h"
+#include "DDSegmentation/CartesianGridXY.h"
+#include "DDSegmentation/CartesianGridXYZ.h"
+#include "DDSegmentation/CartesianGridXZ.h"
+#include "DDSegmentation/CartesianGridYZ.h"
+#include "DDSegmentation/CylindricalSegmentation.h"
+#include "DDSegmentation/GridPhiEta.h"
+#include "DDSegmentation/GridRPhiEta.h"
+#include "DDSegmentation/MegatileLayerGridXY.h"
+#include "DDSegmentation/MultiSegmentation.h"
+#include "DDSegmentation/NoSegmentation.h"
+#include "DDSegmentation/PolarGrid.h"
+#include "DDSegmentation/PolarGridRPhi2.h"
+#include "DDSegmentation/PolarGridRPhi.h"
+#include "DDSegmentation/ProjectiveCylinder.h"
+
+#include "DDSegmentation/SegmentationParameter.h"
+#include "DDSegmentation/TiledLayerGridXY.h"
+#include "DDSegmentation/TiledLayerSegmentation.h"
+#include "DDSegmentation/WaferGridXY.h"
+typedef dd4hep::DDSegmentation::VolumeID VolumeID;
+typedef dd4hep::DDSegmentation::CellID CellID;
+
+// -------------------------------------------------------------------------
+// DDSegmentation dictionaries
+#ifdef DD4HEP_DICTIONARY_MODE
+#pragma link C++ class dd4hep::DDSegmentation::SegmentationParameter+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<int>+;
+
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<float>+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<double>+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<string>+;
+#pragma link C++ class map<string,dd4hep::DDSegmentation::TypedSegmentationParameter<string>* >+;
+#pragma link C++ class map<string,dd4hep::DDSegmentation::TypedSegmentationParameter<double>* >+;
+#pragma link C++ class map<string,dd4hep::DDSegmentation::TypedSegmentationParameter<float>* >+;
+
+/// Severe problem due to template specialization!
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<int> >+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<float> >+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<double> >+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<string> >+;
+
+#pragma link C++ class dd4hep::DDSegmentation::Segmentation+;
+#pragma link C++ class dd4hep::DDSegmentation::CartesianGrid+;
+#pragma link C++ class dd4hep::DDSegmentation::CartesianGridXY+;
+#pragma link C++ class dd4hep::DDSegmentation::CartesianGridXYZ+;
+#pragma link C++ class dd4hep::DDSegmentation::CartesianGridXZ+;
+#pragma link C++ class dd4hep::DDSegmentation::CartesianGridYZ+;
+#pragma link C++ class dd4hep::DDSegmentation::CylindricalSegmentation+;
+#pragma link C++ class dd4hep::DDSegmentation::GridPhiEta+;
+#pragma link C++ class dd4hep::DDSegmentation::GridRPhiEta+;
+#pragma link C++ class dd4hep::DDSegmentation::MegatileLayerGridXY+;
+#pragma link C++ class dd4hep::DDSegmentation::MultiSegmentation+;
+#pragma link C++ class dd4hep::DDSegmentation::NoSegmentation+;
+#pragma link C++ class dd4hep::DDSegmentation::PolarGrid+;
+#pragma link C++ class dd4hep::DDSegmentation::PolarGridRPhi2+;
+#pragma link C++ class dd4hep::DDSegmentation::PolarGridRPhi+;
+#pragma link C++ class dd4hep::DDSegmentation::ProjectiveCylinder+;
+#pragma link C++ class dd4hep::DDSegmentation::TiledLayerGridXY+;
+#pragma link C++ class dd4hep::DDSegmentation::TiledLayerSegmentation+;
+#pragma link C++ class dd4hep::DDSegmentation::WaferGridXY+;
+
+#pragma link C++ class dd4hep::DDSegmentation::BitFieldValue+;
+#pragma link C++ class dd4hep::DDSegmentation::BitField64+;
+
+#endif  // __CINT__
+#endif  // __HAVE_DDSEGMENTATION__
+
+#endif  /* DD4HEP_DDCORE_ROOTDICTIONARY_H  */

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -94,12 +94,32 @@ dd4hep_add_test_reg( Conditions_Telescope_root_save
   )
 #
 #---Testing: Save conditions to ROOT file
-dd4hep_add_test_reg( Conditions_Telescope_root_load
+dd4hep_add_test_reg( Conditions_Telescope_root_load_iov
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
     -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
-    -conditions TelescopeConditions.root
-  REGEX_PASS "\\+  Accessed a total of 1600 conditions \\(S:  1600,L:     0,C:     0,M:0\\)"
+    -conditions TelescopeConditions.root -iovs 30 -restore iovpool
+  REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
+#---Testing: Save conditions to ROOT file
+dd4hep_add_test_reg( Conditions_Telescope_root_load_usr
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
+  EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
+    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
+    -conditions TelescopeConditions.root -iovs 30 -restore userpool
+  REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
+#---Testing: Save conditions to ROOT file
+dd4hep_add_test_reg( Conditions_Telescope_root_load_pool
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
+  EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
+    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
+    -conditions TelescopeConditions.root -iovs 30 -restore condpool
+  REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -141,10 +161,30 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_save_LONGTEST
   )
 #
 #---Testing: Save conditions to ROOT file
-dd4hep_add_test_reg( Conditions_CLICSiD_root_load_LONGTEST
+dd4hep_add_test_reg( Conditions_CLICSiD_root_load_iov_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
-    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3
+    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore iovpool
+    -conditions CLICSiDConditions.root
+  REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
+#---Testing: Save conditions to ROOT file
+dd4hep_add_test_reg( Conditions_CLICSiD_root_load_usr_LONGTEST
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
+  EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
+    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore userpool
+    -conditions CLICSiDConditions.root
+  REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
+#---Testing: Save conditions to ROOT file
+dd4hep_add_test_reg( Conditions_CLICSiD_root_load_cond_LONGTEST
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
+  EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
+    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore condpool
     -conditions CLICSiDConditions.root
   REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -52,7 +52,7 @@ dd4hep_add_test_reg( Conditions_Telescope_populate
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_ConditionExample_populate
       -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 5
-  REGEX_PASS "Accessed Total 800 conditions \\(S:   500,L:     0,C:   300,M:0\\)"
+  REGEX_PASS "Accessed a total of 800 conditions \\(S:   500,L:     0,C:   300,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -61,7 +61,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_ConditionExample_stress 
     -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 10 -runs 20
-  REGEX_PASS "\\+  Accessed Total 3200 conditions \\(S:  2660,L:     0,C:   540,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 3200 conditions \\(S:  2660,L:     0,C:   540,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -70,7 +70,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress2
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_ConditionExample_stress2 
     -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 10
-  REGEX_PASS "\\+  Accessed Total 1600 conditions \\(S:  1000,L:     0,C:   600,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 1600 conditions \\(S:  1000,L:     0,C:   600,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -83,12 +83,32 @@ dd4hep_add_test_reg( Conditions_Telescope_MT_LONGTEST
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
+#---Testing: Save conditions to ROOT file
+dd4hep_add_test_reg( Conditions_Telescope_root_save
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
+  EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_save
+    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 30
+    -conditions TelescopeConditions.root
+  REGEX_PASS "\\+ Successfully saved 14400 condition to file."
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
+#---Testing: Save conditions to ROOT file
+dd4hep_add_test_reg( Conditions_Telescope_root_load
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
+  EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
+    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
+    -conditions TelescopeConditions.root
+  REGEX_PASS "\\+  Accessed a total of 1600 conditions \\(S:  1600,L:     0,C:     0,M:0\\)"
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
 #---Testing: Simple stress: Load CLICSiD geometry and have multiple runs on IOVs
 dd4hep_add_test_reg( Conditions_CLICSiD_stress_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_ConditionExample_stress 
     -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 10 -runs 100
-  REGEX_PASS "\\+  Accessed Total 28008800 conditions \\(S:26958470,L:     0,C:1050330,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 28008800 conditions \\(S:26958470,L:     0,C:1050330,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -97,7 +117,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress2_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_ConditionExample_stress2 
     -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 20
-  REGEX_PASS "\\+  Accessed Total 5601760 conditions \\(S:3501100,L:     0,C:2100660,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 5601760 conditions \\(S:3501100,L:     0,C:2100660,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -107,5 +127,25 @@ dd4hep_add_test_reg( Conditions_CLICSiD_MT_LONGTEST
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_ConditionExample_MT 
     -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -runs 2 -threads 1
   REGEX_PASS "\\+  Accessed a total of 9522992 conditions \\(S:8892794,L:     0,C:630198,M:0\\)"
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
+#---Testing: Save conditions to ROOT file
+dd4hep_add_test_reg( Conditions_CLICSiD_root_save_LONGTEST
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
+  EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_save
+    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3
+    -conditions CLICSiDConditions.root
+  REGEX_PASS "\\+ Successfully saved 2520792 condition to file."
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+#
+#---Testing: Save conditions to ROOT file
+dd4hep_add_test_reg( Conditions_CLICSiD_root_load_LONGTEST
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
+  EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
+    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3
+    -conditions CLICSiDConditions.root
+  REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -99,6 +99,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_iov
   EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
     -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore iovpool
+  DEPENDS Conditions_Telescope_root_save
   REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -109,6 +110,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_usr
   EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
     -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore userpool
+  DEPENDS Conditions_Telescope_root_save
   REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -119,6 +121,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_pool
   EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
     -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore condpool
+  DEPENDS Conditions_Telescope_root_save
   REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -166,6 +169,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_iov_LONGTEST
   EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
     -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore iovpool
     -conditions CLICSiDConditions.root
+  DEPENDS Conditions_CLICSiD_root_save_LONGTEST
   REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -176,6 +180,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_usr_LONGTEST
   EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
     -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore userpool
     -conditions CLICSiDConditions.root
+  DEPENDS Conditions_CLICSiD_root_save_LONGTEST
   REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -186,6 +191,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_cond_LONGTEST
   EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_ConditionExample_load
     -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore condpool
     -conditions CLICSiDConditions.root
+  DEPENDS Conditions_CLICSiD_root_save_LONGTEST
   REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )

--- a/examples/Conditions/src/ConditionExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionExampleObjects.cpp
@@ -110,12 +110,15 @@ ConditionsDependencyCreator::~ConditionsDependencyCreator()  {
 /// Callback to process a single detector element
 int ConditionsDependencyCreator::operator()(DetElement de, int)  const  {
   ConditionKey      key(de,"derived_data");
-  ConditionKey      target1(de,"derived_1");
-  ConditionKey      target2(de,"derived_2");
-  ConditionKey      target3(de,"derived_3");
+  ConditionKey      target1(de,"derived_data/derived_1");
+  ConditionKey      target2(de,"derived_data/derived_2");
+  ConditionKey      target3(de,"derived_data/derived_3");
   DependencyBuilder build_1(de, target1.item_key(), call1->addRef());
   DependencyBuilder build_2(de, target2.item_key(), call2->addRef());
   DependencyBuilder build_3(de, target3.item_key(), call3->addRef());
+  //DependencyBuilder build_1(de, "derived_data/derived_1", call1->addRef());
+  //DependencyBuilder build_2(de, "derived_data/derived_2", call2->addRef());
+  //DependencyBuilder build_3(de, "derived_data/derived_3", call3->addRef());
 
   // Compute the derived stuff
   build_1.add(key);

--- a/examples/Conditions/src/ConditionExample_save.cpp
+++ b/examples/Conditions/src/ConditionExample_save.cpp
@@ -16,15 +16,19 @@
    This plugin behaves like a main program.
    Invoke the plugin with something like this:
 
-   geoPluginRun -volmgr -destroy -plugin DD4hep_ConditionExample_populate \
-   -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
+   geoPluginRun -volmgr -destroy -plugin DD4hep_ConditionExample_save \
+   -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml \
+   -conditions Conditions.root
 
-   Populate the conditions store by hand for a set of IOVs.
+   Save the conditions store by hand for a set of IOVs.
    Then compute the corresponding alignment entries....
 
 */
 // Framework include files
 #include "ConditionExampleObjects.h"
+#include "DDCond/ConditionsManager.h"
+#include "DDCond/ConditionsIOVPool.h"
+#include "DDCond/ConditionsRootPersistency.h"
 #include "DD4hep/Factories.h"
 
 using namespace std;
@@ -33,7 +37,7 @@ using namespace dd4hep::ConditionExamples;
 
 /// Plugin function: Condition program example
 /**
- *  Factory: DD4hep_ConditionExample_populate
+ *  Factory: DD4hep_ConditionExample_save
  *
  *  \author  M.Frank
  *  \version 1.0
@@ -41,24 +45,27 @@ using namespace dd4hep::ConditionExamples;
  */
 static int condition_example (Detector& description, int argc, char** argv)  {
 
-  string input;
+  string input, conditions;
   int    num_iov = 10;
   bool   arg_error = false;
   for(int i=0; i<argc && argv[i]; ++i)  {
     if ( 0 == ::strncmp("-input",argv[i],4) )
       input = argv[++i];
+    else if ( 0 == ::strncmp("-conditions",argv[i],4) )
+      conditions = argv[++i];
     else if ( 0 == ::strncmp("-iovs",argv[i],4) )
       num_iov = ::atol(argv[++i]);
     else
       arg_error = true;
   }
-  if ( arg_error || input.empty() )   {
+  if ( arg_error || input.empty() || conditions.empty() )   {
     /// Help printout describing the basic command line interface
     cout <<
       "Usage: -plugin <name> -arg [-arg]                                             \n"
-      "     name:   factory name     DD4hep_ConditionExample_populate                \n"
-      "     -input   <string>        Geometry file                                   \n"
-      "     -iovs    <number>        Number of parallel IOV slots for processing.    \n"
+      "     name:   factory name     DD4hep_ConditionExample_save                    \n"
+      "     -input       <string>    Geometry file                                   \n"
+      "     -conditions  <string>    Conditions output file                          \n"
+      "     -iovs        <number>    Number of parallel IOV slots for processing.    \n"
       "\tArguments given: " << arguments(argc,argv) << endl << flush;
     ::exit(EINVAL);
   }
@@ -78,7 +85,7 @@ static int condition_example (Detector& description, int argc, char** argv)  {
   Scanner(ConditionsKeys(*content,INFO),description.world());
   Scanner(ConditionsDependencyCreator(*content,DEBUG),description.world());
 
-  /******************** Populate the conditions store *********************/
+  /******************** Save the conditions store *********************/
   // Have 10 run-slices [11,20] .... [91,100]
   for(int i=0; i<num_iov; ++i)  {
     IOV iov(iov_typ, IOV::Key(1+i*10,(i+1)*10));
@@ -86,7 +93,13 @@ static int condition_example (Detector& description, int argc, char** argv)  {
     // Create conditions with all deltas. Use a generic creator
     Scanner(ConditionsCreator(*slice, *iov_pool, INFO),description.world(),0,true);
   }
-  
+
+  char text[132];
+  bool output_iovpool  = true;
+  bool output_userpool = true;
+  bool output_condpool = true;
+  size_t count = 0, total_count = 0;
+  auto* persist = new cond::ConditionsRootPersistency("DD4hep Conditions");
   // ++++++++++++++++++++++++ Now compute the conditions for each of these IOVs
   ConditionsManager::Result total;
   for(int i=0; i<num_iov; ++i)  {
@@ -98,16 +111,52 @@ static int condition_example (Detector& description, int argc, char** argv)  {
       Scanner(ConditionsPrinter(slice.get(),"Example"),description.world());
     }
     // Now compute the tranformation matrices
-    printout(INFO,"Prepare","Total %ld conditions (S:%ld,L:%ld,C:%ld,M:%ld) of IOV %s",
+    printout(ALWAYS,"Prepare","Total %ld conditions (S:%ld,L:%ld,C:%ld,M:%ld) of IOV %s",
              r.total(), r.selected, r.loaded, r.computed, r.missing, req_iov.str().c_str());
-  }  
-  printout(INFO,"Statistics","+=========================================================================");
-  printout(INFO,"Statistics","+  Accessed a total of %ld conditions (S:%6ld,L:%6ld,C:%6ld,M:%ld)",
+    if ( output_userpool )  {
+      /// Add the conditions UserPool to the persistent file
+      ::snprintf(text,sizeof(text),"User pool %s:[%ld]",iov_typ->name.c_str(),req_iov.key().first);
+      count = persist->add(text,*slice->pool);
+      total_count += count;
+      printout(ALWAYS,"Example","+++ Added %ld conditions to persistent user pool.",count);
+    }
+  }
+  if ( output_condpool )  {
+    cond::ConditionsIOVPool* iov_pool = manager.iovPool(*iov_typ);
+    for( const auto& p : iov_pool->elements )  {
+      ::snprintf(text,sizeof(text),"Conditions pool %s:[%ld,%ld]",
+                 iov_typ->name.c_str(),p.second->iov->key().first,p.second->iov->key().second);
+      count = persist->add(text,*p.second);
+      total_count += count;
+      printout(ALWAYS,"Example","+++ Added %ld conditions to persistent conditions pool.",count);
+    }
+  }
+  if ( output_iovpool )  {
+    count = persist->add("ConditionsIOVPool No 1",*manager.iovPool(*iov_typ));
+    total_count += count;
+    printout(ALWAYS,"Example","+++ Added %ld conditions to persistent IOV pool.",count);
+    //count = persist->add("ConditionsIOVPool No 2",*manager.iovPool(*iov_typ));
+    //total_count += count;
+    printout(ALWAYS,"Example","+++ Added %ld conditions to persistent IOV pool.",count);
+  }
+  int nBytes = persist->save(conditions.c_str());
+  printout(ALWAYS,"Example",
+           "+++ Wrote %d Bytes (%ld conditions) of data to '%s'  [%8.3f seconds].",
+           nBytes, total_count, conditions.c_str(), persist->duration);
+  if ( nBytes > 0 )  {
+    printout(ALWAYS,"Example",
+             "+++ Successfully saved %ld condition to file.",total_count);
+  }
+  delete persist;
+  
+  printout(ALWAYS,"Statistics","+=========================================================================");
+  printout(ALWAYS,"Statistics","+  Accessed a total of %ld conditions (S:%6ld,L:%6ld,C:%6ld,M:%ld)",
            total.total(), total.selected, total.loaded, total.computed, total.missing);
-  printout(INFO,"Statistics","+=========================================================================");
+  printout(ALWAYS,"Statistics","+=========================================================================");
+
   // All done.
   return 1;
 }
 
 // first argument is the type from the xml file
-DECLARE_APPLY(DD4hep_ConditionExample_populate,condition_example)
+DECLARE_APPLY(DD4hep_ConditionExample_save,condition_example)

--- a/examples/Conditions/src/ConditionExample_stress.cpp
+++ b/examples/Conditions/src/ConditionExample_stress.cpp
@@ -123,7 +123,7 @@ static int condition_example (Detector& description, int argc, char** argv)  {
            cr_stat.GetName(), cr_stat.GetMean(), cr_stat.GetMeanErr(), cr_stat.GetRMS(), cr_stat.GetN());
   printout(INFO,"Statistics","+  %-12s:  %11.5g +- %11.4g  RMS = %11.5g  N = %lld",
            acc_stat.GetName(), acc_stat.GetMean(), acc_stat.GetMeanErr(), acc_stat.GetRMS(), acc_stat.GetN());
-  printout(INFO,"Statistics","+  Accessed Total %ld conditions (S:%6ld,L:%6ld,C:%6ld,M:%ld). Created:%ld",
+  printout(INFO,"Statistics","+  Accessed a total of %ld conditions (S:%6ld,L:%6ld,C:%6ld,M:%ld). Created:%ld",
            total.total(), total.selected, total.loaded, total.computed, total.missing, total_created);
   printout(INFO,"Statistics","+=========================================================================");
   // All done.

--- a/examples/Conditions/src/ConditionExample_stress2.cpp
+++ b/examples/Conditions/src/ConditionExample_stress2.cpp
@@ -114,7 +114,7 @@ static int condition_example (Detector& description, int argc, char** argv)  {
            cr_stat.GetName(), cr_stat.GetMean(), cr_stat.GetMeanErr(), cr_stat.GetRMS(), cr_stat.GetN());
   printout(INFO,"Statistics","+  %-12s:  %11.5g +- %11.4g  RMS = %11.5g  N = %lld",
            acc_stat.GetName(), acc_stat.GetMean(), acc_stat.GetMeanErr(), acc_stat.GetRMS(), acc_stat.GetN());
-  printout(INFO,"Statistics","+  Accessed Total %ld conditions (S:%6ld,L:%6ld,C:%6ld,M:%ld)",
+  printout(INFO,"Statistics","+  Accessed a total of %ld conditions (S:%6ld,L:%6ld,C:%6ld,M:%ld)",
            total.total(), total.selected, total.loaded, total.computed, total.missing, total_created);
   printout(INFO,"Statistics","+=========================================================================");
   // All done.


### PR DESCRIPTION
BEGINRELEASENOTES
  ## Implement ROOT persistency mechanism for the conditions

Conditions pools can now be made persistent provided all the dictionaries for the payload objects are provided. A new class `ConditionsRootPersistency` allows to save and re-load conditions pools to/from a ROOT file. Such pools can either be:
 - Simple `ConditionsPool` objects
 - The entire `IOV` indexed pool set (class `ConditionsIOVPool`) or
 - A the pool used by a `ConditionsSlice` (class `UserPool`).
 - A std::vector<Condition> which belong all to the same IOV

In any case the restoration of the saved conditions is performed through the `ConditionsManager` interface in order to ensure proper management of the added condition objects.

Some example plugin tasks were added in examples/Conditions:
 - `DD4hep_ConditionExample_save` to save conditions to a ROOT file.
 - `DD4hep_ConditionExample_load` to restore conditions from file.

Others to come.

## Split of dictionary files
The ROOT dictionary creation in `DDCore` was getting increasingly large. Now the ROOT dictionaries are created in several files, what firstly allows them to be produced in parallel and secondly eases the compilation due to smaller generated file sizes.

ENDRELEASENOTES