### PR TITLE
dd4hep_generate_rootmap: use CMAKE_INSTALL_LIBDIR if it is set

### DIFF
--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -109,8 +109,13 @@ function(dd4hep_generate_rootmap_notapple library)
   #                   DEPENDS ${library})
   ##add_custom_target(${library}Rootmap ALL DEPENDS ${rootmapfile})
 
+  SET( install_destination "lib" )
+  if( CMAKE_INSTALL_LIBDIR )
+    SET( install_destination ${CMAKE_INSTALL_LIBDIR} )
+  endif()
+
   install(FILES ${LIBRARY_OUTPUT_PATH}/${rootmapfile}
-    DESTINATION lib
+    DESTINATION ${install_destination}
   )
 endfunction()
 #


### PR DESCRIPTION


BEGINRELEASENOTES
- CMake:: dd4hep_generate_rootmap: use CMAKE_INSTALL_LIBDIR if it is set. If the macro is called from other libraries this variable might be set and should be used for consistency. Fixes #212 

ENDRELEASENOTES