### PR TITLE
Beampipe modifications

### DIFF
--- a/DDCore/include/XML/UnicodeValues.h
+++ b/DDCore/include/XML/UnicodeValues.h
@@ -254,6 +254,7 @@ UNICODE (n);
 UNICODE (N);
 UNICODE (NIL);
 UNICODE (name);
+UNICODE (nocore);
 UNICODE (nmodules);
 UNICODE (nModules);
 UNICODE (normal);

--- a/DDCore/include/XML/detail/Dimension.h
+++ b/DDCore/include/XML/detail/Dimension.h
@@ -401,6 +401,10 @@ namespace dd4hep {
       bool reflect() const;
       /// Access attribute values: reflect
       bool reflect(bool default_value) const;
+      /// Access attribute values: nocore
+      bool nocore() const;
+      /// Access attribute values: nocore
+      bool nocore(bool default_value) const;
       /// Access attribute values: crossing_angle
       double crossing_angle() const;
       /// Access attribute values: repeat

--- a/DDCore/include/XML/detail/Dimension.imp
+++ b/DDCore/include/XML/detail/Dimension.imp
@@ -147,6 +147,8 @@ XML_ATTR_ACCESSOR(int, number)
 XML_ATTR_ACCESSOR(int, repeat)
 XML_ATTR_ACCESSOR(bool, reflect)
 XML_ATTR_ACCESSOR_BOOL(reflect)
+XML_ATTR_ACCESSOR(bool, nocore)
+XML_ATTR_ACCESSOR_BOOL(nocore)
 
 XML_ATTR_ACCESSOR(int, nmodules)
 XML_ATTR_ACCESSOR(int, nModules)

--- a/DDDetectors/src/Beampipe_o1_v01_geo.cpp
+++ b/DDDetectors/src/Beampipe_o1_v01_geo.cpp
@@ -111,7 +111,7 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
   //Access to the XML File
   xml_det_t xmlBeampipe = element;
   const std::string name = xmlBeampipe.nameStr();
-
+  bool nocore  = xmlBeampipe.nocore(false);
 
   dd4hep::DetElement tube(  name, xmlBeampipe.id()  ) ;
 
@@ -210,10 +210,6 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       Volume tubeLog( volName, tubeSolid, coreMaterial ) ;
       Volume tubeLog2( volName, tubeSolid, coreMaterial ) ;
 
-      // placement of the tube in the world, both at +z and -z
-      envelope.placeVolume( tubeLog,  transformer );
-      envelope.placeVolume( tubeLog2,  transmirror );
-
       // if inner and outer radii are equal, then omit the tube wall
       if (rInnerStart != rOuterStart || rInnerEnd != rOuterEnd) {
 
@@ -266,9 +262,25 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 	tubeLog.setVisAttributes(description, "VacVis");
 	tubeLog2.setVisAttributes(description, "VacVis");
 
-	// placement as a daughter volume of the tube, will appear in both placements of the tube
-	tubeLog.placeVolume( wallLog,  Transform3D() );
-	tubeLog2.placeVolume( wallLog2,  Transform3D() );
+	if (nocore){
+
+	  //placement of the wall only
+	  envelope.placeVolume( wallLog,  transformer );
+	  envelope.placeVolume( wallLog2,  transmirror );
+
+	}
+
+	else{
+
+	  // placement of the tube in the world, both at +z and -z
+	  envelope.placeVolume( tubeLog,  transformer );
+	  envelope.placeVolume( tubeLog2,  transmirror );
+
+	  // placement as a daughter volume of the tube, will appear in both placements of the tube
+	  tubeLog.placeVolume( wallLog,  Transform3D() );
+	  tubeLog2.placeVolume( wallLog2,  Transform3D() );
+	}
+
       }
     }
       break;
@@ -294,10 +306,6 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       // tube consists of vacuum (will later have two different daughters)
       Volume tubeLog0( volName + "_0", tubeSolid, coreMaterial );
       Volume tubeLog1( volName + "_1", tubeSolid, coreMaterial );
-
-      // placement of the tube in the world, both at +z and -z
-      envelope.placeVolume( tubeLog0, placementTransformer );
-      envelope.placeVolume( tubeLog1, placementTransmirror );
 
       // the wall solid and placeholders for possible SubtractionSolids
       ConeSegment wholeSolid(  zHalf, 0, rOuterStart, 0, rOuterEnd, phi1, phi2);
@@ -335,9 +343,24 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       tubeLog0.setVisAttributes(description, "VacVis");
       tubeLog1.setVisAttributes(description, "VacVis");
 
-      // placement as a daughter volumes of the tube
-      tubeLog0.placeVolume( wallLog0, Position() );
-      tubeLog1.placeVolume( wallLog1, Position() );
+      if (nocore){
+
+	// placement of the wall only
+	envelope.placeVolume( wallLog0, placementTransformer );
+	envelope.placeVolume( wallLog1, placementTransmirror );
+
+      }
+
+      else{
+
+	// placement of the tube in the world, both at +z and -z
+	envelope.placeVolume( tubeLog0, placementTransformer );
+	envelope.placeVolume( tubeLog1, placementTransmirror );
+
+	// placement as a daughter volumes of the tube
+	tubeLog0.placeVolume( wallLog0, Position() );
+	tubeLog1.placeVolume( wallLog1, Position() );
+      }
 
       break;
     }
@@ -365,10 +388,6 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       Volume tubeLog0( volName + "_0", tubeSolid, coreMaterial );
       Volume tubeLog1( volName + "_1", tubeSolid, coreMaterial );
 
-      // placement of the tube in the world, both at +z and -z
-      envelope.placeVolume( tubeLog0, placementTransformer );
-      envelope.placeVolume( tubeLog1, placementTransmirror );
-
       // the wall solid and the piece (only a tube, for the moment) which will be punched out
       ConeSegment wholeSolid( zHalf, rCenterPunch , rOuterStart, rCenterPunch, rOuterEnd, phi1, phi2);
 
@@ -393,6 +412,25 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       // placement as a daughter volumes of the tube
       tubeLog0.placeVolume( wallLog0 , Position() );
       tubeLog1.placeVolume( wallLog1 , Position() );
+
+      if (nocore){
+
+	// placement of the wall only
+	envelope.placeVolume( wallLog0, placementTransformer );
+	envelope.placeVolume( wallLog1, placementTransmirror );
+
+      }
+
+      else{
+
+	// placement of the tube in the world, both at +z and -z
+	envelope.placeVolume( tubeLog0, placementTransformer );
+	envelope.placeVolume( tubeLog1, placementTransmirror );
+
+	// placement as a daughter volumes of the tube
+	tubeLog0.placeVolume( wallLog0 , Position() );
+	tubeLog1.placeVolume( wallLog1 , Position() );
+      }
 
       break;
     }
@@ -431,9 +469,11 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       Volume tubeLog0( volName + "_0", tubeSolid0, coreMaterial );
       Volume tubeLog1( volName + "_1", tubeSolid1, coreMaterial );
 
-      // placement of the tube in the world, both at +z and -z
-      envelope.placeVolume( tubeLog0, placementTransformer );
-      envelope.placeVolume( tubeLog1, placementTransmirror );
+      if (nocore==false){
+	// placement of the tube in the world, both at +z and -z
+	envelope.placeVolume( tubeLog0, placementTransformer );
+	envelope.placeVolume( tubeLog1, placementTransmirror );
+      }
 
       if (rInnerStart != rOuterStart || rInnerEnd != rOuterEnd) {
 	// the wall solid: a tubular cone
@@ -452,10 +492,15 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 
 	tubeLog0.setVisAttributes(description, "VacVis");
 	tubeLog1.setVisAttributes(description, "VacVis");
-
-	// placement as a daughter volumes of the tube
-	tubeLog0.placeVolume( wallLog0, Position() );
-	tubeLog1.placeVolume( wallLog1, Position() );
+	if (nocore==false){
+	  // placement as a daughter volumes of the tube
+	  tubeLog0.placeVolume( wallLog0, Position() );
+	  tubeLog1.placeVolume( wallLog1, Position() );
+	}
+	else{    // placement of the wall only
+	  envelope.placeVolume( wallLog0, placementTransformer );
+	  envelope.placeVolume( wallLog1, placementTransmirror );
+	}
       }
     }
       break;
@@ -493,9 +538,11 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       Volume tubeLog0( volName + "_0", tubeSolid0, coreMaterial );
       Volume tubeLog1( volName + "_1", tubeSolid1, coreMaterial );
 
-      // placement of the tube in the world, both at +z and -z
-      envelope.placeVolume( tubeLog0, placementTransformer );
-      envelope.placeVolume( tubeLog1, placementTransmirror );
+      if (nocore==false){
+	// placement of the tube in the world, both at +z and -z
+	envelope.placeVolume( tubeLog0, placementTransformer );
+	envelope.placeVolume( tubeLog1, placementTransmirror );
+      }
 
       if (rInnerStart != rOuterStart || rInnerEnd != rOuterEnd) {
 	// the wall solid: a tubular cone
@@ -515,9 +562,15 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 	tubeLog0.setVisAttributes(description, "VacVis");
 	tubeLog1.setVisAttributes(description, "VacVis");
 
+	if (nocore==false){
 	// placement as a daughter volumes of the tube
-	tubeLog0.placeVolume( wallLog0, Transform3D() );
-	tubeLog1.placeVolume( wallLog1, Transform3D() );
+	  tubeLog0.placeVolume( wallLog0, Transform3D() );
+	  tubeLog1.placeVolume( wallLog1, Transform3D() );
+	}
+	else{   // placement of the wall only
+	  envelope.placeVolume( wallLog0, placementTransformer );
+	  envelope.placeVolume( wallLog1, placementTransmirror );
+	}
       }
       break;
     }
@@ -560,9 +613,11 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       Volume tubeLog0( volName + "_0", tubeSolid0, coreMaterial );
       Volume tubeLog1( volName + "_1", tubeSolid1, coreMaterial );
 
-      // placement of the tube in the world, both at +z and -z
-      envelope.placeVolume( tubeLog0, placementTransformer );
-      envelope.placeVolume( tubeLog1, placementTransmirror );
+      if (nocore==false){
+	// placement of the tube in the world, both at +z and -z
+	envelope.placeVolume( tubeLog0, placementTransformer );
+	envelope.placeVolume( tubeLog1, placementTransmirror );
+      }
 
       if (rInnerStart != rOuterStart || rInnerEnd != rOuterEnd) {
 	// the wall solid: a tubular cone
@@ -584,9 +639,15 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 	tubeLog0.setVisAttributes(description, "VacVis");
 	tubeLog1.setVisAttributes(description, "VacVis");
 
-	// placement as a daughter volumes of the tube
-	tubeLog0.placeVolume( wallLog0, Transform3D() );
-	tubeLog1.placeVolume( wallLog1, Transform3D() );
+	if (nocore==false){
+	  // placement as a daughter volumes of the tube
+	  tubeLog0.placeVolume( wallLog0, Transform3D() );
+	  tubeLog1.placeVolume( wallLog1, Transform3D() );
+	}
+	else{  // placement of the wall only
+	  envelope.placeVolume( wallLog0, placementTransformer );
+	  envelope.placeVolume( wallLog1, placementTransmirror );
+	}
       }
       break;
     }

--- a/DDDetectors/src/Beampipe_o1_v01_geo.cpp
+++ b/DDDetectors/src/Beampipe_o1_v01_geo.cpp
@@ -263,24 +263,22 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 	tubeLog2.setVisAttributes(description, "VacVis");
 
 	if (nocore){
-
+	  
 	  //placement of the wall only
 	  envelope.placeVolume( wallLog,  transformer );
 	  envelope.placeVolume( wallLog2,  transmirror );
-
-	}
-
-	else{
-
+	  
+	}else{
+	  
 	  // placement of the tube in the world, both at +z and -z
 	  envelope.placeVolume( tubeLog,  transformer );
 	  envelope.placeVolume( tubeLog2,  transmirror );
-
+	  
 	  // placement as a daughter volume of the tube, will appear in both placements of the tube
 	  tubeLog.placeVolume( wallLog,  Transform3D() );
 	  tubeLog2.placeVolume( wallLog2,  Transform3D() );
 	}
-
+	
       }
     }
       break;
@@ -344,19 +342,17 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       tubeLog1.setVisAttributes(description, "VacVis");
 
       if (nocore){
-
+	
 	// placement of the wall only
 	envelope.placeVolume( wallLog0, placementTransformer );
 	envelope.placeVolume( wallLog1, placementTransmirror );
-
-      }
-
-      else{
-
+	
+      }else{
+	
 	// placement of the tube in the world, both at +z and -z
 	envelope.placeVolume( tubeLog0, placementTransformer );
 	envelope.placeVolume( tubeLog1, placementTransmirror );
-
+	
 	// placement as a daughter volumes of the tube
 	tubeLog0.placeVolume( wallLog0, Position() );
 	tubeLog1.placeVolume( wallLog1, Position() );
@@ -409,9 +405,6 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
       tubeLog0.setVisAttributes(description, "VacVis");
       tubeLog1.setVisAttributes(description, "VacVis");
 
-      // placement as a daughter volumes of the tube
-      tubeLog0.placeVolume( wallLog0 , Position() );
-      tubeLog1.placeVolume( wallLog1 , Position() );
 
       if (nocore){
 
@@ -419,9 +412,7 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 	envelope.placeVolume( wallLog0, placementTransformer );
 	envelope.placeVolume( wallLog1, placementTransmirror );
 
-      }
-
-      else{
+      }else{
 
 	// placement of the tube in the world, both at +z and -z
 	envelope.placeVolume( tubeLog0, placementTransformer );
@@ -496,8 +487,7 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 	  // placement as a daughter volumes of the tube
 	  tubeLog0.placeVolume( wallLog0, Position() );
 	  tubeLog1.placeVolume( wallLog1, Position() );
-	}
-	else{    // placement of the wall only
+	}else{    // placement of the wall only
 	  envelope.placeVolume( wallLog0, placementTransformer );
 	  envelope.placeVolume( wallLog1, placementTransmirror );
 	}
@@ -566,8 +556,7 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 	// placement as a daughter volumes of the tube
 	  tubeLog0.placeVolume( wallLog0, Transform3D() );
 	  tubeLog1.placeVolume( wallLog1, Transform3D() );
-	}
-	else{   // placement of the wall only
+	}else{   // placement of the wall only
 	  envelope.placeVolume( wallLog0, placementTransformer );
 	  envelope.placeVolume( wallLog1, placementTransmirror );
 	}
@@ -643,8 +632,7 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 	  // placement as a daughter volumes of the tube
 	  tubeLog0.placeVolume( wallLog0, Transform3D() );
 	  tubeLog1.placeVolume( wallLog1, Transform3D() );
-	}
-	else{  // placement of the wall only
+	}else{  // placement of the wall only
 	  envelope.placeVolume( wallLog0, placementTransformer );
 	  envelope.placeVolume( wallLog1, placementTransmirror );
 	}
@@ -664,11 +652,13 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& description,
 
 
   // add a surface just inside the beampipe for tracking:
-  Vector3D oIPCyl( (min_radius-1.e-3)  , 0. , 0.  ) ;
-  SimpleCylinder ipCylSurf( envelope , SurfaceType( SurfaceType::Helper ) , 1.e-5  , 1e-5 , oIPCyl ) ;
-  // the length does not really matter here as long as it is long enough for all tracks ...
-  ipCylSurf->setHalfLength(  100*units::cm ) ;
-  dd4hep::rec::volSurfaceList( tube )->push_back( ipCylSurf ) ;
+  if (nocore==false){
+    Vector3D oIPCyl( (min_radius-1.e-3)  , 0. , 0.  ) ;
+    SimpleCylinder ipCylSurf( envelope , SurfaceType( SurfaceType::Helper ) , 1.e-5  , 1e-5 , oIPCyl ) ;
+    // the length does not really matter here as long as it is long enough for all tracks ...
+    ipCylSurf->setHalfLength(  100*units::cm ) ;
+    dd4hep::rec::volSurfaceList( tube )->push_back( ipCylSurf ) ;
+  }
 
   tube.addExtension< dd4hep::rec::ConicalSupportData >( beampipeData ) ;
 

--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -109,8 +109,13 @@ function(dd4hep_generate_rootmap_notapple library)
   #                   DEPENDS ${library})
   ##add_custom_target(${library}Rootmap ALL DEPENDS ${rootmapfile})
 
+  SET( install_destination "lib" )
+  if( CMAKE_INSTALL_LIBDIR )
+    SET( install_destination ${CMAKE_INSTALL_LIBDIR} )
+  endif()
+
   install(FILES ${LIBRARY_OUTPUT_PATH}/${rootmapfile}
-    DESTINATION lib
+    DESTINATION ${install_destination}
   )
 endfunction()
 #


### PR DESCRIPTION
BEGINRELEASENOTES
  * Adding variable "nocore" for beam pipe (with default value = false) In case the variable appears in the BP xml file as "true", the BP sections will have no core of beam material, in order that someone might add various BP walls made of different materials while avoiding G4 overlaps. Example of use:
```xml
<detector name="BeBeampipe" type="DD4hep_Beampipe_o1_v01" insideTrackingVolume="true" nocore="true" vis="BeamPipeVis">
```

ENDRELEASENOTES