### PR TITLE
LCIOFileReader: fix llvm compiler error; fix printout, cannot use std::string

### DIFF
--- a/DDG4/lcio/LCIOFileReader.cpp
+++ b/DDG4/lcio/LCIOFileReader.cpp
@@ -120,7 +120,7 @@ dd4hep::sim::LCIOFileReader::readParticleCollection(int /*event_number*/, EVENT:
     *particles = evt->getCollection(m_collectionName);
     if ( *particles ) {
       printout(INFO,"LCIOFileReader","read collection %s from event %d in run %d ", 
-               m_collectionName, evt->getEventNumber(), evt->getRunNumber());
+               m_collectionName.c_str(), evt->getEventNumber(), evt->getRunNumber());
       return EVENT_READER_OK;
     }
   }


### PR DESCRIPTION

Followup for #215 
Fix for
```
FAILED: DDG4/CMakeFiles/DDG4LCIO.dir/lcio/LCIOFileReader.cpp.o 
/cvmfs/clicdp.cern.ch/compilers/llvm/4.0.0/x86_64-slc6/bin/clang++  [snip] -c ../DDG4/lcio/LCIOFileReader.cpp
../DDG4/lcio/LCIOFileReader.cpp:123:16: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char>') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
               m_collectionName, evt->getEventNumber(), evt->getRunNumber());
               ^
1 error generated.
```