### PR TITLE
Fix genstat

### DIFF
--- a/DDG4/include/DDG4/Geant4Particle.h
+++ b/DDG4/include/DDG4/Geant4Particle.h
@@ -65,15 +65,19 @@ namespace dd4hep {
       G4PARTICLE_KEEP_ALWAYS = 1<<10,
       G4PARTICLE_FORCE_KILL = 1<<11,
 
-      // Generator status for a given particles: bit 0...3 come from LCIO, rest is internal
+      // Generator status for a given particles: bit 0...4, agreed by many formats (HepMC, LCIO, ....):
       G4PARTICLE_GEN_EMPTY           = 1<<0,  // Empty line
       G4PARTICLE_GEN_STABLE          = 1<<1,  // undecayed particle, stable in the generator
       G4PARTICLE_GEN_DECAYED         = 1<<2,  // particle decayed in the generator
       G4PARTICLE_GEN_DOCUMENTATION   = 1<<3,  // documentation line
+      G4PARTICLE_GEN_BEAM            = 1<<4,  // beam particle
+
+      G4PARTICLE_GEN_OTHER           = 1<<9,  // any other generator status
 
       G4PARTICLE_GEN_GENERATOR       =        // Particle comes from generator
       (  G4PARTICLE_GEN_EMPTY+G4PARTICLE_GEN_STABLE+
-         G4PARTICLE_GEN_DECAYED+G4PARTICLE_GEN_DOCUMENTATION  ),
+         G4PARTICLE_GEN_DECAYED+G4PARTICLE_GEN_DOCUMENTATION+
+	 G4PARTICLE_GEN_BEAM+G4PARTICLE_GEN_OTHER),
       G4PARTICLE_GEN_STATUS          = 0x3FF, // Mask for generator status (bit 0...9)
 
       // Simulation status of a given particle

--- a/DDG4/lcio/Geant4Output2LCIO.cpp
+++ b/DDG4/lcio/Geant4Output2LCIO.cpp
@@ -240,9 +240,11 @@ lcio::LCCollectionVec* Geant4Output2LCIO::saveParticles(Geant4ParticleMap* parti
 
       // Set generator status
       q->setGeneratorStatus(0);
-      if ( mask.isSet(G4PARTICLE_GEN_STABLE) ) q->setGeneratorStatus(1);
-      else if ( mask.isSet(G4PARTICLE_GEN_DECAYED) ) q->setGeneratorStatus(2);
+      if ( mask.isSet(G4PARTICLE_GEN_STABLE) )             q->setGeneratorStatus(1);
+      else if ( mask.isSet(G4PARTICLE_GEN_DECAYED) )       q->setGeneratorStatus(2);
       else if ( mask.isSet(G4PARTICLE_GEN_DOCUMENTATION) ) q->setGeneratorStatus(3);
+      else if ( mask.isSet(G4PARTICLE_GEN_BEAM) )          q->setGeneratorStatus(4);
+      else if ( mask.isSet(G4PARTICLE_GEN_OTHER) )         q->setGeneratorStatus(9);
       //      std::cout << " ********** mcp genstatus : " << q->getGeneratorStatus() << std::endl ;
 
       // Set simulation status

--- a/DDG4/lcio/Geant4Output2LCIO.cpp
+++ b/DDG4/lcio/Geant4Output2LCIO.cpp
@@ -21,6 +21,7 @@
 #include "G4Threading.hh"
 #include "G4AutoLock.hh"
 
+#include "LCIOParticleExtension.h"
 #include "DD4hep/Detector.h"
 #include <G4Version.hh>
 
@@ -240,12 +241,23 @@ lcio::LCCollectionVec* Geant4Output2LCIO::saveParticles(Geant4ParticleMap* parti
 
       // Set generator status
       q->setGeneratorStatus(0);
-      if ( mask.isSet(G4PARTICLE_GEN_STABLE) )             q->setGeneratorStatus(1);
-      else if ( mask.isSet(G4PARTICLE_GEN_DECAYED) )       q->setGeneratorStatus(2);
-      else if ( mask.isSet(G4PARTICLE_GEN_DOCUMENTATION) ) q->setGeneratorStatus(3);
-      else if ( mask.isSet(G4PARTICLE_GEN_BEAM) )          q->setGeneratorStatus(4);
-      else if ( mask.isSet(G4PARTICLE_GEN_OTHER) )         q->setGeneratorStatus(9);
-      //      std::cout << " ********** mcp genstatus : " << q->getGeneratorStatus() << std::endl ;
+
+      // see if we have preserved the original generator code in the stdhep or LCIO reader
+      const LCIOParticleExtension* p_ext = dynamic_cast< LCIOParticleExtension*>( p->extension.get() ) ;
+
+      if( p_ext ) {
+
+	q->setGeneratorStatus(  p_ext->generatorStatus ) ;
+
+      } else {
+
+	if ( mask.isSet(G4PARTICLE_GEN_STABLE) )             q->setGeneratorStatus(1);
+	else if ( mask.isSet(G4PARTICLE_GEN_DECAYED) )       q->setGeneratorStatus(2);
+	else if ( mask.isSet(G4PARTICLE_GEN_DOCUMENTATION) ) q->setGeneratorStatus(3);
+	else if ( mask.isSet(G4PARTICLE_GEN_BEAM) )          q->setGeneratorStatus(4);
+	else if ( mask.isSet(G4PARTICLE_GEN_OTHER) )         q->setGeneratorStatus(9);
+      }
+//      std::cout << " ********** mcp genstatus : " << q->getGeneratorStatus() << std::endl ;
 
       // Set simulation status
       q->setCreatedInSimulation(         mask.isSet(G4PARTICLE_SIM_CREATED) );

--- a/DDG4/lcio/LCIOEventReader.cpp
+++ b/DDG4/lcio/LCIOEventReader.cpp
@@ -75,16 +75,6 @@ LCIOEventReader::readParticles(int event_number,
   // check if there is at least one particle
   if ( NHEP == 0 ) return EVENT_READER_NO_PRIMARIES;
 
-  //fg: for now we create exactly one event vertex here ( as before )
-  Geant4Vertex* vtx = new Geant4Vertex ;
-  vertices.push_back( vtx );
-  vtx->x = 0;
-  vtx->y = 0;
-  vtx->z = 0;
-  vtx->time = 0;
-  //  bool haveVertex = false ;
-
-
   mcpcoll.resize(NHEP,0);
   for(int i=0; i<NHEP; ++i ) {
     EVENT::MCParticle* p = dynamic_cast<EVENT::MCParticle*>(primaries->getElementAt(i));
@@ -143,19 +133,9 @@ LCIOEventReader::readParticles(int event_number,
     p_ext->generatorStatus =  mcp->getGeneratorStatus();
     p->extension.adopt( p_ext ) ;
 
-    //fixme: need to define the correct logic for selecting the particle to use
-    //       for the _one_ event vertex 
-    // fill vertex information from first stable particle
-    // if( !haveVertex &&  genStatus == 1 ){
-    //   vtx->x = p->vsx ;
-    //   vtx->y = p->vsy ;
-    //   vtx->z = p->vsz ;
-    //   vtx->time = p->time ;
-    //   haveVertex = true ;
-    // }
 
-    //fg: we simply add all particles without parents as outgoing to the main
-    //    event vertex. This might include the incoming beam particles, e.g. in
+    //fg: we simply add all particles without parents as with their own vertex.
+    //    This might include the incoming beam particles, e.g. in
     //    the case of lcio files written with Whizard2, which is slightly odd,
     //    however should be treated correctly in Geant4InputHandling.cpp.
     //    We no longer make an attempt to identify the incoming particles
@@ -164,7 +144,14 @@ LCIOEventReader::readParticles(int event_number,
 
     if ( p->parents.size() == 0 )  {
 
-      vtx->out.insert(p->id); // Stuff, to be given to Geant4 together with daughters
+      Geant4Vertex* vtx = new Geant4Vertex ;
+      vertices.push_back( vtx );
+      vtx->x = p->vsx;
+      vtx->y = p->vsy;
+      vtx->z = p->vsz;
+      vtx->time = p->time;
+
+      vtx->out.insert(p->id) ;
     }
 
     if ( mcp->isCreatedInSimulation() )       status.set(G4PARTICLE_SIM_CREATED);

--- a/DDG4/lcio/LCIOEventReader.cpp
+++ b/DDG4/lcio/LCIOEventReader.cpp
@@ -14,6 +14,7 @@
 
 // Framework include files
 #include "LCIOEventReader.h"
+#include "LCIOParticleExtension.h"
 #include "DD4hep/Printout.h"
 #include "DDG4/Geant4Primary.h"
 #include "DDG4/Geant4Context.h"
@@ -137,6 +138,10 @@ LCIOEventReader::readParticles(int event_number,
     else
       status.set(G4PARTICLE_GEN_OTHER);
 
+    // store the original generator status in case it is not in [0,4]
+    LCIOParticleExtension* p_ext = new LCIOParticleExtension ;
+    p_ext->generatorStatus =  mcp->getGeneratorStatus();
+    p->extension.adopt( p_ext ) ;
 
     //fixme: need to define the correct logic for selecting the particle to use
     //       for the _one_ event vertex 

--- a/DDG4/lcio/LCIOEventReader.cpp
+++ b/DDG4/lcio/LCIOEventReader.cpp
@@ -133,10 +133,10 @@ LCIOEventReader::readParticles(int event_number,
     else if ( genStatus == 1 ) status.set(G4PARTICLE_GEN_STABLE);
     else if ( genStatus == 2 ) status.set(G4PARTICLE_GEN_DECAYED);
     else if ( genStatus == 3 ) status.set(G4PARTICLE_GEN_DOCUMENTATION);
-    else {
-      cout << " #### WARNING - LCIOInputAction : unknown generator status : "
-           << genStatus << " -> ignored ! " << endl;
-    }
+    else if ( genStatus == 4 ) status.set(G4PARTICLE_GEN_BEAM);
+    else
+      status.set(G4PARTICLE_GEN_OTHER);
+
 
     //fixme: need to define the correct logic for selecting the particle to use
     //       for the _one_ event vertex 

--- a/DDG4/lcio/LCIOParticleExtension.h
+++ b/DDG4/lcio/LCIOParticleExtension.h
@@ -1,0 +1,50 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+#ifndef DD4HEP_LCIOParticleExtension_H
+#define DD4HEP_LCIOParticleExtension_H
+
+#include "DDG4/Geant4Particle.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep  {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim  {
+
+
+   /** Simple helper class for additional MCParticle information
+    *  used with LCIO readers and writers.
+    * 
+    *  @author  F.Gaede, DESY
+    *  @version 1.0
+    *  @ingroup DD4HEP_SIMULATION
+    */
+    class LCIOParticleExtension : public ParticleExtension{
+
+    public:
+
+      /// original generator status
+      int generatorStatus ;
+
+      /// Default constructor
+      LCIOParticleExtension() {}
+
+      /// Default destructor
+      virtual ~LCIOParticleExtension() {} ;
+   
+    };
+  }
+}
+
+#endif

--- a/DDG4/src/Geant4Particle.cpp
+++ b/DDG4/src/Geant4Particle.cpp
@@ -204,6 +204,8 @@ std::string Geant4ParticleHandle::processName() const   {
   else if ( particle->status&G4PARTICLE_GEN_STABLE ) return "Gen.Stable";
   else if ( particle->status&G4PARTICLE_GEN_DECAYED ) return "Gen.Decay";
   else if ( particle->status&G4PARTICLE_GEN_DOCUMENTATION ) return "Gen.DOC";
+  else if ( particle->status&G4PARTICLE_GEN_BEAM ) return "Gen.Beam";
+  else if ( particle->status&G4PARTICLE_GEN_OTHER ) return "Gen.Other";
   return "???";
 }
 
@@ -380,6 +382,8 @@ void Geant4ParticleHandle::dump4(int level, const std::string& src, const char* 
            status.isSet(G4PARTICLE_GEN_STABLE) ? 'S' : '.',
            status.isSet(G4PARTICLE_GEN_DECAYED) ? 'D' : '.',
            status.isSet(G4PARTICLE_GEN_DOCUMENTATION) ? 'd' : '.',
+           status.isSet(G4PARTICLE_GEN_BEAM) ? 'B' : '.',
+           status.isSet(G4PARTICLE_GEN_OTHER) ? 'o' : '.',
 
            status.isSet(G4PARTICLE_SIM_CREATED) ? 's' : '.',
            status.isSet(G4PARTICLE_SIM_BACKSCATTER) ? 'b' : '.',

--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -631,7 +631,7 @@ void Geant4ParticleHandler::checkConsistency()  const   {
     }
     // We assume that particles from the generator have consistent parents
     // For all other particles except the primaries, the parent must be contained in the record.
-    if ( !mask.isSet(G4PARTICLE_PRIMARY) && !status.anySet(G4PARTICLE_GEN_GENERATOR) )  {
+    if ( !mask.isSet(G4PARTICLE_PRIMARY) && !status.anySet(G4PARTICLE_GEN_STATUS) )  {
       TrackEquivalents::const_iterator eq_it = m_equivalentTracks.find(p->g4Parent);
       bool in_map = false, in_parent_list = false;
       int parent_id = -1;


### PR DESCRIPTION

BEGINRELEASENOTES
- fix reading of stdhep/lcio generator files with generator statuses not in [0,3]
- add G4PARTICLE_GEN_BEAM and G4PARTICLE_GEN_OTHER to DDG4
      -  G4PARTICLE_GEN_BEAM  is generally agreed to be used for beam particles (HepMC, LCIO)
      -  all other status codes vary from generator to generator and we use OTHER
- for stdhep or lcio input the true generator status is preserved in the lcio output, regardless of its value
- create a vertex for every parent-less particle in LCIOEventReader
       - this allows for example to read GuineaPig files ( non-prompt pair particles) or
          special user created files with non-prompt particles

ENDRELEASENOTES