### PR TITLE
Add thread safe BitFieldCoder

### DIFF
--- a/DDCore/include/DD4hep/BitField64.h
+++ b/DDCore/include/DD4hep/BitField64.h
@@ -23,7 +23,7 @@ namespace dd4hep {
   namespace detail {
 
     using DDSegmentation::BitField64;
-    using DDSegmentation::BitFieldValue;
+    using DDSegmentation::BitFieldElement;
 
   }       /* End namespace detail           */
 }         /* End namespace dd4hep             */

--- a/DDCore/include/DD4hep/BitFieldCoder.h
+++ b/DDCore/include/DD4hep/BitFieldCoder.h
@@ -1,0 +1,30 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_DDCORE_BITFIELD64_H
+#define DD4HEP_DDCORE_BITFIELD64_H
+
+// Framework include files
+#include "DDSegmentation/BitFieldCoder.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for implementation details of the AIDA detector description toolkit
+  namespace detail {
+
+    using DDSegmentation::BitFieldCoder;
+    using DDSegmentation::BitFieldElement;
+
+  }       /* End namespace detail           */
+}         /* End namespace dd4hep             */
+#endif    /* DD4HEP_DDCORE_BITFIELD64_H     */

--- a/DDCore/include/DD4hep/Factories.h
+++ b/DDCore/include/DD4hep/Factories.h
@@ -43,7 +43,7 @@ namespace dd4hep {
 
   /// Namespace describing generic detector segmentations
   namespace DDSegmentation  {
-    class BitField64;
+    class BitFieldCoder;
   }
   
   
@@ -80,7 +80,7 @@ namespace dd4hep {
    */
   template <typename T> class SegmentationFactory : public PluginFactoryBase {
   public:
-    static SegmentationObject* create(DDSegmentation::BitField64* decoder);
+    static SegmentationObject* create(const DDSegmentation::BitFieldCoder* decoder);
   };
 
   /// Template class with a generic signature to apply Detector plugins
@@ -203,7 +203,7 @@ namespace {
     typedef dd4hep::json::Handle_t      json_h;
     typedef dd4hep::Handle<Named>       ref_t;
     typedef dd4hep::SegmentationObject  SegmentationObject;
-    typedef dd4hep::DDSegmentation::BitField64   BitField64;
+    typedef dd4hep::DDSegmentation::BitFieldCoder   BitFieldCoder;
   }
 
   DD4HEP_PLUGIN_FACTORY_ARGS_1(void*,const char*)  
@@ -212,7 +212,7 @@ namespace {
   DD4HEP_PLUGIN_FACTORY_ARGS_1(ns::Named*,dd4hep::Detector*)
   {    return dd4hep::TranslationFactory<P>::create(*a0).ptr();                         }
 
-  DD4HEP_PLUGIN_FACTORY_ARGS_1(ns::SegmentationObject*,ns::BitField64*)
+  DD4HEP_PLUGIN_FACTORY_ARGS_1(ns::SegmentationObject*,const ns::BitFieldCoder*)
   {    return dd4hep::SegmentationFactory<P>::create(a0);                               }
 
   DD4HEP_PLUGIN_FACTORY_ARGS_3(void*,dd4hep::Detector*,int,char**)
@@ -250,12 +250,12 @@ namespace {
 #define DECLARE_NAMED_DETELEMENT_FACTORY(n,x)       namespace dd4hep    \
   { DD4HEP_PLUGINSVC_FACTORY(n::x,x,dd4hep::*(),__LINE__) }
 
-// Call function of the type [SegmentationObject (*func)(dd4hep::Detector*,DDSegmentation::BitField64*)]
+// Call function of the type [SegmentationObject (*func)(dd4hep::Detector*,DDSegmentation::BitFieldCoder*)]
 #define DECLARE_SEGMENTATION(name,func) DD4HEP_OPEN_PLUGIN(dd4hep,name)   { \
     template <> SegmentationObject*                           \
-      SegmentationFactory<name>::create(DDSegmentation::BitField64* d) { return func(d); } \
+      SegmentationFactory<name>::create(const DDSegmentation::BitFieldCoder* d) { return func(d); } \
     DD4HEP_PLUGINSVC_FACTORY(name,segmentation_constructor__##name,     \
-                             SegmentationObject*(DDSegmentation::BitField64*),__LINE__)}
+                             SegmentationObject*(const DDSegmentation::BitFieldCoder*),__LINE__)}
 
 // Call function of the type [long (*func)(const char* arg)]
 #define DECLARE_APPLY(name,func)        DD4HEP_OPEN_PLUGIN(dd4hep,name)   { \

--- a/DDCore/include/DD4hep/IDDescriptor.h
+++ b/DDCore/include/DD4hep/IDDescriptor.h
@@ -15,7 +15,7 @@
 
 // Framework include files
 #include "DD4hep/Handle.h"
-#include "DD4hep/BitField64.h"
+#include "DD4hep/BitFieldCoder.h"
 
 // C++ include files
 #include <string>
@@ -36,7 +36,7 @@ namespace dd4hep {
    */
   class IDDescriptor: public Handle<IDDescriptorObject> {
   public:
-    typedef std::vector<std::pair<std::string, BitFieldValue*> >  FieldMap;
+    typedef std::vector<std::pair<std::string, const BitFieldElement*> >  FieldMap;
     typedef std::vector<std::pair<size_t, std::string> >          FieldIDs;
 
   public:
@@ -55,25 +55,25 @@ namespace dd4hep {
     /// Access the fieldmap container
     const FieldMap& fields() const;
     /// Get the field descriptor of one field by name
-    const BitFieldValue* field(const std::string& field_name) const;
+    const BitFieldElement* field(const std::string& field_name) const;
     /// Get the field identifier of one field by name
     size_t fieldID(const std::string& field_name) const;
     /// Get the field descriptor of one field by its identifier
-    const BitFieldValue* field(size_t identifier) const;
+    const BitFieldElement* field(size_t identifier) const;
 #ifndef __MAKECINT__
     /// Encode a set of volume identifiers (corresponding to this description of course!) to a volumeID.
     VolumeID encode(const std::vector<std::pair<std::string, int> >& ids) const;
 #endif
     /// Decode volume IDs and return filled descriptor with all fields
-    void decodeFields(VolumeID vid, std::vector<std::pair<const BitFieldValue*, VolumeID> >& fields)  const;
+    void decodeFields(VolumeID vid, std::vector<std::pair<const BitFieldElement*, VolumeID> >& fields)  const;
     /// Decode volume IDs and return string reprensentation for debugging purposes
     std::string str(VolumeID vid)  const;
     /// Decode volume IDs and return string reprensentation for debugging purposes
     std::string str(VolumeID vid, VolumeID mask)  const;
     /// Access string representation
     std::string toString() const;
-    /// Access the BitField64 object
-    BitField64* decoder();
+    /// Access the BitFieldCoder object
+    BitFieldCoder* decoder();
     /// Re-build object in place
     void rebuild(const std::string& description);
   };

--- a/DDCore/include/DD4hep/MultiSegmentation.h
+++ b/DDCore/include/DD4hep/MultiSegmentation.h
@@ -72,7 +72,7 @@ namespace dd4hep {
     /// access the field name used to discriminate sub-segmentations
     const std::string& discriminatorName() const;
     /// Discriminating bitfield entry
-    BitFieldValue* discriminator() const;
+    const BitFieldElement* discriminator() const;
     /// The underlying sub-segementations
     const Segmentations& subSegmentations()  const;
     /// determine the position based on the cell ID

--- a/DDCore/include/DD4hep/Primitives.h
+++ b/DDCore/include/DD4hep/Primitives.h
@@ -32,8 +32,8 @@ namespace dd4hep {
 
   /// Namespace describing generic detector segmentations
   namespace DDSegmentation  {
-    class BitField64;
-    class BitFieldValue;
+    class BitFieldCoder;
+    class BitFieldElement;
     /// Useful typedefs to differentiate cell IDs and volume IDs
     typedef long long int CellID;
     typedef long long int VolumeID;
@@ -44,13 +44,13 @@ namespace dd4hep {
 #ifdef __CINT__
   typedef DDSegmentation::CellID CellID;
   typedef DDSegmentation::VolumeID VolumeID;
-  typedef DDSegmentation::BitField64 BitField64;
-  typedef DDSegmentation::BitFieldValue BitFieldValue;
+  typedef DDSegmentation::BitFieldCoder BitFieldCoder;
+  typedef DDSegmentation::BitFieldElement BitFieldElement;
 #else
   using DDSegmentation::CellID;
   using DDSegmentation::VolumeID;
-  using DDSegmentation::BitField64;
-  using DDSegmentation::BitFieldValue;
+  using DDSegmentation::BitFieldCoder;
+  using DDSegmentation::BitFieldElement;
 #endif
 
   /// Specialized exception to be thrown if invalid handles are accessed

--- a/DDCore/include/DD4hep/Segmentations.h
+++ b/DDCore/include/DD4hep/Segmentations.h
@@ -16,7 +16,7 @@
 // Framework include files
 #include "DD4hep/Handle.h"
 #include "DD4hep/Objects.h"
-#include "DD4hep/BitField64.h"
+#include "DD4hep/BitFieldCoder.h"
 #include "DDSegmentation/Segmentation.h"
 
 /// Namespace for the AIDA detector description toolkit
@@ -41,7 +41,7 @@ namespace dd4hep {
   class Segmentation : public Handle<SegmentationObject> {
   public:
     /// Initializing constructor creating a new object of the given DDSegmentation type
-    Segmentation(const std::string& type, const std::string& name, BitField64* decoder);
+    Segmentation(const std::string& type, const std::string& name, const BitFieldCoder* decoder);
     /// Default constructor
     Segmentation() = default;
     /// Copy Constructor from object
@@ -69,9 +69,9 @@ namespace dd4hep {
     /// Access the sensitive detector using this segmetnation object
     Handle<SensitiveDetectorObject> sensitive() const;
     /// Access the underlying decoder
-    const BitField64* decoder() const;
+    const BitFieldCoder* decoder() const;
     /// Set the underlying decoder
-    void setDecoder(BitField64* decoder) const;
+    void setDecoder(const BitFieldCoder* decoder) const;
     /// determine the local position based on the cell ID
     Position position(const long64& cellID) const;
     /// determine the cell ID based on the local position

--- a/DDCore/include/DD4hep/detail/ObjectsInterna.h
+++ b/DDCore/include/DD4hep/detail/ObjectsInterna.h
@@ -18,7 +18,7 @@
 #include "DD4hep/NamedObject.h"
 #include "DD4hep/IDDescriptor.h"
 #include "DD4hep/Segmentations.h"
-#include "DD4hep/BitField64.h"
+#include "DD4hep/BitFieldCoder.h"
 
 // C/C++ include files
 #include <set>
@@ -192,14 +192,14 @@ namespace dd4hep {
    */
   class IDDescriptorObject: public NamedObject {
   public:
-    typedef std::vector<std::pair<std::string, BitFieldValue*> > FieldMap;
+    typedef std::vector<std::pair<std::string, const BitFieldElement*> > FieldMap;
     typedef std::vector<std::pair<size_t, std::string> >         FieldIDs;
     /// Map of id-fields in the descriptor
     FieldMap fieldMap;  //! not ROOT-persistent
     /// String map of id descriptors
     FieldIDs fieldIDs;  //! not ROOT-persistent
     /// Decoder object
-    BitField64 decoder; //! not ROOT-persistent
+    BitFieldCoder decoder; //! not ROOT-persistent
     
     /// The description string to build the bit-field descriptors.
     std::string description;
@@ -211,8 +211,8 @@ namespace dd4hep {
     virtual ~IDDescriptorObject();
 #if 0
 #ifndef __CINT__
-    /// Access to the field container of the BitField64
-    const std::vector<BitFieldValue*>& fields() const {
+    /// Access to the field container of the BitFieldCoder
+    const std::vector<BitFieldElement*>& fields() const {
       return decoder.fields();
     }
 #endif

--- a/DDCore/include/DD4hep/detail/SegmentationsInterna.h
+++ b/DDCore/include/DD4hep/detail/SegmentationsInterna.h
@@ -16,7 +16,7 @@
 // Framework include files
 #include "DD4hep/Handle.h"
 #include "DD4hep/Objects.h"
-#include "DD4hep/BitField64.h"
+#include "DD4hep/BitFieldCoder.h"
 #include "DDSegmentation/Segmentation.h"
 
 // C/C++ include files
@@ -55,9 +55,9 @@ namespace dd4hep {
     /// Access the description of the segmentation
     const std::string& description() const;
     /// Access the underlying decoder
-    const BitField64* decoder() const;
+    const BitFieldCoder* decoder() const;
     /// Set the underlying decoder
-    void setDecoder(BitField64* decoder) const;
+    void setDecoder(const BitFieldCoder* decoder) const;
     /// Access to parameter by name
     DDSegmentation::Parameter  parameter(const std::string& parameterName) const;
     /// Access to all parameters
@@ -106,14 +106,14 @@ namespace dd4hep {
     SegmentationWrapper() : SegmentationObject(implementation=new IMP(0)) { }
 #endif
     /// Standard constructor
-    SegmentationWrapper(BitField64* decoder);
+    SegmentationWrapper(const BitFieldCoder* decoder);
     /// Default destructor
     virtual ~SegmentationWrapper();
   };
   
   /// Standard constructor
   template <typename IMP> inline
-  SegmentationWrapper<IMP>::SegmentationWrapper(BitField64* decode)
+  SegmentationWrapper<IMP>::SegmentationWrapper(const BitFieldCoder* decode)
     :  SegmentationObject(implementation=new IMP(decode))
   {
   }

--- a/DDCore/include/DD4hep/detail/VolumeManagerInterna.h
+++ b/DDCore/include/DD4hep/detail/VolumeManagerInterna.h
@@ -58,7 +58,7 @@ namespace dd4hep {
       /// The reference to the TOP level VolumeManager
       VolumeManagerObject* top    = 0;
       /// The system field descriptor
-      const BitFieldValue* system = 0;   //! Not ROOT persistent
+      const BitFieldElement* system = 0;   //! Not ROOT persistent
       /// System identifier
       VolumeID sysID              = 0;
       /// Sub-detector mask

--- a/DDCore/include/DDSegmentation/BitField64.h
+++ b/DDCore/include/DDSegmentation/BitField64.h
@@ -17,7 +17,9 @@ namespace dd4hep {
   
   namespace DDSegmentation {
     
-    /** Helper class for BitField64 that corresponds to one field value. 
+    /** Lightweight helper class for BitField64 that corresponds to one field value.
+     *  (Not thread safe - only use directly through BitField64).
+     *
      *    @author F.Gaede, DESY
      *    @date  2017-09
      */
@@ -92,8 +94,8 @@ namespace dd4hep {
      *    unsigned phiIndex = b.index("phi") ;        <br>
      *    int phi = b[  phiIndex ] ;                  <br>
      *
+     *    Sep-2017: FG: re-implemented as lightweight wrapper around BitFieldCoder
      *    @author F.Gaede, DESY
-     *    @version $Id:$
      *    @date  2013-06
      */  
     class BitField64{
@@ -103,8 +105,8 @@ namespace dd4hep {
     public :
 
       virtual ~BitField64() {
-
-	delete _coder ;
+	if( _owner)
+	  delete _coder ;
       } ; 
   
       /** No default c'tor */
@@ -128,6 +130,11 @@ namespace dd4hep {
       
 	_coder = new BitFieldCoder( initString ) ;
       }
+
+      /// Initialize from existing BitFieldCoder
+      BitField64( const BitFieldCoder* coder ) : _owner(false), _coder( coder ) {
+      }
+
 
       /** Returns the current 64bit value 
        */
@@ -212,7 +219,7 @@ namespace dd4hep {
     protected:
 
       // -------------- data members:--------------
-
+      bool  _owner{true} ;
       long64    _value{} ;
       const BitFieldCoder* _coder{} ;
     
@@ -227,6 +234,7 @@ namespace dd4hep {
   
   } // end namespace
 
+  using DDSegmentation::BitField64 ;
 } // end namespace
 
 #endif

--- a/DDCore/include/DDSegmentation/BitField64.h
+++ b/DDCore/include/DDSegmentation/BitField64.h
@@ -8,306 +8,224 @@
 #include <map>
 #include <sstream>
 
+#include "BitFieldCoder.h"
 
 namespace dd4hep {
-
-//fixme: do  need to do this also for 32 bit machines ?
-typedef long long int long64 ;
-typedef unsigned long long ulong64 ;
-
-namespace DDSegmentation {
-
-  class BitFieldValue ;
-  class StringTokenizer ; 
-
-
-  /** A bit field of 64bits that allows convenient declaration and 
-   *  manipulation of sub fields of various widths.<br>
-   *  Example:<br>
-   *    BitField64 b("layer:7,system:-3,barrel:3,theta:32:11,phi:11" ) ; <br> 
-   *    b[ "layer"  ]  = 123 ;         <br> 
-   *    b[ "system" ]  = -4 ;          <br> 
-   *    b[ "barrel" ]  = 7 ;           <br> 
-   *    b[ "theta" ]   = 180 ;         <br> 
-   *    b[ "phi" ]     = 270 ;         <br> 
-   *    ...                            <br>
-   *    int theta = b["theta"] ;                    <br>
-   *    ...                                         <br>
-   *    unsigned phiIndex = b.index("phi") ;        <br>
-   *    int phi = b[  phiIndex ] ;                  <br>
-   *
-   *    @author F.Gaede, DESY
-   *    @version $Id:$
-   *    @date  2013-06
-   */  
-  class BitField64{
-
-    friend std::ostream& operator<<(std::ostream& os, const BitField64& b) ;
-
-  public :
-
-    typedef std::map<std::string, unsigned int> IndexMap ;
-
-
-    virtual ~BitField64();  // clean up
   
-    /** The c'tor takes an initialization string of the form:<br>
-     *  \<fieldDesc\>[,\<fieldDesc\>...]<br>
-     *  fieldDesc = name:[start]:[-]length<br>
-     *  where:<br>
-     *  name: The name of the field<br>
-     *  start: The start bit of the field. If omitted assumed to start 
-     *  immediately following previous field, or at the least significant 
-     *  bit if the first field.<br>
-     *  length: The number of bits in the field. If preceeded by '-' 
-     *  the field is signed, otherwise unsigned.<br>
-     *  Bit numbering is from the least significant bit (bit 0) to the most 
-     *  significant (bit 63). <br>
-     *  Example: "layer:7,system:-3,barrel:3,theta:32:11,phi:11"
-     */
-    BitField64( const std::string& initString ) : _value(0), _joined(0){
+  typedef long long int long64 ;
+  typedef unsigned long long ulong64 ;
+  
+  namespace DDSegmentation {
     
-      init( initString ) ;
-    }
-
-    /** Returns the current 64bit value 
+    /** Helper class for BitField64 that corresponds to one field value. 
+     *    @author F.Gaede, DESY
+     *    @date  2017-09
      */
-    long64 getValue() const { return _value ; }
+
+    class BitFieldValue{
+
+      long64& _value ;
+      const BitFieldCoder::BitFieldValue& _bv ;
     
-    /** Set a new 64bit value  - bits not used in description are set to 0.
-     */
-    void  setValue(long64 value ) { _value = ( _joined & value ) ; }
-
-    /** Set a new 64bit value given as high and low 32bit words.
-     */
-    void  setValue(unsigned low_Word, unsigned high_Word ) {
-      setValue( ( low_Word & 0xffffffffULL ) |  ( ( high_Word & 0xffffffffULL ) << 32 ) ) ; 
-    }
+    public :
     
-    /** Operator for setting a new value and accessing the BitField directly */
-    BitField64& operator()(long64 val) { setValue( val ) ; return *this ; }
- 
-    /** Reset - same as setValue(0) - useful if the same encoder is used for many objects.
-     */
-    void  reset() { _value = 0 ; }
-
-    /** Acces to field through index 
-     */
-    BitFieldValue& operator[](size_t idx) { 
-      return *_fields.at( idx )  ; 
-    }
+      BitFieldValue() = delete ;
     
-    /** Const acces to field through index 
-     */
-    const BitFieldValue& operator[](size_t idx) const { 
-      return *_fields.at( idx )  ; 
-    }
-
-    /** Highest bit used in fields [0-63]
-     */
-    unsigned highestBit() const ;
+      /// only c'tor with reference to bitfield and BitFieldCoder::BitFieldValue
+      BitFieldValue( long64& bitfield, const BitFieldCoder::BitFieldValue& bv ) :
+	_value( bitfield ), _bv( bv) {}
     
-    /** Number of values */
-    size_t size() const { return _fields.size() ; }
+      /** Returns the current field value 
+       */
+      long64 value() const { return _value ; }
+  
+      /// Calculate Field value given an external 64 bit bitmap value
+      long64 value(long64 id) const { return _bv.value( id ) ; }
 
-    /** Index for field named 'name' 
-     */
-    size_t index( const std::string& name) const ;
-
-    /** Access to field through name .
-     */
-    BitFieldValue& operator[](const std::string& name) { 
-
-      return *_fields[ index( name ) ] ;
-    }
-    /** Const Access to field through name .
-     */
-    const BitFieldValue& operator[](const std::string& name) const { 
-
-      return *_fields[ index( name ) ] ;
-    }
-
-
-    /** The low  word, bits 0-31
-     */
-    unsigned lowWord() const { return unsigned( _value &  0xffffFFFFUL )  ; } 
-
-    /** The high  word, bits 32-63
-     */
-    unsigned highWord() const { return unsigned(_value >> 32) ; } 
-
-
-    /** Return a valid description string of all fields
-     */
-    std::string fieldDescription() const ;
-
-    /** Return a string with a comma separated list of the current sub field values 
-     */
-    std::string valueString() const ;
-
-    const std::vector<BitFieldValue*>& fields()  const  {
-      return _fields;
-    }
+      //// Assignment operator for user convenience 
+      BitFieldValue& operator=(long64 in) {
+	_bv.set( _value, in ) ;
+	return *this ;
+      } 
     
-  protected:
-
-    /** Add an additional field to the list 
-     */
-    void addField( const std::string& name,  unsigned offset, int width ); 
-
-    /** Decode the initialization string as described in the constructor.
-     *  @see BitField64( const std::string& initString )
-     */
-    void init( const std::string& initString) ;
-
-  public:
-    /** No default c'tor */
-    BitField64() : _value(0) , _joined(0) { }
-
-  protected:
-
-    // -------------- data members:--------------
-
-    std::vector<BitFieldValue*> _fields;   //! Not ROOT persistent
-    long64    _value ;
-    IndexMap  _map ;
-    long64    _joined ;
-
-
-  };
-
-
-
-  /** Operator for dumping BitField64 to streams 
-   */
-  std::ostream& operator<<(std::ostream& os, const BitField64& b) ;
-
-
-
- /** Helper class  for string tokenization. Usage:<br>
-   *    std::vector<std::string> tokens ; <br>
-   *    StringTokenizer t( tokens ,',') ; <br>
-   *    std::for_each( aString.begin(), aString.end(), t ) ;  <br>
-   *
-   *    @author F.Gaede, DESY
-   *    @date  2013-06
-   */
-  class StringTokenizer{
+      /** Conversion operator for long64 - allows to write:<br>
+       *  long64 index = myBitFieldValue ;
+       */
+      operator long64() const { return value() ; } 
     
-    std::vector< std::string >& _tokens ;
-    char _del ;
-    char _last ;
+      /** The field's name */
+      const std::string& name() const { return _bv.name() ; }
 
-  public:
+      /** The field's offset */
+      unsigned offset() const { return _bv.offset() ; }
+
+      /** The field's width */
+      unsigned width() const { return _bv.width() ; }
+
+      /** True if field is interpreted as signed */
+      bool isSigned() const { return _bv.isSigned() ; }
+
+      /** The field's mask */
+      ulong64 mask() const { return _bv.mask() ; }
+
+      /** Minimal value  */
+      int  minValue()  const  { return _bv.minValue();  }
+
+      /** Maximal value  */
+      int  maxValue()  const  { return _bv.maxValue();  }
+
+    } ;
     
-    /** Only c'tor, give (empty) token vector and delimeter character */
-    StringTokenizer( std::vector< std::string >& tokens, char del ) 
-      : _tokens(tokens) 
-	, _del(del), 
-	_last(del) {
-    }
-    
-    /** Operator for use with algorithms, e.g. for_each */
-    void operator()(const char& c) { 
+  
+    /** A bit field of 64bits that allows convenient declaration and 
+     *  manipulation of sub fields of various widths.<br>
+     *  Example:<br>
+     *    BitField64 b("layer:7,system:-3,barrel:3,theta:32:11,phi:11" ) ; <br> 
+     *    b[ "layer"  ]  = 123 ;         <br> 
+     *    b[ "system" ]  = -4 ;          <br> 
+     *    b[ "barrel" ]  = 7 ;           <br> 
+     *    b[ "theta" ]   = 180 ;         <br> 
+     *    b[ "phi" ]     = 270 ;         <br> 
+     *    ...                            <br>
+     *    int theta = b["theta"] ;                    <br>
+     *    ...                                         <br>
+     *    unsigned phiIndex = b.index("phi") ;        <br>
+     *    int phi = b[  phiIndex ] ;                  <br>
+     *
+     *    @author F.Gaede, DESY
+     *    @version $Id:$
+     *    @date  2013-06
+     */  
+    class BitField64{
       
-      if( c != _del  ) {
-	
-	if( _last == _del  ) {
-	  _tokens.push_back("") ; 
-	}
-	_tokens.back() += c ;
+      friend std::ostream& operator<<(std::ostream& os, const BitField64& b) ;
+
+    public :
+
+      virtual ~BitField64() {
+
+	delete _coder ;
+      } ; 
+  
+      /** No default c'tor */
+      BitField64() = delete ;
+
+      /** The c'tor takes an initialization string of the form:<br>
+       *  \<fieldDesc\>[,\<fieldDesc\>...]<br>
+       *  fieldDesc = name:[start]:[-]length<br>
+       *  where:<br>
+       *  name: The name of the field<br>
+       *  start: The start bit of the field. If omitted assumed to start 
+       *  immediately following previous field, or at the least significant 
+       *  bit if the first field.<br>
+       *  length: The number of bits in the field. If preceeded by '-' 
+       *  the field is signed, otherwise unsigned.<br>
+       *  Bit numbering is from the least significant bit (bit 0) to the most 
+       *  significant (bit 63). <br>
+       *  Example: "layer:7,system:-3,barrel:3,theta:32:11,phi:11"
+       */
+      BitField64( const std::string& initString ){
+      
+	_coder = new BitFieldCoder( initString ) ;
       }
-      _last = c ;
-    } 
+
+      /** Returns the current 64bit value 
+       */
+      long64 getValue() const { return _value ; }
     
-  };
+      /** Set a new 64bit value  - bits not used in description are set to 0.
+       */
+      void  setValue(long64 value ) { _value = ( _coder->mask() & value ) ; }
 
-
-  /** Helper class for BitField64 that corresponds to one field value. 
-   *    @author F.Gaede, DESY
-   *    @date  2013-06
-   */
-
-  class BitFieldValue{
-  
-  public :
-    virtual ~BitFieldValue() {}
-  
-    /** The default c'tor.
-     * @param  bitfield      reference to the 64bit bitfield
-     * @param  name          name of the field
-     * @param  offset        offset of field
-     * @param  signedWidth   width of field, negative if field is signed
-     */
-    BitFieldValue( long64& bitfield, const std::string& name, 
-		   unsigned offset, int signedWidth ) ; 
-
-
-    /** Returns the current field value 
-     */
-    long64 value() const ;
-  
-    /// Calculate Field value given an external 64 bit bitmap value
-    long64 value(long64 id) const;
-
-    /** Assignment operator for user convenience 
-     */
-    BitFieldValue& operator=(long64 in) ;
-
-    /** Conversion operator for long64 - allows to write:<br>
-     *  long64 index = myBitFieldValue ;
-     */
-    operator long64() const { return value() ; } 
+      /** Set a new 64bit value given as high and low 32bit words.
+       */
+      void  setValue(unsigned low_Word, unsigned high_Word ) {
+	setValue( ( low_Word & 0xffffffffULL ) |  ( ( high_Word & 0xffffffffULL ) << 32 ) ) ; 
+      }
     
-    /** fg: removed because it causes ambiguities with operator long64().
-     *  Conversion operator for int - allows to write:<br>
-     *  int index = myBitFieldValue ;
-     */
-    //     operator int() const { return (int) value() ; } 
+      /** Operator for setting a new value and accessing the BitField directly */
+      BitField64& operator()(long64 val) { setValue( val ) ; return *this ; }
+ 
+      /** Reset - same as setValue(0) - useful if the same encoder is used for many objects.
+       */
+      void  reset() { _value = 0 ; }
+
+      /** Acces to field through index 
+       */
+      BitFieldValue operator[](size_t idx) {
+	return BitFieldValue( _value,  _coder->operator[]( idx  ) ) ; 
+      }
     
-    /** The field's name */
-    const std::string& name() const { return _name ; }
+      // /** Const acces to field through index 
+      //  */
+      // const BitFieldValue& operator[](size_t idx) const { 
+      
+      //   return BitFieldValue( _value,  _coder->operator[]( idx  ) ) ; 
+      // }
 
-    /** The field's offset */
-    unsigned offset() const { return _offset ; }
+      /** Highest bit used in fields [0-63]
+       */
+      unsigned highestBit() const { return _coder->highestBit() ; }
+    
+      /** Number of values */
+      size_t size() const { return _coder->size() ; }
 
-    /** The field's width */
-    unsigned width() const { return _width ; }
+      /** Index for field named 'name' 
+       */
+      size_t index( const std::string& name) const { return _coder->index( name ) ; } 
 
-    /** True if field is interpreted as signed */
-    bool isSigned() const { return _isSigned ; }
+      /** Access to field through name .
+       */
+      BitFieldValue operator[](const std::string& name) { 
 
-    /** The field's mask */
-    ulong64 mask() const { return _mask ; }
+	return BitFieldValue( _value,  _coder->operator[]( name ) ) ; 
+      }
+      // /** Const Access to field through name .
+      //  */
+      // const BitFieldValue& operator[](const std::string& name) const { 
 
-    /** Minimal value  */
-    int  minValue()  const  { return _minVal;  }
+      //   return BitFieldValue( _value,  _coder->operator[]( name )  ); 
+      // }
 
-    /** Maximal value  */
-    int  maxValue()  const  { return _maxVal;  }
 
-  protected:
+      /** The low  word, bits 0-31
+       */
+      unsigned lowWord() const { return unsigned( _value &  0xffffFFFFUL )  ; } 
+
+      /** The high  word, bits 32-63
+       */
+      unsigned highWord() const { return unsigned(_value >> 32) ; } 
+
+
+      /** Return a valid description string of all fields
+       */
+      std::string fieldDescription() const { return _coder->fieldDescription() ; }
+
+      /** Return a string with a comma separated list of the current sub field values 
+       */
+      std::string valueString() const ;
+
+      // const std::vector<BitFieldValue*>& fields()  const  {
+      //   return _coder->fields() ;
+      // }
+    
+    protected:
+
+      // -------------- data members:--------------
+
+      long64    _value{} ;
+      const BitFieldCoder* _coder{} ;
+    
+    };
   
-    long64& _b ;
-    ulong64 _mask ;
-    std::string _name ;
-    unsigned _offset ;
-    unsigned _width ;
-    int _minVal ;
-    int _maxVal ;
-    bool _isSigned ;
-
-  };
-
-
-  inline BitField64::~BitField64() {  // clean up
-    for(unsigned i=0;i<_fields.size();i++){
-      delete _fields[i] ;
-    }
-  }
-
-
-} // end namespace
+  
+    /** Operator for dumping BitField64 to streams 
+     */
+    std::ostream& operator<<(std::ostream& os, const BitField64& b) ;
+  
+  
+  
+  } // end namespace
 
 } // end namespace
 

--- a/DDCore/include/DDSegmentation/BitField64.h
+++ b/DDCore/include/DDSegmentation/BitField64.h
@@ -25,14 +25,14 @@ namespace dd4hep {
     class BitFieldValue{
 
       long64& _value ;
-      const BitFieldCoder::BitFieldValue& _bv ;
+      const BitFieldElement& _bv ;
     
     public :
     
       BitFieldValue() = delete ;
     
-      /// only c'tor with reference to bitfield and BitFieldCoder::BitFieldValue
-      BitFieldValue( long64& bitfield, const BitFieldCoder::BitFieldValue& bv ) :
+      /// only c'tor with reference to bitfield and BitFieldElement
+      BitFieldValue( long64& bitfield, const BitFieldElement& bv ) :
 	_value( bitfield ), _bv( bv) {}
     
       /** Returns the current field value 

--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -41,6 +41,7 @@ namespace DDSegmentation {
    */  
   class BitFieldCoder{
     
+  public:
 
     /** Helper class for BitFieldCoder that corresponds to one field value. 
      */
@@ -63,7 +64,7 @@ namespace DDSegmentation {
 
 
       // assign the given value to the bit field
-      void set(long64& bitfield, long64 value) ;
+      void set(long64& bitfield, long64 value) const ;
 
 
       /** The field's name */
@@ -195,6 +196,13 @@ namespace DDSegmentation {
       return *_fields[ index( name ) ] ;
     }
 
+    /** Const Access to field through index .
+     */
+    const BitFieldValue& operator[](unsigned index) const { 
+
+      return *_fields[ index ] ;
+    }
+
     /** Return a valid description string of all fields
      */
     std::string fieldDescription() const ;
@@ -207,6 +215,10 @@ namespace DDSegmentation {
       return _fields;
     }
     
+
+    /** the mask of all the bits used in the description */
+    ulong64 mask() const { return _joined ; }
+
   protected:
 
     /** Add an additional field to the list 

--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -1,0 +1,281 @@
+#ifndef DDSegmentation_BitFieldCoder_H
+#define DDSegmentation_BitFieldCoder_H 1
+
+
+#include <string>
+#include <vector>
+#include <map>
+#include <sstream>
+
+
+namespace dd4hep {
+
+typedef long long int long64 ;
+typedef unsigned long long ulong64 ;
+
+namespace DDSegmentation {
+
+  class BitFieldValue ;
+  class StringTokenizer ; 
+
+
+  /** Helper class for decoding and encoding a bit field of 64bits for convenient declaration and 
+   *  manipulation of sub fields of various widths.<br>
+   *  This is a thread safe re-implementation of the functionality in the deprected BitField64.
+   *  
+   *  Example:<br>
+   *    BitFieldCoder bc("layer:7,system:-3,barrel:3,theta:32:11,phi:11" ) ; <br> 
+   *    bc.set( field,  "layer"  , 123 );         <br> 
+   *    bc.set( field,  "system" , -4  );         <br> 
+   *    bc.set( field,  "barrel" , 7   );         <br> 
+   *    bc.set( field,  "theta"  , 180 );         <br> 
+   *    bc.set( field,  "phi"    , 270 );         <br> 
+   *    ...                                       <br>
+   *    int theta = bc.get( field, "theta" ) ;                    <br>
+   *    ...                                       <br>
+   *    unsigned phiIndex = bc.index("phi") ;     <br>
+   *    int phi = bc.get( field, phiIndex ) ;                <br>
+   *
+   *    @author F.Gaede, DESY
+   *    @date  2017-09
+   */  
+  class BitFieldCoder{
+    
+
+    /** Helper class for BitFieldCoder that corresponds to one field value. 
+     */
+
+    class BitFieldValue{
+  
+    public :
+      virtual ~BitFieldValue() {}
+  
+      /** The default c'tor.
+       * @param  name          name of the field
+       * @param  offset        offset of field
+       * @param  signedWidth   width of field, negative if field is signed
+       */
+      BitFieldValue( const std::string& name, 
+		     unsigned offset, int signedWidth ) ; 
+
+      /// calculate this field's value given an external 64 bit bitmap 
+      long64 value(long64 bitfield) const;
+
+
+      // assign the given value to the bit field
+      void set(long64& bitfield, long64 value) ;
+
+
+      /** The field's name */
+      const std::string& name() const { return _name ; }
+
+      /** The field's offset */
+      unsigned offset() const { return _offset ; }
+
+      /** The field's width */
+      unsigned width() const { return _width ; }
+
+      /** True if field is interpreted as signed */
+      bool isSigned() const { return _isSigned ; }
+
+      /** The field's mask */
+      ulong64 mask() const { return _mask ; }
+
+      /** Minimal value  */
+      int  minValue()  const  { return _minVal;  }
+
+      /** Maximal value  */
+      int  maxValue()  const  { return _maxVal;  }
+
+    protected:
+  
+      ulong64 _mask{} ;
+      unsigned _offset{} ;
+      unsigned _width{} ;
+      int _minVal{} ;
+      int _maxVal{} ;
+      bool _isSigned{} ;
+      std::string _name{} ;
+
+    };
+
+
+  public :
+    
+    typedef std::map<std::string, unsigned int> IndexMap ;
+
+    /** No default c'tor */
+    BitFieldCoder() = delete ;
+
+    ~BitFieldCoder() {  // clean up
+      for(unsigned i=0;i<_fields.size();i++){
+	delete _fields[i] ;
+      }
+  }
+    
+    /** The c'tor takes an initialization string of the form:<br>
+     *  \<fieldDesc\>[,\<fieldDesc\>...]<br>
+     *  fieldDesc = name:[start]:[-]length<br>
+     *  where:<br>
+     *  name: The name of the field<br>
+     *  start: The start bit of the field. If omitted assumed to start 
+     *  immediately following previous field, or at the least significant 
+     *  bit if the first field.<br>
+     *  length: The number of bits in the field. If preceeded by '-' 
+     *  the field is signed, otherwise unsigned.<br>
+     *  Bit numbering is from the least significant bit (bit 0) to the most 
+     *  significant (bit 63). <br>
+     *  Example: "layer:7,system:-3,barrel:3,theta:32:11,phi:11"
+     */
+    BitFieldCoder( const std::string& initString ) : _joined(0){
+    
+      init( initString ) ;
+    }
+
+    /** return a new 64bit value given as high and low 32bit words.
+     */
+    static long64 toLong(unsigned low_Word, unsigned high_Word ) {
+      return (  ( low_Word & 0xffffffffULL ) |  ( ( high_Word & 0xffffffffULL ) << 32 ) ) ; 
+    }
+    
+    /** The low  word, bits 0-31
+     */
+    static unsigned lowWord(long64 bitfield) { return unsigned( bitfield &  0xffffFFFFUL )  ; } 
+
+    /** The high  word, bits 32-63
+     */
+    static unsigned highWord(long64 bitfield) { return unsigned( bitfield >> 32) ; } 
+
+
+    /** get value of sub-field specified by index 
+     */
+    long64 get(long64 bitfield, size_t index) const { 
+      return _fields.at(index)->value( bitfield )  ; 
+    }
+    
+    /** Access to field through name .
+     */
+    long64 get(long64 bitfield, const std::string& name) const {
+
+      return _fields.at( index( name ) )->value( bitfield ) ;
+    }
+
+    /** set value of sub-field specified by index 
+     */
+    void set(long64& bitfield, size_t index, ulong64 value) const { 
+      _fields.at(index)->set( bitfield , value )  ; 
+    }
+    
+    /** Access to field through name .
+     */
+    void set(long64& bitfield, const std::string& name, ulong64 value) const {
+
+      _fields.at( index( name ) )->set( bitfield, value ) ;
+    }
+
+
+
+    /** Highest bit used in fields [0-63]
+     */
+    unsigned highestBit() const ;
+    
+
+    /** Number of values */
+    size_t size() const { return _fields.size() ; }
+
+    /** Index for field named 'name' 
+     */
+    size_t index( const std::string& name) const ;
+
+
+    /** Const Access to field through name .
+     */
+    const BitFieldValue& operator[](const std::string& name) const { 
+
+      return *_fields[ index( name ) ] ;
+    }
+
+    /** Return a valid description string of all fields
+     */
+    std::string fieldDescription() const ;
+
+    /** Return a string with a comma separated list of the current sub field values 
+     */
+    std::string valueString(ulong64 bitfield) const ;
+
+    const std::vector<BitFieldValue*>& fields()  const  {
+      return _fields;
+    }
+    
+  protected:
+
+    /** Add an additional field to the list 
+     */
+    void addField( const std::string& name,  unsigned offset, int width ); 
+
+    /** Decode the initialization string as described in the constructor.
+     *  @see BitFieldCoder( const std::string& initString )
+     */
+    void init( const std::string& initString) ;
+
+  public:
+
+  protected:
+
+    // -------------- data members:--------------
+
+    std::vector<BitFieldValue*> _fields{} ;
+    IndexMap  _map{} ;
+    long64    _joined{} ;
+
+
+  };
+
+
+ /** Helper class  for string tokenization. Usage:<br>
+   *    std::vector<std::string> tokens ; <br>
+   *    StringTokenizer t( tokens ,',') ; <br>
+   *    std::for_each( aString.begin(), aString.end(), t ) ;  <br>
+   *
+   *    @author F.Gaede, DESY
+   *    @date  2013-06
+   */
+  class StringTokenizer{
+    
+    std::vector< std::string >& _tokens ;
+    char _del ;
+    char _last ;
+
+  public:
+    
+    /** Only c'tor, give (empty) token vector and delimeter character */
+    StringTokenizer( std::vector< std::string >& tokens, char del ) 
+      : _tokens(tokens) 
+	, _del(del), 
+	_last(del) {
+    }
+    
+    /** Operator for use with algorithms, e.g. for_each */
+    void operator()(const char& c) { 
+      
+      if( c != _del  ) {
+	
+	if( _last == _del  ) {
+	  _tokens.push_back("") ; 
+	}
+	_tokens.back() += c ;
+      }
+      _last = c ;
+    } 
+    
+  };
+
+} // end namespace
+
+} // end namespace
+
+#endif
+
+
+
+

--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -15,48 +15,22 @@ typedef unsigned long long ulong64 ;
 
 namespace DDSegmentation {
 
-  class BitFieldValue ;
   class StringTokenizer ; 
 
-
-  /** Helper class for decoding and encoding a bit field of 64bits for convenient declaration and 
-   *  manipulation of sub fields of various widths.<br>
-   *  This is a thread safe re-implementation of the functionality in the deprected BitField64.
-   *  
-   *  Example:<br>
-   *    BitFieldCoder bc("layer:7,system:-3,barrel:3,theta:32:11,phi:11" ) ; <br> 
-   *    bc.set( field,  "layer"  , 123 );         <br> 
-   *    bc.set( field,  "system" , -4  );         <br> 
-   *    bc.set( field,  "barrel" , 7   );         <br> 
-   *    bc.set( field,  "theta"  , 180 );         <br> 
-   *    bc.set( field,  "phi"    , 270 );         <br> 
-   *    ...                                       <br>
-   *    int theta = bc.get( field, "theta" ) ;                    <br>
-   *    ...                                       <br>
-   *    unsigned phiIndex = bc.index("phi") ;     <br>
-   *    int phi = bc.get( field, phiIndex ) ;                <br>
-   *
-   *    @author F.Gaede, DESY
-   *    @date  2017-09
-   */  
-  class BitFieldCoder{
-    
-  public:
-
-    /** Helper class for BitFieldCoder that corresponds to one field value. 
+      /** Helper class for BitFieldCoder that corresponds to one field value. 
      */
 
-    class BitFieldValue{
+    class BitFieldElement{
   
     public :
-      virtual ~BitFieldValue() {}
+      virtual ~BitFieldElement() {}
   
       /** The default c'tor.
        * @param  name          name of the field
        * @param  offset        offset of field
        * @param  signedWidth   width of field, negative if field is signed
        */
-      BitFieldValue( const std::string& name, 
+      BitFieldElement( const std::string& name, 
 		     unsigned offset, int signedWidth ) ; 
 
       /// calculate this field's value given an external 64 bit bitmap 
@@ -101,12 +75,35 @@ namespace DDSegmentation {
     };
 
 
+  
+  /** Helper class for decoding and encoding a bit field of 64bits for convenient declaration and 
+   *  manipulation of sub fields of various widths.<br>
+   *  This is a thread safe re-implementation of the functionality in the deprected BitField64.
+   *  
+   *  Example:<br>
+   *    BitFieldCoder bc("layer:7,system:-3,barrel:3,theta:32:11,phi:11" ) ; <br> 
+   *    bc.set( field,  "layer"  , 123 );         <br> 
+   *    bc.set( field,  "system" , -4  );         <br> 
+   *    bc.set( field,  "barrel" , 7   );         <br> 
+   *    bc.set( field,  "theta"  , 180 );         <br> 
+   *    bc.set( field,  "phi"    , 270 );         <br> 
+   *    ...                                       <br>
+   *    int theta = bc.get( field, "theta" ) ;                    <br>
+   *    ...                                       <br>
+   *    unsigned phiIndex = bc.index("phi") ;     <br>
+   *    int phi = bc.get( field, phiIndex ) ;                <br>
+   *
+   *    @author F.Gaede, DESY
+   *    @date  2017-09
+   */  
+  class BitFieldCoder{
+    
   public :
     
     typedef std::map<std::string, unsigned int> IndexMap ;
 
     /** No default c'tor */
-    BitFieldCoder() = delete ;
+    BitFieldCoder() {} ;
 
     ~BitFieldCoder() {  // clean up
       for(unsigned i=0;i<_fields.size();i++){
@@ -191,14 +188,14 @@ namespace DDSegmentation {
 
     /** Const Access to field through name .
      */
-    const BitFieldValue& operator[](const std::string& name) const { 
+    const BitFieldElement& operator[](const std::string& name) const { 
 
       return *_fields[ index( name ) ] ;
     }
 
     /** Const Access to field through index .
      */
-    const BitFieldValue& operator[](unsigned index) const { 
+    const BitFieldElement& operator[](unsigned index) const { 
 
       return *_fields[ index ] ;
     }
@@ -211,7 +208,7 @@ namespace DDSegmentation {
      */
     std::string valueString(ulong64 bitfield) const ;
 
-    const std::vector<BitFieldValue*>& fields()  const  {
+    const std::vector<BitFieldElement*>& fields()  const  {
       return _fields;
     }
     
@@ -236,7 +233,7 @@ namespace DDSegmentation {
 
     // -------------- data members:--------------
 
-    std::vector<BitFieldValue*> _fields{} ;
+    std::vector<BitFieldElement*> _fields{} ;
     IndexMap  _map{} ;
     long64    _joined{} ;
 

--- a/DDCore/include/DDSegmentation/CartesianGrid.h
+++ b/DDCore/include/DDSegmentation/CartesianGrid.h
@@ -21,7 +21,7 @@ protected:
 	/// Default constructor used by derived classes passing the encoding string
 	CartesianGrid(const std::string& cellEncoding = "");
 	/// Default constructor used by derived classes passing an existing decoder
-	CartesianGrid(BitField64* decoder);
+	CartesianGrid(const BitFieldCoder* decoder);
 };
 
 } /* namespace DDSegmentation */

--- a/DDCore/include/DDSegmentation/CartesianGridXY.h
+++ b/DDCore/include/DDSegmentation/CartesianGridXY.h
@@ -18,7 +18,7 @@ public:
 	/// Default constructor passing the encoding string
 	CartesianGridXY(const std::string& cellEncoding = "");
 	/// Default constructor used by derived classes passing an existing decoder
-	CartesianGridXY(BitField64* decoder);
+	CartesianGridXY(const BitFieldCoder* decoder);
 	/// destructor
 	virtual ~CartesianGridXY();
 

--- a/DDCore/include/DDSegmentation/CartesianGridXYZ.h
+++ b/DDCore/include/DDSegmentation/CartesianGridXYZ.h
@@ -18,7 +18,7 @@ public:
 	/// default constructor using an arbitrary type
 	CartesianGridXYZ(const std::string& cellEncoding);
 	/// Default constructor used by derived classes passing an existing decoder
-	CartesianGridXYZ(BitField64* decoder);
+	CartesianGridXYZ(const BitFieldCoder* decoder);
 	/// destructor
 	virtual ~CartesianGridXYZ();
 

--- a/DDCore/include/DDSegmentation/CartesianGridXZ.h
+++ b/DDCore/include/DDSegmentation/CartesianGridXZ.h
@@ -18,7 +18,7 @@ public:
 	/// default constructor using an arbitrary type
 	CartesianGridXZ(const std::string& cellEncoding);
 	/// Default constructor used by derived classes passing an existing decoder
-	CartesianGridXZ(BitField64* decoder);
+	CartesianGridXZ(const BitFieldCoder* decoder);
 	/// destructor
 	virtual ~CartesianGridXZ();
 

--- a/DDCore/include/DDSegmentation/CartesianGridYZ.h
+++ b/DDCore/include/DDSegmentation/CartesianGridYZ.h
@@ -20,7 +20,7 @@ public:
 	/// Default constructor passing the encoding string
 	CartesianGridYZ(const std::string& cellEncoding = "");
 	/// Default constructor used by derived classes passing an existing decoder
-	CartesianGridYZ(BitField64* decoder);
+	CartesianGridYZ(const BitFieldCoder* decoder);
 	/// destructor
 	virtual ~CartesianGridYZ();
 

--- a/DDCore/include/DDSegmentation/CylindricalSegmentation.h
+++ b/DDCore/include/DDSegmentation/CylindricalSegmentation.h
@@ -24,7 +24,7 @@ protected:
 	/// default constructor using an arbitrary type
 	CylindricalSegmentation(const std::string& cellEncoding);
 	/// Default constructor used by derived classes passing an existing decoder
-	CylindricalSegmentation(BitField64* decoder);
+	CylindricalSegmentation(const BitFieldCoder* decoder);
 };
 
 

--- a/DDCore/include/DDSegmentation/GridPhiEta.h
+++ b/DDCore/include/DDSegmentation/GridPhiEta.h
@@ -20,7 +20,7 @@ public:
   /// default constructor using an arbitrary type
   GridPhiEta(const std::string& aCellEncoding);
   /// Default constructor used by derived classes passing an existing decoder
-  GridPhiEta(BitField64* aDecoder);
+  GridPhiEta(const BitFieldCoder* decoder);
 
   /// destructor
   virtual ~GridPhiEta() = default;
@@ -128,10 +128,6 @@ public:
   }
 
 protected:
-  /// determine the pseudorapidity based on the current cell ID
-  double eta() const;
-  /// determine the azimuthal angle phi based on the current cell ID
-  double phi() const;
 
   /// the grid size in eta
   double m_gridSizeEta;

--- a/DDCore/include/DDSegmentation/GridRPhiEta.h
+++ b/DDCore/include/DDSegmentation/GridRPhiEta.h
@@ -21,7 +21,7 @@ public:
   GridRPhiEta(const std::string& aCellEncoding);
 
   /// Default constructor used by derived classes passing an existing decoder
-  GridRPhiEta(BitField64* aDecoder);
+  GridRPhiEta(const BitFieldCoder* decoder);
 
   /// destructor
   virtual ~GridRPhiEta() = default;
@@ -81,8 +81,6 @@ public:
   }
 
 private:
-  /// determine the radial distance R based on the current cell ID
-  double r() const;
 
   /// the grid size in r
   double m_gridSizeR;

--- a/DDCore/include/DDSegmentation/MegatileLayerGridXY.h
+++ b/DDCore/include/DDSegmentation/MegatileLayerGridXY.h
@@ -43,7 +43,7 @@ namespace dd4hep {
       MegatileLayerGridXY(const std::string& cellEncoding = "");
 
       /// Default constructor used by derived classes passing an existing decoder
-      MegatileLayerGridXY(BitField64* decoder);
+      MegatileLayerGridXY(const BitFieldCoder* decoder);
 
       /// destructor
       virtual ~MegatileLayerGridXY();

--- a/DDCore/include/DDSegmentation/MultiSegmentation.h
+++ b/DDCore/include/DDSegmentation/MultiSegmentation.h
@@ -44,7 +44,7 @@ namespace dd4hep {
       std::string    m_discriminatorId;
 
       /// Bitfield corresponding to dicriminator identifier
-      BitFieldValue* m_discriminator;
+      const BitFieldElement* m_discriminator;
 
       /// Debug flags
       int m_debug;
@@ -54,7 +54,7 @@ namespace dd4hep {
       MultiSegmentation(const std::string& cellEncoding = "");
 
       /// Default constructor used by derived classes passing an existing decoder
-      MultiSegmentation(BitField64* decoder);
+      MultiSegmentation(const BitFieldCoder* decoder);
 
       /// Default destructor
       virtual ~MultiSegmentation();
@@ -83,10 +83,10 @@ namespace dd4hep {
       const std::string& discriminatorName() const {  return m_discriminatorId;  }
 
       /// Discriminating bitfield entry
-      BitFieldValue* discriminator() const         {  return m_discriminator;    }
+      const BitFieldElement* discriminator() const         {  return m_discriminator;    }
 
       /// Set the underlying decoder
-      virtual void setDecoder(BitField64* decoder);
+      virtual void setDecoder(const BitFieldCoder* decoder);
 
       /// The underlying sub-segementations
       const Segmentations& subSegmentations()  const { return m_segmentations;   }

--- a/DDCore/include/DDSegmentation/NoSegmentation.h
+++ b/DDCore/include/DDSegmentation/NoSegmentation.h
@@ -20,7 +20,7 @@ namespace dd4hep {
         virtual ~NoSegmentation();
 
         NoSegmentation(const std::string& cellEncoding = "");
-        NoSegmentation(BitField64* decoder);
+        NoSegmentation(const BitFieldCoder* decoder);
 	
         virtual Vector3D position(const CellID& cellID) const;
         virtual CellID cellID(const Vector3D& localPosition, const Vector3D& globalPosition, const VolumeID& volumeID) const;

--- a/DDCore/include/DDSegmentation/PolarGrid.h
+++ b/DDCore/include/DDSegmentation/PolarGrid.h
@@ -21,7 +21,7 @@ protected:
 	/// Default constructor used by derived classes passing the encoding string
 	PolarGrid(const std::string& cellEncoding = "");
 	/// Default constructor used by derived classes passing an existing decoder
-	PolarGrid(BitField64* decoder);
+	PolarGrid(const BitFieldCoder* decoder);
 };
 
 } /* namespace DDSegmentation */

--- a/DDCore/include/DDSegmentation/PolarGridRPhi.h
+++ b/DDCore/include/DDSegmentation/PolarGridRPhi.h
@@ -19,7 +19,7 @@ public:
 	/// Default constructor passing the encoding string
 	PolarGridRPhi(const std::string& cellEncoding = "");
 	/// Default constructor used by derived classes passing an existing decoder
-	PolarGridRPhi(BitField64* decoder);
+	PolarGridRPhi(const BitFieldCoder* decoder);
 	/// destructor
 	virtual ~PolarGridRPhi();
 

--- a/DDCore/include/DDSegmentation/PolarGridRPhi2.h
+++ b/DDCore/include/DDSegmentation/PolarGridRPhi2.h
@@ -47,7 +47,7 @@ public:
 	/// Default constructor passing the encoding string
 	PolarGridRPhi2(const std::string& cellEncoding = "");
 	/// Default constructor used by derived classes passing an existing decoder
-	PolarGridRPhi2(BitField64* decoder);
+	PolarGridRPhi2(const BitFieldCoder* decoder);
 	/// destructor
 	virtual ~PolarGridRPhi2();
 

--- a/DDCore/include/DDSegmentation/ProjectiveCylinder.h
+++ b/DDCore/include/DDSegmentation/ProjectiveCylinder.h
@@ -18,7 +18,7 @@ public:
 	/// default constructor using an arbitrary type
 	ProjectiveCylinder(const std::string& cellEncoding);
 	/// Default constructor used by derived classes passing an existing decoder
-	ProjectiveCylinder(BitField64* decoder);
+	ProjectiveCylinder(const BitFieldCoder* decoder);
 	/// destructor
 	virtual ~ProjectiveCylinder();
 
@@ -92,11 +92,6 @@ protected:
 	std::string _thetaID;
 	/// the field name used for phi
 	std::string _phiID;
-
-	/// determine the polar angle theta based on the current cell ID
-	double theta() const;
-	/// determine the azimuthal angle phi based on the current cell ID
-	double phi() const;
 
 };
 

--- a/DDCore/include/DDSegmentation/Segmentation.h
+++ b/DDCore/include/DDSegmentation/Segmentation.h
@@ -8,7 +8,7 @@
 #ifndef DDSegmentation_SEGMENTATION_H_
 #define DDSegmentation_SEGMENTATION_H_
 
-#include "DDSegmentation/BitField64.h"
+#include "DDSegmentation/BitFieldCoder.h"
 #include "DDSegmentation/SegmentationFactory.h"
 #include "DDSegmentation/SegmentationParameter.h"
 
@@ -102,11 +102,11 @@ public:
 		return _description;
 	}
 	/// Access the underlying decoder
-	virtual BitField64* decoder()  const {
+	virtual const BitFieldCoder* decoder()  const {
 		return _decoder;
 	}
 	/// Set the underlying decoder
-	virtual void setDecoder(BitField64* decoder);
+	virtual void setDecoder(const BitFieldCoder* decoder);
 	/// Access to parameter by name
 	virtual Parameter parameter(const std::string& parameterName) const;
 	/// Access to all parameters
@@ -125,7 +125,7 @@ protected:
 	/// Default constructor used by derived classes passing the encoding string
 	Segmentation(const std::string& cellEncoding = "");
 	/// Default constructor used by derived classes passing an existing decoder
-	Segmentation(BitField64* decoder);
+	Segmentation(const BitFieldCoder* decoder);
 
 	/// Add a parameter to this segmentation. Used by derived classes to define their parameters
 	template<typename TYPE> void registerParameter(const std::string& nam, const std::string& desc,
@@ -158,8 +158,8 @@ protected:
 	/// The indices used for the encoding
 	std::map<std::string, StringParameter> _indexIdentifiers;   //! No ROOT persistency
 	/// The cell ID encoder and decoder
-	mutable BitField64* _decoder = 0;    //! Not ROOT persistent
-	/// Keeps track of the decoder ownership
+	const BitFieldCoder* _decoder = 0;
+        /// Keeps track of the decoder ownership
 	bool _ownsDecoder = false;
 private:
 	/// No copy constructor allowed

--- a/DDCore/include/DDSegmentation/TiledLayerGridXY.h
+++ b/DDCore/include/DDSegmentation/TiledLayerGridXY.h
@@ -22,7 +22,7 @@ public:
 	/// Default constructor passing the encoding string
 	TiledLayerGridXY(const std::string& cellEncoding = "");
 	/// Default constructor used by derived classes passing an existing decoder
-	TiledLayerGridXY(BitField64* decoder);
+	TiledLayerGridXY(const BitFieldCoder* decoder);
 	/// destructor
 	virtual ~TiledLayerGridXY();
 

--- a/DDCore/include/DDSegmentation/TiledLayerSegmentation.h
+++ b/DDCore/include/DDSegmentation/TiledLayerSegmentation.h
@@ -29,7 +29,7 @@ public:
 	/// Default constructor passing the encoding string
 	TiledLayerSegmentation(const std::string& cellEncoding = "");
 	/// Default constructor used by derived classes passing an existing decoder
-	TiledLayerSegmentation(BitField64* decoder);
+	TiledLayerSegmentation(const BitFieldCoder* decoder);
 	/// destructor
 	virtual ~TiledLayerSegmentation();
 

--- a/DDCore/include/DDSegmentation/WaferGridXY.h
+++ b/DDCore/include/DDSegmentation/WaferGridXY.h
@@ -21,7 +21,7 @@ namespace dd4hep {
       /// Default constructor passing the encoding string
       WaferGridXY(const std::string& cellEncoding = "");
       /// Default constructor used by derived classes passing an existing decoder
-      WaferGridXY(BitField64* decoder);
+      WaferGridXY(const BitFieldCoder* decoder);
       /// destructor
       virtual ~WaferGridXY();
 

--- a/DDCore/src/DetectorTools.cpp
+++ b/DDCore/src/DetectorTools.cpp
@@ -388,7 +388,7 @@ std::string detail::tools::toString(const PlacedVolume::VolIDs& ids)   {
 std::string detail::tools::toString(const IDDescriptor& dsc, const PlacedVolume::VolIDs& ids, VolumeID code)   {
   stringstream log;
   for( const auto& id : ids )  {
-    const BitFieldValue* f = dsc.field(id.first);
+    const BitFieldElement* f = dsc.field(id.first);
     VolumeID value = f->value(code);
     log << id.first << "=" << id.second << "," << value << " [" << f->offset() << "," << f->width() << "] ";
   }

--- a/DDCore/src/MultiSegmentation.cpp
+++ b/DDCore/src/MultiSegmentation.cpp
@@ -27,7 +27,7 @@ const std::string& MultiSegmentation::discriminatorName() const   {
 }
 
 /// Discriminating bitfield entry
-BitFieldValue* MultiSegmentation::discriminator() const  {
+const BitFieldElement* MultiSegmentation::discriminator() const  {
   return access()->implementation->discriminator();
 }
 

--- a/DDCore/src/SegmentationDictionary.h
+++ b/DDCore/src/SegmentationDictionary.h
@@ -85,7 +85,7 @@ typedef dd4hep::DDSegmentation::CellID CellID;
 #pragma link C++ class dd4hep::DDSegmentation::WaferGridXY+;
 
 #pragma link C++ class dd4hep::DDSegmentation::BitFieldValue+;
-#pragma link C++ class dd4hep::DDSegmentation::BitField64+;
+#pragma link C++ class dd4hep::DDSegmentation::BitFieldCoder+;
 
 #endif  // __CINT__
 #endif  // __HAVE_DDSEGMENTATION__

--- a/DDCore/src/Segmentations.cpp
+++ b/DDCore/src/Segmentations.cpp
@@ -30,7 +30,7 @@ using namespace dd4hep::detail;
 DD4HEP_INSTANTIATE_HANDLE_UNNAMED(SegmentationObject);
 
 /// Constructor to used when creating a new object
-Segmentation::Segmentation(const string& typ, const string& nam, BitField64* dec) : Handle<Object>()
+Segmentation::Segmentation(const string& typ, const string& nam, const BitFieldCoder* dec) : Handle<Object>()
 {
   string seg_type = "segmentation_constructor__"+typ;
   SegmentationObject* obj = PluginService::Create<SegmentationObject*>(seg_type, dec);
@@ -103,12 +103,12 @@ DDSegmentation::Segmentation* Segmentation::segmentation() const  {
 }
 
 /// Access the underlying decoder
-const BitField64* Segmentation::decoder()  const {
+const BitFieldCoder* Segmentation::decoder()  const {
   return data<Object>()->segmentation->decoder();
 }
 
 /// Set the underlying decoder
-void Segmentation::setDecoder(BitField64* decode) const  {
+void Segmentation::setDecoder(const BitFieldCoder* decode) const  {
   data<Object>()->segmentation->setDecoder(decode);
 }
 

--- a/DDCore/src/SegmentationsInterna.cpp
+++ b/DDCore/src/SegmentationsInterna.cpp
@@ -59,12 +59,12 @@ const string& SegmentationObject::description() const {
 }
 
 /// Access the underlying decoder
-const BitField64* SegmentationObject::decoder() const {
+const BitFieldCoder* SegmentationObject::decoder() const {
   return segmentation->decoder();
 }
 
 /// Set the underlying decoder
-void SegmentationObject::setDecoder(BitField64* ptr_decoder) const {
+void SegmentationObject::setDecoder(const BitFieldCoder* ptr_decoder) const {
   segmentation->setDecoder(ptr_decoder);
 }
 

--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -335,7 +335,7 @@ namespace dd4hep {
         VolumeID volume_id = initial.first, mask = initial.second;
         for (VolIDs::const_iterator i = ids.begin(); i != ids.end(); ++i) {
           const auto& id = (*i);
-          const BitFieldValue* f = iddesc.field(id.first);
+          const BitFieldElement* f = iddesc.field(id.first);
           VolumeID msk = f->mask();
           int      off = f->offset();
           VolumeID val = id.second;    // Necessary to extend volume IDs > 32 bit
@@ -349,7 +349,7 @@ namespace dd4hep {
         VolumeID volume_id = 0, mask = 0;
         for (VolIDs::const_iterator i = ids.begin(); i != ids.end(); ++i) {
           const auto& id = (*i);
-          const BitFieldValue* f = iddesc.field(id.first);
+          const BitFieldElement* f = iddesc.field(id.first);
           VolumeID msk = f->mask();
           int      off = f->offset();
           VolumeID val = id.second;    // Necessary to extend volume IDs > 32 bit
@@ -508,7 +508,7 @@ VolumeManager VolumeManager::addSubdetector(DetElement det, Readout ro) {
       i = o.subdetectors.insert(make_pair(det, VolumeManager(det,ro))).first;
       const auto& id = (*vit);
       VolumeManager m = (*i).second;
-      const BitFieldValue* field = ro.idSpec().field(id.first);
+      const BitFieldElement* field = ro.idSpec().field(id.first);
       if (!field) {
         throw runtime_error("dd4hep: VolumeManager::addSubdetector: IdDescriptor of " + 
                             string(det.name()) + " has no field " + id.first);

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -630,7 +630,7 @@ template <> void Converter<Segmentation>::operator()(xml_h seg) const {
   string name = seg.hasAttr(_U(name)) ? seg.attr<string>(_U(name)) : string();
   std::pair<Segmentation,IDDescriptor>* opt = _option<pair<Segmentation,IDDescriptor> >();
 
-  BitField64* bitfield = &opt->second->decoder;
+  const BitFieldCoder* bitfield = &opt->second->decoder;
   Segmentation segment(type, name, bitfield);
   if ( segment.isValid() ) {
     const DDSegmentation::Parameters& pars = segment.parameters();

--- a/DDCore/src/plugins/LCDDConverter.cpp
+++ b/DDCore/src/plugins/LCDDConverter.cpp
@@ -934,7 +934,7 @@ xml_h LCDDConverter::handleIdSpec(const std::string& name, IDDescriptor id_spec)
     for (const auto& i : fm )  {
       xml_h idfield = xml_elt_t(geo.doc, _U(idfield));
 #if 0
-      const BitFieldValue* f = i.second;
+      const BitFieldElement* f = i.second;
       start = f.first;
       length = f.second<0 ? -f.second : f.second;
       idfield.setAttr(_U(signed),f.second<0 ? true : false);
@@ -942,7 +942,7 @@ xml_h LCDDConverter::handleIdSpec(const std::string& name, IDDescriptor id_spec)
       idfield.setAttr(_U(length),length);
       idfield.setAttr(_U(start),start);
 #else
-      const BitFieldValue* f = i.second;
+      const BitFieldElement* f = i.second;
       idfield.setAttr(_U(signed),f->isSigned() ? true : false);
       idfield.setAttr(_U(label), f->name());
       idfield.setAttr(_U(length), (int) f->width());

--- a/DDCore/src/plugins/ReadoutSegmentations.cpp
+++ b/DDCore/src/plugins/ReadoutSegmentations.cpp
@@ -20,7 +20,7 @@ using namespace dd4hep::DDSegmentation;
 
 namespace {
   template<typename T> dd4hep::SegmentationObject*
-  create_segmentation(dd4hep::BitField64* decoder)  {
+  create_segmentation(const dd4hep::BitFieldCoder* decoder)  {
     return new dd4hep::SegmentationWrapper<T>(decoder);
   }
 }

--- a/DDCore/src/segmentations/BitField64.cpp
+++ b/DDCore/src/segmentations/BitField64.cpp
@@ -8,282 +8,39 @@ namespace dd4hep{
 
 namespace DDSegmentation {
   
-    BitFieldValue::BitFieldValue( long64& bitfield, const std::string& fieldName,
-				  unsigned fieldOffset, int signedWidth ) :
-    _b(bitfield),
-    _mask(0), 
-    _name( fieldName ),
-    _offset( fieldOffset ),
-    _width( abs( signedWidth ) ),
-    _minVal(0),
-    _maxVal(0),
-    _isSigned( signedWidth < 0 ) {
-    
-    // sanity check
-    if( _offset > 63 || _offset+_width > 64 ) {
-      
-      std::stringstream s ;
-      s << " BitFieldValue '" << _name << "': out of range -  offset : " 
-	<< _offset  << " width " << _width  ;
-      
-      throw( std::runtime_error( s.str() ) ) ;
-    }
-    
-    _mask = ( ( 0x0001LL << _width ) - 1 ) << _offset ;
-    
-    
-    // compute extreme values for later checks
-    if( _isSigned ){
-      
-      _minVal =  ( 1LL << ( _width - 1 ) ) - ( 1LL << _width )  ;
-      _maxVal =  ( 1LL << ( _width - 1 ) ) - 1 ;
-      
-    } else {
-      
-      _maxVal = 0x0001<<_width  ;
-    }
-    
-    //       std::cout << " _mask :" << std::hex << _mask  
-    //                 <<  std::dec <<  std::endl ; 
-    //       std::cout << " min " << _minVal 
-    // 		<< " max " << _maxVal
-    // 		<< " width " << _width 
-    // 		<< std::endl ; 
- 
-  }
-  
-
-  long64 BitFieldValue::value() const { 
-      
-    if(  _isSigned   ) {
-
-      long64 val = ( _b & _mask ) >> _offset ;
-      
-      if( ( val  & ( 1LL << ( _width - 1 ) ) ) != 0 ) { // negative value
-	  
-	val -= ( 1LL << _width );
-      }
-	
-      return val ;
-
-    } else { 
-      
-      return  ( _b & _mask ) >> _offset ;
-    }
-  }
-
-  long64 BitFieldValue::value(long64 id) const { 
-      
-    if(  _isSigned   ) {
-
-      long64 val = ( id & _mask ) >> _offset ;
-      
-      if( ( val  & ( 1LL << ( _width - 1 ) ) ) != 0 ) { // negative value
-	  
-	val -= ( 1LL << _width );
-      }
-	
-      return val ;
-
-    } else { 
-      
-      return  ( id & _mask ) >> _offset ;
-    }
-  }
-
-   BitFieldValue& BitFieldValue::operator=(long64 in) {
-    
-    // check range 
-    if( in < _minVal || in > _maxVal  ) {
-      
-      std::stringstream s ;
-      s << " BitFieldValue '" << _name << "': out of range : " << in 
-	<< " for width " << _width  ; 
-      
-      throw( std::runtime_error( s.str() ) );
-    }
-    
-    _b &= ~_mask ;  // zero out the field's range
-    
-    _b |=  ( (  in  << _offset )  & _mask  ) ; 
-    
-    return *this ;
-  }
-  
-
-
-
-  size_t BitField64::index( const std::string& name) const {
-    
-    IndexMap::const_iterator it = _map.find( name ) ;
-    
-    if( it != _map.end() ) 
-      
-      return it->second  ;
-    
-    else
-      throw std::runtime_error(" BitFieldValue: unknown name: " + name ) ;
-  }
-  
-  unsigned BitField64::highestBit() const {
-
-    unsigned hb(0) ;
-
-    for(unsigned i=0;i<_fields.size();i++){
-
-      if( hb < ( _fields[i]->offset() + _fields[i]->width() ) )
-	hb = _fields[i]->offset() + _fields[i]->width()  ;
-    }    
-    return hb ;
-  }
-
 
   std::string BitField64::valueString() const {
 
     std::stringstream  os ;
 
-    for(unsigned i=0;i<_fields.size();i++){
+    for(unsigned i=0;i<size();i++){
       
       if( i != 0 )   os << "," ;
 
-      os << _fields[i]->name() <<  ":" << _fields[i]->value() ;
+      os << fields()[i]->name() <<  ":" << _coder->get( _value , i ) ;
 
     }
     return os.str() ;
   }
   
-  std::string BitField64::fieldDescription() const {
-    
-    std::stringstream  os ;
-    
-    for(unsigned i=0;i<_fields.size();i++){
-      
-      if( i != 0 )   os << "," ;
-      
-      os << _fields[i]->name() <<  ":"
-	 << _fields[i]->offset() << ":" ;
-      
-      if(  _fields[i]->isSigned()  )  
-	os << "-" ;
-      
-      os  << _fields[i]->width() ;
-      
-    }
-//     for( IndexMap::const_iterator it = _map.begin()  ;
-// 	 it !=  _map.end() ; ++it ){
-
-//       if( it !=  _map.begin() )
-// 	os << "," ;
-      
-//       os << it->first <<  ":"
-// 	 << _fields[ it->second ]->offset() << ":" ;
-      
-//       if(  _fields[ it->second ]->isSigned()  )  
-// 	os << "-" ;
-
-//       os  << _fields[ it->second ]->width() ;
-
-//     }
-    
-    return os.str() ;
-  }
-
-  void BitField64::addField( const std::string& name,  unsigned offset, int width ){
-
-      
-    BitFieldValue* bfv =  new  BitFieldValue( _value, name, offset, width ) ;
-
-    _fields.push_back(  bfv ) ;
-    
-    _map[ name ] = _fields.size()-1 ;
-
-    if( _joined & bfv->mask()  ) {
-      
-      std::stringstream s ;
-      s << " BitFieldValue::addField(" << name << "): bits already used " << std::hex << _joined
-	<< " for mask " <<  bfv->mask()   ; 
-
-      throw( std::runtime_error( s.str() ) ) ;
-      
-    }
-
-    _joined |= _fields.back()->mask() ;
-
-  }
-
-  void BitField64::init( const std::string& initString) {
-
-    unsigned offset = 0  ;
-    
-    // need to compute bit field masks and offsets ...
-    std::vector<std::string> fieldDescriptors ;
-    StringTokenizer t( fieldDescriptors ,',') ;
-
-    std::for_each( initString.begin(), initString.end(), t ) ; 
-
-    for(unsigned i=0; i< fieldDescriptors.size() ; i++ ){
-      
-      std::vector<std::string> subfields ;
-      StringTokenizer ts( subfields ,':') ;
-      
-      std::for_each( fieldDescriptors[i].begin(), fieldDescriptors[i].end(), ts );
-
-      std::string name ; 
-      int  width ; 
-      unsigned thisOffset ;
-
-      switch( subfields.size() ){
-	
-      case 2: 
-
-	name = subfields[0] ; 
-	width = atol( subfields[1].c_str()  ) ;
-	thisOffset = offset ;
-
-	offset += abs( width ) ;
-	
-	break ;
-	
-      case 3: 
-	name = subfields[0] ;
-	thisOffset = atol( subfields[1].c_str()  ) ;
-	width = atol( subfields[2].c_str()  ) ;
-
-	offset = thisOffset + abs( width ) ;
-
-	break ;
-	
-      default:
-
-	std::stringstream s ;
-	s << " BitField64: invalid number of subfields " 
-	  <<  fieldDescriptors[i] ;
-
-	throw( std::runtime_error( s.str() ) ) ;
-      }
-
-      addField( name , thisOffset, width ) ;
-    }
-  }
-
-
 
   std::ostream& operator<<(std::ostream& os, const BitField64& b){
 
     os << " bitfield:  0x" << std::hex // << std::ios::width(16) << std::ios::fill('0') <<
        << b._value << std::dec << std::endl ;
 
-    for( BitField64::IndexMap::const_iterator it = b._map.begin()  ;
-	 it !=  b._map.end() ; ++it ){
+    for(unsigned i=0;i<_coder->size();i++){
       
-      os << "  " << it->first << " [" <<  b[ it->second ].offset()  << ":"  ;
+      const BitFieldCoder::BitFieldValue* bv = b.fields()[i] ;
       
-      if(  b[ it->second ].isSigned()  )  os << "-" ;
+      os << "  " <<  bv->name()
+	 << " [" <<  bv->offset()  << ":"  ;
       
-      os <<  b[ it->second ].width() << "]  : "  ;
+      if(  bv->isSigned()  )  os << "-" ;
+
+      os <<  bv->width() << "]  : "  ;
       
-      
-      os <<    b[ it->second ].value() 
+      os <<   _coder->get( _value , i) 
 	 << std::endl ;
       
     }

--- a/DDCore/src/segmentations/BitField64.cpp
+++ b/DDCore/src/segmentations/BitField64.cpp
@@ -17,7 +17,7 @@ namespace DDSegmentation {
       
       if( i != 0 )   os << "," ;
 
-      os << fields()[i]->name() <<  ":" << _coder->get( _value , i ) ;
+      os << _coder->fields()[i]->name() <<  ":" << _coder->get( _value , i ) ;
 
     }
     return os.str() ;
@@ -29,9 +29,10 @@ namespace DDSegmentation {
     os << " bitfield:  0x" << std::hex // << std::ios::width(16) << std::ios::fill('0') <<
        << b._value << std::dec << std::endl ;
 
-    for(unsigned i=0;i<_coder->size();i++){
+
+    for(unsigned i=0;i<b._coder->size();i++){
       
-      const BitFieldCoder::BitFieldValue* bv = b.fields()[i] ;
+      const BitFieldElement* bv = b._coder->fields()[i] ;
       
       os << "  " <<  bv->name()
 	 << " [" <<  bv->offset()  << ":"  ;
@@ -40,7 +41,7 @@ namespace DDSegmentation {
 
       os <<  bv->width() << "]  : "  ;
       
-      os <<   _coder->get( _value , i) 
+      os <<   b._coder->get( b._value , i) 
 	 << std::endl ;
       
     }

--- a/DDCore/src/segmentations/BitFieldCoder.cpp
+++ b/DDCore/src/segmentations/BitFieldCoder.cpp
@@ -8,8 +8,8 @@ namespace dd4hep{
 
 namespace DDSegmentation {
   
-  BitFieldCoder::BitFieldValue::BitFieldValue( const std::string& fieldName,
-				unsigned fieldOffset, int signedWidth ) :
+  BitFieldElement::BitFieldElement( const std::string& fieldName,
+				    unsigned fieldOffset, int signedWidth ) :
     _mask(0), 
     _offset( fieldOffset ),
     _width( abs( signedWidth ) ),
@@ -22,7 +22,7 @@ namespace DDSegmentation {
     if( _offset > 63 || _offset+_width > 64 ) {
       
       std::stringstream s ;
-      s << " BitFieldValue '" << _name << "': out of range -  offset : " 
+      s << " BitFieldElement '" << _name << "': out of range -  offset : " 
 	<< _offset  << " width " << _width  ;
       
       throw( std::runtime_error( s.str() ) ) ;
@@ -45,7 +45,7 @@ namespace DDSegmentation {
   }
   
 
-  long64 BitFieldCoder::BitFieldValue::value(long64 id) const { 
+  long64 BitFieldElement::value(long64 id) const { 
       
     if(  _isSigned   ) {
 
@@ -64,13 +64,13 @@ namespace DDSegmentation {
     }
   }
 
-  void BitFieldCoder::BitFieldValue::set(long64& field, long64 in) {
+  void BitFieldElement::set(long64& field, long64 in) const {
     
     // check range 
     if( in < _minVal || in > _maxVal  ) {
       
       std::stringstream s ;
-      s << " BitFieldValue '" << _name << "': out of range : " << in 
+      s << " BitFieldElement '" << _name << "': out of range : " << in 
 	<< " for width " << _width  ; 
       
       throw( std::runtime_error( s.str() ) );
@@ -94,7 +94,7 @@ namespace DDSegmentation {
       return it->second  ;
     
     else
-      throw std::runtime_error(" BitFieldValue: unknown name: " + name ) ;
+      throw std::runtime_error(" BitFieldElement: unknown name: " + name ) ;
   }
   
   unsigned BitFieldCoder::highestBit() const {
@@ -163,7 +163,7 @@ namespace DDSegmentation {
   void BitFieldCoder::addField( const std::string& name,  unsigned offset, int width ){
 
       
-    BitFieldValue* bfv =  new  BitFieldValue( name, offset, width ) ;
+    BitFieldElement* bfv =  new  BitFieldElement( name, offset, width ) ;
 
     _fields.push_back(  bfv ) ;
     
@@ -172,7 +172,7 @@ namespace DDSegmentation {
     if( _joined & bfv->mask()  ) {
       
       std::stringstream s ;
-      s << " BitFieldValue::addField(" << name << "): bits already used " << std::hex << _joined
+      s << " BitFieldElement::addField(" << name << "): bits already used " << std::hex << _joined
 	<< " for mask " <<  bfv->mask()   ; 
 
       throw( std::runtime_error( s.str() ) ) ;

--- a/DDCore/src/segmentations/BitFieldCoder.cpp
+++ b/DDCore/src/segmentations/BitFieldCoder.cpp
@@ -1,0 +1,246 @@
+#include "DDSegmentation/BitFieldCoder.h"
+
+#include <cmath>
+#include <algorithm>
+#include <stdexcept>
+
+namespace dd4hep{
+
+namespace DDSegmentation {
+  
+  BitFieldCoder::BitFieldValue::BitFieldValue( const std::string& fieldName,
+				unsigned fieldOffset, int signedWidth ) :
+    _mask(0), 
+    _offset( fieldOffset ),
+    _width( abs( signedWidth ) ),
+    _minVal(0),
+    _maxVal(0),
+    _isSigned( signedWidth < 0 ),
+    _name( fieldName ) {
+    
+    // sanity check
+    if( _offset > 63 || _offset+_width > 64 ) {
+      
+      std::stringstream s ;
+      s << " BitFieldValue '" << _name << "': out of range -  offset : " 
+	<< _offset  << " width " << _width  ;
+      
+      throw( std::runtime_error( s.str() ) ) ;
+    }
+    
+    _mask = ( ( 0x0001LL << _width ) - 1 ) << _offset ;
+    
+    
+    // compute extreme values for later checks
+    if( _isSigned ){
+      
+      _minVal =  ( 1LL << ( _width - 1 ) ) - ( 1LL << _width )  ;
+      _maxVal =  ( 1LL << ( _width - 1 ) ) - 1 ;
+      
+    } else {
+      
+      _maxVal = 0x0001<<_width  ;
+    }
+    
+  }
+  
+
+  long64 BitFieldCoder::BitFieldValue::value(long64 id) const { 
+      
+    if(  _isSigned   ) {
+
+      long64 val = ( id & _mask ) >> _offset ;
+      
+      if( ( val  & ( 1LL << ( _width - 1 ) ) ) != 0 ) { // negative value
+	  
+	val -= ( 1LL << _width );
+      }
+	
+      return val ;
+
+    } else { 
+      
+      return  ( id & _mask ) >> _offset ;
+    }
+  }
+
+  void BitFieldCoder::BitFieldValue::set(long64& field, long64 in) {
+    
+    // check range 
+    if( in < _minVal || in > _maxVal  ) {
+      
+      std::stringstream s ;
+      s << " BitFieldValue '" << _name << "': out of range : " << in 
+	<< " for width " << _width  ; 
+      
+      throw( std::runtime_error( s.str() ) );
+    }
+    
+    field &= ~_mask ;  // zero out the field's range
+    
+    field |=  ( (  in  << _offset )  & _mask  ) ; 
+
+  }
+  
+
+
+
+  size_t BitFieldCoder::index( const std::string& name) const {
+    
+    IndexMap::const_iterator it = _map.find( name ) ;
+    
+    if( it != _map.end() ) 
+      
+      return it->second  ;
+    
+    else
+      throw std::runtime_error(" BitFieldValue: unknown name: " + name ) ;
+  }
+  
+  unsigned BitFieldCoder::highestBit() const {
+    
+    unsigned hb(0) ;
+    
+    for(unsigned i=0;i<_fields.size();i++){
+      
+      if( hb < ( _fields[i]->offset() + _fields[i]->width() ) )
+	hb = _fields[i]->offset() + _fields[i]->width()  ;
+    }    
+    return hb ;
+  }
+
+
+  std::string BitFieldCoder::valueString(ulong64 bitfield) const {
+
+    std::stringstream  os ;
+
+    for(unsigned i=0;i<_fields.size();i++){
+      
+      if( i != 0 )   os << "," ;
+
+      os << _fields[i]->name() <<  ":" << _fields[i]->value(bitfield) ;
+
+    }
+    return os.str() ;
+  }
+  
+  std::string BitFieldCoder::fieldDescription() const {
+    
+    std::stringstream  os ;
+    
+    for(unsigned i=0;i<_fields.size();i++){
+      
+      if( i != 0 )   os << "," ;
+      
+      os << _fields[i]->name() <<  ":"
+	 << _fields[i]->offset() << ":" ;
+      
+      if(  _fields[i]->isSigned()  )  
+	os << "-" ;
+      
+      os  << _fields[i]->width() ;
+      
+    }
+//     for( IndexMap::const_iterator it = _map.begin()  ;
+// 	 it !=  _map.end() ; ++it ){
+
+//       if( it !=  _map.begin() )
+// 	os << "," ;
+      
+//       os << it->first <<  ":"
+// 	 << _fields[ it->second ]->offset() << ":" ;
+      
+//       if(  _fields[ it->second ]->isSigned()  )  
+// 	os << "-" ;
+
+//       os  << _fields[ it->second ]->width() ;
+
+//     }
+    
+    return os.str() ;
+  }
+
+  void BitFieldCoder::addField( const std::string& name,  unsigned offset, int width ){
+
+      
+    BitFieldValue* bfv =  new  BitFieldValue( name, offset, width ) ;
+
+    _fields.push_back(  bfv ) ;
+    
+    _map[ name ] = _fields.size()-1 ;
+
+    if( _joined & bfv->mask()  ) {
+      
+      std::stringstream s ;
+      s << " BitFieldValue::addField(" << name << "): bits already used " << std::hex << _joined
+	<< " for mask " <<  bfv->mask()   ; 
+
+      throw( std::runtime_error( s.str() ) ) ;
+      
+    }
+
+    _joined |= _fields.back()->mask() ;
+
+  }
+
+  void BitFieldCoder::init( const std::string& initString) {
+
+    unsigned offset = 0  ;
+    
+    // need to compute bit field masks and offsets ...
+    std::vector<std::string> fieldDescriptors ;
+    StringTokenizer t( fieldDescriptors ,',') ;
+
+    std::for_each( initString.begin(), initString.end(), t ) ; 
+
+    for(unsigned i=0; i< fieldDescriptors.size() ; i++ ){
+      
+      std::vector<std::string> subfields ;
+      StringTokenizer ts( subfields ,':') ;
+      
+      std::for_each( fieldDescriptors[i].begin(), fieldDescriptors[i].end(), ts );
+
+      std::string name ; 
+      int  width ; 
+      unsigned thisOffset ;
+
+      switch( subfields.size() ){
+	
+      case 2: 
+
+	name = subfields[0] ; 
+	width = atol( subfields[1].c_str()  ) ;
+	thisOffset = offset ;
+
+	offset += abs( width ) ;
+	
+	break ;
+	
+      case 3: 
+	name = subfields[0] ;
+	thisOffset = atol( subfields[1].c_str()  ) ;
+	width = atol( subfields[2].c_str()  ) ;
+
+	offset = thisOffset + abs( width ) ;
+
+	break ;
+	
+      default:
+
+	std::stringstream s ;
+	s << " BitFieldCoder: invalid number of subfields " 
+	  <<  fieldDescriptors[i] ;
+
+	throw( std::runtime_error( s.str() ) ) ;
+      }
+
+      addField( name , thisOffset, width ) ;
+    }
+  }
+
+
+
+
+} // namespace
+
+} // namespace

--- a/DDCore/src/segmentations/CartesianGrid.cpp
+++ b/DDCore/src/segmentations/CartesianGrid.cpp
@@ -16,7 +16,7 @@ namespace dd4hep {
     }
 
     /// Default constructor used by derived classes passing an existing decoder
-    CartesianGrid::CartesianGrid(BitField64* decode) : Segmentation(decode) {
+    CartesianGrid::CartesianGrid(const BitFieldCoder* decode) : Segmentation(decode) {
     }
 
     /// Destructor

--- a/DDCore/src/segmentations/CartesianGridXY.cpp
+++ b/DDCore/src/segmentations/CartesianGridXY.cpp
@@ -27,7 +27,7 @@ CartesianGridXY::CartesianGridXY(const std::string& cellEncoding) :
 }
 
 /// Default constructor used by derived classes passing an existing decoder
-CartesianGridXY::CartesianGridXY(BitField64* decode) :
+CartesianGridXY::CartesianGridXY(const BitFieldCoder* decode) :
 		CartesianGrid(decode)
 {
 	// define type and description
@@ -50,19 +50,18 @@ CartesianGridXY::~CartesianGridXY() {
 
 /// determine the position based on the cell ID
 Vector3D CartesianGridXY::position(const CellID& cID) const {
-	_decoder->setValue(cID);
 	Vector3D cellPosition;
-	cellPosition.X = binToPosition((*_decoder)[_xId].value(), _gridSizeX, _offsetX);
-	cellPosition.Y = binToPosition((*_decoder)[_yId].value(), _gridSizeY, _offsetY);
+	cellPosition.X = binToPosition( _decoder->get(cID,_xId ), _gridSizeX, _offsetX);
+	cellPosition.Y = binToPosition( _decoder->get(cID,_yId ), _gridSizeY, _offsetY);
 	return cellPosition;
 }
 
 /// determine the cell ID based on the position
   CellID CartesianGridXY::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */, const VolumeID& vID) const {
-	_decoder->setValue(vID);
-	(*_decoder)[_xId] = positionToBin(localPosition.X, _gridSizeX, _offsetX);
-	(*_decoder)[_yId] = positionToBin(localPosition.Y, _gridSizeY, _offsetY);
-	return _decoder->getValue();
+        CellID cID = vID ;
+	_decoder->set( cID,_xId, positionToBin(localPosition.X, _gridSizeX, _offsetX) );
+	_decoder->set( cID,_yId, positionToBin(localPosition.Y, _gridSizeY, _offsetY) );
+	return cID ;
 }
 
 std::vector<double> CartesianGridXY::cellDimensions(const CellID&) const {

--- a/DDCore/src/segmentations/CartesianGridXYZ.cpp
+++ b/DDCore/src/segmentations/CartesianGridXYZ.cpp
@@ -24,7 +24,7 @@ CartesianGridXYZ::CartesianGridXYZ(const std::string& cellEncoding) :
 }
 
 /// Default constructor used by derived classes passing an existing decoder
-CartesianGridXYZ::CartesianGridXYZ(BitField64* decode) :
+CartesianGridXYZ::CartesianGridXYZ(const BitFieldCoder* decode) :
 		CartesianGridXY(decode) {
 	// define type and description
 	_type = "CartesianGridXYZ";
@@ -43,21 +43,20 @@ CartesianGridXYZ::~CartesianGridXYZ() {
 
 /// determine the position based on the cell ID
 Vector3D CartesianGridXYZ::position(const CellID& cID) const {
-	_decoder->setValue(cID);
 	Vector3D cellPosition;
-	cellPosition.X = binToPosition((*_decoder)[_xId].value(), _gridSizeX, _offsetX);
-	cellPosition.Y = binToPosition((*_decoder)[_yId].value(), _gridSizeY, _offsetY);
-	cellPosition.Z = binToPosition((*_decoder)[_zId].value(), _gridSizeZ, _offsetZ);
+	cellPosition.X = binToPosition( _decoder->get(cID,_xId ), _gridSizeX, _offsetX);
+	cellPosition.Y = binToPosition( _decoder->get(cID,_yId ), _gridSizeY, _offsetY);
+	cellPosition.Z = binToPosition( _decoder->get(cID,_zId ), _gridSizeZ, _offsetZ);
 	return cellPosition;
 }
 
 /// determine the cell ID based on the position
   CellID CartesianGridXYZ::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */, const VolumeID& vID) const {
-	_decoder->setValue(vID);
-	(*_decoder)[_xId] = positionToBin(localPosition.X, _gridSizeX, _offsetX);
-	(*_decoder)[_yId] = positionToBin(localPosition.Y, _gridSizeY, _offsetY);
-	(*_decoder)[_zId] = positionToBin(localPosition.Z, _gridSizeZ, _offsetZ);
-	return _decoder->getValue();
+        CellID cID = vID ;
+	_decoder->set( cID,_xId, positionToBin(localPosition.X, _gridSizeX, _offsetX) );
+	_decoder->set( cID,_yId, positionToBin(localPosition.Y, _gridSizeY, _offsetY) );
+	_decoder->set( cID,_zId, positionToBin(localPosition.Z, _gridSizeZ, _offsetZ) );
+	return cID ;
 }
 
 std::vector<double> CartesianGridXYZ::cellDimensions(const CellID&) const {

--- a/DDCore/src/segmentations/CartesianGridXZ.cpp
+++ b/DDCore/src/segmentations/CartesianGridXZ.cpp
@@ -30,7 +30,7 @@ CartesianGridXZ::CartesianGridXZ(const std::string& cellEncoding) :
 }
 
 /// Default constructor used by derived classes passing an existing decoder
-CartesianGridXZ::CartesianGridXZ(BitField64* decode) :
+CartesianGridXZ::CartesianGridXZ(const BitFieldCoder* decode) :
 	CartesianGrid(decode) {
 	// define type and description
 	_type = "CartesianGridXZ";
@@ -52,20 +52,19 @@ CartesianGridXZ::~CartesianGridXZ() {
 
 /// determine the position based on the cell ID
 Vector3D CartesianGridXZ::position(const CellID& cID) const {
-	_decoder->setValue(cID);
 	vector<double> localPosition(3);
 	Vector3D cellPosition;
-	cellPosition.X = binToPosition((*_decoder)[_xId].value(), _gridSizeX, _offsetX);
-	cellPosition.Z = binToPosition((*_decoder)[_zId].value(), _gridSizeZ, _offsetZ);
+	cellPosition.X = binToPosition( _decoder->get(cID,_xId ), _gridSizeX, _offsetX);
+	cellPosition.Z = binToPosition( _decoder->get(cID,_zId ), _gridSizeZ, _offsetZ);
 	return cellPosition;
 }
 
 /// determine the cell ID based on the position
   CellID CartesianGridXZ::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */, const VolumeID& vID) const {
-	_decoder->setValue(vID);
-	(*_decoder)[_xId] = positionToBin(localPosition.X, _gridSizeX, _offsetX);
-	(*_decoder)[_zId] = positionToBin(localPosition.Z, _gridSizeZ, _offsetZ);
-	return _decoder->getValue();
+        CellID cID = vID ;
+        _decoder->set( cID,_xId, positionToBin(localPosition.X, _gridSizeX, _offsetX) );
+	_decoder->set( cID,_zId, positionToBin(localPosition.Z, _gridSizeZ, _offsetZ) );
+	return cID ;
 }
 
 std::vector<double> CartesianGridXZ::cellDimensions(const CellID&) const {

--- a/DDCore/src/segmentations/CartesianGridYZ.cpp
+++ b/DDCore/src/segmentations/CartesianGridYZ.cpp
@@ -29,7 +29,7 @@ CartesianGridYZ::CartesianGridYZ(const std::string& cellEncoding) :
 
 
 /// Default constructor used by derived classes passing an existing decoder
-CartesianGridYZ::CartesianGridYZ(BitField64* decode) : CartesianGrid(decode)
+CartesianGridYZ::CartesianGridYZ(const BitFieldCoder* decode) : CartesianGrid(decode)
 {
 	// define type and description
 	_type = "CartesianGridYZ";
@@ -51,19 +51,18 @@ CartesianGridYZ::~CartesianGridYZ() {
 
 /// determine the position based on the cell ID
 Vector3D CartesianGridYZ::position(const CellID& cID) const {
-	_decoder->setValue(cID);
 	Vector3D cellPosition;
-	cellPosition.Y = binToPosition((*_decoder)[_yId].value(), _gridSizeY, _offsetY);
-	cellPosition.Z = binToPosition((*_decoder)[_zId].value(), _gridSizeZ, _offsetZ);
+	cellPosition.Y = binToPosition( _decoder->get(cID,_yId ), _gridSizeY, _offsetY);
+	cellPosition.Z = binToPosition( _decoder->get(cID,_zId ), _gridSizeZ, _offsetZ);
 	return cellPosition;
 }
 
 /// determine the cell ID based on the position
   CellID CartesianGridYZ::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */, const VolumeID& vID) const {
-	_decoder->setValue(vID);
-	(*_decoder)[_yId] = positionToBin(localPosition.Y, _gridSizeY, _offsetY);
-	(*_decoder)[_zId] = positionToBin(localPosition.Z, _gridSizeZ, _offsetZ);
-	return _decoder->getValue();
+        CellID cID = vID ;
+	_decoder->set( cID,_yId, positionToBin(localPosition.Y, _gridSizeY, _offsetY) );
+	_decoder->set( cID,_zId, positionToBin(localPosition.Z, _gridSizeZ, _offsetZ) );
+	return cID ;
 }
 
 std::vector<double> CartesianGridYZ::cellDimensions(const CellID&) const {

--- a/DDCore/src/segmentations/CylindricalSegmentation.cpp
+++ b/DDCore/src/segmentations/CylindricalSegmentation.cpp
@@ -16,7 +16,7 @@ namespace dd4hep {
     }
 
     /// Default constructor used by derived classes passing an existing decoder
-    CylindricalSegmentation::CylindricalSegmentation(BitField64* decode) :
+    CylindricalSegmentation::CylindricalSegmentation(const BitFieldCoder* decode) :
       Segmentation(decode) {
     }
 

--- a/DDCore/src/segmentations/GridPhiEta.cpp
+++ b/DDCore/src/segmentations/GridPhiEta.cpp
@@ -19,7 +19,7 @@ GridPhiEta::GridPhiEta(const std::string& cellEncoding) :
   registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "phi");
 }
 
-GridPhiEta::GridPhiEta(BitField64* aDecoder) :
+GridPhiEta::GridPhiEta(const BitFieldCoder* aDecoder) :
   Segmentation(aDecoder) {
   // define type and description
   _type = "GridPhiEta";
@@ -35,36 +35,24 @@ GridPhiEta::GridPhiEta(BitField64* aDecoder) :
 }
 
 Vector3D GridPhiEta::position(const CellID& cID) const {
-  _decoder->setValue(cID);
-  return Util::positionFromREtaPhi(1.0, eta(), phi());
+  return Util::positionFromREtaPhi(1.0, eta(cID), phi(cID));
 }
 
 CellID GridPhiEta::cellID(const Vector3D& /* localPosition */, const Vector3D& globalPosition, const VolumeID& vID) const {
-  _decoder->setValue(vID);
   double lEta = Util::etaFromXYZ(globalPosition);
   double lPhi = Util::phiFromXYZ(globalPosition);
-  (*_decoder)[m_etaID] = positionToBin(lEta, m_gridSizeEta, m_offsetEta);
-  (*_decoder)[m_phiID] = positionToBin(lPhi, 2 * M_PI / (double) m_phiBins, m_offsetPhi);
-  return _decoder->getValue();
-}
-
-double GridPhiEta::eta() const {
-  CellID etaValue = (*_decoder)[m_etaID].value();
-  return binToPosition(etaValue, m_gridSizeEta, m_offsetEta);
-}
-double GridPhiEta::phi() const {
-  CellID phiValue = (*_decoder)[m_phiID].value();
-  return binToPosition(phiValue, 2.*M_PI/(double)m_phiBins, m_offsetPhi);
+  CellID cID = vID ;
+  _decoder->set( cID, m_etaID, positionToBin(lEta, m_gridSizeEta, m_offsetEta) );
+  _decoder->set( cID, m_phiID, positionToBin(lPhi, 2 * M_PI / (double) m_phiBins, m_offsetPhi) );
+  return cID;
 }
 
 double GridPhiEta::eta(const CellID& cID) const {
-  _decoder->setValue(cID);
-  CellID etaValue = (*_decoder)[m_etaID].value();
+  CellID etaValue = _decoder->get(cID, m_etaID);
   return binToPosition(etaValue, m_gridSizeEta, m_offsetEta);
 }
 double GridPhiEta::phi(const CellID& cID) const {
-  _decoder->setValue(cID);
-  CellID phiValue = (*_decoder)[m_phiID].value();
+  CellID phiValue = _decoder->get(cID, m_phiID);
   return binToPosition(phiValue, 2.*M_PI/(double)m_phiBins, m_offsetPhi);
 }
 REGISTER_SEGMENTATION(GridPhiEta)

--- a/DDCore/src/segmentations/GridRPhiEta.cpp
+++ b/DDCore/src/segmentations/GridRPhiEta.cpp
@@ -16,7 +16,7 @@ GridRPhiEta::GridRPhiEta(const std::string& cellEncoding) :
   registerIdentifier("identifier_r", "Cell ID identifier for R", m_rID, "r");
 }
 
-GridRPhiEta::GridRPhiEta(BitField64* aDecoder) :
+GridRPhiEta::GridRPhiEta(const BitFieldCoder* aDecoder) :
   GridPhiEta(aDecoder) {
   // define type and description
   _type = "GridRPhiEta";
@@ -29,29 +29,22 @@ GridRPhiEta::GridRPhiEta(BitField64* aDecoder) :
 }
 
 Vector3D GridRPhiEta::position(const CellID& cID) const {
-  _decoder->setValue(cID);
-  return Util::positionFromREtaPhi(r(), eta(), phi());
+  return Util::positionFromREtaPhi(r(cID), eta(cID), phi(cID));
 }
 
 CellID GridRPhiEta::cellID(const Vector3D& /* localPosition */, const Vector3D& globalPosition, const VolumeID& vID) const {
-  _decoder->setValue(vID);
   double lRadius = Util::radiusFromXYZ(globalPosition);
   double lEta = Util::etaFromXYZ(globalPosition);
   double lPhi = Util::phiFromXYZ(globalPosition);
-  (*_decoder)[m_etaID] = positionToBin(lEta, m_gridSizeEta, m_offsetEta);
-  (*_decoder)[m_phiID] = positionToBin(lPhi, 2 * M_PI / (double) m_phiBins, m_offsetPhi);
-  (*_decoder)[m_rID] = positionToBin(lRadius, m_gridSizeR, m_offsetR);
-  return _decoder->getValue();
-}
-
-double GridRPhiEta::r() const {
-  CellID rValue = (*_decoder)[m_rID].value();
-  return binToPosition(rValue, m_gridSizeR, m_offsetR);
+  CellID cID = vID ;
+  _decoder->set( cID, m_etaID, positionToBin(lEta, m_gridSizeEta, m_offsetEta) );
+  _decoder->set( cID, m_phiID, positionToBin(lPhi, 2 * M_PI / (double) m_phiBins, m_offsetPhi) );
+  _decoder->set( cID, m_rID  , positionToBin(lRadius, m_gridSizeR, m_offsetR) );
+  return cID;
 }
 
 double GridRPhiEta::r(const CellID& cID) const {
-  _decoder->setValue(cID);
-  CellID rValue = (*_decoder)[m_rID].value();
+  CellID rValue = _decoder->get(cID, m_rID);
   return binToPosition(rValue, m_gridSizeR, m_offsetR);
 }
 REGISTER_SEGMENTATION(GridRPhiEta)

--- a/DDCore/src/segmentations/MegatileLayerGridXY.cpp
+++ b/DDCore/src/segmentations/MegatileLayerGridXY.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cassert>
 #include <algorithm>
+#include <iostream>
 
 namespace dd4hep {
   namespace DDSegmentation {
@@ -23,7 +24,7 @@ namespace dd4hep {
       setup();
     }
 
-    MegatileLayerGridXY::MegatileLayerGridXY(BitField64* decode) :
+    MegatileLayerGridXY::MegatileLayerGridXY(const BitFieldCoder* decode) :
       CartesianGrid(decode) {
       setup();
     }
@@ -62,11 +63,10 @@ namespace dd4hep {
     Vector3D MegatileLayerGridXY::position(const CellID& cID) const {
       // this is local position within the megatile
 
-      _decoder->setValue(cID);
-      unsigned int layerIndex = (*_decoder)[_identifierLayer];
-      unsigned int waferIndex = (*_decoder)[_identifierWafer];
-      int cellIndexX = (*_decoder)[_xId];
-      int cellIndexY = (*_decoder)[_yId];
+      unsigned int layerIndex = _decoder->get(cID,_identifierLayer);
+      unsigned int waferIndex = _decoder->get(cID,_identifierWafer);
+      int cellIndexX = _decoder->get(cID,_xId);
+      int cellIndexY = _decoder->get(cID,_yId);
 
       // segmentation info for this megatile ("wafer")
       getSegInfo(layerIndex, waferIndex);
@@ -94,9 +94,8 @@ namespace dd4hep {
       // this is the local position within a megatile, local coordinates
 
       // get the layer, wafer, module indices from the volumeID
-      _decoder->setValue(vID);
-      unsigned int layerIndex = (*_decoder)[_identifierLayer];
-      unsigned int waferIndex = (*_decoder)[_identifierWafer];
+      unsigned int layerIndex = _decoder->get(vID,_identifierLayer);
+      unsigned int waferIndex = _decoder->get(vID,_identifierWafer);
 
       // segmentation info for this megatile ("wafer")
       getSegInfo(layerIndex, waferIndex);
@@ -112,17 +111,17 @@ namespace dd4hep {
       int _cellIndexX = int ( localX / ( _currentSegInfo.megaTileSizeX / _currentSegInfo.nCellsX ) );
       int _cellIndexY = int ( localY / ( _currentSegInfo.megaTileSizeY / _currentSegInfo.nCellsY ) );
 
-      (*_decoder)[_xId] = _cellIndexX;
-      (*_decoder)[_yId] = _cellIndexY;
+      CellID cID = vID ;
+      _decoder->set(cID,_xId,_cellIndexX);
+      _decoder->set(cID,_yId,_cellIndexY);
 
-      return _decoder->getValue();
+      return cID;
     }
 
 
     std::vector<double> MegatileLayerGridXY::cellDimensions(const CellID& cID) const {
-      _decoder->setValue( cID );
-      unsigned int layerIndex = (*_decoder)[_identifierLayer];
-      unsigned int waferIndex = (*_decoder)[_identifierWafer];
+      unsigned int layerIndex = _decoder->get(cID,_identifierLayer);
+      unsigned int waferIndex = _decoder->get(cID,_identifierWafer);
       return cellDimensions(layerIndex, waferIndex);
     }
 

--- a/DDCore/src/segmentations/MultiSegmentation.cpp
+++ b/DDCore/src/segmentations/MultiSegmentation.cpp
@@ -8,6 +8,7 @@
 #include "DDSegmentation/MultiSegmentation.h"
 #include <iomanip>
 #include <stdexcept>
+#include <iostream>
 
 using namespace std;
 
@@ -26,7 +27,7 @@ namespace dd4hep {
     }
 
     /// Default constructor used by derived classes passing an existing decoder
-    MultiSegmentation::MultiSegmentation(BitField64* decode)
+    MultiSegmentation::MultiSegmentation(const BitFieldCoder* decode)
       :	Segmentation(decode), m_discriminator(0), m_debug(0)
     {
       // define type and description
@@ -53,7 +54,7 @@ namespace dd4hep {
     }
 
     /// Set the underlying decoder
-    void MultiSegmentation::setDecoder(BitField64* newDecoder) {
+    void MultiSegmentation::setDecoder(const BitFieldCoder* newDecoder) {
       this->Segmentation::setDecoder(newDecoder);
       for(Segmentations::iterator i=m_segmentations.begin(); i != m_segmentations.end(); ++i)
         (*i).segmentation->setDecoder(newDecoder);

--- a/DDCore/src/segmentations/NoSegmentation.cpp
+++ b/DDCore/src/segmentations/NoSegmentation.cpp
@@ -17,7 +17,7 @@ namespace dd4hep {
       _description = "None Segmentation";
     }
 
-    NoSegmentation::NoSegmentation(BitField64* decode) : Segmentation(decode)
+    NoSegmentation::NoSegmentation(const BitFieldCoder* decode) : Segmentation(decode)
     { 
       _type = "NoSegmentation";
       _description = "None Segmentation";

--- a/DDCore/src/segmentations/PolarGrid.cpp
+++ b/DDCore/src/segmentations/PolarGrid.cpp
@@ -15,7 +15,7 @@ namespace dd4hep {
       Segmentation(cellEncoding) {
     }
     /// Default constructor used by derived classes passing an existing decoder
-    PolarGrid::PolarGrid(BitField64* decode)	: Segmentation(decode) {
+    PolarGrid::PolarGrid(const BitFieldCoder* decode)	: Segmentation(decode) {
     }
 
     /// Destructor

--- a/DDCore/src/segmentations/ProjectiveCylinder.cpp
+++ b/DDCore/src/segmentations/ProjectiveCylinder.cpp
@@ -35,7 +35,7 @@ ProjectiveCylinder::ProjectiveCylinder(const std::string& cellEncoding) :
 
 
 /// Default constructor used by derived classes passing an existing decoder
-ProjectiveCylinder::ProjectiveCylinder(BitField64* decode) :	CylindricalSegmentation(decode) {
+ProjectiveCylinder::ProjectiveCylinder(const BitFieldCoder* decode) :	CylindricalSegmentation(decode) {
 	// define type and description
 	_type = "ProjectiveCylinder";
 	_description = "Projective segmentation in the global coordinates";
@@ -56,41 +56,27 @@ ProjectiveCylinder::~ProjectiveCylinder() {
 
 /// determine the local based on the cell ID
 Vector3D ProjectiveCylinder::position(const CellID& cID) const {
-	_decoder->setValue(cID);
-	return Util::positionFromRThetaPhi(1.0, theta(), phi());
+	return Util::positionFromRThetaPhi(1.0, theta(cID), phi(cID));
 }
 
 /// determine the cell ID based on the position
 CellID ProjectiveCylinder::cellID(const Vector3D& /* localPosition */, const Vector3D& globalPosition, const VolumeID& vID) const {
-	_decoder->setValue(vID);
+        CellID cID = vID ;
 	double lTheta = thetaFromXYZ(globalPosition);
 	double lPhi = phiFromXYZ(globalPosition);
-	(*_decoder)[_thetaID] = positionToBin(lTheta, M_PI / (double) _thetaBins, _offsetTheta);
-	(*_decoder)[_phiID] = positionToBin(lPhi, 2 * M_PI / (double) _phiBins, _offsetPhi);
-	return _decoder->getValue();
-}
-
-/// determine the polar angle theta based on the current cell ID
-double ProjectiveCylinder::theta() const {
-	CellID thetaIndex = (*_decoder)[_thetaID].value();
-	return M_PI * ((double) thetaIndex + 0.5) / (double) _thetaBins;
-}
-/// determine the azimuthal angle phi based on the current cell ID
-double ProjectiveCylinder::phi() const {
-	CellID phiIndex = (*_decoder)[_phiID].value();
-	return 2. * M_PI * ((double) phiIndex + 0.5) / (double) _phiBins;
+	_decoder->set(cID,_thetaID, positionToBin(lTheta, M_PI / (double) _thetaBins, _offsetTheta));
+	_decoder->set(cID,_phiID  , positionToBin(lPhi, 2 * M_PI / (double) _phiBins, _offsetPhi));
+	return cID;
 }
 
 /// determine the polar angle theta based on the cell ID
 double ProjectiveCylinder::theta(const CellID& cID) const {
-	_decoder->setValue(cID);
-	CellID thetaIndex = (*_decoder)[_thetaID].value();
+        CellID thetaIndex = _decoder->get(cID,_thetaID);
 	return M_PI * ((double) thetaIndex + 0.5) / (double) _thetaBins;
 }
 /// determine the azimuthal angle phi based on the cell ID
 double ProjectiveCylinder::phi(const CellID& cID) const {
-	_decoder->setValue(cID);
-	CellID phiIndex = (*_decoder)[_phiID].value();
+        CellID phiIndex = _decoder->get(cID,_phiID);
 	return 2. * M_PI * ((double) phiIndex + 0.5) / (double) _phiBins;
 }
 

--- a/DDCore/src/segmentations/WaferGridXY.cpp
+++ b/DDCore/src/segmentations/WaferGridXY.cpp
@@ -31,7 +31,7 @@ WaferGridXY::WaferGridXY(const std::string& cellEncoding) :
 }
 
 /// Default constructor used by derived classes passing an existing decoder
-WaferGridXY::WaferGridXY(BitField64* decode) :	CartesianGrid(decode) {
+WaferGridXY::WaferGridXY(const BitFieldCoder* decode) :	CartesianGrid(decode) {
 	// define type and description
 	_type = "WaferGridXY";
 	_description = "Cartesian segmentation in the local XY-plane for both Normal wafer and Magic wafer(depending on the layer dimensions)";
@@ -56,30 +56,29 @@ WaferGridXY::~WaferGridXY() {
 
 /// determine the position based on the cell ID
 Vector3D WaferGridXY::position(const CellID& cID) const {
-	_decoder->setValue(cID);
         unsigned int _groupMGWaferIndex;
         unsigned int _waferIndex;
 	Vector3D cellPosition;
 
-        _groupMGWaferIndex = (*_decoder)[_identifierMGWaferGroup];
-        _waferIndex = (*_decoder)[_identifierWafer];
+        _groupMGWaferIndex = _decoder->get(cID,_identifierMGWaferGroup);
+        _waferIndex = _decoder->get(cID,_identifierWafer);
 
 	if ( _waferOffsetX[_groupMGWaferIndex][_waferIndex] > 0 || _waferOffsetX[_groupMGWaferIndex][_waferIndex] < 0 )
 	  {
-	    cellPosition.X = binToPosition((*_decoder)[_xId].value(), _gridSizeX, _offsetX+_waferOffsetX[_groupMGWaferIndex][_waferIndex]);
+	    cellPosition.X = binToPosition(_decoder->get(cID,_xId), _gridSizeX, _offsetX+_waferOffsetX[_groupMGWaferIndex][_waferIndex]);
 	  }
 	else
 	  {
-	    cellPosition.X = binToPosition((*_decoder)[_xId].value(), _gridSizeX, _offsetX);
+	    cellPosition.X = binToPosition(_decoder->get(cID,_xId), _gridSizeX, _offsetX);
 	  }
 
 	if ( _waferOffsetY[_groupMGWaferIndex][_waferIndex] > 0 || _waferOffsetY[_groupMGWaferIndex][_waferIndex] < 0 )
 	  {
-	    cellPosition.Y = binToPosition((*_decoder)[_yId].value(), _gridSizeY, _offsetY+_waferOffsetY[_groupMGWaferIndex][_waferIndex]);
+	    cellPosition.Y = binToPosition(_decoder->get(cID,_yId), _gridSizeY, _offsetY+_waferOffsetY[_groupMGWaferIndex][_waferIndex]);
 	  }
 	else
 	  {
-	    cellPosition.Y = binToPosition((*_decoder)[_yId].value(), _gridSizeY, _offsetY);
+	    cellPosition.Y = binToPosition(_decoder->get(cID,_yId), _gridSizeY, _offsetY);
 	  }
 
 	return cellPosition;
@@ -87,32 +86,33 @@ Vector3D WaferGridXY::position(const CellID& cID) const {
 
 /// determine the cell ID based on the position
   CellID WaferGridXY::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */, const VolumeID& vID) const {
-	_decoder->setValue(vID);
         unsigned int _groupMGWaferIndex;
         unsigned int _waferIndex;
 
-        _groupMGWaferIndex = (*_decoder)[_identifierMGWaferGroup];
-        _waferIndex = (*_decoder)[_identifierWafer];
+	CellID cID = vID ;
+
+        _groupMGWaferIndex = _decoder->get(cID,_identifierMGWaferGroup);
+        _waferIndex = _decoder->get(cID,_identifierWafer);
 
 	if ( _waferOffsetX[_groupMGWaferIndex][_waferIndex] > 0 || _waferOffsetX[_groupMGWaferIndex][_waferIndex] < 0 )
 	  {
-	    (*_decoder)[_xId] = positionToBin(localPosition.X, _gridSizeX, _offsetX+_waferOffsetX[_groupMGWaferIndex][_waferIndex]);
+	    _decoder->set(cID,_xId, positionToBin(localPosition.X, _gridSizeX, _offsetX+_waferOffsetX[_groupMGWaferIndex][_waferIndex]));
 	  }
 	else
 	  {
-	    (*_decoder)[_xId] = positionToBin(localPosition.X, _gridSizeX, _offsetX);
+	    _decoder->set(cID,_xId, positionToBin(localPosition.X, _gridSizeX, _offsetX));
 	  }
 
 	if ( _waferOffsetY[_groupMGWaferIndex][_waferIndex] > 0 ||  _waferOffsetY[_groupMGWaferIndex][_waferIndex] < 0)
 	  {
-	    (*_decoder)[_yId] = positionToBin(localPosition.Y, _gridSizeY, _offsetY+_waferOffsetY[_groupMGWaferIndex][_waferIndex]);
+	    _decoder->set(cID,_yId, positionToBin(localPosition.Y, _gridSizeY, _offsetY+_waferOffsetY[_groupMGWaferIndex][_waferIndex]));
 	  }
 	else
 	  {
-	    (*_decoder)[_yId] = positionToBin(localPosition.Y, _gridSizeY, _offsetY);
+	    _decoder->set(cID,_yId, positionToBin(localPosition.Y, _gridSizeY, _offsetY));
 	  }
 
-	return _decoder->getValue();
+	return cID;
 }
 
 std::vector<double> WaferGridXY::cellDimensions(const CellID&) const {

--- a/DDG4/include/DDG4/Geant4ReadoutVolumeFilter.h
+++ b/DDG4/include/DDG4/Geant4ReadoutVolumeFilter.h
@@ -37,7 +37,7 @@ namespace dd4hep {
       /// Collection index
       const HitCollection* m_collection;
       /// Bit field value from ID descriptor
-      const BitFieldValue* m_key;
+      const BitFieldElement* m_key;
 
     public:
       /// Standard constructor

--- a/DDG4/include/DDG4/Geant4VolumeManager.h
+++ b/DDG4/include/DDG4/Geant4VolumeManager.h
@@ -75,10 +75,10 @@ namespace dd4hep {
       VolumeID volumeID(const G4VTouchable* touchable) const;
       /// Accessfully decoded volume fields  by placement path
       void volumeDescriptor(const std::vector<const G4VPhysicalVolume*>&   path,
-                            std::pair<VolumeID,std::vector<std::pair<const BitFieldValue*, VolumeID> > >& volume_desc) const;
+                            std::pair<VolumeID,std::vector<std::pair<const BitFieldElement*, VolumeID> > >& volume_desc) const;
       /// Access fully decoded volume fields by Geant4 touchable object
       void volumeDescriptor(const G4VTouchable* touchable,
-                            std::pair<VolumeID,std::vector<std::pair<const BitFieldValue*, VolumeID> > >& volume_desc) const;
+                            std::pair<VolumeID,std::vector<std::pair<const BitFieldElement*, VolumeID> > >& volume_desc) const;
     };
 
   }    // End namespace sim

--- a/DDG4/src/Geant4VolumeManager.cpp
+++ b/DDG4/src/Geant4VolumeManager.cpp
@@ -36,7 +36,7 @@ using namespace dd4hep;
 using namespace std;
 
 #include "DDG4/Geant4AssemblyVolume.h"
-typedef pair<VolumeID,vector<pair<const BitFieldValue*, VolumeID> > > VolIDDescriptor;
+typedef pair<VolumeID,vector<pair<const BitFieldElement*, VolumeID> > > VolIDDescriptor;
 namespace {
 
   /// Helper class to populate the Geant4 volume manager

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -21,6 +21,7 @@ dd4hep_add_test_reg ( test_surface             BUILD_EXEC REGEX_FAIL "TEST_FAILE
   EXEC_ARGS file:${CMAKE_CURRENT_SOURCE_DIR}/units.xml )
 
 dd4hep_add_test_reg ( test_bitfield64          BUILD_EXEC REGEX_FAIL "TEST_FAILED" )
+dd4hep_add_test_reg ( test_bitfieldcoder       BUILD_EXEC REGEX_FAIL "TEST_FAILED" )
 dd4hep_add_test_reg ( test_DetType             BUILD_EXEC REGEX_FAIL "TEST_FAILED" )
 dd4hep_add_test_reg ( test_PolarGridRPhi2      BUILD_EXEC REGEX_FAIL "TEST_FAILED" )
 dd4hep_add_test_reg ( test_cellDimensions      BUILD_EXEC REGEX_FAIL "TEST_FAILED" )

--- a/DDTest/src/test_PolarGridRPhi2.cc
+++ b/DDTest/src/test_PolarGridRPhi2.cc
@@ -129,8 +129,8 @@ int main() {
 		<< std::endl;
 
       std::cout << std::setw(20) <<  "Calculated"
-		<< std::setw(20) <<  (*seg.decoder())["r"]
-		<< std::setw(20) <<  (*seg.decoder())["phi"]
+		<< std::setw(20) <<  seg.decoder()->get(cid,"r")
+		<< std::setw(20) <<  seg.decoder()->get(cid,"phi")
 		<< std::endl;
 
     }
@@ -164,10 +164,11 @@ int main() {
       const long long rB = (*it)._rB;
       const long long pB = (*it)._pB;
 
-      (*seg.decoder())["r"] = rB;
-      (*seg.decoder())["phi"] = pB;
+      dd4hep::DDSegmentation::CellID cellID  ;
 
-      dd4hep::DDSegmentation::CellID cellID = (*seg.decoder()).getValue();
+      seg.decoder()->set(cellID,"r"  , rB);
+      seg.decoder()->set(cellID,"phi", pB);
+
       std::cout << "CellID: " << cellID  << std::endl;
 
       dd4hep::DDSegmentation::Vector3D expectedPosition( r*cos(phi), r*sin(phi), 0.0);

--- a/DDTest/src/test_bitfieldcoder.cc
+++ b/DDTest/src/test_bitfieldcoder.cc
@@ -1,0 +1,58 @@
+#include "DD4hep/DDTest.h"
+#include <exception>
+#include <iostream>
+#include <assert.h>
+#include <cmath>
+
+#include "DDSegmentation/BitFieldCoder.h"
+
+
+using namespace std ;
+using namespace dd4hep ;
+using namespace DDSegmentation ;
+
+// this should be the first line in your test
+static DDTest test( "bitfield64" ) ; 
+
+//=============================================================================
+
+int main(int /* argc */, char** /* argv */ ){
+    
+  try{
+    
+    // ----- write your tests in here -------------------------------------
+
+    test.log( "test bitfieldcoder" );
+
+
+    // initialize with a string that uses all 64 bits :
+    const BitFieldCoder bf("system:5,side:-2,layer:9,module:8,sensor:8,x:32:-16,y:-16" ) ;
+
+    // set some 'random' values to bf2 
+    long64 field = 0  ;
+    
+    bf.set( field, "layer",  373 );
+    bf.set( field, "module", 254 );
+    bf.set( field, "sensor", 202 );
+    bf.set( field, "side",   1 );
+    bf.set( field, "system", 30 );
+    bf.set( field, "x",      -310 );
+    bf.set( field, "y",      -16710 );
+
+
+    test(  field , long64(0xbebafecacafebabeUL)  , " same value 0xbebafecacafebabeUL from individual initialization " ); 
+
+    // --------------------------------------------------------------------
+
+
+  } catch( exception &e ){
+    //} catch( ... ){
+
+    test.log( e.what() );
+    test.error( "exception occurred" );
+  }
+
+  return 0;
+}
+
+//=============================================================================

--- a/DDTest/src/test_cellDimensionsRPhi2.cc
+++ b/DDTest/src/test_cellDimensionsRPhi2.cc
@@ -100,9 +100,10 @@ Segmentation* createPolarGridRPhi2() {
 }
 
 CellID getCellID(dd4hep::DDSegmentation::Segmentation* seg, long long rB, long long pB){
-  (*seg->decoder())["r"] = rB;
-  (*seg->decoder())["phi"] = pB;
-  return (*seg->decoder()).getValue();
+  CellID cID ;
+  seg->decoder()->set(cID,"r",rB) ;
+  seg->decoder()->set(cID,"phi",pB);
+  return cID;
 }
 
 void testRPhi2(){

--- a/DDTest/src/test_segmentationHandles.cc
+++ b/DDTest/src/test_segmentationHandles.cc
@@ -16,10 +16,11 @@
 static dd4hep::DDTest test( "CellDimensions" ) ;
 using namespace dd4hep;
 using namespace dd4hep::detail;
+//using dd4hep::DDSegmentation::BitFieldCoder;
 
 int main() {
   try{
-    BitField64 bf("system:8,barrel:3,layer:8,slice:5,x:16,y:16");
+    BitFieldCoder bf("system:8,barrel:3,layer:8,slice:5,x:16,y:16");
     Segmentation base("CartesianGridXY","Test",&bf);
     CartesianGridXY seg(base);
     const double xSize=12343.43243;
@@ -41,7 +42,7 @@ int main() {
   }
 
   try{
-    BitField64 bf("system:8,barrel:3,layer:8,slice:5,x:16,z:16");
+    BitFieldCoder bf("system:8,barrel:3,layer:8,slice:5,x:16,z:16");
     Segmentation base("CartesianGridXZ","Test",&bf);
     CartesianGridXZ seg(base);
 
@@ -64,7 +65,7 @@ int main() {
   }
 
   try{
-    BitField64 bf("system:8,barrel:3,layer:8,slice:5,y:16,z:16");
+    BitFieldCoder bf("system:8,barrel:3,layer:8,slice:5,y:16,z:16");
     Segmentation base("CartesianGridYZ","Test",&bf);
     CartesianGridYZ seg = base;
 
@@ -87,7 +88,7 @@ int main() {
   }
 
   try{
-    BitField64 bf("system:8,barrel:3,layer:8,slice:7,x:10,y:10,z:10");
+    BitFieldCoder bf("system:8,barrel:3,layer:8,slice:7,x:10,y:10,z:10");
     Segmentation base("CartesianGridXYZ","Test",&bf);
     CartesianGridXYZ seg = base;
 

--- a/UtilityApps/src/test_cellid_position_converter.cpp
+++ b/UtilityApps/src/test_cellid_position_converter.cpp
@@ -16,7 +16,7 @@
 #include "DD4hep/DDTest.h"
 
 #include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/BitField64.h"
+#include "DD4hep/BitFieldCoder.h"
 #include "DDRec/CellIDPositionConverter.h"
 
 #include "lcio.h"
@@ -124,8 +124,8 @@ int main_wrapper(int argc, char** argv ){
 
       std::string cellIDEcoding = col->getParameters().getStringVal("CellIDEncoding") ;
       
-      dd4hep::BitField64 idDecoder0( cellIDEcoding ) ;
-      dd4hep::BitField64 idDecoder1( cellIDEcoding ) ;
+      dd4hep::BitFieldCoder idDecoder0( cellIDEcoding ) ;
+      dd4hep::BitFieldCoder idDecoder1( cellIDEcoding ) ;
 
       int nHit = std::min( col->getNumberOfElements(), maxHit )  ;
      
@@ -137,10 +137,7 @@ int main_wrapper(int argc, char** argv ){
         dd4hep::long64 id0 = sHit->getCellID0() ;
         dd4hep::long64 id1 = sHit->getCellID1() ;
 
-	idDecoder0.setValue( id0 , id1 ) ;
-
-	dd4hep::long64 id = idDecoder0.getValue() ;
-	
+	dd4hep::long64 id =  idDecoder0.toLong( id0 , id1 ) ;                                                                                                                  
 
 	Position point( sHit->getPosition()[0]* dd4hep::mm , sHit->getPosition()[1]* dd4hep::mm ,  sHit->getPosition()[2]* dd4hep::mm ) ;
 	
@@ -150,11 +147,8 @@ int main_wrapper(int argc, char** argv ){
 	
 	CellID idFromDecoder = idposConv.cellID( point ) ;
 
-        idDecoder1.setValue( idFromDecoder ) ;
-
-	
 	std::stringstream sst ;
-	sst << " compare ids: " << det.name() << " " <<  idDecoder0.valueString() << "  -  " << idDecoder1.valueString() ;
+	sst << " compare ids: " << det.name() << " " <<  idDecoder0.valueString(id) << "  -  " << idDecoder1.valueString(idFromDecoder) ;
 
 	test( id, idFromDecoder,  sst.str() ) ;
 	

--- a/UtilityApps/src/test_surfaces.cpp
+++ b/UtilityApps/src/test_surfaces.cpp
@@ -114,7 +114,7 @@ int main_wrapper(int argc, char** argv ){
 
       std::string cellIDEcoding = col->getParameters().getStringVal("CellIDEncoding") ;
       
-      dd4hep::BitField64 idDecoder( cellIDEcoding ) ;
+      BitField64 idDecoder( cellIDEcoding ) ;
 
       int nHit = col->getNumberOfElements() ;
       


### PR DESCRIPTION
Resolves #187 
BEGINRELEASENOTES
- add new threadsafe class `BitFieldCoder` as replacement for `BitField64`
- use as `const` everywhere
- re-implement `BitField64` using `BitFieldCoder`
  - is thread safe if used locally 
  - can be instantiated from `const BitFieldCoder*`

ENDRELEASENOTES