### PR TITLE
add dd4hep::rec::FixedPadSizeTPCData.zMinReadout

### DIFF
--- a/DDRec/include/DDRec/DetectorData.h
+++ b/DDRec/include/DDRec/DetectorData.h
@@ -47,6 +47,8 @@ namespace dd4hep {
       double rMax ;
       /// driftLength in z (half length of active volume)
       double driftLength ;
+      /// start z of active Volume (typically cathode half thickness)
+      double zMinReadout ;
       /// inner r of active volume
       double rMinReadout ;
       /// outer r of active volume

--- a/DDRec/src/DetectorData.cpp
+++ b/DDRec/src/DetectorData.cpp
@@ -13,7 +13,8 @@ namespace dd4hep {
       io <<  "   zHalf : "              <<  d.zHalf  << std::endl ; 
       io <<  "   rMin : "               <<  d.rMin << std::endl ; 
       io <<  "   rMax : "               <<  d.rMax << std::endl ; 
-      io <<  "   driftLength : "        <<  d.driftLength << std::endl ; 
+      io <<  "   driftLength : "        <<  d.driftLength << std::endl ;
+      io <<  "   zMinReadout : "        <<  d.zMinReadout << std::endl ;
       io <<  "   rMinReadout : "        <<  d.rMinReadout << std::endl ; 
       io <<  "   rMaxReadout : "        <<  d.rMaxReadout << std::endl ; 
       io <<  "   innerWallThickness : " <<  d.innerWallThickness << std::endl ; 


### PR DESCRIPTION
BEGINRELEASENOTES
- add `dd4hep::rec::FixedPadSizeTPCData.zMinReadout`
     - needed to describe the cathode thickness 

ENDRELEASENOTES