### PR TITLE
rm heap allocation of elements in BitFieldCoder

### DIFF
--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -24,7 +24,13 @@ namespace DDSegmentation {
   
     public :
   
-      /** The default c'tor.
+      BitFieldElement() = default ;
+      ~BitFieldElement() = default ;
+      BitFieldElement(const BitFieldElement&) = default ;
+      BitFieldElement(BitFieldElement&&) = default ;
+
+
+      /** The standard c'tor.
        * @param  name          name of the field
        * @param  offset        offset of field
        * @param  signedWidth   width of field, negative if field is signed

--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -23,7 +23,6 @@ namespace DDSegmentation {
     class BitFieldElement{
   
     public :
-      virtual ~BitFieldElement() {}
   
       /** The default c'tor.
        * @param  name          name of the field
@@ -102,14 +101,11 @@ namespace DDSegmentation {
     
     typedef std::map<std::string, unsigned int> IndexMap ;
 
-    /** No default c'tor */
-    BitFieldCoder() {} ;
+    BitFieldCoder() = default ;
+    ~BitFieldCoder() = default ;
+    BitFieldCoder(const BitFieldCoder&) = default ;
+    BitFieldCoder(BitFieldCoder&&) = default ;
 
-    ~BitFieldCoder() {  // clean up
-      for(unsigned i=0;i<_fields.size();i++){
-	delete _fields[i] ;
-      }
-  }
     
     /** The c'tor takes an initialization string of the form:<br>
      *  \<fieldDesc\>[,\<fieldDesc\>...]<br>
@@ -148,27 +144,27 @@ namespace DDSegmentation {
     /** get value of sub-field specified by index 
      */
     long64 get(long64 bitfield, size_t index) const { 
-      return _fields.at(index)->value( bitfield )  ; 
+      return _fields.at(index).value( bitfield )  ;
     }
     
     /** Access to field through name .
      */
     long64 get(long64 bitfield, const std::string& name) const {
 
-      return _fields.at( index( name ) )->value( bitfield ) ;
+      return _fields.at( index( name ) ).value( bitfield ) ;
     }
 
     /** set value of sub-field specified by index 
      */
     void set(long64& bitfield, size_t index, ulong64 value) const { 
-      _fields.at(index)->set( bitfield , value )  ; 
+      _fields.at(index).set( bitfield , value )  ;
     }
     
     /** Access to field through name .
      */
     void set(long64& bitfield, const std::string& name, ulong64 value) const {
 
-      _fields.at( index( name ) )->set( bitfield, value ) ;
+      _fields.at( index( name ) ).set( bitfield, value ) ;
     }
 
 
@@ -190,14 +186,14 @@ namespace DDSegmentation {
      */
     const BitFieldElement& operator[](const std::string& name) const { 
 
-      return *_fields[ index( name ) ] ;
+      return _fields[ index( name ) ] ;
     }
 
     /** Const Access to field through index .
      */
     const BitFieldElement& operator[](unsigned index) const { 
 
-      return *_fields[ index ] ;
+      return _fields[ index ] ;
     }
 
     /** Return a valid description string of all fields
@@ -208,7 +204,7 @@ namespace DDSegmentation {
      */
     std::string valueString(ulong64 bitfield) const ;
 
-    const std::vector<BitFieldElement*>& fields()  const  {
+    const std::vector<BitFieldElement>& fields()  const  {
       return _fields;
     }
     
@@ -233,7 +229,7 @@ namespace DDSegmentation {
 
     // -------------- data members:--------------
 
-    std::vector<BitFieldElement*> _fields{} ;
+    std::vector<BitFieldElement> _fields{} ;
     IndexMap  _map{} ;
     long64    _joined{} ;
 

--- a/DDCore/src/IDDescriptor.cpp
+++ b/DDCore/src/IDDescriptor.cpp
@@ -135,29 +135,29 @@ VolumeID IDDescriptor::encode(const std::vector<std::pair<std::string, int> >& i
 void IDDescriptor::decodeFields(VolumeID vid,
                                 vector<pair<const BitFieldElement*, VolumeID> >& flds)  const
 {
-  const vector<BitFieldElement*>& v = access()->decoder.fields();
+  const vector<BitFieldElement>& v = access()->decoder.fields();
   flds.clear();
-  for (auto f : v )
-    flds.push_back(make_pair(f, f->value(vid)));
+  for (auto& f : v )
+    flds.push_back(make_pair(&f, f.value(vid)));
 }
 
 /// Decode volume IDs and return string reprensentation for debugging purposes
 string IDDescriptor::str(VolumeID vid)   const {
-  const vector<BitFieldElement*>& v = access()->decoder.fields();
+  const vector<BitFieldElement>& v = access()->decoder.fields();
   stringstream str;
-  for (auto f : v )
-    str << f->name() << ":" << setw(4) << setfill('0') << hex << right << f->value(vid)
+  for (auto& f : v )
+    str << f.name() << ":" << setw(4) << setfill('0') << hex << right << f.value(vid)
         << left << dec << " ";
   return str.str().substr(0,str.str().length()-1);
 }
 
 /// Decode volume IDs and return string reprensentation for debugging purposes
 string IDDescriptor::str(VolumeID vid, VolumeID mask)   const {
-  const vector<BitFieldElement*>& v = access()->decoder.fields();
+  const vector<BitFieldElement>& v = access()->decoder.fields();
   stringstream str;
-  for (auto f : v )  {
-    if ( 0 == (mask&f->mask()) ) continue;
-    str << f->name() << ":" << setw(4) << setfill('0') << hex << right << f->value(vid)
+  for (auto& f : v )  {
+    if ( 0 == (mask&f.mask()) ) continue;
+    str << f.name() << ":" << setw(4) << setfill('0') << hex << right << f.value(vid)
         << left << dec << " ";
   }
   return str.str().substr(0,str.str().length()-1);

--- a/DDCore/src/segmentations/BitField64.cpp
+++ b/DDCore/src/segmentations/BitField64.cpp
@@ -17,7 +17,7 @@ namespace DDSegmentation {
       
       if( i != 0 )   os << "," ;
 
-      os << _coder->fields()[i]->name() <<  ":" << _coder->get( _value , i ) ;
+      os << _coder->fields()[i].name() <<  ":" << _coder->get( _value , i ) ;
 
     }
     return os.str() ;
@@ -32,16 +32,16 @@ namespace DDSegmentation {
 
     for(unsigned i=0;i<b._coder->size();i++){
       
-      const BitFieldElement* bv = b._coder->fields()[i] ;
+      const BitFieldElement& bv = b._coder->fields()[i] ;
       
-      os << "  " <<  bv->name()
-	 << " [" <<  bv->offset()  << ":"  ;
+      os << "  " <<  bv.name()
+	 << " [" <<  bv.offset()  << ":"  ;
       
-      if(  bv->isSigned()  )  os << "-" ;
+      if(  bv.isSigned()  )  os << "-" ;
 
-      os <<  bv->width() << "]  : "  ;
+      os << bv.width() << "]  : "  ;
       
-      os <<   b._coder->get( b._value , i) 
+      os << b._coder->get( b._value , i)
 	 << std::endl ;
       
     }

--- a/DDCore/src/segmentations/BitFieldCoder.cpp
+++ b/DDCore/src/segmentations/BitFieldCoder.cpp
@@ -103,8 +103,8 @@ namespace DDSegmentation {
     
     for(unsigned i=0;i<_fields.size();i++){
       
-      if( hb < ( _fields[i]->offset() + _fields[i]->width() ) )
-	hb = _fields[i]->offset() + _fields[i]->width()  ;
+      if( hb < ( _fields[i].offset() + _fields[i].width() ) )
+	hb = _fields[i].offset() + _fields[i].width()  ;
     }    
     return hb ;
   }
@@ -118,7 +118,7 @@ namespace DDSegmentation {
       
       if( i != 0 )   os << "," ;
 
-      os << _fields[i]->name() <<  ":" << _fields[i]->value(bitfield) ;
+      os << _fields[i].name() <<  ":" << _fields[i].value(bitfield) ;
 
     }
     return os.str() ;
@@ -132,54 +132,39 @@ namespace DDSegmentation {
       
       if( i != 0 )   os << "," ;
       
-      os << _fields[i]->name() <<  ":"
-	 << _fields[i]->offset() << ":" ;
+      os << _fields[i].name() <<  ":"
+	 << _fields[i].offset() << ":" ;
       
-      if(  _fields[i]->isSigned()  )  
+      if(  _fields[i].isSigned()  )
 	os << "-" ;
       
-      os  << _fields[i]->width() ;
+      os  << _fields[i].width() ;
       
     }
-//     for( IndexMap::const_iterator it = _map.begin()  ;
-// 	 it !=  _map.end() ; ++it ){
 
-//       if( it !=  _map.begin() )
-// 	os << "," ;
-      
-//       os << it->first <<  ":"
-// 	 << _fields[ it->second ]->offset() << ":" ;
-      
-//       if(  _fields[ it->second ]->isSigned()  )  
-// 	os << "-" ;
-
-//       os  << _fields[ it->second ]->width() ;
-
-//     }
-    
     return os.str() ;
   }
 
   void BitFieldCoder::addField( const std::string& name,  unsigned offset, int width ){
 
       
-    BitFieldElement* bfv =  new  BitFieldElement( name, offset, width ) ;
-
-    _fields.push_back(  bfv ) ;
+    _fields.push_back( BitFieldElement( name, offset, width ) ) ;
     
+    BitFieldElement& bfv = _fields.back() ;
+
     _map[ name ] = _fields.size()-1 ;
 
-    if( _joined & bfv->mask()  ) {
+    if( _joined & bfv.mask()  ) {
       
       std::stringstream s ;
       s << " BitFieldElement::addField(" << name << "): bits already used " << std::hex << _joined
-	<< " for mask " <<  bfv->mask()   ; 
+	<< " for mask " <<  bfv.mask() ;
 
       throw( std::runtime_error( s.str() ) ) ;
       
     }
 
-    _joined |= _fields.back()->mask() ;
+    _joined |= bfv.mask() ;
 
   }
 

--- a/DDTest/src/test_bitfieldcoder.cc
+++ b/DDTest/src/test_bitfieldcoder.cc
@@ -42,6 +42,30 @@ int main(int /* argc */, char** /* argv */ ){
 
     test(  field , long64(0xbebafecacafebabeUL)  , " same value 0xbebafecacafebabeUL from individual initialization " ); 
 
+
+    // make a copy for testing the access
+    const BitFieldCoder bf2 = bf ;
+
+    test( bf2.get( field, "layer") ,  373 , " acces field value: layer" );
+    test( bf2.get( field, "module"),  254 , " acces field value: module" );
+    test( bf2.get( field, "sensor"),  202 , " acces field value: sensor" );
+    test( bf2.get( field, "side"),    1   , " acces field value: side" );
+    test( bf2.get( field, "system"),  30  , " acces field value: system" );
+    test( bf2.get( field, "x"),      -310 , " acces field value: x" );
+    test( bf2.get( field, "y"),    -16710 , " acces field value: y" );
+
+
+
+
+    test( bf2.get( field, bf2.index( "layer")) ,  373 , " acces field value: layer" );
+    test( bf2.get( field, bf2.index( "module")),  254 , " acces field value: module" );
+    test( bf2.get( field, bf2.index( "sensor")),  202 , " acces field value: sensor" );
+    test( bf2.get( field, bf2.index( "side")),    1   , " acces field value: side" );
+    test( bf2.get( field, bf2.index( "system")),  30  , " acces field value: system" );
+    test( bf2.get( field, bf2.index( "x")),      -310 , " acces field value: x" );
+    test( bf2.get( field, bf2.index( "y")),    -16710 , " acces field value: y" );
+
+
     // --------------------------------------------------------------------
 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- improve BitFieldCoder class
    - remove heap allocation of BitFieldElements
    - add move constructors for efficient filling of vector 

ENDRELEASENOTES