### PR TITLE
add unbounded surfaces (volume boundaries ignored)

### DIFF
--- a/DDRec/include/DDRec/ISurface.h
+++ b/DDRec/include/DDRec/ISurface.h
@@ -138,7 +138,8 @@ namespace dd4hep { namespace rec {
       OrthogonalToZ,
       Invisible,
       Measurement1D,
-      Cone
+      Cone,
+      Unbounded
     } ;
     
     ///default c'tor
@@ -222,6 +223,9 @@ namespace dd4hep { namespace rec {
     /// true if the measurement is only 1D, i.e. the second direction v is not used
     bool isMeasurement1D() const { return _bits[ SurfaceType::Measurement1D ] ; } 
 
+    /// true if the surface is unbounded ( ISurface::insideBounds() does not check volume boundaries)
+
+    bool isUnbounded() const { return  _bits[ SurfaceType::Unbounded ] ; } 
 
     /// true if all properties of otherType are also true for this type.
     bool isSimilar( const SurfaceType& otherType) const {
@@ -286,7 +290,9 @@ namespace dd4hep { namespace rec {
        << "] zCylinder["     << t.isZCylinder() 
        << "] zCone["         << t.isZCone() 
        << "] zPlane["        << t.isZPlane()  
-       << "] zDisk["         << t.isZDisk() << "]"  ; 
+       << "] zDisk["         << t.isZDisk()
+       << "] unbounded["     << t.isUnbounded()
+       << "]"  ; 
 
     return os ;
   }

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -194,22 +194,30 @@ namespace dd4hep {
 
     /// Checks if the given point lies within the surface
     bool VolSurfaceBase::insideBounds(const Vector3D& point, double epsilon) const {
-      
+
 #if 0
+
+      bool inShape = ( type().isUnbounded() ? true : volume()->GetShape()->Contains( point.const_array() ) ) ;
+
       double dist = std::abs ( distance( point ) ) ;
-      
-      bool inShape = volume()->GetShape()->Contains( point.const_array() ) ;
-      
+
       std::cout << " ** Surface::insideBound( " << point << " ) - distance = " << dist 
                 << " origin = " << origin() << " normal = " << normal() 
                 << " p * n = " << point * normal() 
                 << " isInShape : " << inShape << std::endl ;
-	
+
       return dist < epsilon && inShape ;
 #else
-	
-      //fixme: older versions of ROOT (~<5.34.10 ) take a non const pointer as argument - therefore use a const cast here for the time being ...
-      return ( std::abs ( distance( point ) ) < epsilon )  &&  volume()->GetShape()->Contains( const_cast<double*> (point.const_array() )  ) ; 
+
+      if(  type().isUnbounded() ){
+
+	return std::abs ( distance( point ) ) < epsilon ;
+
+      } else {
+
+	return (  std::abs ( distance( point ) ) < epsilon &&  volume()->GetShape()->Contains( point.const_array() ) ) ;
+      }
+
 #endif
  
     }


### PR DESCRIPTION
BEGINRELEASENOTES
- allow for unbounded surfaces in DDRec
     - add new property `SurfaceType::Unbounded`
     - if a surface is marked unbounded `Surface::insideBounds()` ignores the volume boundaries (and only checks the distance to the surface)

ENDRELEASENOTES