### PR TITLE
 Fix C++11 pointer error by adding 'include <memory>' for 'unique_ptr'.

### DIFF
--- a/UtilityApps/src/plugin_runner.cpp
+++ b/UtilityApps/src/plugin_runner.cpp
@@ -16,6 +16,7 @@
 
 // Framework include files
 #include "run_plugin.h"
+#include <memory>
 
 using namespace std;
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix C++11 pointer error by adding include <memory> for 'unique_ptr'.
    - nightly integration build with c++11.

ENDRELEASENOTES