### PR TITLE
Fix bug in VolumeManager returning bad top level subdetectors

### DIFF
--- a/DDCMS/include/DDCMS/DDCMS.h
+++ b/DDCMS/include/DDCMS/DDCMS.h
@@ -229,9 +229,6 @@ namespace dd4hep {
 
     /// Helper: Convert the name of a placed volume into a subdetector name
     std::string detElementName(PlacedVolume pv);
-    /// Compute the material fraction of a given element in a volume 
-    double material_fraction(Volume vol, const TGeoElement* e);
-
     /// Create 3D rotation matrix from angles.
     Rotation3D make_rotation3D(double thetaX, double phiX,
                                double thetaY, double phiY,

--- a/DDCMS/include/DDCMS/DDCMSPlugins.h
+++ b/DDCMS/include/DDCMS/DDCMSPlugins.h
@@ -18,9 +18,9 @@
 #define DD4HEP_DDCMS_DDCMSPLUGINS_H
 
 // Framework includes
+#include "DDCMS/DDCMS.h"
 #include "DD4hep/Plugins.h"
 #include "CLHEP/Units/SystemOfUnits.h"
-#include "DDCMS/DDCMS.h"
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -37,26 +37,32 @@ namespace dd4hep {
    */
   template <typename T> class DDCMSDetElementFactory : public PluginFactoryBase {
   public:
-    static long create(Detector& description,cms::ParsingContext& ctxt,xml::Handle_t e,SensitiveDetector& sens);
+    static long create(Detector&            dsc,
+                       cms::ParsingContext& ctx,
+                       xml::Handle_t        elt,
+                       SensitiveDetector&   sens);
   };
 }     /* End namespace dd4hep          */
+
 namespace {
+
   /// Forward declartion of the base factory template
   template <typename P, typename S> class Factory;
   DD4HEP_PLUGIN_FACTORY_ARGS_4(long,dd4hep::Detector*,dd4hep::cms::ParsingContext*,ns::xml_h*,dd4hep::SensitiveDetector*)
   {    return dd4hep::DDCMSDetElementFactory<P>::create(*a0,*a1,*a2,*a3);                     }
 }
 
-#define DECLARE_DDCMS_DETELEMENT(name,func)                                                   \
-  DD4HEP_OPEN_PLUGIN(dd4hep,ddcms_det_element_##name) {                                       \
-    template <> long                                                                          \
-      DDCMSDetElementFactory< ddcms_det_element_##name >::create(dd4hep::Detector& d,         \
-                                                                 cms::ParsingContext& c,      \
-                                                                 xml::Handle_t e,             \
-                                                                 SensitiveDetector& h)        \
-    {  return func(d,c,e,h);       }                                                          \
-    DD4HEP_PLUGINSVC_FACTORY(ddcms_det_element_##name,name,                                   \
-                             long(dd4hep::Detector*,dd4hep::cms::ParsingContext*,             \
+#define DECLARE_DDCMS_DETELEMENT(name,func)                             \
+  DD4HEP_OPEN_PLUGIN(dd4hep,ddcms_det_element_##name) {                 \
+    typedef DDCMSDetElementFactory< ddcms_det_element_##name > _IMP;    \
+    template <> long                                                    \
+      _IMP::create(dd4hep::Detector& d,                                 \
+                   cms::ParsingContext& c,                              \
+                   xml::Handle_t e,                                     \
+                   SensitiveDetector& h)                                \
+    {  return func(d,c,e,h);       }                                    \
+    DD4HEP_PLUGINSVC_FACTORY(ddcms_det_element_##name,name,             \
+                             long(dd4hep::Detector*,dd4hep::cms::ParsingContext*, \
                                   ns::xml_h*,dd4hep::SensitiveDetector*),__LINE__)  }
 
 #endif /* DD4HEP_DDCMS_DDCMSPLUGINS_H  */

--- a/DDCMS/src/DDCMS.cpp
+++ b/DDCMS/src/DDCMS.cpp
@@ -57,32 +57,6 @@ string dd4hep::cms::detElementName(PlacedVolume pv)   {
   return string();
 }
 
-/// Compute the material fraction of a given element in a volume 
-double dd4hep::cms::material_fraction(Volume vol, const TGeoElement* element)    {
-  double frac = 0e0, tot = 0e0;
-  TGeoMaterial* m = vol.material()->GetMaterial();
-  for ( int i=0, n=m->GetNelements(); i<n; ++i )  {
-    TGeoElement* e = m->GetElement(i);
-    if ( m->IsMixture() )  {
-      TGeoMixture* mix = (TGeoMixture*)m;
-      tot  += mix->GetWmixt()[i];
-    }
-    else {
-      tot = 1e0;
-    }
-    if ( e == element )   {
-      if ( m->IsMixture() )  {
-        TGeoMixture* mix = (TGeoMixture*)m;
-        frac += mix->GetWmixt()[i];
-      }
-      else  {
-        frac = 1e0;
-      }
-    }
-  }
-  return tot>1e-20 ? frac/tot : 0.0;
-}
-
 /// Initializing constructor
 Namespace::Namespace(ParsingContext* ctx, xml_h element) : context(ctx)  {
   xml_dim_t elt(element);

--- a/DDCMS/src/plugins/DDCMSDetElementCreator.cpp
+++ b/DDCMS/src/plugins/DDCMSDetElementCreator.cpp
@@ -17,19 +17,8 @@
 
 // Framework include files
 #include "DD4hep/VolumeProcessor.h"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DD4hep/DetFactoryHelper.h"
 
-// ROOT include files
-#include "TGeoElement.h"
-#include "TGeoManager.h"
-
-//#include <set>
-
-using namespace std;
-using namespace dd4hep;
-
-namespace {
+namespace dd4hep {
   
   /// DD4hep DetElement creator for the CMS geometry.
   /*  Heuristically assign DetElement structures to the sensitive volume pathes.
@@ -40,7 +29,7 @@ namespace {
    */
   class DDCMSDetElementCreator : public PlacedVolumeProcessor  {
     Detector&    description;
-    TGeoElement* silicon = 0;
+    Atom silicon;
     struct Data {
       PlacedVolume pv {0};
       DetElement   element {};
@@ -96,19 +85,24 @@ namespace {
 }
 
 
+#include "DD4hep/detail/DetectorInterna.h"
+#include "DD4hep/DetFactoryHelper.h"
+#include "DD4hep/DetectorHelper.h"
 #include "DD4hep/Printout.h"
 #include "DDCMS/DDCMS.h"
+
 #include <sstream>
+
+using namespace std;
+using namespace dd4hep;
 
 /// Initializing constructor
 DDCMSDetElementCreator::DDCMSDetElementCreator(Detector& desc)
   : description(desc)
 {
-  TGeoElementTable* tab = description.manager().GetElementTable();
-  silicon = tab->FindElement("SI");
-  if ( !silicon ) silicon = tab->FindElement("Si");
-  if ( !silicon ) silicon = tab->FindElement("si");
-  if ( !silicon )   {
+  DetectorHelper helper(description);
+  silicon = helper.element("SI");
+  if ( !silicon.isValid() )   {
     except("DDCMSDetElementCreator",
            "++ Failed to extract SILICON from the element table.");
   }
@@ -250,7 +244,7 @@ DetElement DDCMSDetElementCreator::addSubdetector(const std::string& nam, Placed
 
 /// Callback to output PlacedVolume information of an single Placement
 int DDCMSDetElementCreator::operator()(PlacedVolume pv, int vol_level)   {
-  double frac_si = dd4hep::cms::material_fraction(pv.volume(),silicon);
+  double frac_si = pv.volume().material().fraction(silicon);
   if ( frac_si > 90e-2 )  {
     Data& data = stack.back();
     data.sensitive     = true;

--- a/DDCMS/src/plugins/DDCMSDetElementCreator.cpp
+++ b/DDCMS/src/plugins/DDCMSDetElementCreator.cpp
@@ -29,7 +29,7 @@ namespace dd4hep {
    */
   class DDCMSDetElementCreator : public PlacedVolumeProcessor  {
     Detector&    description;
-    Atom silicon;
+    Atom         silicon;
     struct Data {
       PlacedVolume pv {0};
       DetElement   element {};
@@ -38,7 +38,7 @@ namespace dd4hep {
       int          vol_count = 0;
       int          daughter_count = 0;
       int          sensitive_count = 0;
-      
+
       Data() = default;
       Data(PlacedVolume v) : pv(v) {}
       Data(const Data& d) = default;

--- a/DDCore/include/DD4hep/DD4hepUI.h
+++ b/DDCore/include/DD4hep/DD4hepUI.h
@@ -15,6 +15,7 @@
 
 // Framework includes
 #include "DD4hep/Detector.h"
+#include "DD4hep/Printout.h"
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -45,6 +46,8 @@ namespace dd4hep {
       Detector* instance()  const;
       /// Access to the Detector instance
       Detector* detectorDescription()  const;
+      /// Set the printout level from the interactive prompt
+      PrintLevel setPrintLevel(PrintLevel level)   const;
 
       /// Install the dd4hep conditions manager object
       Handle<NamedObject> conditionsMgr()  const;

--- a/DDCore/include/DD4hep/DetectorHelper.h
+++ b/DDCore/include/DD4hep/DetectorHelper.h
@@ -11,8 +11,9 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DetectorHELPER_H
-#define DD4HEP_DetectorHELPER_H
+#ifndef DD4HEP_DDCORE_DETECTORHELPER_H
+#define DD4HEP_DDCORE_DETECTORHELPER_H
+
 #include "DD4hep/Detector.h"
 
 /// Namespace for the AIDA detector description toolkit
@@ -50,7 +51,11 @@ namespace dd4hep {
     SensitiveDetector sensitiveDetector(DetElement detector) const;      
     /// Find a detector element by it's system ID
     DetElement detectorByID(int id)  const;
+    /// Access an element from the element table by name
+    Atom element(const std::string& name)  const;
+    /// Access a material from the material table by name
+    Material material(const std::string& name)  const;
   };
 
-}       /* End namespace dd4hep    */
-#endif  /* DD4HEP_DetectorHELPER_H     */
+}       /* End namespace dd4hep               */
+#endif  /* DD4HEP_DDCORE_DETECTORHELPER_H     */

--- a/DDCore/include/DD4hep/Objects.h
+++ b/DDCore/include/DD4hep/Objects.h
@@ -230,6 +230,10 @@ namespace dd4hep {
   public:
     /// Default constructor
     Atom() = default;
+    /// Copy constructor
+    Atom(const Atom& copy) = default;
+    /// Initialization from pointer
+    Atom(Object* e) : Handle<Object>(e) { }
 #ifndef __CINT__
     /// Constructorto be used for assignment from a handle
     Atom(const Handle<Object>& e) : Handle<Object>(e) {   }
@@ -238,6 +242,8 @@ namespace dd4hep {
     template <typename Q> Atom(const Handle<Q>& e) : Handle<Object>(e) { }
     /// Constructor to be used when reading the already parsed DOM tree
     Atom(const std::string& name, const std::string& formula, int Z, int N, double density);
+    /// Assignment operator
+    Atom& operator=(const Atom& copy) = default;
   };
 
   /// Handle class describing a material
@@ -254,12 +260,18 @@ namespace dd4hep {
   public:
     /// Default constructor
     Material() = default;
+    /// Copy constructor
+    Material(const Material& copy) = default;
+    /// Initialization from pointer
+    Material(Object* e) : Handle<Object>(e) { }
 #ifndef __CINT__
     /// Constructorto be used for assignment from material handle
     Material(const Handle<Object>& e) : Handle<Object>(e) { }
 #endif
     /// Constructorto be used for assignment from object handle
     template <typename Q> Material(const Handle<Q>& e) : Handle<Object>(e) {  }
+    /// Assignment operator
+    Material& operator=(const Material& copy) = default;
     /// proton number of the underlying material
     double Z() const ;
     /// atomic number of the underlying material
@@ -272,6 +284,8 @@ namespace dd4hep {
     double radLength() const;
     /// Access the interaction length of the underlying material
     double intLength() const;
+    /// Access the fraction of an element within the material
+    double fraction(Atom atom) const;
   };
 
   /// Handle class describing visualization attributes

--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -24,7 +24,8 @@ namespace DDSegmentation {
   
     public :
   
-      BitFieldElement() = default ;
+      /// The empty I/O c'tor.
+      BitFieldElement() = default;
       ~BitFieldElement() = default ;
       BitFieldElement(const BitFieldElement&) = default ;
       BitFieldElement(BitFieldElement&&) = default ;

--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -24,12 +24,12 @@ namespace DDSegmentation {
   
     public :
   
-      /// The empty I/O c'tor.
-      BitFieldElement() = default;
-      ~BitFieldElement() = default ;
+      /// Default constructor
+      BitFieldElement() = default ;
+      /// Copy constructor
       BitFieldElement(const BitFieldElement&) = default ;
+      /// Move constructor
       BitFieldElement(BitFieldElement&&) = default ;
-
 
       /** The standard c'tor.
        * @param  name          name of the field
@@ -37,6 +37,11 @@ namespace DDSegmentation {
        * @param  signedWidth   width of field, negative if field is signed
        */
       BitFieldElement( const std::string& name, unsigned offset, int signedWidth ) ; 
+      /// Default destructor
+      ~BitFieldElement() = default ;
+
+      /// Assignment operator
+      BitFieldElement& operator=(const BitFieldElement&) = default ;
 
       /// calculate this field's value given an external 64 bit bitmap 
       long64 value(long64 bitfield) const;
@@ -107,11 +112,17 @@ namespace DDSegmentation {
     
     typedef std::map<std::string, unsigned int> IndexMap ;
 
+    /// Default constructor
     BitFieldCoder() = default ;
-    ~BitFieldCoder() = default ;
+    /// Copy constructor
     BitFieldCoder(const BitFieldCoder&) = default ;
+    /// Move constructor
     BitFieldCoder(BitFieldCoder&&) = default ;
+    /// Default destructor
+    ~BitFieldCoder() = default ;
 
+    /// Assignment operator
+    BitFieldCoder& operator=(const BitFieldCoder&) = default ;
     
     /** The c'tor takes an initialization string of the form:<br>
      *  \<fieldDesc\>[,\<fieldDesc\>...]<br>

--- a/DDCore/src/DD4hepUI.cpp
+++ b/DDCore/src/DD4hepUI.cpp
@@ -38,6 +38,11 @@ Detector* DD4hepUI::detectorDescription()  const   {
   return &m_detDesc;
 }
 
+/// Set the printout level from the interactive prompt
+PrintLevel DD4hepUI::setPrintLevel(PrintLevel level)   const   {
+  return dd4hep::setPrintLevel(level);
+}
+
 /// Install the dd4hep conditions manager object
 Handle<NamedObject> DD4hepUI::conditionsMgr()  const  {
   if ( !m_condMgr.isValid() )  {

--- a/DDCore/src/DetectorHelper.cpp
+++ b/DDCore/src/DetectorHelper.cpp
@@ -11,7 +11,11 @@
 //
 //==========================================================================
 
+// Framework include files
 #include "DD4hep/DetectorHelper.h"
+
+// ROOT include files
+#include "TGeoManager.h"
 
 using namespace std;
 using namespace dd4hep;
@@ -51,3 +55,43 @@ DetElement DetectorHelper::detectorByID(int id)  const    {
   return DetElement();
 }
 
+/// Access an element from the element table by name
+Atom DetectorHelper::element(const std::string& nam)  const   {
+  TGeoManager&      mgr = access()->manager();
+  TGeoElementTable* tab = mgr.GetElementTable();
+  TGeoElement*      elt = tab->FindElement(nam.c_str());
+  if ( !elt )    {
+    string n = nam;
+    transform(n.begin(), n.end(), n.begin(), ::toupper);
+    elt = tab->FindElement(n.c_str());     // Check for IRON
+    if ( !elt )    {
+      transform(n.begin(), n.end(), n.begin(), ::tolower);
+      elt = tab->FindElement(n.c_str());   // Check for iron
+      if ( !elt )    {
+        n[0] = ::toupper(n[0]);
+        elt = tab->FindElement(n.c_str()); // Check for Iron
+      }
+    }
+  }
+  return elt;
+}
+
+/// Access a material from the material table by name
+Material DetectorHelper::material(const std::string& nam)  const   {
+  TGeoManager& mgr = access()->manager();
+  TGeoMedium*  m   = mgr.GetMedium(nam.c_str());
+  if ( !m )    {
+    string n = nam;
+    transform(n.begin(), n.end(), n.begin(), ::toupper);
+    m = mgr.GetMedium(n.c_str());     // Check for IRON
+    if ( !m )    {
+      transform(n.begin(), n.end(), n.begin(), ::tolower);
+      m = mgr.GetMedium(n.c_str());   // Check for iron
+      if ( !m )    {
+        n[0] = ::toupper(n[0]);
+        m = mgr.GetMedium(n.c_str()); // Check for Iron
+      }
+    }
+  }
+  return m;
+}

--- a/DDCore/src/Objects.cpp
+++ b/DDCore/src/Objects.cpp
@@ -229,6 +229,33 @@ double Material::intLength() const {
   throw runtime_error("Attempt to access interaction length from invalid material handle!");
 }
 
+/// Access the fraction of an element within the material
+double Material::fraction(Atom atom) const    {
+  double frac = 0e0, tot = 0e0;
+  TGeoElement* elt = atom.access();
+  TGeoMaterial* m = access()->GetMaterial();
+  for ( int i=0, n=m->GetNelements(); i<n; ++i )  {
+    TGeoElement* e = m->GetElement(i);
+    if ( m->IsMixture() )  {
+      TGeoMixture* mix = (TGeoMixture*)m;
+      tot  += mix->GetWmixt()[i];
+    }
+    else {
+      tot = 1e0;
+    }
+    if ( e == elt )   {
+      if ( m->IsMixture() )  {
+        TGeoMixture* mix = (TGeoMixture*)m;
+        frac += mix->GetWmixt()[i];
+      }
+      else  {
+        frac = 1e0;
+      }
+    }
+  }
+  return tot>1e-20 ? frac/tot : 0.0;
+}
+
 /// String representation of this object
 string Material::toString() const {
   if ( isValid() ) {

--- a/DDCore/src/RootDictionary.h
+++ b/DDCore/src/RootDictionary.h
@@ -19,6 +19,7 @@
 // Framework include files
 #include "DDParsers/Evaluator.h"
 #include "DD4hep/DD4hepRootPersistency.h"
+#include "DD4hep/Printout.h"
 #include "DD4hep/detail/Grammar.h"
 #include "DD4hep/detail/ObjectsInterna.h"
 #include "DD4hep/detail/DetectorInterna.h"
@@ -80,6 +81,8 @@ using namespace std;
 #pragma link C++ namespace dd4hep::cond;
 #pragma link C++ namespace dd4hep::align;
 #pragma link C++ namespace dd4hep::DDSegmentation;
+
+#pragma link C++ enum dd4hep::PrintLevel;
 
 #ifndef __ROOTCLING__
 template pair<unsigned int, string>;

--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -561,7 +561,7 @@ IDDescriptor VolumeManager::idSpec() const {
 }
 
 /// Register physical volume with the manager (normally: section manager)
-bool VolumeManager::adoptPlacement(VolumeID /* sys_id */, VolumeManagerContext* context) {
+bool VolumeManager::adoptPlacement(VolumeID sys_id, VolumeManagerContext* context) {
   stringstream err;
   Object&  o      = _data();
   VolumeID vid    = context->identifier;
@@ -586,9 +586,10 @@ bool VolumeManager::adoptPlacement(VolumeID /* sys_id */, VolumeManagerContext* 
         << " ["     << pv.name() << "]"
         << " id:"   << setw(16) << hex << right << setfill('0') << vid  << dec << setfill(' ')
         << " mask:" << setw(16) << hex << right << setfill('0') << mask << dec << setfill(' ')
-        << " Det:"  << context->element.path();
+        << " Det:"  << setw(4)  << hex << right << setfill('0') << context->element.volumeID()
+        << " / "    << setw(4)  << sys_id << dec << setfill(' ') << ": " << context->element.path();
     printout(VERBOSE, "VolumeManager", err.str().c_str());
-    //printout(INFO, "VolumeManager", err.str().c_str());
+    //printout(ALWAYS, "VolumeManager", err.str().c_str());
     return true;
   }
   err << "+++ Attempt to register duplicate"
@@ -704,9 +705,12 @@ DetElement VolumeManager::lookupDetector(VolumeID volume_id) const {
     }
     else  {
       for (const auto& j : o.subdetectors )  {
-        if ( (volume_id&j.second->sysID) == j.second->sysID )  {
-          sys_id = j.second->sysID;
-          break;
+        if ( j.second->system )  {
+          VolumeID vid = volume_id&j.second->system->mask();
+          if ( (volume_id&j.second->sysID) == vid )  {
+            sys_id = j.second->sysID;
+            break;
+          }
         }
       }
     }

--- a/DDCore/src/Volumes.cpp
+++ b/DDCore/src/Volumes.cpp
@@ -620,7 +620,7 @@ Material Volume::material() const {
 
 /// Set Visualization attributes to the volume
 const Volume& Volume::setVisAttributes(const VisAttr& attr) const {
-  if (attr.isValid()) {
+  if ( attr.isValid() ) {
     VisAttr::Object* vis = attr.data<VisAttr::Object>();
     Color_t bright = vis->color;//kBlue;//TColor::GetColorBright(vis->color);
     Color_t dark = vis->color;//kRed;//TColor::GetColorDark(vis->color);

--- a/DDCore/src/plugins/VisProcessor.cpp
+++ b/DDCore/src/plugins/VisProcessor.cpp
@@ -35,6 +35,8 @@ namespace dd4hep  {
     VisAttr                activeVis;
     VisAttr                inactiveVis;
     double                 fraction = 0e0;
+    bool                   setAllInactive = false;
+
   public:
     /// Initializing constructor
     VisProcessor(Detector& desc);
@@ -55,8 +57,7 @@ using namespace std;
 using namespace dd4hep;
 
 /// Initializing constructor
-VisProcessor::VisProcessor(Detector& desc)
-  : description(desc)
+VisProcessor::VisProcessor(Detector& desc) : description(desc)
 {
 }
 
@@ -64,41 +65,55 @@ VisProcessor::VisProcessor(Detector& desc)
 VisProcessor::~VisProcessor()   {
 }
 
+namespace {
+  void set_attr(Volume vol, VisAttr attr)   {
+    if ( vol.visAttributes().ptr() != attr.ptr() )  {
+      vol.setVisAttributes(attr);
+    }
+  }
+}
+
 /// Callback to output PlacedVolume information of an single Placement
 int VisProcessor::operator()(PlacedVolume pv, int /* level */)   {
   Volume vol = pv.volume();
   double frac_active = 0.0;
+  VisAttr attr;
+
   for ( Atom a : activeElements )   {
     frac_active += vol.material().fraction(a);
   }
-  if ( activeVis.isValid() )  {
-    if ( frac_active > fraction )   {
-      vol.setVisAttributes(activeVis);
-    }
-    else   {
-      for ( Material m : activeMaterials )  {
-        if ( m.ptr() == vol.material().ptr() )   {
-          vol.setVisAttributes(activeVis);
-          break;
-        }
-      }
-    }
-  }
+  //if ( frac_active >= fraction )
+    printout(INFO,"VisProcessor",
+             "++ Volume:%s [%s] active:%s fraction:%.3f active-vis:%s inactive-vis:%s",
+             pv.name(), vol.name(), yes_no(frac_active >= fraction), frac_active,
+             yes_no(activeVis.isValid()), yes_no(inactiveVis.isValid()));
 
-  if ( inactiveVis.isValid() )   {
-    bool inactive = false;
-    for ( Material m : inactiveMaterials )   {
+  if ( frac_active >= fraction )
+    attr = activeVis;
+  if ( !attr.isValid() )  {
+    for ( Material m : activeMaterials )  {
       if ( m.ptr() == vol.material().ptr() )   {
-        vol.setVisAttributes(inactiveVis);
-        inactive = true;
+        attr = activeVis;
         break;
       }
     }
-    if ( !inactive )   {
-      if ( !activeElements.empty() && frac_active<fraction )   {
-        vol.setVisAttributes(inactiveVis);
+  }
+  // If we get here, the material is definitely inactive
+  if ( !attr.isValid() && setAllInactive )
+    attr = inactiveVis;
+  if ( !attr.isValid() )  {
+    for ( Material m : inactiveMaterials )   {
+      if ( m.ptr() == vol.material().ptr() )   {
+        attr = inactiveVis;
+        break;
       }
     }
+    if ( !activeElements.empty() && frac_active<fraction )   {
+      attr = inactiveVis;
+    }
+  }
+  if ( attr.isValid() )  {
+    set_attr(vol,activeVis);
   }
   return 1;
 }
@@ -118,7 +133,7 @@ static void* create_object(Detector& description, int argc, char** argv)   {
         if ( vis.isValid() ) proc->inactiveVis = vis;
         continue;
       }
-      else if ( ::strncmp(argv[i],"-element",4) == 0 )   {
+      else if ( ::strncmp(argv[i],"-elt-active",6) == 0 )   {
         Atom a = helper.element(argv[++i]);
         if ( a.isValid() ) proc->activeElements.push_back(a);
         continue;
@@ -133,10 +148,16 @@ static void* create_object(Detector& description, int argc, char** argv)   {
         if ( m.isValid() ) proc->inactiveMaterials.push_back(m);
         continue;
       }
+      else if ( ::strncmp(argv[i],"-all-inactive",6) == 0 )   {
+        proc->setAllInactive = true;
+        continue;
+      }
       else if ( ::strncmp(argv[i],"-fraction",3) == 0 )   {
         stringstream str(argv[++i]);
-        str >> proc->fraction;
-        if ( str.good() ) continue;
+        if ( str.good() )  {
+          str >> proc->fraction;
+          if ( !str.fail() ) continue;
+        }
       }
       cout <<
         "Usage: DD4hep_VisProcessor -arg [-arg]                                              \n"
@@ -147,6 +168,7 @@ static void* create_object(Detector& description, int argc, char** argv)   {
         "                              the volume is considered active                       \n"
         "     -mat-active   <name>     Add material by name to the list of   active materials\n"
         "     -mat-inactive <name>     Add material by name to the list of inactive materials\n"
+        "     -all-inactive            Auto set all volumes inactive, which are NOT active   \n"
         "     -fraction     <double>   Set the fraction above which the active elment content\n"
         "                              defines an active volume.                             \n"
         "\tArguments given: " << arguments(argc,argv) << endl << flush;

--- a/DDCore/src/plugins/VisProcessor.cpp
+++ b/DDCore/src/plugins/VisProcessor.cpp
@@ -1,0 +1,161 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_DDCORE_VISPROCESSOR_H
+#define DD4HEP_DDCORE_VISPROCESSOR_H
+
+// Framework include files
+#include "DD4hep/VolumeProcessor.h"
+
+namespace dd4hep  {
+
+  
+  /// DD4hep DetElement creator for the CMS geometry.
+  /*  Set visualization attributes for sensitive volumes
+   *
+   *  \author  M.Frank
+   *  \version 1.0
+   *  \ingroup DD4HEP_CORE
+   */
+  class VisProcessor : public PlacedVolumeProcessor  {
+  public:
+    Detector&    description;
+    std::vector<Atom>      activeElements;
+    std::vector<Material>  activeMaterials;
+    std::vector<Material>  inactiveMaterials;
+    VisAttr                activeVis;
+    VisAttr                inactiveVis;
+    double                 fraction = 0e0;
+  public:
+    /// Initializing constructor
+    VisProcessor(Detector& desc);
+    /// Default destructor
+    virtual ~VisProcessor();
+    /// Callback to output PlacedVolume information of an single Placement
+    virtual int operator()(PlacedVolume pv, int level);
+  };
+}
+#endif //  DD4HEP_DDCORE_VISPROCESSOR_H
+
+#include "DD4hep/Printout.h"
+#include "DD4hep/DetectorHelper.h"
+#include "DD4hep/DetFactoryHelper.h"
+#include <sstream>
+
+using namespace std;
+using namespace dd4hep;
+
+/// Initializing constructor
+VisProcessor::VisProcessor(Detector& desc)
+  : description(desc)
+{
+}
+
+/// Default destructor
+VisProcessor::~VisProcessor()   {
+}
+
+/// Callback to output PlacedVolume information of an single Placement
+int VisProcessor::operator()(PlacedVolume pv, int /* level */)   {
+  Volume vol = pv.volume();
+  double frac_active = 0.0;
+  for ( Atom a : activeElements )   {
+    frac_active += vol.material().fraction(a);
+  }
+  if ( activeVis.isValid() )  {
+    if ( frac_active > fraction )   {
+      vol.setVisAttributes(activeVis);
+    }
+    else   {
+      for ( Material m : activeMaterials )  {
+        if ( m.ptr() == vol.material().ptr() )   {
+          vol.setVisAttributes(activeVis);
+          break;
+        }
+      }
+    }
+  }
+
+  if ( inactiveVis.isValid() )   {
+    bool inactive = false;
+    for ( Material m : inactiveMaterials )   {
+      if ( m.ptr() == vol.material().ptr() )   {
+        vol.setVisAttributes(inactiveVis);
+        inactive = true;
+        break;
+      }
+    }
+    if ( !inactive )   {
+      if ( !activeElements.empty() && frac_active<fraction )   {
+        vol.setVisAttributes(inactiveVis);
+      }
+    }
+  }
+  return 1;
+}
+
+static void* create_object(Detector& description, int argc, char** argv)   {
+  DetectorHelper helper(description);
+  VisProcessor* proc = new VisProcessor(description);
+  for ( int i=0; i<argc; ++i )   {
+    if ( argv[i] )    {
+      if ( ::strncmp(argv[i],"-vis-active",6) == 0 )   {
+        VisAttr vis = description.visAttributes(argv[++i]);
+        if ( vis.isValid() ) proc->activeVis = vis;
+        continue;
+      }
+      else if ( ::strncmp(argv[i],"-vis-inactive",6) == 0 )   {
+        VisAttr vis = description.visAttributes(argv[++i]);
+        if ( vis.isValid() ) proc->inactiveVis = vis;
+        continue;
+      }
+      else if ( ::strncmp(argv[i],"-element",4) == 0 )   {
+        Atom a = helper.element(argv[++i]);
+        if ( a.isValid() ) proc->activeElements.push_back(a);
+        continue;
+      }
+      else if ( ::strncmp(argv[i],"-mat-active",6) == 0 )   {
+        Material m = helper.material(argv[++i]);
+        if ( m.isValid() ) proc->activeMaterials.push_back(m);
+        continue;
+      }
+      else if ( ::strncmp(argv[i],"-mat-inactive",6) == 0 )   {
+        Material m = helper.material(argv[++i]);
+        if ( m.isValid() ) proc->inactiveMaterials.push_back(m);
+        continue;
+      }
+      else if ( ::strncmp(argv[i],"-fraction",3) == 0 )   {
+        stringstream str(argv[++i]);
+        str >> proc->fraction;
+        if ( str.good() ) continue;
+      }
+      cout <<
+        "Usage: DD4hep_VisProcessor -arg [-arg]                                              \n"
+        "     -vis-active   <name>     Set the visualization attribute for   active materials\n"
+        "     -vis-inactive <name>     Set the visualization attribute for inactive materials\n"
+        "     -element      <name>     Add active element by name. If the fractional sum of  \n"
+        "                              all active elements in a volume exceeds <fraction>    \n"
+        "                              the volume is considered active                       \n"
+        "     -mat-active   <name>     Add material by name to the list of   active materials\n"
+        "     -mat-inactive <name>     Add material by name to the list of inactive materials\n"
+        "     -fraction     <double>   Set the fraction above which the active elment content\n"
+        "                              defines an active volume.                             \n"
+        "\tArguments given: " << arguments(argc,argv) << endl << flush;
+      ::exit(EINVAL);
+    }
+  }
+  return (void*)((PlacedVolumeProcessor*)proc);
+}
+
+// first argument is the type from the xml file
+DECLARE_DD4HEP_CONSTRUCTOR(DD4hep_VisProcessor,create_object)
+

--- a/DDCore/src/plugins/VolumeMgrTest.cpp
+++ b/DDCore/src/plugins/VolumeMgrTest.cpp
@@ -134,6 +134,7 @@ void VolIDTest::checkVolume(DetElement detector, PlacedVolume pv, const VolIDs& 
         ++m_errors;
       }
       else if ( top_sdet.ptr() != detector.ptr() )   {
+        top_sdet  = m_mgr.lookupDetector(vid);
         err << "VolumeMgrTest: Wrong associated sub-detector element vid="  << volumeID(vid)
             << " got "        << top_sdet.path() << " (" << (void*)top_sdet.ptr() << ") "
             << " instead of " << detector.path() << " (" << (void*)detector.ptr() << ")"

--- a/DDCore/src/plugins/VolumeMgrTest.cpp
+++ b/DDCore/src/plugins/VolumeMgrTest.cpp
@@ -73,18 +73,20 @@ namespace  {
 
 /// Initializing constructor
 VolIDTest::VolIDTest(Detector& description, DetElement sdet, size_t depth) : m_mapping(description.world()), m_det(sdet) {
-  m_mgr    = description.volumeManager();
+  m_mgr = description.volumeManager();
   if ( !m_det.isValid() )   {
     stringstream err;
+    ++m_errors;
     err << "The subdetector " << m_det.name() << " is not known to the geometry.";
-    printout(INFO,"VolIDTest",err.str().c_str());
+    except("VolumeMgrTest",err.str().c_str());
     throw runtime_error(err.str());
   }
   if ( !description.sensitiveDetector(m_det.name()).isValid() )   {
     stringstream err;
+    ++m_errors;
     err << "The sensitive detector of subdetector " << m_det.name()
         << " is not known to the geometry.";
-    printout(INFO,"VolIDTest",err.str().c_str());
+    printout(ERROR,"VolumeMgrTest",err.str().c_str());
     //throw runtime_error(err.str());
     return;
   }
@@ -310,8 +312,12 @@ long VolIDTest::run(Detector& description,int argc,char** argv)    {
       }
       return 1;
     }
+    DetElement sdet = description.detector(name);
+    if ( !sdet.isValid() )   {
+      except("VolumeMgrTest","++ Unknwon top level subdetector: %s",name.c_str());
+    }
     printout(INFO,"DD4hepVolumeMgrTest","++ Processing subdetector: %s",name.c_str());
-    VolIDTest test(description,description.detector(name),99);
+    VolIDTest test(description,sdet,99);
   }
   return 1;
 }

--- a/DDEve/src/DisplayConfigurationParser.cpp
+++ b/DDEve/src/DisplayConfigurationParser.cpp
@@ -310,6 +310,8 @@ static long setup_DDEve(Detector& description, const xml_h& e) {
   if ( first )   {
     first = false;
 #define add_root_enum(x) xml::_toDictionary(xml::Strng_t(#x),int(x))
+    add_root_enum(kBlack);
+    add_root_enum(kWhite);
     add_root_enum(kOrange);
     add_root_enum(kBlue);
     add_root_enum(kAzure);

--- a/examples/DDCMS/CMakeLists.txt
+++ b/examples/DDCMS/CMakeLists.txt
@@ -100,17 +100,16 @@ dd4hep_add_test_reg( DDCMS_VolumeMgrTest_TIB
   )
 #
 #  Dump CMS detector element tree of SD TOB
-#  Sucks. To be investigated. VolumeManager does not work!
-#dd4hep_add_test_reg( DDCMS_VolumeMgrTest_TOB
-#  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDCMS.sh"
-#  EXEC_ARGS  geoPluginRun
-#  -input file:${CMAKE_CURRENT_SOURCE_DIR}/data/dd4hep-config.xml
-#  -destroy -print WARNING
-#  -plugin DD4hep_VolumeMgrTest TOB_1
-#  REGEX_PASS "PASSED: Checked 150699 objects. Num.Errors:0"
-#  REGEX_FAIL "Exception"
-#  REGEX_FAIL "FAILED"
-#  )
+dd4hep_add_test_reg( DDCMS_VolumeMgrTest_TOB
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDCMS.sh"
+  EXEC_ARGS  geoPluginRun
+  -input file:${CMAKE_CURRENT_SOURCE_DIR}/data/dd4hep-config.xml
+  -destroy -print WARNING
+  -plugin DD4hep_VolumeMgrTest TOB_1
+  REGEX_PASS "PASSED: Checked 150699 objects. Num.Errors:0"
+  REGEX_FAIL "Exception"
+  REGEX_FAIL "FAILED"
+  )
 
 #
 #  Test saving geometry to ROOT file

--- a/examples/DDCMS/CMakeLists.txt
+++ b/examples/DDCMS/CMakeLists.txt
@@ -70,7 +70,7 @@ dd4hep_add_test_reg( DDCMS_DumpDetElements
   EXEC_ARGS  geoPluginRun -print WARNING
   -input file:${CMAKE_CURRENT_SOURCE_DIR}/data/dd4hep-config.xml
   -destroy -plugin DD4hep_DetectorDump -sensitive
-  REGEX_PASS "Scanned a total of 36101 elements."
+  REGEX_PASS "Scanned a total of 36096 elements."
   REGEX_FAIL "Exception"
   REGEX_FAIL "FAILED"
   )

--- a/examples/DDCMS/data/cms_tracker.xml
+++ b/examples/DDCMS/data/cms_tracker.xml
@@ -12,8 +12,8 @@
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
--->
     <debug_visattr/>
+-->
   </debug>
   <open_geometry/>
   <close_geometry/>

--- a/examples/DDCMS/data/cms_tracker.xml
+++ b/examples/DDCMS/data/cms_tracker.xml
@@ -13,6 +13,7 @@
     <debug_placements/>
     <debug_algorithms/>
 -->
+    <debug_visattr/>
   </debug>
   <open_geometry/>
   <close_geometry/>
@@ -82,12 +83,40 @@
 
         <vis name="pixbarlayer2_PixelBarrelLayer2Coolant"        alpha="0.5"   r="0"    g="0.4"  b="0.6" showDaughters="true"  visible="false"/>
       <vis name="pixbarlayer2_PixelBarrelLayer2CoolTube"         alpha="1.0"   r="0"    g="0.2"  b="0.8" showDaughters="true"  visible="true"/>
-    <vis name="pixbarlayer2_PixelBarrelLayer2"                   alpha="0.5"   r="0.6"  g="0.6"  b="0.6" showDaughters="true"  visible="true"/>f 
-    <vis name="solid-light-grey"                                 alpha="0.5"   r="0.5"  g="0.5"  b="0.5" showDaughters="true"  visible="true"/>
+    <vis name="pixbarlayer2_PixelBarrelLayer2"                   alpha="0.5"   r="0.6"  g="0.6"  b="0.6" showDaughters="true"  visible="true"/> 
+
+    <vis name="tobmodule0_TOBActiveRphi0"                        alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodule0_TOBWaferSter0"                         alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodule2_TOBActiveRphi2"                        alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodule4_TOBActiveRphi4"                        alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodule4_TOBWaferRphi4"                         alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tobmodpar_TOBInactive"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+
+    <vis name="tibmodule0_TIBActiveRphi0"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule0_TIBActiveSter0"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule2_TIBActiveRphi2"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule0_TIBWaferRphi0"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule0_TIBWaferSter0"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="tibmodule2_TIBWaferRphi2"                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+<!--
+    <vis name=""                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name=""                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name=""                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name=""                            alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+-->
+    <vis name="vis-tob"                                          alpha="0.4"   r="0.0"  g="0.0"  b="0.4" showDaughters="true"  visible="true"/>
+    <vis name="solid-light-grey"                                 alpha="0.5"   r="0.5"  g="0.5"  b="0.5" showDaughters="true"  visible="false"/>
+    <vis name="solid-verylight-grey"                             alpha="0.3"   r="0.5"  g="0.5"  b="0.5" showDaughters="true"  visible="true"/>
     <vis name="solid-red"                                        alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
     <vis name="solid-green"                                      alpha="1.0"   r="0.0"  g="1.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="solid-light-green"                                alpha="0.4"   r="0.0"  g="0.4"  b="0.0" showDaughters="true"  visible="false"/>
     <vis name="solid-blue"                                       alpha="1.0"   r="0.0"  g="0.0"  b="1.0" showDaughters="true"  visible="true"/>
-    <vis name="CMS_Invisible"                                    alpha="1"     r="0.0"  g="0.0"  b="1"   showDaughters="true"  visible="false"/>
+    <vis name="solid-light-blue"                                 alpha="0.4"   r="0.0"  g="0.0"  b="0.4" showDaughters="true"  visible="true"/>
+    <vis name="CMS_Invisible"                                    alpha="0.5"   r="0.9"  g="0.9"  b="0.9"   showDaughters="true"  visible="false"/>
+    <vis name="tracker_Tracker"                                  alpha="0.5"   r="0.9"  g="0.9"  b="0.9"   showDaughters="true"  visible="false"/>
+
+    <vis name="vis-active-material"                              alpha="1.0"   r="1.0"  g="0.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="vis-invisible-daughters"                          alpha="0.5"   r="0.7"  g="0.7"  b="0.7"   showDaughters="true"  visible="false"/>
 
     <vismaterial name="AL"                type="solid-light-grey"/>
     <vismaterial name="SI"                type="solid-red"/>
@@ -99,8 +128,27 @@
     <vismaterial name="materials_T_Air"   type="CMS_Invisible"/>
     <vismaterial name="materials_V_Air"   type="CMS_Invisible"/>
     <vismaterial name="trackermaterial_T_Aluminium" type="solid-light-grey"/>
-    <vismaterial name="tecmaterial_TEC_petalinsert" type="solid-blue"/>
+    <vismaterial name="tecmaterial_TEC_petalinsert" type="solid-light-green"/>
+
   </VisSection>
+  <VisSection2>
+    <vis name="tracker_Tracker"                                  alpha="0.3"   r="0.5"  g="0.5"  b="0.5" showDaughters="true"  visible="false"/>
+    <vis name="solid-light-grey"                                 alpha="0.5"   r="0.5"  g="0.5"  b="0.5" showDaughters="true"  visible="true"/>
+    <vis name="solid-verylight-grey"                             alpha="0.3"   r="0.5"  g="0.5"  b="0.5" showDaughters="true"  visible="false"/>
+    <vis name="solid-red"                                        alpha="0.3"   r="1.0"  g="0.0"  b="1.0" showDaughters="true"  visible="true"/>
+    <vis name="solid-green"                                      alpha="1.0"   r="0.0"  g="1.0"  b="0.0" showDaughters="true"  visible="true"/>
+    <vis name="solid-blue"                                       alpha="1.0"   r="0.0"  g="0.0"  b="1.0" showDaughters="true"  visible="true"/>
+    <vis name="CMS_Invisible"                                    alpha="1"     r="0.0"  g="0.0"  b="1"   showDaughters="true"  visible="false"/>
+    <vismaterial name="materials_Air"     type="CMS_Invisible"/>
+    <vismaterial name="materials_E_Air"   type="CMS_Invisible"/>
+    <vismaterial name="materials_H_Air"   type="CMS_Invisible"/>
+    <vismaterial name="materials_M_B_Air" type="CMS_Invisible"/>
+    <vismaterial name="materials_M_F_Air" type="CMS_Invisible"/>
+    <vismaterial name="materials_T_Air"   type="CMS_Invisible"/>
+    <vismaterial name="materials_V_Air"   type="CMS_Invisible"/>
+    <vismaterial name="trackermaterial_T_Aluminium" type="solid-light-grey"/>
+    <vismaterial name="tecmaterial_TEC_petalinsert" type="solid-blue"/>
+  </VisSection2>
 
   <DisabledAlgo  name="track:DDTOBRadCableAlgo"/>
   <ConstantsSection label="pixfwd" eval="true">

--- a/examples/DDCMS/data/dd4hep-config.xml
+++ b/examples/DDCMS/data/dd4hep-config.xml
@@ -8,10 +8,34 @@
     <arg value="-processor"/>
     <arg value="DDCMS_DetElementCreator"/>
   </plugin>
+<!--
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisProcessor"/>
+    <arg value="-vis-active"/>
+    <arg value="solid-red"/>
+    <arg value="-elt-active"/>
+    <arg value="SI"/>
+    <arg value="-fraction"/>
+    <arg value="0.33"/>
+  </plugin>
+
+  <plugin name="DD4hep_PlacedVolumeProcessor">
+    <arg value="-processor"/>
+    <arg value="DD4hep_VisProcessor"/>
+    <arg value="-vis-active"/>
+    <arg value="solid-red"/>
+    <arg value="-vis-inactive"/>
+    <arg value="solid-verylight-grey"/>
+    <arg value="-elt-active"/>
+    <arg value="SI"/>
+    <arg value="-all-inactive"/>
+    <arg value="-fraction"/>
+    <arg value="0.9"/>
+  </plugin>
   <plugin name="DD4hep_VolumeManager"/>
   <plugin name="DD4hep_InteractiveUI"/>
 
-<!--
   <plugin name="DD4hep_DetectorDump">
     <arg value="-sensitive"/>
   </plugin>

--- a/examples/DDCMS/data/dd4hep-config.xml
+++ b/examples/DDCMS/data/dd4hep-config.xml
@@ -8,6 +8,10 @@
     <arg value="-processor"/>
     <arg value="DDCMS_DetElementCreator"/>
   </plugin>
+  <plugin name="DD4hep_VolumeManager"/>
+  <plugin name="DD4hep_InteractiveUI"/>
+
+
 <!--
   <plugin name="DD4hep_PlacedVolumeProcessor">
     <arg value="-processor"/>
@@ -33,9 +37,6 @@
     <arg value="-fraction"/>
     <arg value="0.9"/>
   </plugin>
-  <plugin name="DD4hep_VolumeManager"/>
-  <plugin name="DD4hep_InteractiveUI"/>
-
   <plugin name="DD4hep_DetectorDump">
     <arg value="-sensitive"/>
   </plugin>

--- a/examples/DDCMS/eve/DDEve.xml
+++ b/examples/DDCMS/eve/DDEve.xml
@@ -1,12 +1,12 @@
 <ddeve>
-  <display visLevel="7" loadLevel="4"/>
+  <display visLevel="7" loadLevel="5"/>
 
-  <collection name="TIDB_2Hits"        hits="PointSet" color="kGreen+3" size="0.3" type="21" towerH="3*MeV" emax="10*GeV"/>
-  <collection name="TIDF_1Hits"        hits="PointSet" color="kGreen+3" size="0.3" type="21" towerH="3*MeV" emax="10*GeV"/>
-  <collection name="TIB_1Hits"         hits="PointSet" color="kBlue" size="0.3" type="21" towerH="3*MeV" emax="2*GeV"/>
-  <collection name="PixelBarrel_1Hits" hits="PointSet" color="kMagenta" size="0.3" type="20"/>
-  <collection name="TOB_1Hits"         hits="PointSet" color="kRed+3" size="0.3" type="20"/>
-  <collection name="MC_Particles"      hits="Particles" size="0.6" width="2" type="kCircle"/>
+  <collection name="TIDB_2Hits"        hits="PointSet" color="kRed+4" size="0.8" type="21" towerH="3*MeV" emax="10*GeV"/>
+  <collection name="TIDF_1Hits"        hits="PointSet" color="kRed+3" size="0.8" type="21" towerH="3*MeV" emax="10*GeV"/>
+  <collection name="TIB_1Hits"         hits="PointSet" color="kBlue+3" size="0.8"  type="21" towerH="3*MeV" emax="2*GeV"/>
+  <collection name="PixelBarrel_1Hits" hits="PointSet" color="kBlack" size="0.8" type="20"/>
+  <collection name="TOB_1Hits"         hits="PointSet" color="kRed" size="0.8"   type="20"/>
+  <collection name="MC_Particles"      hits="Particles" size="0.6" width="1" type="kCircle"/>
 
   <calodata name="PixelBarrel" hits="PixelBarrel_1Hits" towerH="20" emax="200"
 	    n_eta="200" eta_min="-5"  eta_max="5" 


### PR DESCRIPTION

BEGINRELEASENOTES
# VolumeManager Implementation
A possibly important bug was fixed for the lookup of top level subdetectors in the VolumeManager by volume identifers of (sensitive) volumes. Due to a bug in the de-masking possible wrong top level subdetectors were returned. The default use cases typically do not use this call and hence should not be affected.

ENDRELEASENOTES