### PR TITLE
cmake/FindPYTHON.cmake: Added required version

### DIFF
--- a/cmake/FindPYTHON.cmake
+++ b/cmake/FindPYTHON.cmake
@@ -1,7 +1,7 @@
 include ( FindPackageHandleStandardArgs )
 
-find_package(PythonInterp  REQUIRED)
-find_package(PythonLibs    REQUIRED)
+find_package(PythonInterp 2 REQUIRED)
+find_package(PythonLibs   2 REQUIRED)
 
 if (PYTHONLIBS_FOUND)
   get_filename_component(PYTHON_LIBRARY_DIR  ${PYTHON_LIBRARIES} PATH)


### PR DESCRIPTION
Since Python3 moved to wide character in argument of PySys_SetArgv(), DD4hep is
currently incompatible with Python3.  For now, let's resolve this by requiring
Python2 via CMake.

This PR resolves #251

BEGINRELEASENOTES
- Added requirement of Python 2 in cmake/FindPYTHON.cmake.  This makes clear the requirement of Python 2, and resolves the issue where CMake tries to build with Python 3 in a system where both exist.

ENDRELEASENOTES