### PR TITLE
DDG4/python/DDG4.py: Changed failure condition for loadDDG4()

### DIFF
--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -28,7 +28,7 @@ def loadDDG4():
     gSystem.SetDynamicPath(os.environ['DD4HEP_LIBRARY_PATH'])
 
   result = gSystem.Load("libDDG4Plugins")
-  if 0 != result:
+  if result < 0:
     raise Exception('DDG4.py: Failed to load the DDG4 library libDDG4Plugins: '+gSystem.GetErrorStr())
   from ROOT import dd4hep as module
   return module


### PR DESCRIPTION
Since gSystem.Load() can return 1 if the library has already been
loaded, there are cases where requiring `result == 0` raises a false
exception.  This commit changes the required condition to be `result >=
0`

This PR resolves #253 

BEGINRELEASENOTES
- DDG4/python/DDG4.py: loadDDG4() changed to not raise exception if libraries are already loaded

ENDRELEASENOTES