### PR TITLE
Fix bitfield

### DIFF
--- a/DDCore/include/DDSegmentation/BitField64.h
+++ b/DDCore/include/DDSegmentation/BitField64.h
@@ -39,7 +39,7 @@ namespace dd4hep {
     
       /** Returns the current field value 
        */
-      long64 value() const { return _value ; }
+      long64 value() const { return _bv.value( _value ) ; }
   
       /// Calculate Field value given an external 64 bit bitmap value
       long64 value(long64 id) const { return _bv.value( id ) ; }

--- a/DDCore/src/XML/DocumentHandler.cpp
+++ b/DDCore/src/XML/DocumentHandler.cpp
@@ -36,7 +36,7 @@ namespace {
     if ( !fn.empty() )   {
       TString tfn(fn);
       gSystem->ExpandPathName(tfn);
-      return string(tfn);
+      return string(tfn.Data());
     }
     return fn;
   }

--- a/DDTest/src/test_bitfield64.cc
+++ b/DDTest/src/test_bitfield64.cc
@@ -67,6 +67,12 @@ int main(int /* argc */, char** /* argv */ ){
     test(  bf3.getValue() , bf2.getValue()  , " same value 0xbebafecacafebabeUL from setting low and high word " ); 
 
 
+    test(  bf3["layer"] , 373  , " get value for \"layer\": 373  " );
+
+    unsigned xIndex = bf2.index( "x" ) ;
+
+    test(  bf3[xIndex] , -310  , " get value for xIndex : -310  " );
+
     // --------------------------------------------------------------------
 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- bug fix in `BitField64::operator[std::string]() `
- make uses of TString in DocumentHandler.cpp compatible with clang9 (on Mac)

ENDRELEASENOTES