### PR TITLE
Add GDML import and export functionality; Move to python logging

### DIFF
--- a/DDCore/CMakeLists.txt
+++ b/DDCore/CMakeLists.txt
@@ -67,3 +67,9 @@ dd4hep_add_package_library ( DDCore
 
 # Generate DDCore plugins---------------------------------------------------------
 dd4hep_add_plugin ( DDCorePlugins SOURCES src/plugins/*.cpp )
+
+#---------------------------  Specialized  GDML  plugins  --------------------------
+# This plugins depends on the ROOT GDML readers. Hence, extra library
+dd4hep_add_plugin(DDGDMLPlugins
+  OPTIONAL    [ROOT REQUIRED COMPONENTS Gdml SOURCES src/gdml/*.cpp]
+)

--- a/DDCore/include/DD4hep/DetElement.h
+++ b/DDCore/include/DD4hep/DetElement.h
@@ -345,13 +345,13 @@ namespace dd4hep {
      */
     std::string type() const;
     ///  Set detector type (structure, tracker, calorimeter, etc.).
-    DetElement& setType(const std::string& typ);
+    DetElement&  setType(const std::string& typ);
 
     // Return flag word encoding detector types ( ideally use dd4hep::DetType for decoding )
     unsigned int typeFlag() const;
 
     ///  Set the flag word encoding detector types ( ideally use dd4hep::DetType for encoding )
-    DetElement& setTypeFlag(unsigned int types);
+    DetElement&  setTypeFlag(unsigned int types);
 
     /// Access hash key of this detector element (Only valid once geometry is closed!)
     unsigned int key()  const;

--- a/DDCore/include/DD4hep/DetectorTools.h
+++ b/DDCore/include/DD4hep/DetectorTools.h
@@ -79,6 +79,8 @@ namespace dd4hep {
       std::string toString(const PlacedVolume::VolIDs& ids);
       /// Convert VolumeID to string
       std::string toString(const IDDescriptor& dsc, const PlacedVolume::VolIDs& ids, VolumeID code);
+      /// Extract all the path elements from a path
+      std::vector<std::string> pathElements(const std::string& path);
     }
   }
 }         /* End namespace dd4hep                   */

--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -272,6 +272,9 @@ namespace dd4hep {
     /// Check if placement is properly instrumented
     Object* data() const;
 
+    /// If we import volumes from external sources, we have to attach the extensions to the tree
+    Volume& import();
+    
     /** Daughter placements with auto-generated copy number for the daughter volume  */
     /// Place daughter volume. The position and rotation are the identity
     PlacedVolume placeVolume(const Volume& vol) const;

--- a/DDCore/src/DetectorTools.cpp
+++ b/DDCore/src/DetectorTools.cpp
@@ -177,7 +177,7 @@ void detail::tools::elementPath(DetElement element, PlacementPath& det_nodes) {
 }
 
 /// Assemble the path of the PlacedVolume selection
-std::string detail::tools::elementPath(const PlacementPath& nodes, bool reverse)   {
+string detail::tools::elementPath(const PlacementPath& nodes, bool reverse)   {
   string s = "";
   if ( reverse )  {
     for(auto i=nodes.rbegin(); i != nodes.rend(); ++i)
@@ -191,7 +191,7 @@ std::string detail::tools::elementPath(const PlacementPath& nodes, bool reverse)
 }
 
 /// Assemble the path of the PlacedVolume selection
-std::string detail::tools::elementPath(const ElementPath& nodes, bool reverse)  {
+string detail::tools::elementPath(const ElementPath& nodes, bool reverse)  {
   string s = "";
   if ( reverse )  {
     for(ElementPath::const_reverse_iterator i=nodes.rbegin();i!=nodes.rend();++i)
@@ -205,19 +205,19 @@ std::string detail::tools::elementPath(const ElementPath& nodes, bool reverse)  
 }
 
 /// Assemble the path of a particular detector element
-std::string detail::tools::elementPath(DetElement element)  {
+string detail::tools::elementPath(DetElement element)  {
   ElementPath nodes;
   elementPath(element,nodes);
   return elementPath(nodes);
 }
 
 /// Find DetElement as child of the top level volume by it's absolute path
-DetElement detail::tools::findElement(Detector& description, const std::string& path)   {
+DetElement detail::tools::findElement(Detector& description, const string& path)   {
   return findDaughterElement(description.world(),path);
 }
 
 /// Find DetElement as child of a parent by it's relative or absolute path
-DetElement detail::tools::findDaughterElement(DetElement parent, const std::string& subpath)  {
+DetElement detail::tools::findDaughterElement(DetElement parent, const string& subpath)  {
   if ( parent.isValid() )   {
     size_t idx = subpath.find('/',1);
     if ( subpath[0] == '/' )   {
@@ -274,14 +274,14 @@ void detail::tools::placementPath(DetElement parent, DetElement element, Placeme
 }
 
 /// Assemble the path of the PlacedVolume selection
-std::string detail::tools::placementPath(DetElement element)  {
+string detail::tools::placementPath(DetElement element)  {
   PlacementPath path;
   placementPath(element,path);
   return placementPath(path);
 }
 
 /// Assemble the path of the PlacedVolume selection
-std::string detail::tools::placementPath(const PlacementPath& nodes, bool reverse)  {
+string detail::tools::placementPath(const PlacementPath& nodes, bool reverse)  {
   string s="";
   if ( reverse )  {
     for(PlacementPath::const_reverse_iterator i=nodes.rbegin();i!=nodes.rend();++i)
@@ -295,14 +295,14 @@ std::string detail::tools::placementPath(const PlacementPath& nodes, bool revers
 }
 
 /// Assemble the path of the PlacedVolume selection
-std::string detail::tools::placementPath(const std::vector<const TGeoNode*>& nodes, bool reverse)   {
+string detail::tools::placementPath(const vector<const TGeoNode*>& nodes, bool reverse)   {
   string s="";
   if ( reverse )  {
-    for(std::vector<const TGeoNode*>::const_reverse_iterator i=nodes.rbegin();i!=nodes.rend();++i)
+    for(vector<const TGeoNode*>::const_reverse_iterator i=nodes.rbegin();i!=nodes.rend();++i)
       s += "/" + string((*i)->GetName());
   }
   else  {
-    for(std::vector<const TGeoNode*>::const_iterator i=nodes.begin();i!=nodes.end();++i)
+    for(vector<const TGeoNode*>::const_iterator i=nodes.begin();i!=nodes.end();++i)
       s += "/" + string((*i)->GetName());
   }
   return s;
@@ -327,7 +327,7 @@ void detail::tools::placementTrafo(const PlacementPath& nodes, bool inverse, TGe
 }
 
 /// Find a given node in the hierarchy starting from the top node (absolute placement!)
-PlacedVolume detail::tools::findNode(PlacedVolume top_place, const std::string& place)   {
+PlacedVolume detail::tools::findNode(PlacedVolume top_place, const string& place)   {
   TGeoNode* top = top_place.ptr();
   const char* path = place.c_str();
   // Check if a geometry path is valid without changing the state of the navigator.
@@ -377,7 +377,7 @@ PlacedVolume detail::tools::findNode(PlacedVolume top_place, const std::string& 
 }
 
 /// Convert VolumeID to string
-std::string detail::tools::toString(const PlacedVolume::VolIDs& ids)   {
+string detail::tools::toString(const PlacedVolume::VolIDs& ids)   {
   stringstream log;
   for( const auto& v : ids )
     log << v.first << "=" << v.second << "; ";
@@ -385,7 +385,7 @@ std::string detail::tools::toString(const PlacedVolume::VolIDs& ids)   {
 }
 
 /// Convert VolumeID to string
-std::string detail::tools::toString(const IDDescriptor& dsc, const PlacedVolume::VolIDs& ids, VolumeID code)   {
+string detail::tools::toString(const IDDescriptor& dsc, const PlacedVolume::VolIDs& ids, VolumeID code)   {
   stringstream log;
   for( const auto& id : ids )  {
     const BitFieldElement* f = dsc.field(id.first);
@@ -393,6 +393,23 @@ std::string detail::tools::toString(const IDDescriptor& dsc, const PlacedVolume:
     log << id.first << "=" << id.second << "," << value << " [" << f->offset() << "," << f->width() << "] ";
   }
   return log.str();
+}
+
+/// Extract all the path elements from a path
+vector<string> detail::tools::pathElements(const string& path)   {
+  vector<string> result;
+  if ( !path.empty() )  {
+    string tmp = path[0]=='/' ? path.substr(1) : path;
+    for(size_t idx=tmp.find('/'); idx != string::npos; idx=tmp.find('/'))  {
+      string val = tmp.substr(0,idx);
+      result.push_back(val);
+      tmp = tmp.length()>idx ? tmp.substr(idx+1) : string();
+    }
+    if ( !tmp.empty() )  {
+      result.push_back(tmp);
+    }
+  }
+  return result;
 }
 
 

--- a/DDCore/src/gdml/GdmlPlugins.cpp
+++ b/DDCore/src/gdml/GdmlPlugins.cpp
@@ -1,0 +1,151 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/Detector.h"
+#include "DD4hep/Memory.h"
+#include "DD4hep/DD4hepUI.h"
+#include "DD4hep/Factories.h"
+#include "DD4hep/Printout.h"
+#include "DD4hep/DetectorTools.h"
+
+// ROOT includes
+#include "TInterpreter.h"
+#include "TGeoElement.h"
+#include "TGeoManager.h"
+#include "TGDMLParse.h"
+#include "TGDMLWrite.h"
+
+using namespace std;
+using namespace dd4hep;
+
+#ifdef DD4HEP_HAVE_HIGHER_ROOT_VERSION
+
+/// ROOT GDML reader plugin
+/**
+ *  Factory: DD4hep_ROOTGDMLParse
+ *
+ *  \author  M.Frank
+ *  \version 1.0
+ *  \date    01/04/2014
+ */
+static long gdml_parse(Detector& description, int argc, char** argv) {
+  if ( argc > 0 )   {
+    string input, path;
+    for(int i = 0; i < argc && argv[i]; ++i)  {
+      if ( 0 == ::strncmp("-input",argv[i],2) )
+        input = argv[++i];
+      if ( 0 == ::strncmp("-path", argv[i],2) )
+        path  = argv[++i];
+    }
+    if ( input.empty() || path.empty() )   {
+      cout <<
+        "Usage: -plugin <name> -arg [-arg]                                            \n"
+        "     name:   factory name     DD4hep_ROOTGDMLParse                           \n"
+        "     -input  <string>         Input file name.                               \n"
+        "     -path   <string>         Path to parent detector element to attach      \n"
+        "                              top volume from GDML file.                     \n"
+        "\tArguments given: " << arguments(argc,argv) << endl << flush;
+      ::exit(EINVAL);
+    }
+    printout(INFO,"ROOTGDMLParse","+++ Read geometry from GDML file file:%s",input.c_str());
+    vector<string> elements = detail::tools::pathElements(path);
+    if ( !elements.empty() )   {
+      DetElement world = description.world();
+      DetElement parent = world, child;
+      for(size_t i=0; i < elements.size(); ++i)  {
+        const auto& e = elements[i];
+        if ( e == world.name() )
+          continue;
+        child = parent.child(e);
+        if ( child.isValid() )  {
+          parent = child;
+          continue;
+        }
+        child = DetElement(e, 0); // Inactive child, no sensitive detector, no ID
+        PlacedVolume pv;
+        Volume mother = (parent==world) ? description.pickMotherVolume(child) : parent.volume();
+        if ( i == elements.size()-1 )  {
+          TGDMLParse parser;
+          Volume vol = parser.GDMLReadFile(input.c_str());
+          if ( vol.isValid() )   {
+            vol.import(); // We require the extensions in dd4hep.
+            pv = mother.placeVolume(vol);
+            child.setPlacement(pv);
+            if (parent == world) description.add(child);
+            else                 parent.add(child);
+            printout(INFO,"ROOTGDMLParse","+++ Attach GDML volume %s to Element path:%s",
+                     vol.name(), path.c_str());
+            return 1;
+          }
+          except("ROOTGDMLParse","+++ Failed to parse GDML file:%s for path:%s",
+                 input.c_str(),path.c_str());
+        }
+        pv = mother.placeVolume(Assembly(e));
+        child.setPlacement(pv);
+        if (parent == world) description.add(child);
+        else                 parent.add(child);
+      }
+    }
+    except("ROOTGDMLParse","+++ Invalid DetElement path given: %s", path.c_str());
+  }
+  except("ROOTGDMLParse","+++ No input file name given.");
+  return 0;
+}
+DECLARE_APPLY(DD4hep_ROOTGDMLParse,gdml_parse)
+
+
+/// ROOT GDML writer plugin
+/**
+ *  Factory: DD4hep_ROOTGDMLExtract
+ *
+ *  \author  M.Frank
+ *  \version 1.0
+ *  \date    01/04/2014
+ */
+static long gdml_extract(Detector& description, int argc, char** argv) {
+  if ( argc > 0 )   {
+    string output, path;
+    for(int i = 0; i < argc && argv[i]; ++i)  {
+      if ( 0 == ::strncmp("-output",argv[i],2) )
+        output = argv[++i];
+      if ( 0 == ::strncmp("-path", argv[i],2) )
+        path  = argv[++i];
+    }
+    if ( output.empty() || path.empty() )   {
+      cout <<
+        "Usage: -plugin <name> -arg [-arg]                                            \n"
+        "     name:   factory name     DD4hep_ROOTGDMLExtract                         \n"
+        "     -output <string>         Output file name.                              \n"
+        "     -path   <string>         Path to parent detector element to attach      \n"
+        "                              top volume from GDML file.                     \n"
+        "\tArguments given: " << arguments(argc,argv) << endl << flush;
+      ::exit(EINVAL);
+    }
+    printout(INFO,"ROOTGDMLExtract","+++ Write geometry %s to GDML file file:%s",
+             path.c_str(), output.c_str());
+    DetElement detector = detail::tools::findElement(description,path);
+    if ( detector.isValid() )   {
+      TGDMLWrite extract;
+      Volume volume = detector.volume();
+      extract.WriteGDMLfile(&description.manager(), volume.ptr(), output.c_str());
+      return 1;
+    }
+    except("ROOTGDMLExtract","+++ Invalid DetElement path given: %s", path.c_str());
+  }
+  except("ROOTGDMLExtract","+++ No output file name given.");
+  return 0;
+}
+DECLARE_APPLY(DD4hep_ROOTGDMLExtract,gdml_extract)
+
+#endif

--- a/DDG4/examples/CLICSidSimuMarkus.py
+++ b/DDG4/examples/CLICSidSimuMarkus.py
@@ -1,9 +1,10 @@
 #
 #
-import os, time, DDG4
+import os, time, logging, DDG4
 from DDG4 import OutputLevel as Output
 from SystemOfUnits import *
 #
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 #
 """
 
@@ -48,23 +49,7 @@ def run():
   # Configure UI
   #geant4.setupCshUI(macro='run.mac',ui=None)
   geant4.setupCshUI()
-
-  field = geant4.addConfig('Geant4FieldTrackingSetupAction/MagFieldTrackingSetup')
-  field.stepper            = "HelixSimpleRunge"
-  field.equation           = "Mag_UsualEqRhs"
-  field.eps_min            = 5e-05*mm
-  field.eps_max            = 0.001*mm
-  field.min_chord_step     = 0.01*mm
-  field.delta_chord        = 0.25*mm
-  field.delta_intersection = 1e-05*mm
-  field.delta_one_step     = 0.001*mm
-  print '+++++> ',field.name,'-> stepper  = ',field.stepper
-  print '+++++> ',field.name,'-> equation = ',field.equation
-  print '+++++> ',field.name,'-> eps_min  = ',field.eps_min
-  print '+++++> ',field.name,'-> eps_max  = ',field.eps_max
-  print '+++++> ',field.name,'-> delta_one_step = ',field.delta_one_step
-
-
+  geant4.setupTrackingField()
 
   # Configure Run actions
   run1 = DDG4.RunAction(kernel,'Geant4TestRunAction/RunInit')
@@ -185,7 +170,7 @@ def run():
 
   #DDG4.setPrintLevel(Output.DEBUG)
   kernel.run()
-  print 'End of run. Terminating .......'
+  logging.info('End of run. Terminating .......')
   kernel.terminate()
 
 if __name__ == "__main__":

--- a/DDG4/examples/SiDSim_MT.py
+++ b/DDG4/examples/SiDSim_MT.py
@@ -1,12 +1,12 @@
 #
 #
-import os, time, DDG4
+import os, time, logging, DDG4
 from DDG4 import OutputLevel as Output
 from SystemOfUnits import *
 #
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 #
-print \
-"""
+logging.info("""
 
    dd4hep simulation example setup DDG4
    in multi-threaded mode using the python configuration
@@ -14,28 +14,28 @@ print \
    @author  M.Frank
    @version 1.0
 
-"""
+""")
 
 
 def setupWorker(geant4):
   kernel = geant4.kernel()
-  print '#PYTHON: +++ Creating Geant4 worker thread ....'
-  print "#PYTHON:  Configure Run actions"
+  logging.info('#PYTHON: +++ Creating Geant4 worker thread ....')
+  logging.info("#PYTHON:  Configure Run actions")
   run1 = DDG4.RunAction(kernel,'Geant4TestRunAction/RunInit',shared=True)
   run1.Property_int    = int(12345)
   run1.Property_double = -5e15*keV
   run1.Property_string = 'Startrun: Hello_2'
-  print run1.Property_string, run1.Property_double, run1.Property_int
+  logging.info("%s %f %d",run1.Property_string, run1.Property_double, run1.Property_int)
   run1.enableUI()
   kernel.runAction().adopt(run1)
 
-  print "#PYTHON:  Configure Event actions"
+  logging.info("#PYTHON:  Configure Event actions")
   prt = DDG4.EventAction(kernel,'Geant4ParticlePrint/ParticlePrint')
   prt.OutputLevel = Output.INFO
   prt.OutputType  = 3 # Print both: table and tree
   kernel.eventAction().adopt(prt)
 
-  print "\n#PYTHON:  Configure I/O\n"
+  logging.info("\n#PYTHON:  Configure I/O\n")
   evt_lcio = geant4.setupLCIOOutput('LcioOutput','CLICSiD_'+time.strftime('%Y-%m-%d_%H-%M'))
   evt_lcio.OutputLevel = Output.ERROR
 
@@ -46,29 +46,29 @@ def setupWorker(geant4):
   gen = DDG4.GeneratorAction(kernel,"Geant4GeneratorActionInit/GenerationInit")
   kernel.generatorAction().adopt(gen)
   #VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
-  print "#PYTHON:\n#PYTHON:  Generation of isotrope tracks of a given multiplicity with overlay:\n#PYTHON:"
-  print "#PYTHON:  First particle generator: pi+"
+  logging.info("#PYTHON:\n#PYTHON:  Generation of isotrope tracks of a given multiplicity with overlay:\n#PYTHON:")
+  logging.info("#PYTHON:  First particle generator: pi+")
   gen = DDG4.GeneratorAction(kernel,"Geant4IsotropeGenerator/IsotropPi+");
   gen.Mask     = 1
   gen.Particle = 'pi+'
   gen.Energy   = 20 * GeV
   gen.Multiplicity = 2
   kernel.generatorAction().adopt(gen)
-  print "#PYTHON:  Install vertex smearing for this interaction"
+  logging.info("#PYTHON:  Install vertex smearing for this interaction")
   gen = DDG4.GeneratorAction(kernel,"Geant4InteractionVertexSmear/SmearPi+");
   gen.Mask   = 1
   gen.Offset = (20*mm, 10*mm, 10*mm, 0*ns)
   gen.Sigma  = (4*mm, 1*mm, 1*mm, 0*ns)
   kernel.generatorAction().adopt(gen)
 
-  print "#PYTHON:  Second particle generator: e-"
+  logging.info("#PYTHON:  Second particle generator: e-")
   gen = DDG4.GeneratorAction(kernel,"Geant4IsotropeGenerator/IsotropE-");
   gen.Mask     = 2
   gen.Particle = 'e-'
   gen.Energy   = 15 * GeV
   gen.Multiplicity = 3
   kernel.generatorAction().adopt(gen)
-  print "#PYTHON:  Install vertex smearing for this interaction"
+  logging.info("#PYTHON:  Install vertex smearing for this interaction")
   gen = DDG4.GeneratorAction(kernel,"Geant4InteractionVertexSmear/SmearE-");
   gen.Mask   = 2
   gen.Offset = (-20*mm, -10*mm, -10*mm, 0*ns)
@@ -76,19 +76,19 @@ def setupWorker(geant4):
   kernel.generatorAction().adopt(gen)
   #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  print "#PYTHON:  Merge all existing interaction records"
+  logging.info("#PYTHON:  Merge all existing interaction records")
   gen = DDG4.GeneratorAction(kernel,"Geant4InteractionMerger/InteractionMerger")
   gen.OutputLevel = 4 #generator_output_level
   gen.enableUI()
   kernel.generatorAction().adopt(gen)
 
-  print "#PYTHON:  Finally generate Geant4 primaries"
+  logging.info("#PYTHON:  Finally generate Geant4 primaries")
   gen = DDG4.GeneratorAction(kernel,"Geant4PrimaryHandler/PrimaryHandler")
   gen.OutputLevel = 4 #generator_output_level
   gen.enableUI()
   kernel.generatorAction().adopt(gen)
 
-  print "#PYTHON:  ....and handle the simulation particles."
+  logging.info("#PYTHON:  ....and handle the simulation particles.")
   part = DDG4.GeneratorAction(kernel,"Geant4ParticleHandler/ParticleHandler")
   kernel.generatorAction().adopt(part)
   #part.SaveProcesses = ['conv','Decay']
@@ -101,24 +101,24 @@ def setupWorker(geant4):
   user.TrackingVolume_Rmax = DDG4.EcalBarrel_rmin
   user.enableUI()
   part.adopt(user)
-  print '#PYTHON: +++ Geant4 worker thread configured successfully....'
+  logging.info('#PYTHON: +++ Geant4 worker thread configured successfully....')
   return 1
   
 def setupMaster(geant4):
   kernel = geant4.master()
-  print '#PYTHON: +++ Setting up master thread for ',kernel.NumberOfThreads,' workers.'
+  logging.info('#PYTHON: +++ Setting up master thread for %d workers',kernel.NumberOfThreads)
   return 1
 
 def setupSensitives(geant4):
-  print "#PYTHON:  Setting up all sensitive detectors"
+  logging.info("#PYTHON:  Setting up all sensitive detectors")
   geant4.printDetectors()
-  print "#PYTHON:  First the tracking detectors"
+  logging.info("#PYTHON:  First the tracking detectors")
   seq,act = geant4.setupTracker('SiVertexBarrel')
   seq,act = geant4.setupTracker('SiVertexEndcap')
   seq,act = geant4.setupTracker('SiTrackerBarrel')
   seq,act = geant4.setupTracker('SiTrackerEndcap')
   seq,act = geant4.setupTracker('SiTrackerForward')
-  print "#PYTHON:  Now setup the calorimeters"
+  logging.info("#PYTHON:  Now setup the calorimeters")
   seq,act = geant4.setupCalorimeter('EcalBarrel')
   seq,act = geant4.setupCalorimeter('EcalEndcap')
   seq,act = geant4.setupCalorimeter('HcalBarrel')
@@ -140,46 +140,33 @@ def run():
 
   kernel.NumberOfThreads = 3
   geant4 = DDG4.Geant4(kernel,tracker='Geant4TrackerCombineAction')
-  print "#  Configure UI"
+  logging.info("#  Configure UI")
   geant4.setupCshUI()
 
-  print "#  Geant4 user initialization action"
+  logging.info("#  Geant4 user initialization action")
   geant4.addUserInitialization(worker=setupWorker, worker_args=(geant4,),
                                master=setupMaster,master_args=(geant4,))
 
-  print "#  Configure G4 geometry setup"
+  logging.info("#  Configure G4 geometry setup")
   seq,act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
 
-  print "# Configure G4 sensitive detectors: python setup callback"
+  logging.info("# Configure G4 sensitive detectors: python setup callback")
   seq,act = geant4.addDetectorConstruction("Geant4PythonDetectorConstruction/SetupSD",
                                            sensitives=setupSensitives,sensitives_args=(geant4,))
-  print "# Configure G4 sensitive detectors: atach'em to the sensitive volumes"
+  logging.info("# Configure G4 sensitive detectors: atach'em to the sensitive volumes")
   seq,act = geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
   #                                           allow_threads=True)
 
-  print "#  Configure G4 magnetic field tracking"
-  seq,field = geant4.addDetectorConstruction("Geant4FieldTrackingConstruction/MagFieldTrackingSetup")
-  field.stepper            = "HelixGeant4Runge"
-  field.equation           = "Mag_UsualEqRhs"
-  field.eps_min            = 5e-05 * mm
-  field.eps_max            = 0.001 * mm
-  field.min_chord_step     = 0.01 * mm
-  field.delta_chord        = 0.25 * mm
-  field.delta_intersection = 1e-05 * mm
-  field.delta_one_step     = 0.001 * mm
-  print '+++++> ',field.name,'-> stepper  = ',field.stepper
-  print '+++++> ',field.name,'-> equation = ',field.equation
-  print '+++++> ',field.name,'-> eps_min  = ',field.eps_min
-  print '+++++> ',field.name,'-> eps_max  = ',field.eps_max
-  print '+++++> ',field.name,'-> delta_one_step = ',field.delta_one_step
+  logging.info("#  Configure G4 magnetic field tracking")
+  geant4.setupTrackingFieldMT()
 
-  print "#  Setup random generator"
+  logging.info("#  Setup random generator")
   rndm = DDG4.Action(kernel,'Geant4Random/Random')
   rndm.Seed = 987654321
   rndm.initialize()
   ##rndm.showStatus()
 
-  print "#  Now build the physics list:"
+  logging.info("#  Now build the physics list:")
   phys = geant4.setupPhysics('QGSP_BERT')
   phys.dump()
 

--- a/DDG4/examples/SiD_Markus.py
+++ b/DDG4/examples/SiD_Markus.py
@@ -1,10 +1,11 @@
 #
 #
-import os, time, DDG4
+import os, time, logging, DDG4
 from DDG4 import OutputLevel as Output
 from SystemOfUnits import *
 #
 global geant4
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 #
 """
 
@@ -25,7 +26,7 @@ def setupWorker():
   run1.Property_int    = 12345
   run1.Property_double = -5e15*keV
   run1.Property_string = 'Startrun: Hello_2'
-  print run1.Property_string, run1.Property_double, run1.Property_int
+  logging.info("%s %f %d",run1.Property_string, run1.Property_double, run1.Property_int)
   run1.enableUI()
   kernel.registerGlobalAction(run1)
   kernel.runAction().adopt(run1)
@@ -116,11 +117,11 @@ def setupWorker():
   user.TrackingVolume_Rmax = DDG4.EcalBarrel_rmin
   user.enableUI()
   part.adopt(user)
-  print 'PYTHON: +++ Geant4 worker thread configured successfully....'
+  logging.info('PYTHON: +++ Geant4 worker thread configured successfully....')
   return 1
   
 def setupMaster():
-  print 'PYTHON: +++ Setting up master thread.....'
+  logging.info('PYTHON: +++ Setting up master thread.....')
   return 1
 
 def setupSensitives():
@@ -132,17 +133,16 @@ def setupSensitives():
   seq,act = geant4.setupTracker('SiVertexEndcap')
   act.OutputLevel = Output.ERROR
   act.CollectSingleDeposits = False
-  print 'PYTHON: +++ Setting up Geant4 sensitive detectors for worker thread.....'
+  logging.info('PYTHON: +++ Setting up Geant4 sensitive detectors for worker thread.....')
   return 1
 
 def dummy_sd():
-  print 'PYTHON: +++ Setting up DUMMY Geant4 sensitive detectors for worker thread.....'
+  logging.info('PYTHON: +++ Setting up DUMMY Geant4 sensitive detectors for worker thread.....')
   return 1
   
 def dummy_geom():
-  print 'PYTHON: +++ Setting up DUMMY Geant4 geometry for worker thread.....'
+  logging.info('PYTHON: +++ Setting up DUMMY Geant4 geometry for worker thread.....')
   return 1
-  
 
 def run():
   global geant4
@@ -167,20 +167,7 @@ def run():
   seq,act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
 
   # Configure G4 magnetic field tracking
-  seq,fld = geant4.addDetectorConstruction("Geant4FieldTrackingConstruction/MagFieldTrackingSetup")
-  fld.stepper            = "HelixGeant4Runge"
-  fld.equation           = "Mag_UsualEqRhs"
-  fld.eps_min            = 5e-05 * mm
-  fld.eps_max            = 0.001 * mm
-  fld.min_chord_step     = 0.01 * mm
-  fld.delta_chord        = 0.25 * mm
-  fld.delta_intersection = 1e-05 * mm
-  fld.delta_one_step     = 0.001 * mm
-  print '+++++> ',fld.name,'-> stepper  = ',fld.stepper
-  print '+++++> ',fld.name,'-> equation = ',fld.equation
-  print '+++++> ',fld.name,'-> eps_min  = ',fld.eps_min
-  print '+++++> ',fld.name,'-> eps_max  = ',fld.eps_max
-  print '+++++> ',fld.name,'-> delta_one_step = ',fld.delta_one_step
+  self.setupTrackingFieldMT()
 
   seq,act = geant4.addDetectorConstruction("Geant4PythonDetectorConstruction/DummyDet",
                                            geometry=dummy_geom,
@@ -236,5 +223,5 @@ def run():
 
 if __name__ == "__main__":
   import sys
-  print sys.argv
+  logging.info('Arguments: %s',str(sys.argv))
   run()

--- a/DDG4/examples/readHEPMC.py
+++ b/DDG4/examples/readHEPMC.py
@@ -6,6 +6,9 @@ dd4hep simulation example setup using the python configuration
 @version 1.0
 
 """
+import logging
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
+
 def run(input_file):
   import DDG4
   from DDG4 import OutputLevel as Output
@@ -25,21 +28,21 @@ def run(input_file):
     try:
       ret = gen.readParticles(0,prim_vtx,parts)
     except Exception,X:
-      print '\nException: readParticles:',str(X)
+      logging.info( '\nException: readParticles: %s',str(X))
       ret = None
     if ret:
       for v in prim_vtx:
-        print 'Mask:%04X (X:%8.2g,Y:%8.2g,Z:%8.2g) time:%8.2g Outgoing:%4d particles'%\
-              (v.mask,v.x,v.y,v.z,v.time,len(v.out),)
+        logging.info( 'Mask:%04X (X:%8.2g,Y:%8.2g,Z:%8.2g) time:%8.2g Outgoing:%4d particles',
+                      v.mask,v.x,v.y,v.z,v.time,len(v.out))
       for p in parts:
-        print 'Mask:%04X ID:%5d PDG-id:%8d Charge:%1d Mass:%8.3g Momentum:(%8.2g,%8.2g,%8.2g) '\
-              'Vertex:(%8.2g,%8.2g,%8.2g) NDau:%2d Status:%08X'%\
-              (p.mask,p.id,p.pdgID,int(p.charge3()),p.mass,p.psx,p.psy,p.psz,\
-               p.vsx,p.vsy,p.vsz,len(p.daughters),p.status,)
+        logging.info( 'Mask:%04X ID:%5d PDG-id:%8d Charge:%1d Mass:%8.3g Momentum:(%8.2g,%8.2g,%8.2g) '\
+                      'Vertex:(%8.2g,%8.2g,%8.2g) NDau:%2d Status:%08X',
+                      p.mask,p.id,p.pdgID,int(p.charge3()),p.mass,p.psx,p.psy,p.psz,\
+                      p.vsx,p.vsy,p.vsz,len(p.daughters),p.status)
       parts.clear()
     else:
-      print '*** End of recordset or read failure.....'
-    print 132*'*'
+      logging.info( '*** End of recordset or read failure.....')
+    logging.info( 132*'*')
   return 0
   
 if __name__ == "__main__":
@@ -49,5 +52,5 @@ if __name__ == "__main__":
     input_file = sys.argv[1]
     sys.exit(run(input_file))
   else:
-    print 'No input file given. Try again....'
+    logging.info( 'No input file given. Try again....')
     sys.exit(2)  # ENOENT

--- a/DDG4/plugins/Geant4Steppers.cpp
+++ b/DDG4/plugins/Geant4Steppers.cpp
@@ -22,9 +22,11 @@
 #include "G4ClassicalRK4.hh"
 #include "G4ConstRK4.hh"
 #include "G4CashKarpRKF45.hh"
-#include "G4BogackiShampine45.hh"
+#include "G4DoLoMcPriRK34.hh"
 #include "G4DormandPrince745.hh"
-
+#include "G4DormandPrinceRK56.hh"
+#include "G4DormandPrinceRK78.hh"
+#include "G4BogackiShampine23.hh"
 
 DECLARE_GEANT4_STEPPER(ImplicitEuler)
 DECLARE_GEANT4_STEPPER(ExplicitEuler)
@@ -33,8 +35,16 @@ DECLARE_GEANT4_STEPPER(SimpleHeum)
 DECLARE_GEANT4_MAGSTEPPER(ConstRK4)
 DECLARE_GEANT4_STEPPER(ClassicalRK4)
 DECLARE_GEANT4_STEPPER(CashKarpRKF45)
+DECLARE_GEANT4_STEPPER(DoLoMcPriRK34)
 DECLARE_GEANT4_STEPPER(DormandPrince745)
+DECLARE_GEANT4_STEPPER(DormandPrinceRK56)
+DECLARE_GEANT4_STEPPER(DormandPrinceRK78)
+DECLARE_GEANT4_STEPPER(BogackiShampine23)
+
+#if G4VERSION_NUMBER>=1003
+#include "G4BogackiShampine45.hh"
 DECLARE_GEANT4_STEPPER(BogackiShampine45)
+#endif
 
 // Geant 4 include files
 #include "G4HelixExplicitEuler.hh"

--- a/DDG4/plugins/Geant4Steppers.cpp
+++ b/DDG4/plugins/Geant4Steppers.cpp
@@ -22,7 +22,6 @@
 #include "G4ClassicalRK4.hh"
 #include "G4ConstRK4.hh"
 #include "G4CashKarpRKF45.hh"
-#include "G4DoLoMcPriRK34.hh"
 #include "G4DormandPrince745.hh"
 #include "G4DormandPrinceRK56.hh"
 #include "G4DormandPrinceRK78.hh"
@@ -35,15 +34,16 @@ DECLARE_GEANT4_STEPPER(SimpleHeum)
 DECLARE_GEANT4_MAGSTEPPER(ConstRK4)
 DECLARE_GEANT4_STEPPER(ClassicalRK4)
 DECLARE_GEANT4_STEPPER(CashKarpRKF45)
-DECLARE_GEANT4_STEPPER(DoLoMcPriRK34)
 DECLARE_GEANT4_STEPPER(DormandPrince745)
 DECLARE_GEANT4_STEPPER(DormandPrinceRK56)
 DECLARE_GEANT4_STEPPER(DormandPrinceRK78)
 DECLARE_GEANT4_STEPPER(BogackiShampine23)
 
 #if G4VERSION_NUMBER>=1003
+#include "G4DoLoMcPriRK34.hh"
 #include "G4BogackiShampine45.hh"
 DECLARE_GEANT4_STEPPER(BogackiShampine45)
+DECLARE_GEANT4_STEPPER(DoLoMcPriRK34)
 #endif
 
 // Geant 4 include files

--- a/DDG4/plugins/Geant4Steppers.cpp
+++ b/DDG4/plugins/Geant4Steppers.cpp
@@ -15,6 +15,7 @@
 #include "DDG4/Factories.h"
 
 // Geant 4 include files
+#include "G4Version.hh"
 #include "G4ExplicitEuler.hh"
 #include "G4ImplicitEuler.hh"
 #include "G4SimpleRunge.hh"
@@ -22,10 +23,6 @@
 #include "G4ClassicalRK4.hh"
 #include "G4ConstRK4.hh"
 #include "G4CashKarpRKF45.hh"
-#include "G4DormandPrince745.hh"
-#include "G4DormandPrinceRK56.hh"
-#include "G4DormandPrinceRK78.hh"
-#include "G4BogackiShampine23.hh"
 
 DECLARE_GEANT4_STEPPER(ImplicitEuler)
 DECLARE_GEANT4_STEPPER(ExplicitEuler)
@@ -34,19 +31,24 @@ DECLARE_GEANT4_STEPPER(SimpleHeum)
 DECLARE_GEANT4_MAGSTEPPER(ConstRK4)
 DECLARE_GEANT4_STEPPER(ClassicalRK4)
 DECLARE_GEANT4_STEPPER(CashKarpRKF45)
+
+#if G4VERSION_NUMBER >=1030
+#include "G4DoLoMcPriRK34.hh"
+#include "G4DormandPrince745.hh"
+#include "G4DormandPrinceRK56.hh"
+#include "G4DormandPrinceRK78.hh"
+#include "G4BogackiShampine23.hh"
+#include "G4BogackiShampine45.hh"
+DECLARE_GEANT4_STEPPER(DoLoMcPriRK34)
 DECLARE_GEANT4_STEPPER(DormandPrince745)
 DECLARE_GEANT4_STEPPER(DormandPrinceRK56)
 DECLARE_GEANT4_STEPPER(DormandPrinceRK78)
 DECLARE_GEANT4_STEPPER(BogackiShampine23)
-
-#if G4VERSION_NUMBER>=1003
-#include "G4DoLoMcPriRK34.hh"
-#include "G4BogackiShampine45.hh"
 DECLARE_GEANT4_STEPPER(BogackiShampine45)
-DECLARE_GEANT4_STEPPER(DoLoMcPriRK34)
 #endif
 
 // Geant 4 include files
+#include "G4MagHelicalStepper.hh"
 #include "G4HelixExplicitEuler.hh"
 #include "G4HelixImplicitEuler.hh"
 #include "G4HelixMixedStepper.hh"
@@ -59,6 +61,12 @@ DECLARE_GEANT4_MAGSTEPPER(HelixMixedStepper)
 DECLARE_GEANT4_MAGSTEPPER(HelixSimpleRunge)
 DECLARE_GEANT4_MAGSTEPPER(HelixHeum)
 
+#if G4VERSION_NUMBER>=1020
+#include "G4NystromRK4.hh"
+#include "G4RKG3_Stepper.hh"
+DECLARE_GEANT4_MAGSTEPPER(RKG3_Stepper)
+DECLARE_GEANT4_MAGSTEPPER(NystromRK4)
+#endif
 
 // Geant 4 include files
 #include "G4Mag_EqRhs.hh"
@@ -71,3 +79,20 @@ DECLARE_GEANT4_MAGMOTION(Mag_SpinEqRhs)
 DECLARE_GEANT4_MAGMOTION(Mag_UsualEqRhs)
 //DECLARE_GEANT4_MAGMOTION(KM_OpticalEqRhs);
 //DECLARE_GEANT4_MAGMOTION(KM_NucleonEqRhs);
+
+#if 0 // G4VERSION_NUMBER>=1002
+// Undefined factories !!!
+#include "G4MonopoleEq.hh"
+#include "G4EqEMFieldWithEDM.hh"
+#include "G4EqEMFieldWithSpin.hh"
+#include "G4EqGravityField.hh"
+#include "G4EqMagElectricField.hh"
+
+// G4EquationOfMotion*(G4UniformGravityField*)
+DECLARE_GEANT4_MAGMOTION(EqGravityField)
+// G4EquationOfMotion*(G4ElectroMagneticField*)
+DECLARE_GEANT4_MAGMOTION(MonopoleEq)
+DECLARE_GEANT4_MAGMOTION(EqMagElectricField)
+DECLARE_GEANT4_MAGMOTION(EqEMFieldWithEDM)
+DECLARE_GEANT4_MAGMOTION(EqEMFieldWithSpin)
+#endif

--- a/DDG4/plugins/Geant4Steppers.cpp
+++ b/DDG4/plugins/Geant4Steppers.cpp
@@ -21,6 +21,10 @@
 #include "G4SimpleHeum.hh"
 #include "G4ClassicalRK4.hh"
 #include "G4ConstRK4.hh"
+#include "G4CashKarpRKF45.hh"
+#include "G4BogackiShampine45.hh"
+#include "G4DormandPrince745.hh"
+
 
 DECLARE_GEANT4_STEPPER(ImplicitEuler)
 DECLARE_GEANT4_STEPPER(ExplicitEuler)
@@ -28,7 +32,9 @@ DECLARE_GEANT4_STEPPER(SimpleRunge)
 DECLARE_GEANT4_STEPPER(SimpleHeum)
 DECLARE_GEANT4_MAGSTEPPER(ConstRK4)
 DECLARE_GEANT4_STEPPER(ClassicalRK4)
-
+DECLARE_GEANT4_STEPPER(CashKarpRKF45)
+DECLARE_GEANT4_STEPPER(DormandPrince745)
+DECLARE_GEANT4_STEPPER(BogackiShampine45)
 
 // Geant 4 include files
 #include "G4HelixExplicitEuler.hh"

--- a/DDG4/python/DD4hep.py
+++ b/DDG4/python/DD4hep.py
@@ -8,6 +8,9 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 #==========================================================================
+import logging
+
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 #
 # We compile the DDG4 plugin on the fly if it does not exist using the AClick mechanism:
 def compileAClick(dictionary,g4=True):
@@ -24,11 +27,11 @@ def compileAClick(dictionary,g4=True):
 
   gSystem.AddIncludePath(inc)
   gSystem.AddLinkedLibs(lib)
-  #####print "Includes:   ",gSystem.GetIncludePath(),"\n","Linked libs:",gSystem.GetLinkedLibs()
-  print 'Loading AClick ',dictionary
+  #####logging.info("Includes:   %s\n","Linked libs:%s",gSystem.GetIncludePath(),gSystem.GetLinkedLibs())
+  logging.info('Loading AClick %s',dictionary)
   package = imp.find_module('DDG4')
   dic = os.path.dirname(package[1])+os.sep+dictionary
-  ###print dic
+  ###logging.info(str(dic))
   gInterpreter.ProcessLine('.L '+dic+'+')
   #####gInterpreter.Load('DDG4Dict_C.so')
   from ROOT import dd4hep as module
@@ -60,7 +63,7 @@ def import_namespace_item(ns,nam):
   return attr
 
 def import_root(nam):
-  #print 'import ROOT class ',nam,str(name_space)
+  #logging.info('import ROOT class %s in namespace %s',nam,str(name_space))
   setattr(name_space,nam,getattr(ROOT,nam))
 
 #---------------------------------------------------------------------------
@@ -70,10 +73,10 @@ try:
   import ROOT
 except Exception,X:
   import sys
-  print '+--%-100s--+'%(100*'-',)
-  print '|  %-100s  |'%('Failed to load dd4hep base library:',)
-  print '|  %-100s  |'%(str(X),)
-  print '+--%-100s--+'%(100*'-',)
+  logging.info('+--%-100s--+',100*'-')
+  logging.info('|  %-100s  |','Failed to load dd4hep base library:')
+  logging.info('|  %-100s  |',str(X))
+  logging.info('+--%-100s--+',100*'-')
   sys.exit(1)
 
 class _Levels:

--- a/DDG4/python/checkGeometry.py
+++ b/DDG4/python/checkGeometry.py
@@ -10,8 +10,9 @@
 #
 #==========================================================================
 
-import sys, errno, optparse
+import sys, errno, optparse, logging
 
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 parser = optparse.OptionParser()
 parser.description = "TGeo Geometry checking."
 parser.formatter.width = 132
@@ -51,7 +52,7 @@ parser.add_option("-o", "--option", dest="option", default='ob',
 (opts, args) = parser.parse_args()
 
 if opts.compact is None:
-  print "   ",parser.format_help()
+  logging.info("   %s",parser.format_help())
   sys.exit(1)
 
 try:
@@ -59,30 +60,30 @@ try:
   from ROOT import gROOT
   gROOT.SetBatch(1)
 except ImportError,X:
-  print 'PyROOT interface not accessible:',X
+  logging.error('PyROOT interface not accessible: %s',str(X))
   sys.exit(errno.ENOENT)
 
 try:
   import DD4hep
 except ImportError,X:
-  print 'dd4hep python interface not accessible:',X
+  logging.error('dd4hep python interface not accessible: %s',str(X))
   sys.exit(errno.ENOENT)
 
 DD4hep.setPrintLevel(DD4hep.OutputLevel.ERROR)
-print '+++%s\n+++ Loading compact geometry:%s\n+++%s'%(120*'=',opts.compact,120*'=')
+logging.info('+++%s\n+++ Loading compact geometry:%s\n+++%s',120*'=',opts.compact,120*'=')
 description = DD4hep.Detector.getInstance()
 description.fromXML(opts.compact)
 opts.num_tracks = int(opts.num_tracks)
 opts.vx = float(opts.vx)
 opts.vy = float(opts.vy)
 opts.vz = float(opts.vz)
-print '+++%s\n+++ Checking geometry:%s full-check:%s\n+++%s'%(120*'=',opts.compact,opts.full,120*'=')
+logging.info('+++%s\n+++ Checking geometry:%s full-check:%s\n+++%s',120*'=',opts.compact,opts.full,120*'=')
 if opts.full:
-  print '+++ # tracks:%d vertex:(%7.3f, %7.3f, %7.3f) [cm]'%(opts.num_tracks,opts.vx,opts.vy,opts.vz,)
+  logging.info('+++ # tracks:%d vertex:(%7.3f, %7.3f, %7.3f) [cm]',opts.num_tracks,opts.vx,opts.vy,opts.vz)
   description.manager().CheckGeometryFull(opts.num_tracks,opts.vx,opts.vy,opts.vz,opts.option)
 else:
   description.manager().CheckGeometry()
 #
 #
-print '+++ Execution finished...'
+logging.info('+++ Execution finished...')
 sys.exit(0)

--- a/DDG4/python/checkOverlaps.py
+++ b/DDG4/python/checkOverlaps.py
@@ -10,8 +10,9 @@
 #
 #==========================================================================
 
-import sys, errno, optparse
+import sys, errno, optparse, logging
 
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 parser = optparse.OptionParser()
 parser.formatter.width = 132
 parser.description = "Check TGeo geometries for overlaps."
@@ -35,7 +36,7 @@ parser.add_option("-o", "--option", dest="option", default='',
 (opts, args) = parser.parse_args()
 
 if opts.compact is None:
-  print "   ",parser.format_help()
+  logging.info("    %s",parser.format_help())
   sys.exit(1)
 
 try:
@@ -43,31 +44,31 @@ try:
   from ROOT import gROOT
   gROOT.SetBatch(1)
 except ImportError,X:
-  print 'PyROOT interface not accessible:',X
-  print parser.format_help()
+  logging.error('PyROOT interface not accessible: %s',str(X))
+  logging.error("%s",parser.format_help())
   sys.exit(errno.ENOENT)
 
 try:
   import DD4hep
 except ImportError,X:
-  print 'dd4hep python interface not accessible:',X
-  print parser.format_help()
+  logging.error('dd4hep python interface not accessible: %s',str(X))
+  logging.error("%s",parser.format_help())
   sys.exit(errno.ENOENT)
 #
 #
 opts.tolerance = float(opts.tolerance)
 DD4hep.setPrintLevel(DD4hep.OutputLevel.ERROR)
-print '+++%s\n+++ Loading compact geometry:%s\n+++%s'%(120*'=',opts.compact,120*'=')
+logging.info('+++%s\n+++ Loading compact geometry:%s\n+++%s',120*'=',opts.compact,120*'=')
 description = DD4hep.Detector.getInstance()
 description.fromXML(opts.compact)
-print '+++%s\n+++ Checking overlaps of geometry:%s tolerance:%f option:%s\n+++%s'%(120*'=',opts.compact,opts.tolerance,opts.option,120*'=')
+logging.info('+++%s\n+++ Checking overlaps of geometry:%s tolerance:%f option:%s\n+++%s',120*'=',opts.compact,opts.tolerance,opts.option,120*'=')
 description.manager().CheckOverlaps(opts.tolerance,opts.option)
 #
 #
 if opts.print_overlaps:
-  print '+++%s\n+++ Printing overlaps of geometry:%s\n+++%s'%(120*'=',opts.compact,120*'=')
+  logging.info('+++%s\n+++ Printing overlaps of geometry:%s\n+++%s',120*'=',opts.compact,120*'=')
   description.manager().PrintOverlaps()
 #
 #
-print '+++ Execution finished...'
+logging.info('+++ Execution finished...')
 sys.exit(0)

--- a/DDG4/python/g4MaterialScan.py
+++ b/DDG4/python/g4MaterialScan.py
@@ -10,13 +10,14 @@
 #
 #==========================================================================
 
-import os, sys, errno, optparse
+import os, sys, errno, optparse, logging
 
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 def printOpts(opts):
   o = eval(str(opts))
   prefix = sys.argv[0].split(os.sep)[-1]
   for name,value in o.items():
-    print '%s > %-18s %s  [%s]'%(prefix,name+':',str(value),str(value.__class__),)
+    logging.info('%s > %-18s %s  [%s]',prefix,name+':',str(value),str(value.__class__))
 
 def materialScan(opts):
   kernel = DDG4.Kernel()
@@ -35,7 +36,7 @@ def materialScan(opts):
         geant4.setupDetector(o.name(),geant4.sensitive_types[typ])
         sdtyp = geant4.sensitive_types[typ]
       else:
-        print '+++  %-32s type:%-12s  --> Unknown Sensitive type: %s'%(o.name(), typ, sdtyp,)
+        logging.info('+++  %-32s type:%-12s  --> Unknown Sensitive type: %s',o.name(), typ, sdtyp)
         sys.exit(errno.EINVAL)
 
   gun = geant4.setupGun("Gun",
@@ -91,7 +92,7 @@ parser.add_option('-d', '--direction',
 (opts, args) = parser.parse_args()
 
 if opts.compact is None:
-  print "   ",parser.format_help()
+  logging.info("   ",parser.format_help())
   sys.exit(1)
 
 opts.position=eval('('+opts.position+')')
@@ -103,15 +104,15 @@ try:
   from ROOT import gROOT
   gROOT.SetBatch(1)
 except ImportError,X:
-  print 'PyROOT interface not accessible:',X
-  print parser.format_help()
+  logging.info('PyROOT interface not accessible: %s',str(X))
+  logging.info(parser.format_help())
   sys.exit(errno.ENOENT)
 
 try:
   import DDG4, SystemOfUnits
 except ImportError,X:
-  print 'DDG4 python interface not accessible:',X
-  print parser.format_help()
+  logging.info('DDG4 python interface not accessible: %s',str(X))
+  logging.info(parser.format_help())
   sys.exit(errno.ENOENT)
 #
 ret = materialScan(opts)

--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -58,6 +58,47 @@ dd4hep_add_test_reg( CLICSiD_check_overlaps_LONGTEST
                     --tolerance=0.1
   REGEX_PASS " Execution finished..." )
 #
+if (DD4HEP_HAVE_HIGHER_ROOT_VERSION)
+# ROOT Geometry export to GDML
+dd4hep_add_test_reg( CLICSiD_GDML_export_LONGTEST
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
+  EXEC_ARGS  geoPluginRun -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml -print WARNING -destroy -volmgr
+             -plugin DD4hep_ROOTGDMLExtract -output EcalBarrel.gdml            -path /world/EcalBarrel
+             -plugin DD4hep_ROOTGDMLExtract -output EcalEndcap.gdml            -path /world/EcalEndcap
+             -plugin DD4hep_ROOTGDMLExtract -output HcalBarrel.gdml            -path /world/HcalBarrel 
+             -plugin DD4hep_ROOTGDMLExtract -output HcalEndcap.gdml            -path /world/HcalEndcap
+             -plugin DD4hep_ROOTGDMLExtract -output HcalPlug.gdml              -path /world/HcalPlug
+             -plugin DD4hep_ROOTGDMLExtract -output MuonBarrel.gdml            -path /world/MuonBarrel
+             -plugin DD4hep_ROOTGDMLExtract -output MuonEndcap.gdml            -path /world/MuonEndcap
+             -plugin DD4hep_ROOTGDMLExtract -output LumiCal.gdml               -path /world/LumiCal
+             -plugin DD4hep_ROOTGDMLExtract -output BeamCal.gdml               -path /world/BeamCal
+             -plugin DD4hep_ROOTGDMLExtract -output LumiReadout_Forward.gdml   -path /world/LumiReadout_Forward
+             -plugin DD4hep_ROOTGDMLExtract -output LumiReadout_Backward.gdml  -path /world/LumiReadout_Backward
+             -plugin DD4hep_VolumeDump --topstat
+  REGEX_PASS "Checked 130738 physical volume placements"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR" )
+#
+# ROOT Geometry export to GDML
+dd4hep_add_test_reg( CLICSiD_GDML_import_LONGTEST
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
+  EXEC_ARGS  geoPluginRun -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact_nocalo.xml -print WARNING -destroy -volmgr
+             -plugin DD4hep_ROOTGDMLParse -input EcalBarrel.gdml            -path /world/EcalBarrel
+             -plugin DD4hep_ROOTGDMLParse -input EcalEndcap.gdml            -path /world/EcalEndcap
+             -plugin DD4hep_ROOTGDMLParse -input HcalBarrel.gdml            -path /world/HcalBarrel
+             -plugin DD4hep_ROOTGDMLParse -input HcalEndcap.gdml            -path /world/HcalEndcap
+             -plugin DD4hep_ROOTGDMLParse -input HcalPlug.gdml              -path /world/HcalPlug
+             -plugin DD4hep_ROOTGDMLParse -input MuonBarrel.gdml            -path /world/MuonBarrel
+             -plugin DD4hep_ROOTGDMLParse -input MuonEndcap.gdml            -path /world/MuonEndcap
+             -plugin DD4hep_ROOTGDMLParse -input LumiCal.gdml               -path /world/LumiCal
+             -plugin DD4hep_ROOTGDMLParse -input BeamCal.gdml               -path /world/BeamCal
+             -plugin DD4hep_ROOTGDMLParse -input LumiReadout_Forward.gdml   -path /world/LumiReadout_Forward
+             -plugin DD4hep_ROOTGDMLParse -input LumiReadout_Backward.gdml  -path /world/LumiReadout_Backward
+             -plugin DD4hep_VolumeDump --topstat
+  REGEX_PASS "Checked 130738 physical volume placements"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR" )
+#
+endif(DD4HEP_HAVE_HIGHER_ROOT_VERSION)
+#
 #---Geant4 Testsing-----------------------------------------------------------------
 #
 if (DD4HEP_USE_GEANT4)

--- a/examples/CLICSiD/compact/compact_nocalo.xml
+++ b/examples/CLICSiD/compact/compact_nocalo.xml
@@ -1,0 +1,1339 @@
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="clic_sid_cdr"
+        title="CLIC Silicon Detector CDR"
+        author="Christian Grefe"
+        url="https://twiki.cern.ch/twiki/bin/view/CLIC/ClicSidCdr"
+        status="development"
+        version="$Id$">
+    <comment>The compact format for the CLIC Silicon Detector used for the conceptual design report</comment>        
+  </info>
+
+  <includes>
+    <gdmlFile  ref="./elements.xml"/>
+    <gdmlFile  ref="./materials.xml"/>
+  </includes>
+  
+  <define>
+    <constant name="world_side" value="30000*mm"/>
+    <constant name="world_x" value="world_side"/>
+    <constant name="world_y" value="world_side"/>
+    <constant name="world_z" value="world_side"/>
+    
+    <constant name="CrossingAngle" value="0.020*rad"/>
+    
+    <constant name="CaloSides" value="12"/>
+    <constant name="MuonSides" value="8"/>
+    
+    <constant name="EcalBarrel_rmin" value="126.50*cm"/>
+    <constant name="EcalBarrel_zmax" value="176.50*cm"/>
+    <constant name="EcalEndcap_rmin" value="21.0*cm"/>
+    <constant name="EcalEndcap_rmax" value="(EcalBarrel_rmin - 1.5*cm) / (cos(pi/CaloSides))"/> <!-- Correction from going from inner circle to outer circle -->
+    <constant name="EcalEndcap_zmin" value="165.70*cm"/>
+    
+    <constant name="HcalBarrel_rmin" value="141.90*cm"/>
+    <constant name="HcalBarrel_layers" value="(int) 75"/>
+    <constant name="HcalBarrel_layer_thickness" value="1.0*cm + 0.65*cm"/>
+    <constant name="HcalEndcap_zmin" value="EcalBarrel_zmax + 4.0*cm"/> <!-- Gap for cables -->
+    <constant name="HcalEndcap_rmin" value="50.0*cm"/>
+    <constant name="HcalEndcap_rmax" value="(HcalBarrel_rmin + HcalBarrel_layers * HcalBarrel_layer_thickness) / (cos(pi/CaloSides))"/> <!-- Correction from going from inner circle to outer circle -->
+    <constant name="HcalEndcap_layers" value="60"/>
+    <constant name="HcalEndcap_layer_thickness" value="2.0*cm + 0.65*cm"/>
+    <constant name="HcalEndcap_zmax" value="HcalEndcap_zmin + HcalEndcap_layers * HcalEndcap_layer_thickness"/>
+    
+    <constant name="tracking_region_radius" value="EcalBarrel_rmin - 1.0*mm"/>
+    <constant name="tracking_region_zmax" value="EcalEndcap_zmin - 1.0*mm"/>
+    <constant name="VXD_CF_sensor" value="0.026*cm"/>
+    <constant name="VXD_CF_support" value="0.05*cm"/>
+    
+    <constant name="SolenoidBarrelInnerRadius" value="HcalEndcap_rmax + 2.0*cm"/>
+    <constant name="SolenoidCoilOuterZ" value="HcalEndcap_zmax"/> <!-- Aligned with HCAL endcap -->
+    <constant name="SolenoidBarrelInnerCryostatThickness" value="3.0*cm"/>
+    <constant name="SolenoidBarrelInnerAirgapThickness" value="11.0*cm"/>
+    <constant name="SolenoidBarrelAlConductorThickness" value="38.4*cm"/>
+    <constant name="SolenoidBarrelQuenchbackThickness" value="5.0*cm"/>
+    <constant name="SolenoidBarrelOuterAirgapThickness" value="18.7*cm"/>
+    <constant name="SolenoidBarrelOuterCryostatThickness" value="4.0*cm"/>
+    <constant name="SolenoidEndcapCryostatThickness" value="6.0*cm"/>
+    <constant name="SolenoidEndcapAirgapThickness" value="12.0*cm"/>
+    <constant name="SolenoidBarrelOuterZ" value="SolenoidCoilOuterZ+SolenoidEndcapAirgapThickness"/>
+    <constant name="SolenoidBarrelConductorInnerRadius" value="SolenoidBarrelInnerRadius + SolenoidBarrelInnerCryostatThickness + SolenoidBarrelInnerAirgapThickness"/>
+    <constant name="SolenoidBarrelOuterCryostatInnerRadius" value="SolenoidBarrelConductorInnerRadius + SolenoidBarrelAlConductorThickness + SolenoidBarrelQuenchbackThickness"/>
+    <constant name="SolenoidBarrelOuterRadius" value="SolenoidBarrelOuterCryostatInnerRadius + SolenoidBarrelOuterAirgapThickness + SolenoidBarrelOuterCryostatThickness"/>
+    <constant name="SolenoidalFieldRadius" value="(SolenoidBarrelConductorInnerRadius + SolenoidBarrelAlConductorThickness / 2.0)"/>
+    
+    <constant name="MuonBarrel_rmin" value="SolenoidBarrelOuterRadius + 1.0*cm"/>
+    <constant name="MuonBarrel_zmax" value="SolenoidBarrelOuterZ + SolenoidEndcapCryostatThickness"/>
+    <constant name="MuonBarrel_layers" value="15"/>
+    <constant name="MuonBarrel_layer_thickness" value="10.0*cm + 4.0*cm"/>
+    <constant name="MuonEndcap_zmin" value="MuonBarrel_zmax + 10.0*cm"/> <!-- Space for cables etc. -->
+    <constant name="MuonEndcap_rmin" value="69.0*cm"/> <!-- Space for QD0 and anti-solenoid-->
+    <constant name="MuonEndcap_rmax" value="(MuonBarrel_rmin + 57.0*cm + MuonBarrel_layers * MuonBarrel_layer_thickness) / (cos(pi/MuonSides))"/> <!-- Correction from going from inner circle to outer circle -->
+    <constant name="MuonEndcap_layers" value="18"/>
+    <constant name="MuonEndcap_layer_thickness" value="10.0*cm + 4.0*cm"/>
+    <constant name="MuonEndcap_zmax" value="MuonEndcap_zmin + MuonEndcap_layers * MuonEndcap_layer_thickness"/>
+    
+    <constant name="LumiCal_rmin" value="6.4*cm"/>
+    <constant name="LumiCal_rmax" value="EcalEndcap_rmin + 3.0*cm"/>
+    <constant name="LumiCal_zmin" value="HcalEndcap_zmin"/>
+    <constant name="LumiCal_thickness" value="20*0.371*cm + 15*0.643*cm"/>
+    <constant name="LumiCal_zmax" value="LumiCal_zmin + LumiCal_thickness"/>
+    <constant name="LumiCalElectronics_rmax" value="LumiCal_rmax+5.0*cm"/>
+    
+    <constant name="SupportTube_thickness" value="1.0*cm"/>
+    <constant name="ForwardVacuumValve_thickness" value="36.0*cm"/>
+    <constant name="ForwardShielding_thickness" value="5.0*cm"/>
+    <constant name="ForwardMask_thickness" value="10.0*cm"/>
+    <constant name="ForwardMask_zmin" value="LumiCal_zmax + ForwardShielding_thickness + ForwardVacuumValve_thickness"/>
+    <constant name="BeamCal_rmax" value="13.0*cm"/>
+    <constant name="BeamCal_zmin" value="ForwardMask_zmin + ForwardMask_thickness"/>
+    
+    <constant name="VertexSupport_r1" value="16.87*cm"/>
+    <constant name="VertexSupport_r2" value="18.42*cm"/>
+    <constant name="VertexSupport_zmax" value="89.48*cm"/>
+    
+    <constant name="VertexBarrel_zmax" value="10.0*cm"/>
+    <constant name="VertexBarrel_r1" value="2.7*cm"/>
+    <constant name="VertexBarrel_r2" value="3.8*cm"/>
+    <constant name="VertexBarrel_r3" value="5.1*cm"/>
+    <constant name="VertexBarrel_r4" value="6.4*cm"/>
+    <constant name="VertexBarrel_r5" value="7.7*cm"/>
+    
+    <constant name="CentralBeamPipe_zmax" value="23.0*cm"/>
+    <constant name="CentralBeamPipe_rmax" value="VertexBarrel_r1 - 0.2*cm"/>
+    <constant name="CentralBeamPipe_thickness" value="CentralBeamPipe_rmax * 0.02"/> <!-- 1% of the diameter -->
+    <constant name="CentralBeamPipe_rmin" value="CentralBeamPipe_rmax - CentralBeamPipe_thickness"/>
+    <constant name="BeamPipe_thickness" value="0.4*cm"/>
+    <constant name="BeamPipe_endThickness" value="0.1*cm"/>
+    <constant name="BeamPipe_zmax" value="LumiCal_zmin - 0.5*cm"/>
+    <constant name="BeamPipe_rmax" value="19.0*cm"/>
+    <constant name="BeamPipe_rmin" value="BeamPipe_rmax - BeamPipe_thickness"/>
+    <constant name="bp_cone_slope" value="(BeamPipe_rmax-CentralBeamPipe_rmax)/(tracking_region_zmax-CentralBeamPipe_zmax)"/>
+    <constant name="BeamPipe_zmin" value="CentralBeamPipe_zmax + (BeamPipe_thickness - CentralBeamPipe_thickness)/bp_cone_slope"/>
+    <constant name="BeamPipeLiner_thickness" value="0.0*cm"/>
+    
+    <constant name="VertexEndcap_rmax" value="11.5*cm"/>
+    <constant name="VertexEndcap_z1" value="12.0*cm"/>
+    <constant name="VertexEndcap_z2" value="16.0*cm"/>
+    <constant name="VertexEndcap_z3" value="20.0*cm"/>
+    <constant name="VertexEndcap_z4" value="24.0*cm"/>
+    <constant name="VertexEndcap_offset" value="0.2*cm"/>
+    <constant name="VertexEndcapModules" value="16"/>
+    <constant name="VertexEndcap_rmin1" value="CentralBeamPipe_rmax + VertexEndcap_offset"/>
+    <constant name="VertexEndcap_rmin2" value="CentralBeamPipe_rmax + VertexEndcap_offset"/>
+    <constant name="VertexEndcap_rmin3" value="CentralBeamPipe_rmax + VertexEndcap_offset"/>
+    <constant name="VertexEndcap_rmin4" value="(VertexEndcap_z4 - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + VertexEndcap_offset"/>
+    
+    <constant name="ForwardTracker_rmax" value="16.87*cm"/>
+    <constant name="ForwardTracker_z1" value="28.0*cm"/>
+    <constant name="ForwardTracker_z2" value="50.0*cm"/>
+    <constant name="ForwardTracker_z3" value="83.0*cm"/>
+    <constant name="ForwardTracker_offset" value="0.2*cm"/>
+    <constant name="ForwardTrackerModules" value="16"/>
+    <constant name="ForwardTracker_rmin1" value="(ForwardTracker_z1 - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + ForwardTracker_offset"/>
+    <constant name="ForwardTracker_rmin2" value="(ForwardTracker_z2 - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + ForwardTracker_offset"/>
+    <constant name="ForwardTracker_rmin3" value="(ForwardTracker_z3 - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + ForwardTracker_offset"/>
+    
+    <constant name="VertexService_zmin" value="ForwardTracker_z1 + 1.0*cm"/>
+    <constant name="VertexService_zmax" value="VertexService_zmin + 2.0*cm"/>
+    <constant name="VertexServiceThickness" value="0.3*cm"/>
+    <constant name="VertexCableThickness" value="0.005*cm"/>
+    
+    <constant name="IncomingBP_radius" value="0.25*cm"/>
+    <constant name="IncomingBP_thickness" value="0.05*cm"/>
+    <constant name="OutgoingBP_radius" value="tan(CrossingAngle/2/rad)*BeamCal_zmin"/>
+    <constant name="OutgoingBP_thickness" value="0.1*cm"/>
+    
+  </define>
+  <materials>
+    <material name="TungstenDens23">
+      <D value="17.7" unit="g/cm3"/>
+      <fraction n="0.925" ref="W"/>
+      <fraction n="0.066" ref="Ni"/>
+      <fraction n="0.009" ref="Fe"/>
+    </material>
+    <material name="TungstenDens24">
+      <D value="17.8" unit="g/cm3"/>
+      <fraction n="0.93" ref="W"/>
+      <fraction n="0.061" ref="Ni"/>
+      <fraction n="0.009" ref="Fe"/>
+    </material>
+    <material name="TungstenDens25">
+      <D value="18.2" unit="g/cm3"/>
+      <fraction n="0.950" ref="W"/>
+      <fraction n="0.044" ref="Ni"/>
+      <fraction n="0.006" ref="Fe"/>
+    </material>
+    <material name="CarbonFiber_25percent">
+      <D type="density" value="0.375" unit="g/cm3"/>
+      <fraction n="1.0" ref="CarbonFiber"/>
+    </material>
+    <material name="CarbonFiber_15percent">
+      <D type="density" value="0.225" unit="g/cm3"/>
+      <fraction n="1.0" ref="CarbonFiber"/>
+    </material>
+    <material name="Rohacell31_50percent">
+      <D type="density" value="0.016" unit="g/cm3"/>
+      <fraction n="1.0" ref="Rohacell31"/>
+    </material>
+    <material name="Rohacell31_15percent">
+      <D type="density" value="0.0048" unit="g/cm3"/>
+      <fraction n="1.0" ref="Rohacell31"/>
+    </material>
+    <material name="BoratedPolyethylene5">
+      <D value="0.93" unit="g/cm3"/>
+      <fraction n="0.612" ref="C"/>
+      <fraction n="0.222" ref="O"/>
+      <fraction n="0.116" ref="H"/>
+      <fraction n="0.050" ref="B"/>
+    </material>
+    <material name="SiliconCarbide">
+      <D value="3.1" unit="g/cm3"/>
+      <composite n="1" ref="Si"/>
+      <composite n="1" ref="C"/>
+    </material> 
+    <material name="SiliconCarbide_6percent">
+      <D value="0.186" unit="g/cm3"/>
+      <fraction n="1.0" ref="SiliconCarbide"/>
+    </material>
+    <material name="Graphite">
+      <D value="1.7" unit="g/cm3"/>
+      <composite n="1" ref="C"/>
+    </material>      
+  </materials>
+  <limits>
+    <limitset name="cal_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+  </limits>
+
+  <display>
+    <vis name="InvisibleNoDaughters"      showDaughters="false" visible="false"/>
+    <vis name="InvisibleWithDaughters"    showDaughters="true" visible="false"/>
+    <vis name="SiVertexBarrelModuleVis"   alpha="1.0" r="1" g="1" b="0.6" drawingStyle="wireframe" showDaughters="true" visible="true"/>
+    <vis name="SiVertexSensitiveVis"      alpha="1.0" r="1" g="0.2" b="0.2" drawingStyle="solid" showDaughters="true" visible="true"/>
+    <vis name="SiVertexPassiveVis"        alpha="1.0" r="0" g="0.2" b="1" drawingStyle="solid" showDaughters="true" visible="true"/>
+    <vis name="SiVertexBarrelLayerVis"    alpha="0.1" r="1" g="1" b="0.6" showDaughters="true" visible="false"/>
+    
+    <vis name="SiVertexEndcapLayerVis"    alpha="0.1" r="1" g="0.75" b="0" showDaughters="false" visible="true"/>
+
+    <vis name="SiTrackerBarrelModuleVis"  alpha="0.5" r="0" g="1" b="0.6" drawingStyle="wireframe" showDaughters="false" visible="true"/>
+    <vis name="SiTrackerBarrelLayerVis"   alpha="0.1" r="1" g="1" b="0.6" showDaughters="true" visible="true"/>
+    
+    <vis name="SiTrackerEndcapModuleVis" alpha="0.5" r="0.8" g="1.0" b="0.1" drawingStyle="wireframe" showDaughters="false" visible="true"/>        
+    
+    <vis name="SiTrackerForwardVis" alpha="1.0" r="0.8" g="0.1" b="0.1" showDaughters="false" visible="true"/>
+    
+    <vis name="EcalBarrelVis" alpha="1.0" r="0" g="0" b="0.3" showDaughters="true" visible="true"/>
+    <vis name="EcalBarrelStaveVis" alpha="1.0" r="1" g="0.9" b="0.5" showDaughters="false" visible="true"/>
+
+    <vis name="EcalEndcapVis"       alpha="1" r="0.77" g="0.74" b="0.86" showDaughters="false" visible="true"/>
+
+    <vis name="HcalBarrelVis"          alpha="0.1" r="1"    g="1"    b="0.1" showDaughters="true" visible="true"/>
+    <vis name="HcalBarrelStavesVis"    alpha="0.1" r="1"    g="0"    b="0.3" showDaughters="true" visible="true"/>
+    <vis name="HcalBarrelLayerVis"     alpha="0.5" r="1"    g="0"    b="0.5" showDaughters="true" visible="true"/>
+    <vis name="HcalBarrelSensorVis"    alpha="1"   r="1"    g="1"    b="0.7" showDaughters="true" visible="true"/>
+
+    <vis name="HcalEndcapVis"          alpha="0.1" r="1"    g="1"    b="0.1" showDaughters="false" visible="true"/>
+    <vis name="HcalEndcapLayerVis"     alpha="1"   r="1"    g="0"    b="0.5" showDaughters="false" visible="true"/>
+    
+    <vis name="SolenoidBarrelLayerVis" alpha="1" r="0"    g="0.3"  b="0.3" showDaughters="false" visible="true"/>
+    <vis name="SolenoidCoilEndsVis"    alpha="1" r="0"    g="0.9"  b="0.9" showDaughters="false" visible="true"/>
+    <vis name="AntiSolenoidVis"        alpha="1" r="0.3"  g="1"    b="1"   showDaughters="false" visible="true"/>
+
+    <vis name="MuonBarrelVis"          alpha="0.1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
+    <vis name="MuonBarrelStavesVis"    alpha="0.3" r="0"    g="0.7"  b="0.3" showDaughters="true" visible="true"/>
+    <vis name="MuonBarrelLayerVis"     alpha="0.5" r="0"    g="1"    b="0.3" showDaughters="true" visible="true"/>
+    <vis name="MuonBarrelSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
+    <vis name="MuonBarrelAbsorberVis"  alpha="1" r="0.28" g="0.4"  b="0.62" visible="true"/>        
+
+    <vis name="MuonEndcapVis"          alpha="0.1" r="1"    g="0.4"  b="0.62" showDaughters="true" visible="true"/>
+    <vis name="MuonEndcapLayerVis"     alpha="1" r="0"    g="1"    b="0.3"  showDaughters="true" visible="true"/>
+    <vis name="MuonEndcapSensorVis"    alpha="1" r="0.54" g="0.4"  b="0.41" visible="true"/>
+    <vis name="MuonEndcapAbsorberVis"  alpha="0.3" r="0.28" g="0.4"  b="0.62" visible="true"/>        
+    
+    
+    <vis name="BeamPipeVis" r="0.0" g="0.99" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="CableVis" showDaughters="false" visible="true"/>
+    
+    <vis name="SupportTubeVis" r="0.1" g="0.1" b="0.99" showDaughters="false" visible="true"/>
+    <vis name="TungstenShieldingVis" r="0.99" g="0.1" b="0.2" showDaughters="false" visible="true"/>
+    
+    <vis name="SupportVis" r="0.8" g="0.8" b="0" showDaughters="false" visible="true"/>
+    <vis name="LumiCalVis" showDaughters="false" visible="true"/>
+    <vis name="GreenVis" r="0.0" g="1.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="RedVis" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="BlueVis" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
+  </display>
+
+
+
+  <detectors>
+
+    <comment>Trackers</comment> 
+    <detector id="1" name="SiVertexBarrel" type="DD4hep_SiTrackerBarrel" readout="SiVertexBarrelHits" insideTrackingVolume="true">
+      <comment>Vertex Detector Barrel</comment>
+      <module name="VtxBarrelModuleInner" vis="SiVertexBarrelModuleVis">
+	<module_envelope width="10.0*mm" length="(VertexBarrel_zmax - 0.1*cm) * 2" thickness="0.6*mm"/>
+	<module_component width="7.8*mm" length="(VertexBarrel_zmax - 0.15*cm) * 2" thickness="0.0130*cm" material="Carbon" sensitive="false" vis="SiVertexPassiveVis">
+	  <position z="-0.12*mm"/>
+	</module_component>
+	<module_component width="9.8*mm" length="(VertexBarrel_zmax - 0.15*cm) * 2" thickness="0.005*cm" material="Silicon" sensitive="true" vis="SiVertexSensitiveVis">
+	  <position z="0.225*mm"/>
+	</module_component>
+      </module>
+      <module name="VtxBarrelModuleOuter" vis="SiVertexBarrelModuleVis">
+	<module_envelope width="14.0*mm" length="(VertexBarrel_zmax - 0.1*cm) * 2" thickness="0.6*mm"/>
+	<module_component width="11.6*mm" length="(VertexBarrel_zmax - 0.15*cm) * 2" thickness="0.0130*cm" material="Carbon" sensitive="false" vis="SiVertexPassiveVis">
+	  <position z="-0.12*mm"/>
+	</module_component>
+	<module_component width="13.8*mm" length="(VertexBarrel_zmax - 0.15*cm) * 2" thickness="0.005*cm" material="Silicon" sensitive="true" vis="SiVertexSensitiveVis">
+	  <position z="0.210*mm"/>
+	</module_component>
+      </module>
+      <layer module="VtxBarrelModuleInner" id="1" vis="SiVertexBarrelLayerVis">
+	<barrel_envelope inner_r="VertexBarrel_r1 - 0.2*cm" outer_r="VertexBarrel_r1 + 0.2*cm" z_length="VertexBarrel_zmax * 2"/>
+	<rphi_layout phi_tilt="0.0*rad" nphi="18" phi0="0.2618*rad" rc="VertexBarrel_r1" dr="-1.15*mm"/>
+	<z_layout dr="0.0*mm" z0="0.0*mm" nz="1"/>
+      </layer>
+      <layer module="VtxBarrelModuleOuter" id="2" vis="SiVertexBarrelLayerVis">
+	<barrel_envelope inner_r="VertexBarrel_r2 - 0.2*cm" outer_r="VertexBarrel_r2 + 0.2*cm" z_length="VertexBarrel_zmax * 2"/>
+	<rphi_layout phi_tilt="0.0*rad" nphi="18" phi0="0.2618*rad" rc="VertexBarrel_r2" dr="-1.13*mm"/>
+	<z_layout dr="0.0*mm" z0="0.0*mm" nz="1"/>
+      </layer>
+      <layer module="VtxBarrelModuleOuter" id="3" vis="SiVertexBarrelLayerVis">
+	<barrel_envelope inner_r="VertexBarrel_r3 - 0.2*cm" outer_r="VertexBarrel_r3 + 0.2*cm" z_length="VertexBarrel_zmax * 2"/>
+	<rphi_layout phi_tilt="0.0*rad" nphi="24" phi0="0.0*rad" rc="VertexBarrel_r3" dr="-0.89*mm"/>
+	<z_layout dr="0.0*mm" z0="0.0*mm" nz="1"/>
+      </layer>
+      <layer module="VtxBarrelModuleOuter" id="4" vis="SiVertexBarrelLayerVis">
+	<barrel_envelope inner_r="VertexBarrel_r4 - 0.2*cm" outer_r="VertexBarrel_r4 + 0.2*cm" z_length="VertexBarrel_zmax * 2"/>
+	<rphi_layout phi_tilt="0.0*rad" nphi="30" phi0="0.1309*rad" rc="VertexBarrel_r4" dr="0.81*mm"/>
+	<z_layout dr="0.0*mm" z0="0.0*mm" nz="1"/>
+      </layer>
+      <layer module="VtxBarrelModuleOuter" id="5" vis="SiVertexBarrelLayerVis">
+	<barrel_envelope inner_r="VertexBarrel_r5 - 0.2*cm" outer_r="VertexBarrel_r5 + 0.2*cm" z_length="VertexBarrel_zmax * 2"/>
+	<rphi_layout phi_tilt="0.0*rad" nphi="36" phi0="0.0*rad" rc="VertexBarrel_r5" dr="0.77*mm"/>
+	<z_layout dr="0.0*mm" z0="0.0*mm" nz="1"/>
+      </layer>
+    </detector>
+
+    <comment>Vertex Detector Endcaps</comment>
+    <detector id="2" name="SiVertexEndcap" type="DD4hep_SiTrackerEndcap2" readout="SiVertexEndcapHits" reflect="true">    
+      <module name="SiVertexEndcapModule1">
+	<trd x1="VertexEndcap_rmin1 * tan(pi/(VertexEndcapModules-0.1))" x2="VertexEndcap_rmax * sin(pi/(VertexEndcapModules-0.1*cm))" z="(VertexEndcap_rmax - VertexEndcap_rmin1) / 2" />
+	<module_component thickness="0.005*cm" material="Silicon" sensitive="true"  vis="SiVertexSensitiveVis"/>
+	<module_component thickness="0.013*cm"   material="Carbon" vis="SiVertexPassiveVis" />
+      </module>
+      <module name="SiVertexEndcapModule2">
+	<trd x1="VertexEndcap_rmin2 * tan(pi/(VertexEndcapModules-0.1))" x2="VertexEndcap_rmax * sin(pi/(VertexEndcapModules-0.1*cm))" z="(VertexEndcap_rmax - VertexEndcap_rmin2) / 2" />
+	<module_component thickness="0.005*cm" material="Silicon" sensitive="true"  vis="SiVertexSensitiveVis"/>
+	<module_component thickness="0.013*cm"   material="Carbon" vis="SiVertexPassiveVis" />
+      </module>
+      <module name="SiVertexEndcapModule3">
+	<trd x1="VertexEndcap_rmin3 * tan(pi/(VertexEndcapModules-0.1))" x2="VertexEndcap_rmax * sin(pi/(VertexEndcapModules-0.1*cm))" z="(VertexEndcap_rmax - VertexEndcap_rmin3) / 2" />
+	<module_component thickness="0.005*cm" material="Silicon" sensitive="true"  vis="SiVertexSensitiveVis"/>
+	<module_component thickness="0.013*cm"   material="Carbon" vis="SiVertexPassiveVis" />
+      </module>
+      <module name="SiVertexEndcapModule4">
+	<trd x1="VertexEndcap_rmin4 * tan(pi/(VertexEndcapModules-0.1))" x2="VertexEndcap_rmax * sin(pi/(VertexEndcapModules-0.1*cm))" z="(VertexEndcap_rmax - VertexEndcap_rmin4) / 2" />
+	<module_component thickness="0.005*cm" material="Silicon" sensitive="true"  vis="SiVertexSensitiveVis"/>
+	<module_component thickness="0.013*cm"   material="Carbon"  vis="SiVertexPassiveVis"/>
+      </module>
+      <layer id="1"  vis="SiVertexEndcapLayerVis">
+	<ring r="(VertexEndcap_rmax + VertexEndcap_rmin1) / 2" zstart="VertexEndcap_z1" nmodules="(int) VertexEndcapModules" dz="0.011*cm" module="SiVertexEndcapModule1"/>
+      </layer>
+      <layer id="2"  vis="SiVertexEndcapLayerVis">
+	<ring r="(VertexEndcap_rmax + VertexEndcap_rmin2) / 2" zstart="VertexEndcap_z2" nmodules="(int) VertexEndcapModules" dz="0.011*cm" module="SiVertexEndcapModule2"/>
+      </layer>
+      <layer id="3"  vis="SiVertexEndcapLayerVis">
+	<ring r="(VertexEndcap_rmax + VertexEndcap_rmin3) / 2" zstart="VertexEndcap_z3" nmodules="(int) VertexEndcapModules" dz="0.011*cm" module="SiVertexEndcapModule3"/>
+      </layer>
+      <layer id="4"  vis="SiVertexEndcapLayerVis">
+	<ring r="(VertexEndcap_rmax + VertexEndcap_rmin4) / 2" zstart="VertexEndcap_z4" nmodules="(int) VertexEndcapModules" dz="0.011*cm" module="SiVertexEndcapModule4"/>
+      </layer>
+    </detector> 
+
+    <detector id="3" name="SiTrackerBarrel" type="DD4hep_SiTrackerBarrel" readout="SiTrackerBarrelHits">
+      <comment>Outer Tracker Barrel</comment>
+      <module name="SiTrackerModule_Layer1" vis="SiTrackerBarrelModuleVis">                
+	<module_envelope width="97.79*mm" length="97.79*mm" thickness="0.3*cm"/>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+	  <position z="-0.14*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="-0.122*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+	  <position z="-0.024*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+	  <position z="0.07475*cm" />
+	</module_component>
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="0.0915*cm" />
+	</module_component>                
+	<module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+	  <position z="0.1145*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+	  <position z="0.12974*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0038*cm" material="Kapton" sensitive="false">
+	  <position z="0.1375*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00038*cm" material="Copper" sensitive="false">
+	  <position z="0.146*cm"/>
+	</module_component>                
+      </module>
+      <module name="SiTrackerModule_Layer2" vis="SiTrackerBarrelModuleVis">                
+	<module_envelope width="97.79*mm" length="97.79*mm" thickness="0.3*cm"/>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+	  <position z="-0.14*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="-0.122*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+	  <position z="-0.024*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+	  <position z="0.07475*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="0.0915*cm" />
+	</module_component>                
+	<module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+	  <position z="0.1145*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+	  <position z="0.12974*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0051*cm" material="Kapton" sensitive="false">
+	  <position z="0.1375*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00052*cm" material="Copper" sensitive="false">
+	  <position z="0.146*cm"/>
+	</module_component>                
+      </module>
+      <module name="SiTrackerModule_Layer3" vis="SiTrackerBarrelModuleVis">                
+	<module_envelope width="97.79*mm" length="97.79*mm" thickness="0.3*cm"/>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+	  <position z="-0.14*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="-0.122*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+	  <position z="-0.024*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+	  <position z="0.07475*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="0.0915*cm" />
+	</module_component>                
+	<module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+	  <position z="0.1145*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+	  <position z="0.12974*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0064*cm" material="Kapton" sensitive="false">
+	  <position z="0.1375*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00065*cm" material="Copper" sensitive="false">
+	  <position z="0.146*cm"/>
+	</module_component>                
+      </module>
+      <module name="SiTrackerModule_Layer4" vis="SiTrackerBarrelModuleVis">                
+	<module_envelope width="97.79*mm" length="97.79*mm" thickness="0.3*cm"/>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+	  <position z="-0.14*cm" />
+	</module_component>               
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="-0.122*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+	  <position z="-0.024*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+	  <position z="0.07475*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="0.0915*cm" />
+	</module_component>                
+	<module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+	  <position z="0.1145*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+	  <position z="0.12974*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0078*cm" material="Kapton" sensitive="false">
+	  <position z="0.1375*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00079*cm" material="Copper" sensitive="false">
+	  <position z="0.146*cm"/>
+	</module_component>                
+      </module>
+      <module name="SiTrackerModule_Layer5" vis="SiTrackerBarrelModuleVis">                
+	<module_envelope width="97.79*mm" length="97.79*mm" thickness="0.3*cm"/>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.02*cm" material="PEEK" sensitive="false">
+	  <position z="-0.14*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="-0.122*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.18*cm" material="Rohacell31_50D" sensitive="false">
+	  <position z="-0.024*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0175*cm" material="Epoxy" sensitive="false">
+	  <position z="0.07475*cm" />
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.016*cm" material="CarbonFiber_50D" sensitive="false">
+	  <position z="0.0915*cm" />
+	</module_component>                
+	<module_component width="92.031*mm" length="92.031*mm" thickness="0.03*cm" material="Silicon" sensitive="true">
+	  <position z="0.1145*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00048*cm" material="Silicon" sensitive="false">
+	  <position z="0.12974*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.0091*cm" material="Kapton" sensitive="false">
+	  <position z="0.1375*cm"/>
+	</module_component>                
+	<module_component width="97.79*mm" length="97.79*mm" thickness="0.00093*cm" material="Copper" sensitive="false">
+	  <position z="0.146*cm"/>
+	</module_component>                
+      </module>
+      <layer module="SiTrackerModule_Layer1" id="1" vis="SiTrackerBarrelLayerVis">
+	<barrel_envelope inner_r="215.075*mm" outer_r="245.0*mm" z_length="578 * 2*mm"/>
+	<rphi_layout phi_tilt="0.17506*rad" nphi="20" phi0="0." rc="(216.355 + 5.0)*mm" dr="0.0"/>
+	<z_layout dr="4.0*mm" z0="512.128*mm" nz="13"/>
+      </layer>                
+      <layer module="SiTrackerModule_Layer2" id="2" vis="SiTrackerBarrelLayerVis">
+	<barrel_envelope inner_r="465.075*mm" outer_r="501.0*mm" z_length="749.8 * 2*mm"/>
+	<rphi_layout phi_tilt="0.12217*rad" nphi="38" phi0="0.087*rad" rc="(466.355 + 5.0)*mm" dr="0.0"/>
+	<z_layout dr="4.0*mm" z0="690.605*mm" nz="17"/>
+      </layer>
+      <layer module="SiTrackerModule_Layer3" id="3" vis="SiTrackerBarrelLayerVis">
+	<barrel_envelope inner_r="715.075*mm" outer_r="756.0*mm" z_length="1013.9 * 2*mm"/>
+	<rphi_layout phi_tilt="0.11493*rad" nphi="58" phi0="0.058*rad" rc="(716.355 + 5.0)*mm" dr="0.0"/>
+	<z_layout dr="4.0*mm" z0="954.625*mm" nz="23"/>
+      </layer>            
+      <layer module="SiTrackerModule_Layer4" id="4" vis="SiTrackerBarrelLayerVis">
+	<barrel_envelope inner_r="965.075*mm" outer_r="1012.0*mm" z_length="1272.3 * 2*mm"/>
+	<rphi_layout phi_tilt="0.11502*rad" nphi="80" phi0="0.0436*rad" rc="(966.355 + 5.0)*mm" dr="0.0"/>
+	<z_layout dr="4.0*mm" z0="1213.073*mm" nz="29"/>
+      </layer>                        
+      <layer module="SiTrackerModule_Layer5" id="5" vis="SiTrackerBarrelLayerVis">
+	<barrel_envelope inner_r="1215.075*mm" outer_r="1263.0*mm" z_length="1535.7 * 2*mm"/>
+	<rphi_layout phi_tilt="0.11467*rad" nphi="102" phi0="0.01745*rad" rc="(1216.355 + 5.0)*mm" dr="0.0"/>
+	<z_layout dr="4.0*mm" z0="1476.497*mm" nz="35"/>
+      </layer>
+    </detector>
+
+    <detector id="4" name="SiTrackerEndcap" type="DD4hep_SiTrackerEndcap2" readout="SiTrackerEndcapHits" reflect="true">
+      <comment>Outer Tracker Endcaps</comment>
+      <module name="Module1" vis="SiTrackerEndcapModuleVis">
+	<trd x1="36.112*mm" x2="46.635*mm" z="100.114/2*mm" />
+	<module_component thickness="0.00052*cm"   material="Copper" />
+	<module_component thickness="0.0051*cm"   material="Kapton" />
+	<module_component thickness="0.00048*cm" material="Silicon" />
+	<module_component thickness="0.03*cm"   material="Silicon" sensitive="true" />
+	<module_component thickness="0.016*cm" material="CarbonFiber_50D" />
+	<module_component thickness="0.18*cm" material="Rohacell31_50D" />
+	<module_component thickness="0.016*cm" material="CarbonFiber_50D" />
+	<module_component thickness="0.0175*cm" material="Epoxy" />
+	<module_component thickness="0.03*cm"   material="Silicon" sensitive="true" />
+	<module_component thickness="0.00048*cm" material="Silicon" />
+	<module_component thickness="0.0051*cm"   material="Kapton" />
+	<module_component thickness="0.00052*cm"   material="Copper" />
+      </module> 
+      <module name="Module2" vis="SiTrackerEndcapModuleVis">
+	<trd x1="45.245*mm" x2="54.680*mm" z="89.773/2*mm" />
+	<module_component thickness="0.00079*cm"   material="Copper" />
+	<module_component thickness="0.0078*cm"   material="Kapton" />
+	<module_component thickness="0.00048*cm" material="Silicon" />
+	<module_component thickness="0.03*cm"   material="Silicon" sensitive="true" />
+	<module_component thickness="0.016*cm" material="CarbonFiber_50D" />
+	<module_component thickness="0.18*cm" material="Rohacell31_50D" />
+	<module_component thickness="0.016*cm" material="CarbonFiber_50D" />
+	<module_component thickness="0.0175*cm" material="Epoxy" />
+	<module_component thickness="0.03*cm"   material="Silicon" sensitive="true" />
+	<module_component thickness="0.00048*cm" material="Silicon" />
+	<module_component thickness="0.0078*cm"   material="Kapton" />
+	<module_component thickness="0.00079*cm"   material="Copper" />
+      </module>
+      <layer id="1">
+	<ring r="256.716*mm" zstart="(787.105+1.75)*mm" nmodules="24" dz="1.75*mm" module="Module1"/>
+	<ring r="353.991*mm" zstart="(778.776+1.75)*mm" nmodules="32" dz="1.75*mm" module="Module1"/>
+	<ring r="449.180*mm" zstart="(770.544+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module1"/>
+      </layer>
+      <layer id="2">
+	<ring r="256.716*mm" zstart="(1073.293+1.75)*mm" nmodules="24" dz="1.75*mm" module="Module1"/>
+	<ring r="353.991*mm" zstart="(1064.966+1.75)*mm" nmodules="32" dz="1.75*mm" module="Module1"/>
+	<ring r="449.180*mm" zstart="(1056.734+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module1"/>
+	<ring r="538.520*mm" zstart="(1048.466+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module2"/>
+	<ring r="625.654*mm" zstart="(1041.067+1.75)*mm" nmodules="48" dz="1.75*mm" module="Module2"/>
+	<ring r="703.666*mm" zstart="(1033.725+1.75)*mm" nmodules="54" dz="1.75*mm" module="Module2" phi0="pi/54"/>
+      </layer>
+      <layer id="3">
+	<ring r="256.716*mm" zstart="(1353.786+1.75)*mm" nmodules="24" dz="1.75*mm" module="Module1"/>
+	<ring r="353.991*mm" zstart="(1345.457+1.75)*mm" nmodules="32" dz="1.75*mm" module="Module1"/>
+	<ring r="449.180*mm" zstart="(1337.225+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module1"/>
+	<ring r="538.520*mm" zstart="(1328.957+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module2"/>
+	<ring r="625.654*mm" zstart="(1321.558+1.75)*mm" nmodules="48" dz="1.75*mm" module="Module2"/>
+	<ring r="703.666*mm" zstart="(1314.217+1.75)*mm" nmodules="54" dz="1.75*mm" module="Module2" phi0="pi/54"/>
+	<ring r="793.448*mm" zstart="(1306.828+1.75)*mm" nmodules="58" dz="1.75*mm" module="Module2" phi0="pi/58"/>
+	<ring r="874.239*mm" zstart="(1299.486+1.75)*mm" nmodules="64" dz="1.75*mm" module="Module2"/>
+	<ring r="958.364*mm" zstart="(1292.189+1.75)*mm" nmodules="68" dz="1.75*mm" module="Module2"/>
+      </layer>
+      <layer id="4">
+	<ring r="256.716*mm" zstart="(1639.164+1.75)*mm" nmodules="24" dz="1.75*mm" module="Module1"/>
+	<ring r="353.991*mm" zstart="(1630.835+1.75)*mm" nmodules="32" dz="1.75*mm" module="Module1"/>
+	<ring r="449.180*mm" zstart="(1622.603+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module1"/>
+	<ring r="538.520*mm" zstart="(1614.335+1.75)*mm" nmodules="40" dz="1.75*mm" module="Module2"/>
+	<ring r="625.654*mm" zstart="(1606.936+1.75)*mm" nmodules="48" dz="1.75*mm" module="Module2"/>
+	<ring r="703.666*mm" zstart="(1599.595+1.75)*mm" nmodules="54" dz="1.75*mm" module="Module2" phi0="pi/54"/>
+	<ring r="793.448*mm" zstart="(1592.206+1.75)*mm" nmodules="58" dz="1.75*mm" module="Module2" phi0="pi/58"/>
+	<ring r="874.239*mm" zstart="(1584.864+1.75)*mm" nmodules="64" dz="1.75*mm" module="Module2"/>
+	<ring r="958.364*mm" zstart="(1577.567+1.75)*mm" nmodules="68" dz="1.75*mm" module="Module2"/>
+	<ring r="1040.970*mm" zstart="(1570.222+1.75)*mm" nmodules="72" dz="1.75*mm" module="Module2"/>
+	<ring r="1124.167*mm" zstart="(1562.916+1.75)*mm" nmodules="78" dz="1.75*mm" module="Module2" phi0="pi/78"/>
+	<ring r="1206.937*mm" zstart="(1555.647+1.75)*mm" nmodules="84" dz="1.75*mm" module="Module2"/>
+      </layer>
+    </detector>
+    
+    <detector id="5" name="SiTrackerForward" type="DD4hep_SiTrackerEndcap2" readout="SiTrackerForwardHits">    
+      <comment>Forward Tracker inside Vertex Support Barrel</comment>
+      <module name="SiTrackerForwardModule1">
+	<trd x1="ForwardTracker_rmin1 * tan(pi/(ForwardTrackerModules-0.1))" x2="ForwardTracker_rmax * sin(pi/(ForwardTrackerModules-0.1))" z="(ForwardTracker_rmax - ForwardTracker_rmin1) / 2" />
+	<module_component thickness="0.005*cm" material="Silicon" sensitive="true" />
+	<module_component thickness="0.013*cm"   material="Carbon" />
+      </module>
+      <module name="SiTrackerForwardModule2">
+	<trd x1="ForwardTracker_rmin2 * tan(pi/(ForwardTrackerModules-0.1))" x2="ForwardTracker_rmax * sin(pi/(ForwardTrackerModules-0.1))" z="(ForwardTracker_rmax - ForwardTracker_rmin2) / 2" />
+	<module_component thickness="0.005*cm" material="Silicon" sensitive="true" />
+	<module_component thickness="0.013*cm"   material="Carbon" />
+      </module>
+      <module name="SiTrackerForwardModule3">
+	<trd x1="ForwardTracker_rmin3 * tan(pi/(ForwardTrackerModules-0.1))" x2="ForwardTracker_rmax * sin(pi/(ForwardTrackerModules-0.1))" z="(ForwardTracker_rmax - ForwardTracker_rmin3) / 2" />
+	<module_component thickness="0.005*cm" material="Silicon" sensitive="true" />
+	<module_component thickness="0.013*cm"   material="Carbon" />
+      </module>
+      <layer id="1">
+	<ring r="(ForwardTracker_rmax + ForwardTracker_rmin1) / 2" zstart="ForwardTracker_z1" nmodules="(int) ForwardTrackerModules" dz="0.011*mm" module="SiTrackerForwardModule1"/>
+      </layer>
+      <layer id="2">
+	<ring r="(ForwardTracker_rmax + ForwardTracker_rmin2) / 2" zstart="ForwardTracker_z2" nmodules="(int) ForwardTrackerModules" dz="0.011*mm" module="SiTrackerForwardModule2"/>
+      </layer>
+      <layer id="3">
+	<ring r="(ForwardTracker_rmax + ForwardTracker_rmin3) / 2" zstart="ForwardTracker_z3" nmodules="(int) ForwardTrackerModules" dz="0.011*mm" module="SiTrackerForwardModule3"/>
+      </layer>
+    </detector>
+
+    <comment>Calorimeters</comment>
+
+    <comment>Dead material and supports</comment>
+    <comment>Beampipe</comment> 
+    <detector name="Beampipe" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="BeamPipeVis">
+      <comment>Central Be Beampipe</comment>
+      <material name="Beryllium"/>
+      <zplane rmin="CentralBeamPipe_rmin" rmax="CentralBeamPipe_rmax" z="-CentralBeamPipe_zmax"/>
+      <zplane rmin="CentralBeamPipe_rmin" rmax="CentralBeamPipe_rmax" z="CentralBeamPipe_zmax" />
+    </detector>
+    <detector name="SteelConeZbackward" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="BeamPipeVis">
+      <material name="Iron"/>            
+      <zplane rmin="BeamPipe_rmax - BeamPipe_thickness"
+	      rmax="BeamPipe_rmax"
+	      z="-tracking_region_zmax" /> 
+      <zplane rmin="CentralBeamPipe_rmin"
+	      rmax="(BeamPipe_zmin - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      z="-BeamPipe_zmin" />
+      <zplane rmin="CentralBeamPipe_rmin"
+	      rmax="CentralBeamPipe_rmax"
+	      z="-CentralBeamPipe_zmax"/>
+    </detector>
+    <detector name="SteelConeZbackward2" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="BeamPipeVis">
+      <material name="Iron"/>            
+      <zplane rmin="BeamPipe_rmax - BeamPipe_thickness"
+	      rmax="BeamPipe_rmax"
+	      z="-(tracking_region_zmax + 0.01*cm)" /> 
+      <zplane rmin="BeamPipe_rmax - BeamPipe_thickness"
+	      rmax="BeamPipe_rmax"
+	      z="- BeamPipe_zmax" />
+      <zplane rmin="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      rmax="BeamPipe_rmax"
+	      z="- (LumiCal_zmin - 2*BeamPipe_endThickness)" />
+      <zplane rmin="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      rmax="LumiCal_rmin - BeamPipe_endThickness"
+	      z="- (LumiCal_zmin - BeamPipe_endThickness)" />
+      <zplane rmin="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      rmax="LumiCal_rmin - BeamPipe_endThickness"
+	      z="- (ForwardMask_zmin - BeamPipe_endThickness)" />
+    </detector>
+    <detector name="SteelConeZforward" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="BeamPipeVis">
+      <material name="Iron"/>
+      <zplane rmin="CentralBeamPipe_rmin"
+	      rmax="CentralBeamPipe_rmax"
+	      z="CentralBeamPipe_zmax"/>            
+      <zplane rmin="CentralBeamPipe_rmin"
+	      rmax="(BeamPipe_zmin - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      z="BeamPipe_zmin" /> 
+      <zplane rmin="BeamPipe_rmax - BeamPipe_thickness"
+	      rmax="BeamPipe_rmax"
+	      z="tracking_region_zmax" />
+    </detector>
+    <detector name="SteelConeZforward2" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="BeamPipeVis">
+      <material name="Iron"/>            
+      <zplane rmin="BeamPipe_rmax - BeamPipe_thickness"
+	      rmax="BeamPipe_rmax"
+	      z="tracking_region_zmax + 0.01*cm" /> 
+      <zplane rmin="BeamPipe_rmax - BeamPipe_thickness"
+	      rmax="BeamPipe_rmax"
+	      z="BeamPipe_zmax" />
+      <zplane rmin="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      rmax="BeamPipe_rmax"
+	      z="LumiCal_zmin - 2*BeamPipe_endThickness" />
+      <zplane rmin="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      rmax="LumiCal_rmin - BeamPipe_endThickness"
+	      z="LumiCal_zmin - BeamPipe_endThickness" />
+      <zplane rmin="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      rmax="LumiCal_rmin - BeamPipe_endThickness"
+	      z="ForwardMask_zmin - BeamPipe_endThickness" />
+    </detector>
+
+    <detector name="NorthIncomingBeampipe" type="DD4hep_TubeSegment" vis="BeamPipeVis">
+      <material name="Iron" />
+      <tubs rmin="IncomingBP_radius - IncomingBP_thickness" rmax="IncomingBP_radius" zhalf="(MuonEndcap_zmax - ForwardMask_zmin)/2.0" />
+      <position x="-((ForwardMask_zmin + MuonEndcap_zmax)/2.0*tan(CrossingAngle/rad)/2.0)" y="0" z="(ForwardMask_zmin + MuonEndcap_zmax)/2.0" />
+      <rotation x="0.0" y="CrossingAngle/2.0/rad" z="0.0" />
+    </detector>
+
+
+    <detector name="SouthIncomingBeampipe" type="DD4hep_TubeSegment" vis="BeamPipeVis">
+      <material name="Iron" />
+      <tubs rmin="IncomingBP_radius - IncomingBP_thickness" rmax="IncomingBP_radius" zhalf="(MuonEndcap_zmax - ForwardMask_zmin)/2.0" />
+      <position x="-((ForwardMask_zmin + MuonEndcap_zmax)/2.0*tan(CrossingAngle/rad)/2.0)" y="0" z="- (ForwardMask_zmin + MuonEndcap_zmax)/2.0" />
+      <rotation x="0.0" y="-CrossingAngle/2.0/rad" z="0.0" />
+    </detector>
+
+    <detector name="NorthOutgoingBeampipe" type="DD4hep_TubeSegment" vis="BeamPipeVis">
+      <material name="Iron" />
+      <tubs rmin="OutgoingBP_radius - OutgoingBP_thickness" rmax="OutgoingBP_radius" zhalf="(MuonEndcap_zmax - ForwardMask_zmin)/2.0" />
+      <position x="((ForwardMask_zmin + MuonEndcap_zmax)/2.0*tan(CrossingAngle/rad)/2.0)" y="0" z="(ForwardMask_zmin + MuonEndcap_zmax)/2.0" />
+      <rotation x="0.0" y="-CrossingAngle/2.0/rad" z="0.0" />
+    </detector>
+
+    <detector name="SouthOutgoingBeampipe" type="DD4hep_TubeSegment" vis="BeamPipeVis">
+      <material name="Iron" />
+      <tubs rmin="OutgoingBP_radius - OutgoingBP_thickness" rmax="OutgoingBP_radius" zhalf="(MuonEndcap_zmax - ForwardMask_zmin)/2.0" />
+      <position x="((ForwardMask_zmin + MuonEndcap_zmax)/2.0*tan(CrossingAngle/rad)/2.0)" y="0" z="- (ForwardMask_zmin + MuonEndcap_zmax)/2.0" />
+      <rotation x="0.0" y="CrossingAngle/2.0/rad" z="0.0" />
+    </detector>
+
+    <!-- Beam pipe liner is not needed, use thicker conical steel pipe instead
+	 <detector name="BeamPipeLiner" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+	 <comment>BeamPipe Liner to shield bremsstrahlung photons</comment>
+	 <material name="Titanium"/>
+	 <zplane rmin="(tracking_region_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax - BeamPipe_thickness - BeamPipeLiner_thickness" rmax="(tracking_region_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax - BeamPipe_thickness" z="-tracking_region_zmax" />
+	 <zplane rmin="CentralBeamPipe_rmax - BeamPipe_thickness - BeamPipeLiner_thickness" rmax="CentralBeamPipe_rmax - BeamPipe_thickness"  z="-(CentralBeamPipe_zmax + 0.01*cm)"/>
+	 <zplane rmin="CentralBeamPipe_rmin - BeamPipeLiner_thickness" rmax="CentralBeamPipe_rmin" z="-CentralBeamPipe_zmax"  />
+	 <zplane rmin="CentralBeamPipe_rmin - BeamPipeLiner_thickness" rmax="CentralBeamPipe_rmin" z="CentralBeamPipe_zmax" />
+	 <zplane rmin="CentralBeamPipe_rmax - BeamPipe_thickness - BeamPipeLiner_thickness" rmax="CentralBeamPipe_rmax - BeamPipe_thickness" z="CentralBeamPipe_zmax + 0.01*cm" />
+	 <zplane rmin="(tracking_region_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax - BeamPipe_thickness - BeamPipeLiner_thickness" rmax="(tracking_region_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax - BeamPipe_thickness" z="tracking_region_zmax" />
+	 </detector>
+    -->
+
+    <detector name="BeamPipeVacuum" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="InvisibleNoDaughters">
+      <comment>Vacuum inside beampipe</comment>
+      <material name="Vacuum"/>
+      <zplane rmin="0.*cm"
+	      rmax="BeamPipe_rmax - BeamPipe_thickness - BeamPipeLiner_thickness"
+	      z="-tracking_region_zmax" />
+      <zplane rmin="0.*cm"
+	      rmax="CentralBeamPipe_rmin - BeamPipeLiner_thickness"
+	      z="-BeamPipe_zmin"  />
+      <zplane rmin="0.*cm"
+	      rmax="CentralBeamPipe_rmin - BeamPipeLiner_thickness"
+	      z="BeamPipe_zmin" />
+      <zplane rmin="0.*cm"
+	      rmax="BeamPipe_rmax - BeamPipe_thickness - BeamPipeLiner_thickness"
+	      z="tracking_region_zmax" />
+    </detector>
+    <detector name="ForwardVacuum" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="InvisibleNoDaughters">
+      <material name="Vacuum"/>
+      <zplane rmin="0.*cm"
+	      rmax="BeamPipe_rmax - BeamPipe_thickness"
+	      z="tracking_region_zmax + 0.01*cm" /> 
+      <zplane rmin="0.*cm"
+	      rmax="BeamPipe_rmax - BeamPipe_thickness"
+	      z="BeamPipe_zmax" />
+      <zplane rmin="0.*cm"
+	      rmax="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      z="LumiCal_zmin - 2*BeamPipe_endThickness" />
+      <zplane rmin="0.*cm"
+	      rmax="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      z="LumiCal_zmin - BeamPipe_endThickness" />
+      <zplane rmin="0.*cm"
+	      rmax="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      z="ForwardMask_zmin - BeamPipe_endThickness" />
+    </detector> 
+    <detector name="BackwardVacuum" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="InvisibleNoDaughters">
+      <material name="Vacuum"/>
+      <zplane rmin="0.*cm"
+	      rmax="BeamPipe_rmax - BeamPipe_thickness"
+	      z="- (tracking_region_zmax + 0.01*cm)" /> 
+      <zplane rmin="0.*cm"
+	      rmax="BeamPipe_rmax - BeamPipe_thickness"
+	      z="- BeamPipe_zmax" />
+      <zplane rmin="0.*cm"
+	      rmax="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      z="- (LumiCal_zmin - 2*BeamPipe_endThickness)" />
+      <zplane rmin="0.*cm"
+	      rmax="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      z="- (LumiCal_zmin - BeamPipe_endThickness)" />
+      <zplane rmin="0.*cm"
+	      rmax="LumiCal_rmin - 2*BeamPipe_endThickness"
+	      z="- (ForwardMask_zmin - BeamPipe_endThickness)" />
+    </detector>
+    <comment>Vertex Detector Supports and Readout</comment>
+    <detector name="VertexBarrelSupports" type="DD4hep_MultiLayerTracker" vis="SupportVis" reflect="true">
+      <comment>Double-walled Carbon Fiber support tube</comment>
+      <layer id="6" inner_r = "16.87*cm" outer_z = "89.48*cm">
+	<slice material = "CarbonFiber" thickness ="VXD_CF_support"/>
+      </layer>
+      <layer id="7" inner_r = "18.42*cm" outer_z = "89.48*cm">
+	<slice material = "CarbonFiber" thickness ="VXD_CF_support"/>
+      </layer>
+    </detector>
+    <detector name="VertexEndSupports" type="DD4hep_DiskTracker" reflect="true" vis="SupportVis">    
+      <layer id="7" inner_r = "(86.88*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + VertexEndcap_offset" inner_z = "86.88*cm" outer_r = "16.87*cm">
+	<slice material = "CarbonFiber" thickness = "VXD_CF_support" />
+      </layer>
+      <layer id="8" inner_r = "(89.43*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + VertexEndcap_offset" inner_z = "89.43*cm" outer_r = "16.87*cm">
+	<slice material = "CarbonFiber" thickness = "VXD_CF_support" />
+      </layer>
+    </detector>
+    <detector name="VertexReadout" type="DD4hep_DiskTracker" reflect="true" vis="CableVis">
+      <comment>Readout and Cabling</comment>
+      <layer id="1" inner_r = "VertexBarrel_r1" outer_r="VertexBarrel_r1 + 0.02*cm"  inner_z= "VertexBarrel_zmax + 0.1*cm" vis="GreenVis">
+	<slice material = "G10" thickness ="0.5*cm"/>
+      </layer>
+      <layer id="2" inner_r = "VertexBarrel_r2" outer_r="VertexBarrel_r2 + 0.02*cm" inner_z="VertexBarrel_zmax + 0.1*cm" vis = "BlueVis">
+	<slice material = "G10" thickness ="0.5*cm"/>
+      </layer>
+      <layer id="3" inner_r = "VertexBarrel_r3" outer_r="VertexBarrel_r3 + 0.02*cm"  inner_z="VertexBarrel_zmax + 0.1*cm" vis="RedVis">
+	<slice material = "G10" thickness ="0.5*cm"/>
+      </layer>
+      <layer id="4" inner_r = "VertexBarrel_r4" outer_r = "VertexBarrel_r4 + 0.02*cm"  inner_z= "VertexBarrel_zmax + 0.1*cm">
+	<slice material = "G10" thickness ="0.5*cm"/>
+      </layer>
+      <layer id="5" inner_r = "VertexBarrel_r5" outer_r = "VertexBarrel_r5 + 0.02*cm"  inner_z= "VertexBarrel_zmax + 0.1*cm">
+	<slice material = "G10" thickness ="0.5*cm"/>
+      </layer>
+      <layer id="6" inner_r = "VertexBarrel_r1 - 0.1*cm" outer_r = "VertexBarrel_r2"  inner_z= "VertexBarrel_zmax + 0.6*cm">
+	<slice material = "Copper" thickness ="0.0057*cm"/>
+      </layer>
+      <layer id="7" inner_r = "VertexBarrel_r2 - 0.01*cm" outer_r = "VertexBarrel_r3"  inner_z= "VertexBarrel_zmax + 0.6*cm">
+	<slice material = "Copper" thickness ="0.0031*cm"/>
+      </layer>
+      <layer id="8" inner_r = "VertexBarrel_r3 - 0.01*cm" outer_r = "VertexBarrel_r4"  inner_z= "VertexBarrel_zmax + 0.6*cm">
+	<slice material = "Copper" thickness ="0.0016*cm"/>
+      </layer>
+      <layer id="9" inner_r = "VertexBarrel_r4 - 0.01*cm" outer_r = "VertexBarrel_r5"  inner_z= "VertexBarrel_zmax + 0.6*cm">
+	<slice material = "Copper" thickness ="0.0007*cm"/>
+      </layer>
+      <layer id="10" inner_r = "VertexEndcap_rmin1 - 0.1*cm"  outer_r = "VertexEndcap_rmin1 - 0.01*cm" inner_z = "VertexEndcap_z1 - 0.1*cm">
+	<slice material = "G10" thickness = "0.02*cm" />
+      </layer>
+      <layer id="11" inner_r = "VertexEndcap_rmin2 - 0.1*cm"  outer_r = "VertexEndcap_rmin2 - 0.01*cm" inner_z = "VertexEndcap_z2 - 0.1*cm">
+	<slice material = "G10" thickness = "0.02*cm" />
+      </layer>
+      <layer id="12" inner_r = "VertexEndcap_rmin3 - 0.1*cm"  outer_r = "VertexEndcap_rmin3 - 0.01*cm" inner_z = "VertexEndcap_z3 - 0.1*cm">
+	<slice material = "G10" thickness = "0.02*cm" />
+      </layer>
+      <layer id="13" inner_r = "VertexEndcap_rmin4 - 0.1*cm"  outer_r = "VertexEndcap_rmin4 - 0.01*cm" inner_z = "VertexEndcap_z4 - 0.1*cm">
+	<slice material = "G10" thickness = "0.02*cm" />
+      </layer>
+      <layer id="14" inner_r = "VertexEndcap_rmax + 0.01*cm"  outer_r = "VertexEndcap_rmax + 0.5*cm" inner_z = "VertexEndcap_z1 - 0.1*cm">
+	<slice material = "G10" thickness = "0.02*cm" />
+      </layer>
+      <layer id="15" inner_r = "VertexEndcap_rmax + 0.01*cm"  outer_r = "VertexEndcap_rmax + 0.5*cm" inner_z = "VertexEndcap_z2 - 0.1*cm">
+	<slice material = "G10" thickness = "0.02*cm" />
+      </layer>
+      <layer id="16" inner_r = "VertexEndcap_rmax + 0.01*cm"  outer_r = "VertexEndcap_rmax + 0.5*cm" inner_z = "VertexEndcap_z3 - 0.1*cm">
+	<slice material = "G10" thickness = "0.02*cm" />
+      </layer>
+      <layer id="17" inner_r = "VertexEndcap_rmax + 0.01*cm"  outer_r = "VertexEndcap_rmax + 0.5*cm" inner_z = "VertexEndcap_z4 - 0.1*cm">
+	<slice material = "G10" thickness = "0.02*cm" />
+      </layer>
+    </detector>
+    <detector name="VXDcableZforwardBarrel" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="CableVis">
+      <material name="Copper"/>
+      <zplane rmin = "(CentralBeamPipe_rmax)"
+	      rmax = "(CentralBeamPipe_rmax + VertexCableThickness)"
+	      z="VertexBarrel_zmax + 0.61*cm"/>
+      <zplane rmin = "(CentralBeamPipe_rmax)"
+	      rmax = "(CentralBeamPipe_rmax + VertexCableThickness)"
+	      z="CentralBeamPipe_zmax"/>
+    </detector>
+    <detector name="VXDcableZbackwardBarrel" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="CableVis">
+      <material name="Copper"/>
+      <zplane rmin = "(CentralBeamPipe_rmax)"
+	      rmax = "(CentralBeamPipe_rmax + VertexCableThickness)"
+	      z="-(VertexBarrel_zmax + 0.61*cm)"/>
+      <zplane rmin = "(CentralBeamPipe_rmax)"
+	      rmax = "(CentralBeamPipe_rmax + VertexCableThickness)"
+	      z="-CentralBeamPipe_zmax"/>
+    </detector> 
+    <detector name="VXDcableZbackwardOuter" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="CableVis">
+      <material name="Copper"/>
+      <zplane rmin = "((tracking_region_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax)" 
+	      rmax = "((tracking_region_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + 0.004*cm)" 
+	      z="-tracking_region_zmax" />
+      <zplane rmin="(VertexService_zmax + 0.01*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      rmax="(VertexService_zmax + 0.01*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + 0.01*cm"
+	      z="-(VertexService_zmax + 0.01*cm)"/>
+    </detector>
+    <detector name="VXDcableZbackwardInner" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="CableVis">
+      <material name="Copper"/>
+      <zplane rmin="CentralBeamPipe_rmax"
+	      rmax="CentralBeamPipe_rmax + VertexCableThickness"
+	      z="-(CentralBeamPipe_zmax)"/>
+      <zplane rmin="(VertexService_zmin - 0.01*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      rmax="(VertexService_zmin - 0.01*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + VertexCableThickness"
+	      z="-(VertexService_zmin - 0.01*cm)"/>
+    </detector>
+    <detector name="VXDcableZforwardOuter" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="CableVis">
+      <material name="Copper"/>
+      <zplane rmin = "((tracking_region_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax)" 
+	      rmax = "((tracking_region_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + 0.004*cm)" 
+	      z="tracking_region_zmax" />
+      <zplane rmin="(VertexService_zmax + 0.01*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      rmax="(VertexService_zmax + 0.01*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + 0.01*cm"
+	      z="VertexService_zmax + 0.01*cm"/>
+    </detector>
+    <detector name="VXDcableZforwardInner" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="CableVis">
+      <material name="Copper"/>
+      <zplane rmin="(VertexService_zmin - 0.01*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      rmax="(VertexService_zmin - 0.01*cm - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + VertexCableThickness"
+	      z="VertexService_zmin - 0.01*cm"/>
+      <zplane rmin="CentralBeamPipe_rmax"
+	      rmax="CentralBeamPipe_rmax + VertexCableThickness"
+	      z="CentralBeamPipe_zmax"/>
+    </detector>
+    <detector name="VXDserviceZbackward" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="CableVis">
+      <material name="G10"/>
+      <zplane rmin = "(VertexService_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      rmax="(VertexService_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + VertexServiceThickness"
+	      z="-VertexService_zmax"/>
+      <zplane rmin = "(VertexService_zmin - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      rmax="(VertexService_zmin - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + VertexServiceThickness"
+	      z="-VertexService_zmin"/>
+    </detector>
+    <detector name="VXDserviceZforward" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="CableVis">
+      <material name="G10"/>
+      <zplane rmin = "(VertexService_zmin - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      rmax="(VertexService_zmin - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + VertexServiceThickness"
+	      z="VertexService_zmin"/>
+      <zplane rmin = "(VertexService_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax"
+	      rmax="(VertexService_zmax - CentralBeamPipe_zmax)*bp_cone_slope + CentralBeamPipe_rmax + VertexServiceThickness"
+	      z="VertexService_zmax"/>
+    </detector>
+
+    <comment>Outer Tracker Supports and Readout</comment>
+    <detector name="TrackerBarrelSupports" type="DD4hep_MultiLayerTracker" reflect="true">
+      <comment>Barrels</comment>
+      <layer id="1" inner_r="206.0*mm" outer_z="577.328*mm">
+	<slice material="CarbonFiber" thickness="0.05*cm" />
+	<slice material="Rohacell31_15percent" thickness="0.8075*cm" />
+	<slice material="CarbonFiber" thickness="0.05*cm" />
+      </layer>
+      <layer id="2" inner_r="456.0*mm" outer_z="749.781*mm">
+	<slice material="CarbonFiber" thickness="0.05*cm" />
+	<slice material="Rohacell31_15percent" thickness="0.8075*cm" />
+	<slice material="CarbonFiber" thickness="0.05*cm" />
+      </layer>
+      <layer id="3" inner_r="706.0*mm" outer_z="1013.802*mm">
+	<slice material= "CarbonFiber" thickness = "0.05*cm" />
+	<slice material= "Rohacell31_15percent" thickness="0.8075*cm" />
+	<slice material= "CarbonFiber" thickness="0.05*cm" />
+      </layer>
+      <layer id="4" inner_r="956.0*mm" outer_z="1272.251*mm">
+	<slice material="CarbonFiber" thickness="0.05*cm" />
+	<slice material="Rohacell31_15percent" thickness="0.8075*cm" />
+	<slice material="CarbonFiber" thickness="0.05*cm" />
+      </layer>
+      <layer id="5" inner_r="1206.0*mm" outer_z="1535.676*mm">
+	<slice material="CarbonFiber" thickness="0.05*cm" />
+	<slice material="Rohacell31_15percent" thickness="0.8075*cm" />
+	<slice material="CarbonFiber" thickness="0.05*cm" />
+      </layer>
+    </detector>
+
+    <comment>Dished endcap disks</comment>
+    <detector name="SiTrackerEndcapSupport1" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="510.448*mm" rmax="510.448*mm" z="(750.417-0.001)*mm" />
+      <zplane rmin="504.711*mm" rmax="510.448*mm" z="(750.919-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(777.034-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(777.535-0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport2" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="Rohacell31"/>
+      <zplane rmin="510.448*mm" rmax="510.448*mm" z="750.919*mm" />
+      <zplane rmin="438.449*mm" rmax="510.448*mm" z="757.218*mm" />
+      <zplane rmin="206.234*mm" rmax="278.187*mm" z="777.535*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="783.834*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport3" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="510.448*mm" rmax="510.448*mm" z="(757.218+0.001)*mm" />
+      <zplane rmin="504.711*mm" rmax="510.448*mm" z="(757.720+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(783.834+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(784.336+0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport4" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="763.796*mm" rmax="763.796*mm" z="(1014.437-0.001)*mm" />
+      <zplane rmin="758.059*mm" rmax="763.796*mm" z="(1014.939-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(1063.219-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(1063.721-0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport5" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="Rohacell31"/>
+      <zplane rmin="763.796*mm" rmax="763.796*mm" z="1014.939*mm" />
+      <zplane rmin="691.797*mm" rmax="763.796*mm" z="1021.238*mm" />
+      <zplane rmin="206.234*mm" rmax="278.187*mm" z="1063.721*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="1070.020*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport6" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="763.796*mm" rmax="763.796*mm" z="(1021.238+0.001)*mm" />
+      <zplane rmin="758.059*mm" rmax="763.796*mm" z="(1021.740+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(1070.020+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(1070.522+0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport7" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="(1272.885-0.001)*mm" />
+      <zplane rmin="1010.011*mm" rmax="1015.748*mm" z="(1273.387-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(1343.711-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(1344.213-0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport8" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="Rohacell31"/>
+      <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="1273.387*mm" />
+      <zplane rmin="943.753*mm" rmax="1015.748*mm" z="1279.686*mm" />
+      <zplane rmin="206.234*mm" rmax="278.187*mm" z="1344.213*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="1350.512*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport9" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="(1279.686+0.001)*mm" />
+      <zplane rmin="1010.011*mm" rmax="1015.748*mm" z="(1280.188+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(1350.512+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(1351.014+0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport10" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="(1536.560-0.001)*mm" />
+      <zplane rmin="1258.071*mm" rmax="1263.808*mm" z="(1537.062-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(1629.089-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(1629.591-0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport11" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="Rohacell31"/>
+      <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="1537.062*mm" />
+      <zplane rmin="1191.810*mm" rmax="1263.808*mm" z="1543.361*mm" />
+      <zplane rmin="206.234*mm" rmax="278.187*mm" z="1629.591*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="1635.890*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport12" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="(1543.361+0.001)*mm" />
+      <zplane rmin="1258.071*mm" rmax="1263.808*mm" z="(1543.863+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(1635.890+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(1636.392+0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport1Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="510.448*mm" rmax="510.448*mm" z="(-750.417+0.001)*mm" />
+      <zplane rmin="504.711*mm" rmax="510.448*mm" z="(-750.919+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(-777.034+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(-777.535+0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport2Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="Rohacell31"/>
+      <zplane rmin="510.448*mm" rmax="510.448*mm" z="-750.919*mm" />
+      <zplane rmin="438.449*mm" rmax="510.448*mm" z="-757.218*mm" />
+      <zplane rmin="206.234*mm" rmax="278.187*mm" z="-777.535*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="-783.834*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport3Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="510.448*mm" rmax="510.448*mm" z="(-757.218-0.001)*mm" />
+      <zplane rmin="504.711*mm" rmax="510.448*mm" z="(-757.720-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(-783.834-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(-784.336-0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport4Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="763.796*mm" rmax="763.796*mm" z="(-1014.437+0.001)*mm" />
+      <zplane rmin="758.059*mm" rmax="763.796*mm" z="(-1014.939+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(-1063.219+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(-1063.721+0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport5Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="Rohacell31"/>
+      <zplane rmin="763.796*mm" rmax="763.796*mm" z="-1014.939*mm" />
+      <zplane rmin="691.797*mm" rmax="763.796*mm" z="-1021.238*mm" />
+      <zplane rmin="206.234*mm" rmax="278.187*mm" z="-1063.721*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1070.020*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport6Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="763.796*mm" rmax="763.796*mm" z="(-1021.238-0.001)*mm" />
+      <zplane rmin="758.059*mm" rmax="763.796*mm" z="(-1021.740-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(-1070.020-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(-1070.522-0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport7Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="(-1272.885+0.001)*mm" />
+      <zplane rmin="1010.011*mm" rmax="1015.748*mm" z="(-1273.387+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(-1343.711+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(-1344.213+0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport8Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="Rohacell31"/>
+      <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="-1273.387*mm" />
+      <zplane rmin="943.753*mm" rmax="1015.748*mm" z="-1279.686*mm" />
+      <zplane rmin="206.234*mm" rmax="278.187*mm" z="-1344.213*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1350.512*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport9Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="1015.748*mm" rmax="1015.748*mm" z="(-1279.686-0.001)*mm" />
+      <zplane rmin="1010.011*mm" rmax="1015.748*mm" z="(-1280.188-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(-1350.512-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(-1351.014-0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport10Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="(-1536.560+0.001)*mm" />
+      <zplane rmin="1258.071*mm" rmax="1263.808*mm" z="(-1537.062+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(-1629.089+0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(-1629.591+0.001)*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport11Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="Rohacell31"/>
+      <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="-1537.062*mm" />
+      <zplane rmin="1191.810*mm" rmax="1263.808*mm" z="-1543.361*mm" />
+      <zplane rmin="206.234*mm" rmax="278.187*mm" z="-1629.591*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="-1635.890*mm" />
+    </detector>
+    <detector name="SiTrackerEndcapSupport12Reflect" type="DD4hep_PolyconeSupport" insideTrackingVolume="true" vis="SupportVis">
+      <material name="CarbonFiber"/>
+      <zplane rmin="1263.808*mm" rmax="1263.808*mm" z="(-1543.361-0.001)*mm" />
+      <zplane rmin="1258.071*mm" rmax="1263.808*mm" z="(-1543.863-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="211.970*mm" z="(-1635.890-0.001)*mm" />
+      <zplane rmin="206.234*mm" rmax="206.234*mm" z="(-1636.392-0.001)*mm" />
+    </detector>        
+    <detector name="TrackerReadout" type="DD4hep_DiskTracker" reflect="true" vis="GreenVis">
+      <comment>Readouts</comment>
+      <layer id="1" inner_r="25.7*cm" inner_z="590.402*mm" outer_r="45.6*cm">
+	<slice material="G10" thickness="0.057*cm" />
+	<slice material="Copper" thickness="0.0038*cm" />
+      </layer>
+      <layer id="2" inner_r="51.0*cm" inner_z="762.854*mm" outer_r="70.6*cm">
+	<slice material = "G10" thickness="0.102*cm" />
+	<slice material = "Copper" thickness="0.0068*cm" />
+      </layer>
+      <layer id="3" inner_r="76.3*cm" inner_z="1026.874*mm" outer_r="95.6*cm">
+	<slice material="G10" thickness="0.108*cm" />
+	<slice material="Copper" thickness="0.0072*cm" />
+      </layer>
+      <layer id="4" inner_r="101.3*cm" inner_z="1285.322*mm" outer_r="120.6*cm">
+	<slice material="G10" thickness="0.186*cm" />
+	<slice material="Copper" thickness="0.0124*cm" />
+      </layer>
+      <layer id="5" inner_r= "101.3*cm" inner_z="1610.0*mm" outer_r="120.6*cm">
+	<slice material="G10" thickness="0.246*cm" />
+	<slice material="Copper" thickness="0.0164*cm" />
+      </layer>
+    </detector>
+    <comment>Masks and Shielding</comment>
+    <detector name="LumiShielding_Forward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="TungstenShieldingVis">
+      <material name="TungstenDens24" />
+      <zplane rmin="LumiCal_rmin" rmax="LumiCalElectronics_rmax" z="LumiCal_zmax"/>
+      <zplane rmin="LumiCal_rmin" rmax="LumiCalElectronics_rmax" z="LumiCal_zmax+ForwardShielding_thickness"/>
+    </detector>
+    <detector name="LumiShielding_Backward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="TungstenShieldingVis">
+      <material name="TungstenDens24" />
+      <zplane rmin="LumiCal_rmin" rmax="LumiCalElectronics_rmax" z="-LumiCal_zmax"/>
+      <zplane rmin="LumiCal_rmin" rmax="LumiCalElectronics_rmax" z="-(LumiCal_zmax+ForwardShielding_thickness)"/>
+    </detector>
+    <detector name="ECalShielding_Forward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="TungstenShieldingVis">
+      <material name="TungstenDens24" />
+      <zplane rmin="LumiCalElectronics_rmax" rmax="HcalEndcap_rmin-SupportTube_thickness-1.0*cm" z="HcalEndcap_zmin"/>
+      <zplane rmin="LumiCalElectronics_rmax" rmax="HcalEndcap_rmin-SupportTube_thickness-1.0*cm" z="HcalEndcap_zmin+ForwardShielding_thickness"/>
+    </detector>
+    <detector name="ECalShielding_Backward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="TungstenShieldingVis">
+      <material name="TungstenDens24" />
+      <zplane rmin="LumiCalElectronics_rmax" rmax="HcalEndcap_rmin-SupportTube_thickness-1.0*cm" z="-HcalEndcap_zmin"/>
+      <zplane rmin="LumiCalElectronics_rmax" rmax="HcalEndcap_rmin-SupportTube_thickness-1.0*cm" z="-(HcalEndcap_zmin+ForwardShielding_thickness)"/>
+    </detector>
+    <detector name="ShieldingTube_Forward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="TungstenShieldingVis">
+      <material name="TungstenDens24" />
+      <zplane rmin="HcalEndcap_rmin - SupportTube_thickness - ForwardShielding_thickness - 1.0*cm"
+	      rmax="HcalEndcap_rmin - SupportTube_thickness - 1.0*cm"
+	      z="HcalEndcap_zmin + ForwardShielding_thickness"/>
+      <zplane rmin="HcalEndcap_rmin - SupportTube_thickness - ForwardShielding_thickness - 1.0*cm"
+	      rmax="HcalEndcap_rmin - SupportTube_thickness - 1.0*cm"
+	      z="HcalEndcap_zmax"/>
+    </detector>
+    <detector name="ShieldingTube_Backward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="TungstenShieldingVis">
+      <material name="TungstenDens24" />
+      <zplane rmin="HcalEndcap_rmin - SupportTube_thickness - ForwardShielding_thickness - 1.0*cm"
+	      rmax="HcalEndcap_rmin - SupportTube_thickness - 1.0*cm"
+	      z="-(HcalEndcap_zmin + ForwardShielding_thickness)"/>
+      <zplane rmin="HcalEndcap_rmin - SupportTube_thickness - ForwardShielding_thickness - 1.0*cm"
+	      rmax="HcalEndcap_rmin - SupportTube_thickness - 1.0*cm"
+	      z="-HcalEndcap_zmax"/>
+    </detector>
+    <detector name="SupportTube_Forward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="SupportTubeVis">
+      <material name="Steel235" />
+      <zplane rmin="HcalEndcap_rmin - 2*SupportTube_thickness"
+	      rmax="HcalEndcap_rmin - SupportTube_thickness"
+	      z="HcalEndcap_zmin"/>
+      <zplane rmin="HcalEndcap_rmin - 2*SupportTube_thickness"
+	      rmax="HcalEndcap_rmin - SupportTube_thickness"
+	      z="MuonEndcap_zmax"/>
+    </detector>
+    <detector name="SupportTube_Backward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="SupportTubeVis">
+      <material name="Steel235" />
+      <zplane rmin="HcalEndcap_rmin - 2*SupportTube_thickness"
+	      rmax="HcalEndcap_rmin - SupportTube_thickness"
+	      z="-HcalEndcap_zmin"/>
+      <zplane rmin="HcalEndcap_rmin - 2*SupportTube_thickness"
+	      rmax="HcalEndcap_rmin - SupportTube_thickness"
+	      z="-MuonEndcap_zmax"/>
+    </detector>
+    <detector name="AntiSolenoid_Forward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="AntiSolenoidVis">
+      <material name="Steel235" />
+      <zplane rmin="HcalEndcap_rmin + 1.0*cm"
+	      rmax="MuonEndcap_rmin - 1.0*cm"
+	      z="HcalEndcap_zmax + 1.0*cm"/>
+      <zplane rmin="HcalEndcap_rmin + 1.0*cm"
+	      rmax="MuonEndcap_rmin - 1.0*cm"
+	      z="MuonEndcap_zmax"/>
+    </detector>
+    <detector name="AntiSolenoid_Backward" type="DD4hep_PolyconeSupport" insideTrackingVolume="false" vis="AntiSolenoidVis">
+      <material name="Steel235" />
+      <zplane rmin="HcalEndcap_rmin + 1.0*cm"
+	      rmax="MuonEndcap_rmin - 1.0*cm"
+	      z="-(HcalEndcap_zmax + 1.0*cm)"/>
+      <zplane rmin="HcalEndcap_rmin + 1.0*cm"
+	      rmax="MuonEndcap_rmin - 1.0*cm"
+	      z="-MuonEndcap_zmax"/>
+    </detector>
+
+    <detector name="ForwardLowZ" type="DD4hep_ForwardDetector" vis="TungstenShieldingVis" reflect="true">
+      <dimensions outer_r="BeamCal_rmax" inner_r="0.0*cm" inner_z="ForwardMask_zmin" />
+      <beampipe crossing_angle="CrossingAngle" outgoing_r="OutgoingBP_radius + 0.05*cm" incoming_r="IncomingBP_radius + 0.05*cm" />
+      <layer repeat="1">
+	<slice material = "Graphite" thickness = "ForwardMask_thickness" sensitive = "no" />
+      </layer>
+    </detector>
+    
+    <comment>Solenoid</comment>
+    <detector name="SolenoidCoilBarrel" type="DD4hep_MultiLayerTracker" insideTrackingVolume="false" reflect="true">
+      <layer id="1" inner_r="SolenoidBarrelInnerRadius" outer_z="SolenoidBarrelOuterZ" vis="SolenoidBarrelLayerVis">
+	<slice material="Steel235" thickness="SolenoidBarrelInnerCryostatThickness" />
+	<slice material="Vacuum"   thickness="SolenoidBarrelInnerAirgapThickness" />
+      </layer>
+      <layer id="2" inner_r="SolenoidBarrelConductorInnerRadius" outer_z="SolenoidCoilOuterZ" vis="SolenoidBarrelLayerVis">
+	<slice material="Aluminum" thickness="SolenoidBarrelAlConductorThickness" />
+	<slice material="Aluminum" thickness="SolenoidBarrelQuenchbackThickness" />
+      </layer>
+      <layer id="3" inner_r="SolenoidBarrelOuterCryostatInnerRadius" outer_z="SolenoidBarrelOuterZ" vis="SolenoidBarrelLayerVis">
+	<slice material="Vacuum"   thickness="SolenoidBarrelOuterAirgapThickness" />
+	<slice material="Steel235" thickness="SolenoidBarrelOuterCryostatThickness" />
+      </layer>
+    </detector>
+
+    <detector name="SolenoidCoilEnds" type="DD4hep_DiskTracker" reflect="true" insideTrackingVolume="false">
+      <layer id="1" inner_r="SolenoidBarrelInnerRadius" inner_z="SolenoidBarrelOuterZ" outer_r="SolenoidBarrelOuterRadius" vis="SolenoidCoilEndsVis">
+	<slice material="Steel235" thickness="SolenoidEndcapCryostatThickness" />
+      </layer>
+    </detector>
+
+  </detectors>
+
+  <readouts>
+    <readout name="SiTrackerEndcapHits">
+      <id>system:8,barrel:3,layer:4,module:14,sensor:2,side:32:-2,strip:20</id>
+    </readout>        
+    <readout name="SiTrackerBarrelHits">
+      <id>system:8,barrel:3,layer:4,module:14,sensor:2,side:32:-2,strip:20</id>
+    </readout>
+    <readout name="SiVertexBarrelHits">
+      <id>system:8,barrel:3,layer:4,module:14,sensor:2,side:32:-2,strip:24</id>
+    </readout>
+    <readout name="SiVertexEndcapHits">
+      <id>system:8,barrel:3,layer:4,wedge:6,module:6,sensor:1,side:32:-2,strip:26</id>
+    </readout>
+    <readout name="EcalBarrelHits">
+      <segmentation type="CartesianGridXY" grid_size_x="3.5" grid_size_y="3.5" />
+      <id>system:8,barrel:3,module:4,layer:6,slice:5,x:32:-16,y:-16</id>
+    </readout>        
+    <readout name="EcalEndcapHits">
+      <segmentation type="CartesianGridXY" grid_size_x="3.5" grid_size_y="3.5" />
+      <id>system:8,barrel:3,module:4,layer:6,slice:5,x:32:-16,y:-16</id>
+    </readout>
+    <readout name="HcalBarrelHits">
+      <segmentation type="CartesianGridXY" grid_size_x="3.0*cm" grid_size_y="3.0*cm" />
+      <id>system:8,barrel:3,module:6,layer:8,slice:5,x:32:-16,y:-16</id>
+    </readout>
+    <readout name="HcalEndcapHits">
+      <segmentation type="CartesianGridXY" grid_size_x="3.0*cm" grid_size_y="3.0*cm" />
+      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
+    </readout>
+    <readout name="HcalPlugHits">
+      <segmentation type="CartesianGridXY" grid_size_x="3.0*cm" grid_size_y="3.0*cm" />
+      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
+    </readout>
+    <readout name="MuonBarrelHits">
+      <segmentation type="CartesianGridXY" grid_size_x="3.0*cm" grid_size_y="3.0*cm" />
+      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
+    </readout>
+    <readout name="MuonEndcapHits">
+      <segmentation type="CartesianGridXY" grid_size_x="3.0*cm" grid_size_y="3.0*cm" />
+      <id>system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16</id>
+    </readout>
+    <readout name="SiTrackerForwardHits">
+      <id>system:8,barrel:3,layer:4,wedge:6,module:6,sensor:1,side:32:-2,strip:28</id>
+    </readout>
+    <readout name="LumiCalHits">
+      <segmentation type="CartesianGridXY" grid_size_x="0.35*cm" grid_size_y="0.35*cm" />
+      <id>system:8,barrel:3,layer:8,slice:8,x:32:-16,y:-16</id>
+    </readout>
+    <readout name="BeamCalHits">
+      <segmentation type="CartesianGridXY" grid_size_x="0.35*cm" grid_size_y="0.35*cm" />
+      <id>system:8,layer:8,barrel:3,layer:8,slice:5,x:32:-16,y:-16</id>
+    </readout>
+  </readouts>
+  <fields>
+    <field name="GlobalSolenoid" type="solenoid" 
+	   inner_field="5.0*tesla"
+	   outer_field="-1.5*tesla" 
+	   zmax="SolenoidCoilOuterZ"
+	   outer_radius="SolenoidalFieldRadius">
+    </field>
+  </fields>
+</lccdd>

--- a/examples/CLICSiD/scripts/CLICRandom.py
+++ b/examples/CLICSiD/scripts/CLICRandom.py
@@ -9,20 +9,22 @@ from ROOT import TRandom
 from ROOT import gRandom
 
 if __name__ == "__main__":
-  import CLICSid, DDG4
+  import logging, CLICSid, DDG4
   sid = CLICSid.CLICSid()
-  print 'DEFAULT Engine:', DDG4.CLHEP.HepRandom.getTheEngine().name()
+  
+  logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
+  logging.info('DEFAULT Engine: %s', DDG4.CLHEP.HepRandom.getTheEngine().name())
   # <<-- See this function to know how it's done....
   rndm1 = sid.setupRandom('R1',seed=987654321,type='RunluxEngine')
-  print 'R1:', rndm1.name, ' Default instance:', rndm1.instance().name()
-  print '   Engine: ', rndm1.engine().name()
-  print '   DEFAULT:', DDG4.CLHEP.HepRandom.getTheEngine().name()
+  logging.info('R1: %s Default instance: %s', rndm1.name, rndm1.instance().name())
+  logging.info('   Engine:  %s', rndm1.engine().name())
+  logging.info('   DEFAULT: %s', DDG4.CLHEP.HepRandom.getTheEngine().name())
   rndm1.showStatus()
 
   rndm2 = sid.setupRandom('R2',seed=1234321,type='MTwistEngine')
-  print 'R2:', rndm2.name, ' Default instance:', rndm2.instance().name()
-  print '   Engine:', rndm2.engine().name()
-  print '   DEFAULT:', DDG4.CLHEP.HepRandom.getTheEngine().name()
+  logging.info('R2: %s Default instance: %s', rndm2.name, rndm2.instance().name())
+  logging.info('   Engine:  %s', rndm2.engine().name())
+  logging.info('   DEFAULT: %s', DDG4.CLHEP.HepRandom.getTheEngine().name())
   #rndm2.showStatus()
 
   DDG4.Geant4Random.setMainInstance(rndm1.get())
@@ -31,29 +33,29 @@ if __name__ == "__main__":
   # Move main geant random instance from rndm1 to rndm2:
   # See how gRandom and HepRandom instances move
   DDG4.Geant4Random.setMainInstance(rndm1.get())
-  print 'DEFAULT Engine:', DDG4.CLHEP.HepRandom.getTheEngine().name()
-  print 'DDG4   DEFAULT:', DDG4.Geant4Random.instance().engine().name()
+  logging.info('DEFAULT Engine: %s', DDG4.CLHEP.HepRandom.getTheEngine().name())
+  logging.info('DDG4   DEFAULT: %s', DDG4.Geant4Random.instance().engine().name())
   rndm = DDG4.Geant4Random.instance()
 
   rndm.setSeed(1234)
   rndm.showStatus()
   for i in xrange(10):
-    print rndm.name(), ' -- 0 gRandome.Rndm()        -- Shoot random[',i,']= ',gRandom.Rndm()
+    logging.info("%s  -- 0 gRandome.Rndm()        -- Shoot random[[%d]= %f",rndm.name(),i,gRandom.Rndm())
   
   rndm.setSeed(1234)
   for i in xrange(10):
-    print rndm.name(), ' -- 1 gRandome.Rndm()        -- Shoot random[',i,']= ',gRandom.Rndm()
+    logging.info("%s  -- 1 gRandome.Rndm()        -- Shoot random[[%d]= %f",rndm.name(),i,gRandom.Rndm())
   
   rndm.setSeed(1234)
   for i in xrange(10):
-    print rndm.name(), ' -- 2 Geant4Random(CLHEP)    -- Shoot random[',i,']= ',rndm.rndm_clhep()
+    logging.info("%s  -- 2 Geant4Random(CLHEP)    -- Shoot random[[%d]= %f",rndm.name(),i,rndm.rndm_clhep())
   
   rndm.setSeed(1234)
   for i in xrange(10):
-    print rndm.name(), ' -- 3 Geant4Random(CLHEP)    -- Shoot random[',i,']= ',rndm.rndm_clhep()
+    logging.info("%s  -- 3 Geant4Random(CLHEP)    -- Shoot random[[%d]= %f",rndm.name(),i,rndm.rndm_clhep())
 
   rndm.setSeed(1234)
   for i in xrange(10):
-    print rndm.name(), ' -- 4 HepRandomEngine(CLHEP) -- Shoot random[',i,']= ',rndm.engine().flat()
+    logging.info("%s  -- 4 HepRandomEngine(CLHEP) -- Shoot random[%d]= %f",rndm.name(),i,rndm.engine().flat())
   
   sid.test_run(have_geo=False)

--- a/examples/CLICSiD/scripts/CLICSiDScan.py
+++ b/examples/CLICSiD/scripts/CLICSiDScan.py
@@ -7,7 +7,9 @@
 
 """
 def run():
-  import os, sys, DDG4, SystemOfUnits
+  import os, sys, logging, DDG4, SystemOfUnits
+
+  logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
   kernel = DDG4.Kernel()
   install_dir = os.environ['DD4hepINSTALL']
   kernel.loadGeometry("file:"+install_dir+"/DDDetectors/compact/SiD.xml")
@@ -40,8 +42,8 @@ def run():
   kernel.run()
 
   kernel.terminate()
-  print 'End of run. Terminating .......'
-  print 'TEST_PASSED'
+  logging.info('End of run. Terminating .......')
+  logging.info('TEST_PASSED')
 
 if __name__ == "__main__":
   run()

--- a/examples/CLICSiD/scripts/CLICSid.py
+++ b/examples/CLICSiD/scripts/CLICSid.py
@@ -1,4 +1,4 @@
-import sys, DDG4
+import sys, logging, DDG4
 from SystemOfUnits import *
 
 class CLICSid:
@@ -52,13 +52,13 @@ class CLICSid:
     return self
 
   def setupDetectors(self):
-    print "#  First the tracking detectors"
+    logging.info("#  First the tracking detectors")
     seq,act = self.geant4.setupTracker('SiVertexBarrel')
     seq,act = self.geant4.setupTracker('SiVertexEndcap')
     seq,act = self.geant4.setupTracker('SiTrackerBarrel')
     seq,act = self.geant4.setupTracker('SiTrackerEndcap')
     seq,act = self.geant4.setupTracker('SiTrackerForward')
-    print "#  Now setup the calorimeters"
+    logging.info("#  Now setup the calorimeters")
     seq,act = self.geant4.setupCalorimeter('EcalBarrel')
     seq,act = self.geant4.setupCalorimeter('EcalEndcap')
     seq,act = self.geant4.setupCalorimeter('HcalBarrel')
@@ -82,5 +82,5 @@ class CLICSid:
       self.kernel.NumEvents = 0
       self.kernel.run()
     self.kernel.terminate()
-    print '+++++ All Done....\n\nTEST_PASSED'
+    logging.info('+++++ All Done....\n\nTEST_PASSED')
     sys.exit(0)

--- a/examples/CLICSiD/scripts/CLIC_G4Gun.py
+++ b/examples/CLICSiD/scripts/CLIC_G4Gun.py
@@ -8,9 +8,10 @@
 
 """
 def run():
-  import CLICSid, DDG4
+  import logging, CLICSid, DDG4
   from DDG4 import OutputLevel as Output
   
+  logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
   sid = CLICSid.CLICSid()
   geant4 = sid.geant4
   kernel = sid.kernel
@@ -28,7 +29,7 @@ def run():
 
   gen = DDG4.GeneratorAction(kernel,"Geant4GeneratorActionInit/GenerationInit")
   kernel.generatorAction().adopt(gen)
-  print "#  First particle generator: gun"
+  logging.info("#  First particle generator: gun")
   gun = DDG4.GeneratorAction(kernel,"Geant4GeneratorWrapper/Gun");
   gun.Uses     = 'G4ParticleGun'
   gun.Mask     = 1

--- a/examples/CLICSiD/scripts/testDDPython.py
+++ b/examples/CLICSiD/scripts/testDDPython.py
@@ -1,10 +1,12 @@
 from ROOT import gSystem
-import os
-import platform
+
+import os, logging, platform
 if platform.system()=="Darwin":
   gSystem.SetDynamicPath(os.environ['DD4HEP_LIBRARY_PATH'])
 gSystem.Load('libDDPython')
 from ROOT import dd4hep as Core
+
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 name_space = __import__(__name__)
 def import_namespace_item(ns,nam):  
@@ -14,58 +16,58 @@ def import_namespace_item(ns,nam):
   return attr
 
 def a_func():
-  print 'Hello world'
+  logging.info('Hello world')
   return 1
 
 class a_class:
   def __init__(self):
     pass
   def fcn(self):
-    print 'Hello world from member function fcn'
+    logging.info('Hello world from member function fcn')
     return 1
   def fcn_except(self,args,aa):
-    print 'Hello world from member function fcn1 a1=',args,' a2=',aa
+    logging.info('Hello world from member function fcn1 a1=%s a2=%s',str(args),str(aa))
     raise RuntimeError('Except from python test object a_class')
     return 6
       
 
 py = import_namespace_item('Core','DDPython')
 
-print '+++++ Test: Execute statements in python with C++ indirection'
-py.instance().execute('import sys')
-py.instance().execute('print "Arguments:", sys.argv')
-print '\n'
+logging.info('+++++ Test: Execute statements in python with C++ indirection')
+py.instance().execute('import sys, logging')
+py.instance().execute('logging.info("Arguments: %s", str(sys.argv))')
+logging.info('\n')
 
 obj=a_class()
 import sys, traceback
 
-print '+++++ Test: simple function call'
+logging.info('+++++ Test: simple function call')
 ret = py.instance().call(a_func,None)
-print 'ret:',ret
-print '\n'
+logging.info('ret: %s',str(ret))
+logging.info('\n')
 
-print '+++++ Test: object method call'
+logging.info('+++++ Test: object method call')
 ret = py.instance().call(obj.fcn,None)
-print 'ret:',ret
-print '\n'
+logging.info('ret: %s',str(ret))
+logging.info('\n')
 
-print '+++++ Test: object method call with non callable'
+logging.info('+++++ Test: object method call with non callable')
 try: 
   ret = py.instance().call(1,None)
-  print 'ret:',ret
+  logging.info('ret: %s',str(ret))
 except:
   traceback.print_exc()
-print '\n'
+logging.info('\n')
 
-print '+++++ Test: object method call with exception in python callback'
+logging.info('+++++ Test: object method call with exception in python callback')
 try: 
   ret = py.instance().call(obj.fcn_except,(1,[1,2,3,4,5,6],))
-  print 'ret:',ret
+  logging.info('ret: %s',str(ret))
 except:
   traceback.print_exc()
-print '\n'
-print '+++++ All Done....\n\n'
-print 'TEST_PASSED'
+logging.info('\n')
+logging.info('+++++ All Done....\n\n')
+logging.info('TEST_PASSED')
 
 #py.instance().prompt()
 

--- a/examples/LHeD/scripts/initAClick.C
+++ b/examples/LHeD/scripts/initAClick.C
@@ -63,7 +63,7 @@ int initAClick(const char* command=0)  {
   std::string defs    = "";
   std::string libs    = " -L"+rootsys+"/lib";
   std::string inc     = " -I"+dd4hep+"/examples/LHeD/scripts -I"+dd4hep + " -I"+dd4hep+"/include"+clhep+"/include -I"+geant4+"/include";
-  libs += " -L"+dd4hep+"/lib -lDDCore -lDDG4 -lDDSegmentation";
+  libs += " -L"+dd4hep+"/lib -lDDCore -lDDG4";
   if ( !geant4.empty() )  {
     inc  += " -I"+geant4+"/include/Geant4";
 #ifdef __APPLE__


### PR DESCRIPTION
BEGINRELEASENOTES
# Add Support to Export and Import GDML Data
 - Allow to support exorts and imports of partial geometry trees with GDML
   This requires however a future version of ROOT, since some changes were necessary in
   the ROOT GDML handlers. The code is commented out for the time being.
   The plugin implementation is in DDCore/src/gdml/GdmlPlugin.cpp
# Remove print statements from DDG4 scripts
   - Replace prints with calls to the python logging utility.
    Hopefully this shall give at some point python3 compatibility.
# Update G4Stepper factories
 - Add some missing steppers
ENDRELEASENOTES