### PR TITLE
Fix logic for ignoring warnings in dictionary creation

### DIFF
--- a/.dd4hep-ci.d/compile_and_test.sh
+++ b/.dd4hep-ci.d/compile_and_test.sh
@@ -5,7 +5,7 @@ source /DD4hep/.dd4hep-ci.d/init_x86_64.sh
 cd /DD4hep
 mkdir build
 cd build
-cmake -GNinja -D DD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -D DD4HEP_USE_LCIO=ON -D BUILD_TESTING=ON  -D Geant4_DIR=$G4INSTALL/lib64/Geant4-10.3.3 -D DD4HEP_USE_CXX11=ON -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" .. && \
+cmake -GNinja -D DD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -D DD4HEP_USE_LCIO=ON -D BUILD_TESTING=ON  -D Geant4_DIR=$G4INSTALL/lib64/Geant4-10.3.3 -D DD4HEP_USE_CXX11=ON -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" .. && \
 ninja && \
 ninja install && \
 . ../bin/thisdd4hep.sh && \

--- a/DDCore/include/ROOT/Warnings.h
+++ b/DDCore/include/ROOT/Warnings.h
@@ -15,19 +15,18 @@
 //  M.Frank
 //==========================================================================
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#pragma GCC diagnostic ignored "-Wunused"
-#pragma GCC diagnostic ignored "-Woverlength-strings"
-
-#elif defined(__llvm__) || defined(__clang__) || defined(__APPLE__)
-
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#pragma clang diagnostic ignored "-Wdeprecated"
-#pragma clang diagnostic ignored "-Wunused"
-#pragma clang diagnostic ignored "-Woverlength-strings"
+#if defined(__clang__)
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  #pragma clang diagnostic ignored "-Wdeprecated"
+  #pragma clang diagnostic ignored "-Wunused"
+  #pragma clang diagnostic ignored "-Woverlength-strings"
+#elif defined(__GNUC__) || defined(__GNUG__)
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  #pragma GCC diagnostic ignored "-Wdeprecated"
+  #pragma GCC diagnostic ignored "-Wunused"
+  #pragma GCC diagnostic ignored "-Woverlength-strings"
 #endif
+
 
 #if defined(__CINT__) || defined(__MAKECINT__) || defined(__CLANG__) || defined(__ROOTCLING__)
 #define  DD4HEP_DICTIONARY_MODE 1

--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -1025,7 +1025,7 @@ function( dd4hep_add_library binary building )
         #
         # root-cint produces warnings of type 'unused-function' disable them on generated files
         foreach ( f in  ${ARG_GENERATED} )
-          set_source_files_properties( ${f} PROPERTIES COMPILE_FLAGS -Wno-unused-function GENERATED TRUE )
+          set_source_files_properties( ${f} PROPERTIES COMPILE_FLAGS "-Wno-unused-function -Wno-overlength-strings" GENERATED TRUE )
         endforeach()
         list ( APPEND sources ${ARG_GENERATED} )
       endif()
@@ -1217,7 +1217,7 @@ function ( dd4hep_add_executable binary )
         endif()
         #  Prepare flags for cint generated sources:
         foreach ( f in  ${ARG_GENERATED} )
-          set_source_files_properties( ${f} PROPERTIES COMPILE_FLAGS -Wno-unused-function GENERATED TRUE )
+          set_source_files_properties( ${f} PROPERTIES COMPILE_FLAGS "-Wno-unused-function -Wno-overlength-strings" GENERATED TRUE )
         endforeach()
         #
         set ( sources ${ARG_GENERATED} ${ARG_SOURCES} ${optional_sources} )


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix logic for ignoring warnings in dictionary creation
- Add `-Wno-overlength-strings` to all generated targets

ENDRELEASENOTES

When using `clang` the value for `__clang__` is 1 and the value for `__GNUC__` is 4, whereas in the GCC case `__clang__` is not defined and `__GNUC__` is the main compiler version, thus the logic has to be swapped. But since `clang` accepts `#pragma GCC diagnostic ignored` this does really change much.