### PR TITLE
[WIP] Fixes for ExtraParticles and ParticleHandler

### DIFF
--- a/DDG4/plugins/Geant4ExtraParticles.cpp
+++ b/DDG4/plugins/Geant4ExtraParticles.cpp
@@ -97,6 +97,9 @@ void Geant4ExtraParticles::constructParticle(Constructor& ) {
     // do add particles that don't fly
     // if (lifetime == 0) continue;
 
+    //unstable particles with too small lifetime have width -1
+    bool stable = (width > 0 or width < -0.5) ? false : true;
+
     if(width<0) width = 0;
 
     // normalize to G4 units
@@ -143,7 +146,7 @@ void Geant4ExtraParticles::constructParticle(Constructor& ) {
                                      0,          // lepton number
                                      0,          // baryon number
                                      pdg,        // PDG encoding
-                                     width==0?true:false,      // stable
+                                     stable,     // stable
                                      lifetime,   // lifetime
                                      NULL,       // decay table
                                      false);      // short lived

--- a/DDG4/src/Geant4InputHandling.cpp
+++ b/DDG4/src/Geant4InputHandling.cpp
@@ -464,6 +464,9 @@ int dd4hep::sim::generatePrimaries(const Geant4Action* caller,
 	    }
 	  }
 	}
+        if(caller->outputLevel() <= VERBOSE){
+          v4->Print();
+        }
       }
     }
     for(map<int,G4PrimaryParticle*>::iterator i=prim.begin(); i!=prim.end(); ++i)  {

--- a/DDG4/src/Geant4InputHandling.cpp
+++ b/DDG4/src/Geant4InputHandling.cpp
@@ -379,10 +379,10 @@ getRelevant(set<int>& visited,
     double me = en > std::numeric_limits<double>::epsilon() ? p->mass / en : 0.0;
     //  fix by S.Morozov for real != 0
     double proper_time = fabs(dp->time-p->time) * me;
-    double proper_time_Precision =  pow(10.,-DBL_DIG)*me*fmax(fabs(p->time),fabs(dp->time));
-    bool isProperTimeZero = ( proper_time <= proper_time_Precision ) ;
-    // -- remove original --- if (proper_time != 0) {
-    if ( !isProperTimeZero ) {
+
+    // -- remove original --- if the pdgID is not known (generator "strings") or the particle is quark, gluon, Z, W, etc.
+    const std::set<int> rejectPDGs{1, 2, 3, 4, 5, 6, 21, 23, 24};
+    if (p.definition() && rejectPDGs.count(abs(p->pdgID)) == 0) {
       map<int,G4PrimaryParticle*>::iterator ip4 = prim.find(p->id);
       G4PrimaryParticle* p4 = (ip4 == prim.end()) ? 0 : (*ip4).second;
       if ( !p4 )  {


### PR DESCRIPTION
BEGINRELEASENOTES
- DDG4::ExtraParticles: particles with too small life time were tagged as stable, now correctly marked unstable
- DDG4::Geant4InputHandling: pass all particles except strings, quarks and gluons to Geant4 to get completely consistent MCParticle History, fixes #310 
- DDG4::Geant4InputHandling: print geant4 primary particle chains if VERBOSE

ENDRELEASENOTES


I tried to figure something more generic than a fixed list of pdgIDs to ignore, but the G4ParticleDefinition::IsShortLived also returns true for rho0 for example, so this cannot be used to find particles to ignore either. Quarks could be identified by their non-integer charge, but that doesn't work for gluons. 

TODO:

- [ ] Make the set of pdgIDs to ignore configurable at run time
