### PR TITLE
[WIP] DDCore: added CartesianStrip segmentations

### DIFF
--- a/DDCore/include/DD4hep/CartesianStripX.h
+++ b/DDCore/include/DD4hep/CartesianStripX.h
@@ -1,0 +1,95 @@
+//==========================================================================
+//  AIDA Detector description implementation
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//  \author   Markus Frank, David Blyth
+//  \date     2018-02-20
+//  \version  1.0
+//
+//==========================================================================
+#ifndef DD4HEP_DDCORE_CARTESIANSTRIPX_H
+#define DD4HEP_DDCORE_CARTESIANSTRIPX_H 1
+
+// Framework include files
+#include "DD4hep/Segmentations.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+/// Namespace for base segmentations
+namespace DDSegmentation {
+class CartesianStripX;
+}
+
+/// We need some abbreviation to make the code more readable.
+typedef Handle<SegmentationWrapper<DDSegmentation::CartesianStripX> > CartesianStripXHandle;
+
+/// Implementation class for the strip X segmentation.
+/**
+ *  Concrete user handle to serve specific needs of client code
+ *  which requires access to the base functionality not served
+ *  by the super-class Segmentation.
+ *
+ *  Note:
+ *  We only check the validity of the underlying handle.
+ *  If for whatever reason the implementation object is not valid
+ *  This is not checked.
+ *  In principle this CANNOT happen unless some brain-dead has
+ *  fiddled with the handled object directly.....
+ *
+ *  Note:
+ *  The handle base corrsponding to this object in for
+ *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
+ *
+ *  \author  M.Frank
+ *  \version 1.0
+ *  \ingroup DD4HEP_CORE
+ */
+class CartesianStripX : public CartesianStripXHandle {
+   public:
+    /// Default constructor
+    CartesianStripX() = default;
+    /// Copy constructor
+    CartesianStripX(const CartesianStripX& e) = default;
+    /// Copy Constructor from segmentation base object
+    CartesianStripX(const Segmentation& e) : Handle<Object>(e) {}
+    /// Copy constructor from handle
+    CartesianStripX(const Handle<Object>& e) : Handle<Object>(e) {}
+    /// Copy constructor from other equivalent handle
+    template <typename Q>
+    CartesianStripX(const Handle<Q>& e) : Handle<Object>(e) {}
+    /// Assignment operator
+    CartesianStripX& operator=(const CartesianStripX& seg) = default;
+    /// Equality operator
+    bool operator==(const CartesianStripX& seg) const { return m_element == seg.m_element; }
+
+    /// determine the position based on the cell ID
+    Position position(const CellID& cellID) const;
+    /// determine the cell ID based on the position
+    CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const;
+    /// access the strip size in X
+    double stripSizeX() const;
+    /// set the strip size in X
+    void setStripSizeX(double cellSize) const;
+    /// access the coordinate offset in X
+    double offsetX() const;
+    /// set the coordinate offset in X
+    void setOffsetX(double offset) const;
+    /// access the field name used for X
+    const std::string& fieldNameX() const;
+    /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+        in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+        Returns a vector of the cellDimensions of the given cell ID
+        \param cellID is ignored as all cells have the same dimension
+        \return std::vector<double> size 1:
+        -# size in x
+    */
+    std::vector<double> cellDimensions(const CellID& cellID) const;
+};
+} /* End namespace dd4hep                */
+#endif  // DD4HEP_DDCORE_CARTESIANSTRIPX_H

--- a/DDCore/include/DD4hep/CartesianStripY.h
+++ b/DDCore/include/DD4hep/CartesianStripY.h
@@ -1,0 +1,95 @@
+//==========================================================================
+//  AIDA Detector description implementation
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//  \author   Markus Frank, David Blyth
+//  \date     2018-02-20
+//  \version  1.0
+//
+//==========================================================================
+#ifndef DD4HEP_DDCORE_CARTESIANSTRIPY_H
+#define DD4HEP_DDCORE_CARTESIANSTRIPY_H 1
+
+// Framework include files
+#include "DD4hep/Segmentations.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+/// Namespace for base segmentations
+namespace DDSegmentation {
+class CartesianStripY;
+}
+
+/// We need some abbreviation to make the code more readable.
+typedef Handle<SegmentationWrapper<DDSegmentation::CartesianStripY> > CartesianStripYHandle;
+
+/// Implementation class for the strip Y segmentation.
+/**
+ *  Concrete user handle to serve specific needs of client code
+ *  which requires access to the base functionality not served
+ *  by the super-class Segmentation.
+ *
+ *  Note:
+ *  We only check the validity of the underlying handle.
+ *  If for whatever reason the implementation object is not valid
+ *  This is not checked.
+ *  In principle this CANNOT happen unless some brain-dead has
+ *  fiddled with the handled object directly.....
+ *
+ *  Note:
+ *  The handle base corrsponding to this object in for
+ *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
+ *
+ *  \author  M.Frank
+ *  \version 1.0
+ *  \ingroup DD4HEP_CORE
+ */
+class CartesianStripY : public CartesianStripYHandle {
+   public:
+    /// Default constructor
+    CartesianStripY() = default;
+    /// Copy constructor
+    CartesianStripY(const CartesianStripY& e) = default;
+    /// Copy Constructor from segmentation base object
+    CartesianStripY(const Segmentation& e) : Handle<Object>(e) {}
+    /// Copy constructor from handle
+    CartesianStripY(const Handle<Object>& e) : Handle<Object>(e) {}
+    /// Copy constructor from other equivalent handle
+    template <typename Q>
+    CartesianStripY(const Handle<Q>& e) : Handle<Object>(e) {}
+    /// Assignment operator
+    CartesianStripY& operator=(const CartesianStripY& seg) = default;
+    /// Equality operator
+    bool operator==(const CartesianStripY& seg) const { return m_element == seg.m_element; }
+
+    /// determine the position based on the cell ID
+    Position position(const CellID& cellID) const;
+    /// determine the cell ID based on the position
+    CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const;
+    /// access the strip size in Y
+    double stripSizeY() const;
+    /// set the strip size in Y
+    void setStripSizeY(double cellSize) const;
+    /// access the coordinate offset in Y
+    double offsetY() const;
+    /// set the coordinate offset in Y
+    void setOffsetY(double offset) const;
+    /// access the field name used for Y
+    const std::string& fieldNameY() const;
+    /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+        in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+        Returns a vector of the cellDimensions of the given cell ID
+        \param cellID is ignored as all cells have the same dimension
+        \return std::vector<double> size 1:
+        -# size in x
+    */
+    std::vector<double> cellDimensions(const CellID& cellID) const;
+};
+} /* End namespace dd4hep                */
+#endif  // DD4HEP_DDCORE_CARTESIANSTRIPY_H

--- a/DDCore/include/DD4hep/CartesianStripZ.h
+++ b/DDCore/include/DD4hep/CartesianStripZ.h
@@ -1,0 +1,95 @@
+//==========================================================================
+//  AIDA Detector description implementation
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//  \author   Markus Frank, David Blyth
+//  \date     2018-02-20
+//  \version  1.0
+//
+//==========================================================================
+#ifndef DD4HEP_DDCORE_CARTESIANSTRIPZ_H
+#define DD4HEP_DDCORE_CARTESIANSTRIPZ_H 1
+
+// Framework include files
+#include "DD4hep/Segmentations.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+/// Namespace for base segmentations
+namespace DDSegmentation {
+class CartesianStripZ;
+}
+
+/// We need some abbreviation to make the code more readable.
+typedef Handle<SegmentationWrapper<DDSegmentation::CartesianStripZ> > CartesianStripZHandle;
+
+/// Implementation class for the strip Z segmentation.
+/**
+ *  Concrete user handle to serve specific needs of client code
+ *  which requires access to the base functionality not served
+ *  by the super-class Segmentation.
+ *
+ *  Note:
+ *  We only check the validity of the underlying handle.
+ *  If for whatever reason the implementation object is not valid
+ *  This is not checked.
+ *  In principle this CANNOT happen unless some brain-dead has
+ *  fiddled with the handled object directly.....
+ *
+ *  Note:
+ *  The handle base corrsponding to this object in for
+ *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
+ *
+ *  \author  M.Frank
+ *  \version 1.0
+ *  \ingroup DD4HEP_CORE
+ */
+class CartesianStripZ : public CartesianStripZHandle {
+   public:
+    /// Default constructor
+    CartesianStripZ() = default;
+    /// Copy constructor
+    CartesianStripZ(const CartesianStripZ& e) = default;
+    /// Copy Constructor from segmentation base object
+    CartesianStripZ(const Segmentation& e) : Handle<Object>(e) {}
+    /// Copy constructor from handle
+    CartesianStripZ(const Handle<Object>& e) : Handle<Object>(e) {}
+    /// Copy constructor from other equivalent handle
+    template <typename Q>
+    CartesianStripZ(const Handle<Q>& e) : Handle<Object>(e) {}
+    /// Assignment operator
+    CartesianStripZ& operator=(const CartesianStripZ& seg) = default;
+    /// Equality operator
+    bool operator==(const CartesianStripZ& seg) const { return m_element == seg.m_element; }
+
+    /// determine the position based on the cell ID
+    Position position(const CellID& cellID) const;
+    /// determine the cell ID based on the position
+    CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const;
+    /// access the strip size in Z
+    double stripSizeZ() const;
+    /// set the strip size in Z
+    void setStripSizeZ(double cellSize) const;
+    /// access the coordinate offset in Z
+    double offsetZ() const;
+    /// set the coordinate offset in Z
+    void setOffsetZ(double offset) const;
+    /// access the field name used for Z
+    const std::string& fieldNameZ() const;
+    /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+        in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+        Returns a vector of the cellDimensions of the given cell ID
+        \param cellID is ignored as all cells have the same dimension
+        \return std::vector<double> size 1:
+        -# size in x
+    */
+    std::vector<double> cellDimensions(const CellID& cellID) const;
+};
+} /* End namespace dd4hep                */
+#endif  // DD4HEP_DDCORE_CARTESIANSTRIPZ_H

--- a/DDCore/include/DDSegmentation/CartesianStrip.h
+++ b/DDCore/include/DDSegmentation/CartesianStrip.h
@@ -1,0 +1,29 @@
+/*
+ * CartesianStrip.h
+ *
+ *  Created on: Jun 28, 2013
+ *      Author: Christian Grefe, CERN
+ *              David Blyth, ANL
+ */
+
+#ifndef DDSegmentation_CARTESIANSTRIP_H_
+#define DDSegmentation_CARTESIANSTRIP_H_
+
+#include "DDSegmentation/Segmentation.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+class CartesianStrip : public Segmentation {
+   public:
+    /// Destructor
+    virtual ~CartesianStrip();
+
+   protected:
+    /// Default constructor used by derived classes passing the encoding string
+    CartesianStrip(const std::string& cellEncoding = "");
+    /// Default constructor used by derived classes passing an existing decoder
+    CartesianStrip(const BitFieldCoder* decoder);
+};
+} /* namespace DDSegmentation */
+} /* namespace dd4hep */
+#endif  // DDSegmentation_CARTESIANSTRIP_H_

--- a/DDCore/include/DDSegmentation/CartesianStripX.h
+++ b/DDCore/include/DDSegmentation/CartesianStripX.h
@@ -1,0 +1,62 @@
+/*
+ * CartesianStripX.h
+ *
+ *  Created on: Jun 28, 2013
+ *      Author: Christian Grefe, CERN
+ *              David Blyth, ANL
+ */
+
+#ifndef DDSegmentation_CARTESIANSTRIPX_H_
+#define DDSegmentation_CARTESIANSTRIPX_H_
+
+#include "DDSegmentation/CartesianStrip.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+class CartesianStripX : public DDSegmentation::CartesianStrip {
+   public:
+    /// Default constructor passing the encoding string
+    CartesianStripX(const std::string& cellEncoding = "");
+    /// Default constructor used by derived classes passing an existing decoder
+    CartesianStripX(const BitFieldCoder* decoder);
+    /// destructor
+    virtual ~CartesianStripX();
+
+    /// determine the position based on the cell ID
+    virtual Vector3D position(const CellID& cellID) const;
+    /// determine the cell ID based on the position
+    virtual CellID cellID(const Vector3D& localPosition, const Vector3D& globalPosition,
+                          const VolumeID& volumeID) const;
+    /// access the strip size in X
+    double stripSizeX() const { return _stripSizeX; }
+    /// access the coordinate offset in X
+    double offsetX() const { return _offsetX; }
+    /// access the field name used for X
+    const std::string& fieldNameX() const { return _xId; }
+    /// set the strip size in X
+    void setStripSizeX(double cellSize) { _stripSizeX = cellSize; }
+    /// set the coordinate offset in X
+    void setOffsetX(double offset) { _offsetX = offset; }
+    /// set the field name used for X
+    void setFieldNameX(const std::string& fieldName) { _xId = fieldName; }
+    /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+        in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+        Returns a vector of the cellDimensions of the given cell ID
+        \param cellID is ignored as all cells have the same dimension
+        \return std::vector<double> size 1:
+        -# size in x
+    */
+    virtual std::vector<double> cellDimensions(const CellID& cellID) const;
+
+   protected:
+    /// the strip size in X
+    double _stripSizeX;
+    /// the coordinate offset in X
+    double _offsetX;
+    /// the field name used for X
+    std::string _xId;
+};
+}  // namespace DDSegmentation
+} /* namespace dd4hep */
+#endif  // DDSegmentation_CARTESIANSTRIPX_H_

--- a/DDCore/include/DDSegmentation/CartesianStripY.h
+++ b/DDCore/include/DDSegmentation/CartesianStripY.h
@@ -1,0 +1,62 @@
+/*
+ * CartesianStripY.h
+ *
+ *  Created on: Jun 28, 2013
+ *      Author: Christian Grefe, CERN
+ *              David Blyth, ANL
+ */
+
+#ifndef DDSegmentation_CARTESIANSTRIPY_H_
+#define DDSegmentation_CARTESIANSTRIPY_H_
+
+#include "DDSegmentation/CartesianStrip.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+class CartesianStripY : public DDSegmentation::CartesianStrip {
+   public:
+    /// Default constructor passing the encoding string
+    CartesianStripY(const std::string& cellEncoding = "");
+    /// Default constructor used by derived classes passing an existing decoder
+    CartesianStripY(const BitFieldCoder* decoder);
+    /// destructor
+    virtual ~CartesianStripY();
+
+    /// determine the position based on the cell ID
+    virtual Vector3D position(const CellID& cellID) const;
+    /// determine the cell ID based on the position
+    virtual CellID cellID(const Vector3D& localPosition, const Vector3D& globalPosition,
+                          const VolumeID& volumeID) const;
+    /// access the strip size in Y
+    double stripSizeY() const { return _stripSizeY; }
+    /// access the coordinate offset in Y
+    double offsetY() const { return _offsetY; }
+    /// access the field name used for Y
+    const std::string& fieldNameY() const { return _xId; }
+    /// set the strip size in Y
+    void setStripSizeY(double cellSize) { _stripSizeY = cellSize; }
+    /// set the coordinate offset in Y
+    void setOffsetY(double offset) { _offsetY = offset; }
+    /// set the field name used for Y
+    void setFieldNameY(const std::string& fieldName) { _xId = fieldName; }
+    /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+        in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+        Returns a vector of the cellDimensions of the given cell ID
+        \param cellID is ignored as all cells have the same dimension
+        \return std::vector<double> size 1:
+        -# size in x
+    */
+    virtual std::vector<double> cellDimensions(const CellID& cellID) const;
+
+   protected:
+    /// the strip size in Y
+    double _stripSizeY;
+    /// the coordinate offset in Y
+    double _offsetY;
+    /// the field name used for Y
+    std::string _xId;
+};
+}  // namespace DDSegmentation
+} /* namespace dd4hep */
+#endif  // DDSegmentation_CARTESIANSTRIPY_H_

--- a/DDCore/include/DDSegmentation/CartesianStripZ.h
+++ b/DDCore/include/DDSegmentation/CartesianStripZ.h
@@ -1,0 +1,62 @@
+/*
+ * CartesianStripZ.h
+ *
+ *  Created on: Jun 28, 2013
+ *      Author: Christian Grefe, CERN
+ *              David Blyth, ANL
+ */
+
+#ifndef DDSegmentation_CARTESIANSTRIPZ_H_
+#define DDSegmentation_CARTESIANSTRIPZ_H_
+
+#include "DDSegmentation/CartesianStrip.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+class CartesianStripZ : public DDSegmentation::CartesianStrip {
+   public:
+    /// Default constructor passing the encoding string
+    CartesianStripZ(const std::string& cellEncoding = "");
+    /// Default constructor used by derived classes passing an existing decoder
+    CartesianStripZ(const BitFieldCoder* decoder);
+    /// destructor
+    virtual ~CartesianStripZ();
+
+    /// determine the position based on the cell ID
+    virtual Vector3D position(const CellID& cellID) const;
+    /// determine the cell ID based on the position
+    virtual CellID cellID(const Vector3D& localPosition, const Vector3D& globalPosition,
+                          const VolumeID& volumeID) const;
+    /// access the strip size in Z
+    double stripSizeZ() const { return _stripSizeZ; }
+    /// access the coordinate offset in Z
+    double offsetZ() const { return _offsetZ; }
+    /// access the field name used for Z
+    const std::string& fieldNameZ() const { return _xId; }
+    /// set the strip size in Z
+    void setStripSizeZ(double cellSize) { _stripSizeZ = cellSize; }
+    /// set the coordinate offset in Z
+    void setOffsetZ(double offset) { _offsetZ = offset; }
+    /// set the field name used for Z
+    void setFieldNameZ(const std::string& fieldName) { _xId = fieldName; }
+    /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+        in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+        Returns a vector of the cellDimensions of the given cell ID
+        \param cellID is ignored as all cells have the same dimension
+        \return std::vector<double> size 1:
+        -# size in x
+    */
+    virtual std::vector<double> cellDimensions(const CellID& cellID) const;
+
+   protected:
+    /// the strip size in Z
+    double _stripSizeZ;
+    /// the coordinate offset in Z
+    double _offsetZ;
+    /// the field name used for Z
+    std::string _xId;
+};
+}  // namespace DDSegmentation
+} /* namespace dd4hep */
+#endif  // DDSegmentation_CARTESIANSTRIPZ_H_

--- a/DDCore/src/CartesianStripX.cpp
+++ b/DDCore/src/CartesianStripX.cpp
@@ -1,0 +1,61 @@
+//==========================================================================
+//  AIDA Detector description implementation
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank, D.Blyth
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/CartesianStripX.h"
+#include "DD4hep/detail/SegmentationsInterna.h"
+#include "DDSegmentation/CartesianStripX.h"
+
+using namespace std;
+using namespace dd4hep;
+
+/// determine the position based on the cell ID
+Position CartesianStripX::position(const CellID& id) const {
+    return Position(access()->implementation->position(id));
+}
+
+/// determine the cell ID based on the position
+dd4hep::CellID CartesianStripX::cellID(const Position& local, const Position& global,
+                                       const VolumeID& volID) const {
+    return access()->implementation->cellID(local, global, volID);
+}
+
+/// access the strip size in X
+double CartesianStripX::stripSizeX() const { return access()->implementation->stripSizeX(); }
+
+/// set the strip size in X
+void CartesianStripX::setStripSizeX(double cellSize) const {
+    access()->implementation->setStripSizeX(cellSize);
+}
+
+/// access the coordinate offset in X
+double CartesianStripX::offsetX() const { return access()->implementation->offsetX(); }
+
+/// set the coordinate offset in X
+void CartesianStripX::setOffsetX(double offset) const { access()->implementation->setOffsetX(offset); }
+
+/// access the field name used for X
+const string& CartesianStripX::fieldNameX() const { return access()->implementation->fieldNameX(); }
+
+/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+    Returns a vector of the cellDimensions of the given cell ID
+    \param cellID is ignored as all cells have the same dimension
+    \return vector<double> size 2:
+    -# size in x
+    -# size in y
+*/
+vector<double> CartesianStripX::cellDimensions(const CellID& id) const {
+    return access()->implementation->cellDimensions(id);
+}

--- a/DDCore/src/CartesianStripY.cpp
+++ b/DDCore/src/CartesianStripY.cpp
@@ -1,0 +1,61 @@
+//==========================================================================
+//  AIDA Detector description implementation
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank, D.Blyth
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/CartesianStripY.h"
+#include "DD4hep/detail/SegmentationsInterna.h"
+#include "DDSegmentation/CartesianStripY.h"
+
+using namespace std;
+using namespace dd4hep;
+
+/// determine the position based on the cell ID
+Position CartesianStripY::position(const CellID& id) const {
+    return Position(access()->implementation->position(id));
+}
+
+/// determine the cell ID based on the position
+dd4hep::CellID CartesianStripY::cellID(const Position& local, const Position& global,
+                                       const VolumeID& volID) const {
+    return access()->implementation->cellID(local, global, volID);
+}
+
+/// access the strip size in Y
+double CartesianStripY::stripSizeY() const { return access()->implementation->stripSizeY(); }
+
+/// set the strip size in Y
+void CartesianStripY::setStripSizeY(double cellSize) const {
+    access()->implementation->setStripSizeY(cellSize);
+}
+
+/// access the coordinate offset in Y
+double CartesianStripY::offsetY() const { return access()->implementation->offsetY(); }
+
+/// set the coordinate offset in Y
+void CartesianStripY::setOffsetY(double offset) const { access()->implementation->setOffsetY(offset); }
+
+/// access the field name used for Y
+const string& CartesianStripY::fieldNameY() const { return access()->implementation->fieldNameY(); }
+
+/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+    Returns a vector of the cellDimensions of the given cell ID
+    \param cellID is ignored as all cells have the same dimension
+    \return vector<double> size 2:
+    -# size in x
+    -# size in y
+*/
+vector<double> CartesianStripY::cellDimensions(const CellID& id) const {
+    return access()->implementation->cellDimensions(id);
+}

--- a/DDCore/src/CartesianStripZ.cpp
+++ b/DDCore/src/CartesianStripZ.cpp
@@ -1,0 +1,61 @@
+//==========================================================================
+//  AIDA Detector description implementation
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank, D.Blyth
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/CartesianStripZ.h"
+#include "DD4hep/detail/SegmentationsInterna.h"
+#include "DDSegmentation/CartesianStripZ.h"
+
+using namespace std;
+using namespace dd4hep;
+
+/// determine the position based on the cell ID
+Position CartesianStripZ::position(const CellID& id) const {
+    return Position(access()->implementation->position(id));
+}
+
+/// determine the cell ID based on the position
+dd4hep::CellID CartesianStripZ::cellID(const Position& local, const Position& global,
+                                       const VolumeID& volID) const {
+    return access()->implementation->cellID(local, global, volID);
+}
+
+/// access the strip size in Z
+double CartesianStripZ::stripSizeZ() const { return access()->implementation->stripSizeZ(); }
+
+/// set the strip size in Z
+void CartesianStripZ::setStripSizeZ(double cellSize) const {
+    access()->implementation->setStripSizeZ(cellSize);
+}
+
+/// access the coordinate offset in Z
+double CartesianStripZ::offsetZ() const { return access()->implementation->offsetZ(); }
+
+/// set the coordinate offset in Z
+void CartesianStripZ::setOffsetZ(double offset) const { access()->implementation->setOffsetZ(offset); }
+
+/// access the field name used for Z
+const string& CartesianStripZ::fieldNameZ() const { return access()->implementation->fieldNameZ(); }
+
+/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+    Returns a vector of the cellDimensions of the given cell ID
+    \param cellID is ignored as all cells have the same dimension
+    \return vector<double> size 2:
+    -# size in x
+    -# size in y
+*/
+vector<double> CartesianStripZ::cellDimensions(const CellID& id) const {
+    return access()->implementation->cellDimensions(id);
+}

--- a/DDCore/src/SegmentationDictionary.h
+++ b/DDCore/src/SegmentationDictionary.h
@@ -27,6 +27,9 @@
 #include "DDSegmentation/CartesianGridXYZ.h"
 #include "DDSegmentation/CartesianGridXZ.h"
 #include "DDSegmentation/CartesianGridYZ.h"
+#include "DDSegmentation/CartesianStripX.h"
+#include "DDSegmentation/CartesianStripY.h"
+#include "DDSegmentation/CartesianStripZ.h"
 #include "DDSegmentation/CylindricalSegmentation.h"
 #include "DDSegmentation/GridPhiEta.h"
 #include "DDSegmentation/GridRPhiEta.h"
@@ -70,6 +73,9 @@ typedef dd4hep::DDSegmentation::CellID CellID;
 #pragma link C++ class dd4hep::DDSegmentation::CartesianGridXYZ+;
 #pragma link C++ class dd4hep::DDSegmentation::CartesianGridXZ+;
 #pragma link C++ class dd4hep::DDSegmentation::CartesianGridYZ+;
+#pragma link C++ class dd4hep::DDSegmentation::CartesianStripX+;
+#pragma link C++ class dd4hep::DDSegmentation::CartesianStripY+;
+#pragma link C++ class dd4hep::DDSegmentation::CartesianStripZ+;
 #pragma link C++ class dd4hep::DDSegmentation::CylindricalSegmentation+;
 #pragma link C++ class dd4hep::DDSegmentation::GridPhiEta+;
 #pragma link C++ class dd4hep::DDSegmentation::GridRPhiEta+;

--- a/DDCore/src/Segmentations.cpp
+++ b/DDCore/src/Segmentations.cpp
@@ -140,6 +140,15 @@ DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianGridYZ);
 #include "DDSegmentation/CartesianGridXYZ.h"
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianGridXYZ);
 
+#include "DDSegmentation/CartesianStripX.h"
+DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianStripX);
+
+#include "DDSegmentation/CartesianStripY.h"
+DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianStripY);
+
+#include "DDSegmentation/CartesianStripZ.h"
+DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianStripZ);
+
 #include "DDSegmentation/TiledLayerGridXY.h"
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::TiledLayerGridXY);
 

--- a/DDCore/src/plugins/ReadoutSegmentations.cpp
+++ b/DDCore/src/plugins/ReadoutSegmentations.cpp
@@ -40,6 +40,15 @@ DECLARE_SEGMENTATION(CartesianGridYZ,create_segmentation<dd4hep::DDSegmentation:
 #include "DDSegmentation/CartesianGridXYZ.h"
 DECLARE_SEGMENTATION(CartesianGridXYZ,create_segmentation<dd4hep::DDSegmentation::CartesianGridXYZ>)
 
+#include "DDSegmentation/CartesianStripX.h"
+DECLARE_SEGMENTATION(CartesianStripX,create_segmentation<dd4hep::DDSegmentation::CartesianStripX>)
+
+#include "DDSegmentation/CartesianStripY.h"
+DECLARE_SEGMENTATION(CartesianStripY,create_segmentation<dd4hep::DDSegmentation::CartesianStripY>)
+
+#include "DDSegmentation/CartesianStripZ.h"
+DECLARE_SEGMENTATION(CartesianStripZ,create_segmentation<dd4hep::DDSegmentation::CartesianStripZ>)
+
 #include "DDSegmentation/TiledLayerGridXY.h"
 DECLARE_SEGMENTATION(TiledLayerGridXY,create_segmentation<dd4hep::DDSegmentation::TiledLayerGridXY>)
 

--- a/DDCore/src/segmentations/CartesianStrip.cpp
+++ b/DDCore/src/segmentations/CartesianStrip.cpp
@@ -1,0 +1,22 @@
+/*
+ * CartesianStrip.cpp
+ *
+ *  Created on: Jun 28, 2013
+ *      Author: Christian Grefe, CERN
+ *              David Blyth, ANL
+ */
+
+#include "DDSegmentation/CartesianStrip.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+/// Default constructor used by derived classes passing the encoding string
+CartesianStrip::CartesianStrip(const std::string& cellEncoding) : Segmentation(cellEncoding) {}
+
+/// Default constructor used by derived classes passing an existing decoder
+CartesianStrip::CartesianStrip(const BitFieldCoder* decode) : Segmentation(decode) {}
+
+/// Destructor
+CartesianStrip::~CartesianStrip() {}
+} /* namespace DDSegmentation */
+} /* namespace dd4hep */

--- a/DDCore/src/segmentations/CartesianStripX.cpp
+++ b/DDCore/src/segmentations/CartesianStripX.cpp
@@ -1,0 +1,67 @@
+/*
+ * CartesianStripX.cpp
+ *
+ *  Created on: Jun 28, 2013
+ *      Author: Christian Grefe, CERN
+ *              David Blyth, ANL
+ */
+
+#include "DDSegmentation/CartesianStripX.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+/// default constructor using an encoding string
+CartesianStripX::CartesianStripX(const std::string& cellEncoding) : CartesianStrip(cellEncoding) {
+    // define type and description
+    _type = "CartesianStripX";
+    _description = "Cartesian segmentation on the local X axis";
+
+    // register all necessary parameters
+    registerParameter("strip_size_x", "Cell size in X", _stripSizeX, 1., SegmentationParameter::LengthUnit);
+    registerParameter("offset_x", "Cell offset in X", _offsetX, 0., SegmentationParameter::LengthUnit, true);
+    registerIdentifier("identifier_x", "Cell ID identifier for X", _xId, "strip");
+}
+
+/// Default constructor used by derived classes passing an existing decoder
+CartesianStripX::CartesianStripX(const BitFieldCoder* decode) : CartesianStrip(decode) {
+    // define type and description
+    _type = "CartesianStripX";
+    _description = "Cartesian segmentation on the local X axis";
+
+    // register all necessary parameters
+    registerParameter("strip_size_x", "Cell size in X", _stripSizeX, 1., SegmentationParameter::LengthUnit);
+    registerParameter("offset_x", "Cell offset in X", _offsetX, 0., SegmentationParameter::LengthUnit, true);
+    registerIdentifier("identifier_x", "Cell ID identifier for X", _xId, "strip");
+}
+
+/// destructor
+CartesianStripX::~CartesianStripX() {}
+
+/// determine the position based on the cell ID
+Vector3D CartesianStripX::position(const CellID& cID) const {
+    Vector3D cellPosition;
+    cellPosition.X = binToPosition(_decoder->get(cID, _xId), _stripSizeX, _offsetX);
+    return cellPosition;
+}
+
+/// determine the cell ID based on the position
+CellID CartesianStripX::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */,
+                               const VolumeID& vID) const {
+    CellID cID = vID;
+    _decoder->set(cID, _xId, positionToBin(localPosition.X, _stripSizeX, _offsetX));
+    return cID;
+}
+
+std::vector<double> CartesianStripX::cellDimensions(const CellID&) const {
+#if __cplusplus >= 201103L
+    return {_stripSizeX};
+#else
+    std::vector<double> cellDims(1, 0.0);
+    cellDims[0] = _stripSizeX;
+    return cellDims;
+#endif
+}
+
+REGISTER_SEGMENTATION(CartesianStripX)
+}  // namespace DDSegmentation
+} /* namespace dd4hep */

--- a/DDCore/src/segmentations/CartesianStripY.cpp
+++ b/DDCore/src/segmentations/CartesianStripY.cpp
@@ -1,0 +1,67 @@
+/*
+ * CartesianStripY.cpp
+ *
+ *  Created on: Jun 28, 2013
+ *      Author: Christian Grefe, CERN
+ *              David Blyth, ANL
+ */
+
+#include "DDSegmentation/CartesianStripY.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+/// default constructor using an encoding string
+CartesianStripY::CartesianStripY(const std::string& cellEncoding) : CartesianStrip(cellEncoding) {
+    // define type and description
+    _type = "CartesianStripY";
+    _description = "Cartesian segmentation on the local Y axis";
+
+    // register all necessary parameters
+    registerParameter("strip_size_x", "Cell size in Y", _stripSizeY, 1., SegmentationParameter::LengthUnit);
+    registerParameter("offset_x", "Cell offset in Y", _offsetY, 0., SegmentationParameter::LengthUnit, true);
+    registerIdentifier("identifier_x", "Cell ID identifier for Y", _xId, "strip");
+}
+
+/// Default constructor used by derived classes passing an existing decoder
+CartesianStripY::CartesianStripY(const BitFieldCoder* decode) : CartesianStrip(decode) {
+    // define type and description
+    _type = "CartesianStripY";
+    _description = "Cartesian segmentation on the local Y axis";
+
+    // register all necessary parameters
+    registerParameter("strip_size_x", "Cell size in Y", _stripSizeY, 1., SegmentationParameter::LengthUnit);
+    registerParameter("offset_x", "Cell offset in Y", _offsetY, 0., SegmentationParameter::LengthUnit, true);
+    registerIdentifier("identifier_x", "Cell ID identifier for Y", _xId, "strip");
+}
+
+/// destructor
+CartesianStripY::~CartesianStripY() {}
+
+/// determine the position based on the cell ID
+Vector3D CartesianStripY::position(const CellID& cID) const {
+    Vector3D cellPosition;
+    cellPosition.Y = binToPosition(_decoder->get(cID, _xId), _stripSizeY, _offsetY);
+    return cellPosition;
+}
+
+/// determine the cell ID based on the position
+CellID CartesianStripY::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */,
+                               const VolumeID& vID) const {
+    CellID cID = vID;
+    _decoder->set(cID, _xId, positionToBin(localPosition.Y, _stripSizeY, _offsetY));
+    return cID;
+}
+
+std::vector<double> CartesianStripY::cellDimensions(const CellID&) const {
+#if __cplusplus >= 201103L
+    return {_stripSizeY};
+#else
+    std::vector<double> cellDims(1, 0.0);
+    cellDims[0] = _stripSizeY;
+    return cellDims;
+#endif
+}
+
+REGISTER_SEGMENTATION(CartesianStripY)
+}  // namespace DDSegmentation
+} /* namespace dd4hep */

--- a/DDCore/src/segmentations/CartesianStripZ.cpp
+++ b/DDCore/src/segmentations/CartesianStripZ.cpp
@@ -1,0 +1,67 @@
+/*
+ * CartesianStripZ.cpp
+ *
+ *  Created on: Jun 28, 2013
+ *      Author: Christian Grefe, CERN
+ *              David Blyth, ANL
+ */
+
+#include "DDSegmentation/CartesianStripZ.h"
+
+namespace dd4hep {
+namespace DDSegmentation {
+/// default constructor using an encoding string
+CartesianStripZ::CartesianStripZ(const std::string& cellEncoding) : CartesianStrip(cellEncoding) {
+    // define type and description
+    _type = "CartesianStripZ";
+    _description = "Cartesian segmentation on the local Z axis";
+
+    // register all necessary parameters
+    registerParameter("strip_size_x", "Cell size in Z", _stripSizeZ, 1., SegmentationParameter::LengthUnit);
+    registerParameter("offset_x", "Cell offset in Z", _offsetZ, 0., SegmentationParameter::LengthUnit, true);
+    registerIdentifier("identifier_x", "Cell ID identifier for Z", _xId, "strip");
+}
+
+/// Default constructor used by derived classes passing an existing decoder
+CartesianStripZ::CartesianStripZ(const BitFieldCoder* decode) : CartesianStrip(decode) {
+    // define type and description
+    _type = "CartesianStripZ";
+    _description = "Cartesian segmentation on the local Z axis";
+
+    // register all necessary parameters
+    registerParameter("strip_size_x", "Cell size in Z", _stripSizeZ, 1., SegmentationParameter::LengthUnit);
+    registerParameter("offset_x", "Cell offset in Z", _offsetZ, 0., SegmentationParameter::LengthUnit, true);
+    registerIdentifier("identifier_x", "Cell ID identifier for Z", _xId, "strip");
+}
+
+/// destructor
+CartesianStripZ::~CartesianStripZ() {}
+
+/// determine the position based on the cell ID
+Vector3D CartesianStripZ::position(const CellID& cID) const {
+    Vector3D cellPosition;
+    cellPosition.Z = binToPosition(_decoder->get(cID, _xId), _stripSizeZ, _offsetZ);
+    return cellPosition;
+}
+
+/// determine the cell ID based on the position
+CellID CartesianStripZ::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */,
+                               const VolumeID& vID) const {
+    CellID cID = vID;
+    _decoder->set(cID, _xId, positionToBin(localPosition.Z, _stripSizeZ, _offsetZ));
+    return cID;
+}
+
+std::vector<double> CartesianStripZ::cellDimensions(const CellID&) const {
+#if __cplusplus >= 201103L
+    return {_stripSizeZ};
+#else
+    std::vector<double> cellDims(1, 0.0);
+    cellDims[0] = _stripSizeZ;
+    return cellDims;
+#endif
+}
+
+REGISTER_SEGMENTATION(CartesianStripZ)
+}  // namespace DDSegmentation
+} /* namespace dd4hep */


### PR DESCRIPTION
This PR resolves #303.

The idea is to extend the collection of segmentations to include 1D segmentations in addition to the existing 2D and 3D segmentations.  All code was adapted from 2D segmentations.  This PR is a WIP because testing should be added.

Devs, please let me know what you think.  If this is something you want in the code, I can add tests.  I need something like this, so if not, I'll put it into my own code.

Cheers!

BEGINRELEASENOTES
- DDCore: added CartesianStrip segmentations

ENDRELEASENOTES