### PR TITLE
Passing LCIO input parameters to output 

### DIFF
--- a/DDG4/include/DDG4/Geant4InputAction.h
+++ b/DDG4/include/DDG4/Geant4InputAction.h
@@ -32,6 +32,8 @@ namespace dd4hep  {
 
   /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
   namespace sim  {
+    
+    class Geant4InputAction;
 
     /// Basic geant4 event reader class. This interface/base-class must be implemented by concrete readers.
     /**
@@ -39,6 +41,7 @@ namespace dd4hep  {
      *
      *  \author  P.Kostka (main author)
      *  \author  M.Frank  (code reshuffeling into new DDG4 scheme)
+     *  \author  R.Ete    (added context from input action)
      *  \version 1.0
      *  \ingroup DD4HEP_SIMULATION
      */
@@ -66,6 +69,8 @@ namespace dd4hep  {
       bool m_directAccess;
       /// Current event number
       int  m_currEvent;
+      /// The input action context
+      Geant4InputAction *m_inputAction;
 
       /// transform the string parameter value into the type of parameter
       /**
@@ -89,6 +94,10 @@ namespace dd4hep  {
       Geant4EventReader(const std::string& nam);
       /// Default destructor
       virtual ~Geant4EventReader();
+      /// Get the context (from the input action)
+      Geant4Context* context() const;
+      /// Set the input action
+      void setInputAction(Geant4InputAction* action);
       /// File name
       const std::string& name()  const   {  return m_name;         }
       /// Flag if direct event access (by event sequence number) is supported (Default: false)

--- a/DDG4/lcio/Geant4Output2LCIO.cpp
+++ b/DDG4/lcio/Geant4Output2LCIO.cpp
@@ -352,18 +352,23 @@ lcio::LCCollectionVec* Geant4Output2LCIO::saveParticles(Geant4ParticleMap* parti
 void Geant4Output2LCIO::saveEvent(OutputContext<G4Event>& ctxt)  {
   lcio::LCEventImpl* e = context()->event().extension<lcio::LCEventImpl>();
   LCIOEventParameters* parameters = context()->event().extension<LCIOEventParameters>(false);
+  int runNumber(0), eventNumber(0);
+  const int eventNumberOffset(m_eventNumberOffset > 0 ? m_eventNumberOffset : 0);
+  const int runNumberOffset(m_runNumberOffset > 0 ? m_runNumberOffset : 0);
+  // Get event number, run number and parameters from extension ...
   if ( parameters ) {
-    e->setRunNumber(parameters->runNumber());
-    e->setEventNumber(parameters->eventNumber());
+    runNumber = parameters->runNumber() + runNumberOffset;
+    eventNumber = parameters->eventNumber() + eventNumberOffset;
     LCIOEventParameters::copyLCParameters(parameters->eventParameters(),e->parameters());
-    print("+++ Saving LCIO event %d run %d ....", e->getEventNumber(), e->getRunNumber());
   }
+  // ... or from DD4hep framework 
   else {
-    const int eventNumber = m_eventNumberOffset > 0 ? m_eventNumberOffset + ctxt.context->GetEventID() : ctxt.context->GetEventID();
-    e->setRunNumber(m_runNo);
-    e->setEventNumber(eventNumber);
-    print("+++ Saving LCIO event %d run %d ....", eventNumber, m_runNo);
+    runNumber = m_runNo + runNumberOffset;
+    eventNumber = ctxt.context->GetEventID() + eventNumberOffset;
   }
+  print("+++ Saving LCIO event %d run %d ....", eventNumber, runNumber);
+  e->setRunNumber(runNumber);
+  e->setEventNumber(eventNumber);
   e->setDetectorName(context()->detectorDescription().header().name());
   saveEventParameters<int>(e, m_eventParametersInt);
   saveEventParameters<float>(e, m_eventParametersFloat);

--- a/DDG4/lcio/LCIOEventParameters.cpp
+++ b/DDG4/lcio/LCIOEventParameters.cpp
@@ -1,0 +1,83 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// @author  R.Ete (main author)
+//
+//====================================================================
+
+// Framework include files
+#include "LCIOEventParameters.h"
+
+using namespace std;
+using namespace dd4hep;
+using namespace dd4hep::sim;
+
+/// Initializing constructor
+LCIOEventParameters::LCIOEventParameters()
+  : m_runNumber(0), m_eventNumber(0)
+{
+}
+
+/// Default destructor
+LCIOEventParameters::~LCIOEventParameters()  {
+}
+
+/// Set the event parameters
+void LCIOEventParameters::setParameters(int rNumber, 
+                                        int evtNumber, 
+                                        const EVENT::LCParameters& parameters)
+{
+  m_runNumber = rNumber;
+  m_eventNumber = evtNumber;
+  copyLCParameters(parameters, m_eventParameters);
+}
+
+/// Get the run number
+int LCIOEventParameters::runNumber() const  {
+  return m_runNumber;
+}
+
+/// Get the event number
+int LCIOEventParameters::eventNumber() const  {
+  return m_eventNumber;
+}
+
+/// Get the event parameters
+const IMPL::LCParametersImpl& LCIOEventParameters::eventParameters() const  {
+  return m_eventParameters;
+}
+
+/// Copy the paramaters from source to destination
+void LCIOEventParameters::copyLCParameters(const EVENT::LCParameters& source, 
+                                           EVENT::LCParameters& destination)  
+{
+  EVENT::StringVec intKeys; source.getIntKeys(intKeys);
+  EVENT::StringVec floatKeys; source.getFloatKeys(floatKeys);
+  EVENT::StringVec stringKeys; source.getStringKeys(stringKeys);
+  
+  for(unsigned int i=0; i<intKeys.size(); ++i )  {
+    EVENT::IntVec intVec;
+    source.getIntVals(intKeys.at(i),intVec);
+    destination.setValues(intKeys.at(i),intVec);
+  }
+  
+  for(unsigned int i=0; i<floatKeys.size(); ++i )  {
+    EVENT::FloatVec floatVec;
+    source.getFloatVals(floatKeys.at(i),floatVec);
+    destination.setValues(floatKeys.at(i),floatVec);
+  }
+  
+  for(unsigned int i=0; i<stringKeys.size(); ++i )  {
+    EVENT::StringVec stringVec;
+    source.getStringVals(stringKeys.at(i),stringVec);
+    destination.setValues(stringKeys.at(i),stringVec);
+  }
+}
+
+

--- a/DDG4/lcio/LCIOEventParameters.h
+++ b/DDG4/lcio/LCIOEventParameters.h
@@ -1,0 +1,59 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : R.Ete
+//
+//==========================================================================
+#ifndef DD4HEP_DDG4_LCIOEVENTPARAMETERS_H
+#define DD4HEP_DDG4_LCIOEVENTPARAMETERS_H
+
+// lcio include files
+#include "lcio.h"
+#include "IMPL/LCParametersImpl.h"
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep  {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim  {
+
+    /// Event extension to pass input LCIO event data to output LCIO event
+    /**
+     *  \author  R.Ete (main author)
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class LCIOEventParameters  {
+    private:
+      int                     m_runNumber;
+      int                     m_eventNumber;
+      IMPL::LCParametersImpl  m_eventParameters;
+      
+    public:
+      /// Initializing constructor
+      LCIOEventParameters();
+      /// Default destructor
+      ~LCIOEventParameters();
+
+      /// Set the event parameters
+      void setParameters(int runNumber, int eventNumber, const EVENT::LCParameters& parameters);
+      /// Get the run number
+      int runNumber() const;
+      /// Get the event number
+      int eventNumber() const;
+      /// Get the event parameters
+      const IMPL::LCParametersImpl& eventParameters() const;
+      
+      /// Copy the paramaters from source to destination
+      static void copyLCParameters(const EVENT::LCParameters& source, EVENT::LCParameters& destination);
+    };
+
+  }     /* End namespace sim   */
+}       /* End namespace dd4hep */
+#endif  /* DD4HEP_DDG4_LCIOEVENTPARAMETERS_H  */

--- a/DDG4/lcio/LCIOFileReader.cpp
+++ b/DDG4/lcio/LCIOFileReader.cpp
@@ -125,10 +125,15 @@ dd4hep::sim::LCIOFileReader::readParticleCollection(int /*event_number*/, EVENT:
                m_collectionName.c_str(), evt->getEventNumber(), evt->getRunNumber());
       
       // Create input event parameters context
-      LCIOEventParameters *parameters = new LCIOEventParameters();
-      parameters->setParameters(evt->getRunNumber(), evt->getEventNumber(), evt->parameters());
-      context()->event().addExtension<LCIOEventParameters>( parameters );
-      
+      try {
+        Geant4Context* ctx = context();
+        LCIOEventParameters *parameters = new LCIOEventParameters();
+        parameters->setParameters(evt->getRunNumber(), evt->getEventNumber(), evt->parameters());
+        ctx->event().addExtension<LCIOEventParameters>( parameters );        
+      }
+      catch(std::exception &) 
+      {
+      }
       return EVENT_READER_OK;
     }
   }

--- a/DDG4/lcio/LCIOFileReader.cpp
+++ b/DDG4/lcio/LCIOFileReader.cpp
@@ -27,6 +27,7 @@
 
 // Framework include files
 #include "LCIOEventReader.h"
+#include "LCIOEventParameters.h"
 #include "lcio.h"
 
 using namespace lcio ;
@@ -44,6 +45,7 @@ namespace dd4hep  {
     /**
      *  \author  P.Kostka (main author)
      *  \author  M.Frank  (code reshuffeling into new DDG4 scheme)
+     *  \author  R.Ete    (added event parameters in event context)
      *  \version 1.0
      *  \ingroup DD4HEP_SIMULATION
      */
@@ -121,6 +123,12 @@ dd4hep::sim::LCIOFileReader::readParticleCollection(int /*event_number*/, EVENT:
     if ( *particles ) {
       printout(INFO,"LCIOFileReader","read collection %s from event %d in run %d ", 
                m_collectionName.c_str(), evt->getEventNumber(), evt->getRunNumber());
+      
+      // Create input event parameters context
+      LCIOEventParameters *parameters = new LCIOEventParameters();
+      parameters->setParameters(evt->getRunNumber(), evt->getEventNumber(), evt->parameters());
+      context()->event().addExtension<LCIOEventParameters>( parameters );
+      
       return EVENT_READER_OK;
     }
   }

--- a/DDG4/src/Geant4InputAction.cpp
+++ b/DDG4/src/Geant4InputAction.cpp
@@ -40,7 +40,7 @@ Geant4EventReader::~Geant4EventReader()   {
 /// Get the context (from the input action)
 Geant4Context* Geant4EventReader::context() const {
   if( 0 == m_inputAction ) {
-    printout(FATAL,"Geant4EventReader: %s", "No input action registered!");
+    printout(FATAL,"Geant4EventReader", "No input action registered!");
     throw std::runtime_error("Geant4EventReader: No input action registered!");
   }
   return m_inputAction->context();

--- a/DDG4/src/Geant4InputAction.cpp
+++ b/DDG4/src/Geant4InputAction.cpp
@@ -29,12 +29,26 @@ typedef Geant4InputAction::Vertices Vertices ;
 
 /// Initializing constructor
 Geant4EventReader::Geant4EventReader(const std::string& nam)
-  : m_name(nam), m_directAccess(false), m_currEvent(0)
+  : m_name(nam), m_directAccess(false), m_currEvent(0), m_inputAction(0)
 {
 }
 
 /// Default destructor
 Geant4EventReader::~Geant4EventReader()   {
+}
+
+/// Get the context (from the input action)
+Geant4Context* Geant4EventReader::context() const {
+  if( 0 == m_inputAction ) {
+    printout(FATAL,"Geant4EventReader: %s", "No input action registered!");
+    throw std::runtime_error("Geant4EventReader: No input action registered!");
+  }
+  return m_inputAction->context();
+}
+
+/// Set the input action
+void Geant4EventReader::setInputAction(Geant4InputAction* action) {
+  m_inputAction = action;
 }
 
 /// Skip event. To be implemented for sequential sources
@@ -148,6 +162,7 @@ int Geant4InputAction::readParticles(int evt_number,
       }
       m_reader->setParameters( m_parameters );
       m_reader->checkParameters( m_parameters );
+      m_reader->setInputAction( this );
     }
     catch(const exception& e)  {
       err = e.what();


### PR DESCRIPTION
Resolves #309 
BEGINRELEASENOTES
- Geant4InputAction and Geant4EventReader : 
    - Register input action pointer to event reader, enabling the event reader to access the Geant4 context
- Added new class LCIOEventParameters to handle LCIO input event parameters
- LCIOFileReader : 
    - Add extension with LCIO input event parameters to Geant4event
- Geant4Output2LCIO : 
    - Get LCIO event parameters from event extension (if any) and write them to LCIO output event

ENDRELEASENOTES