### PR TITLE
Fix multipole fields

### DIFF
--- a/DDCore/include/DD4hep/FieldTypes.h
+++ b/DDCore/include/DD4hep/FieldTypes.h
@@ -139,8 +139,8 @@ namespace dd4hep {
    *  If 'volume' is an invalid shape (ie. not defined), then the field
    *  components are valied throughout the 'universe'.
    *
-   *  \see http://cas.web.cern.ch/cas/Belgium-2009/Lectures/PDFs/Wolski-1.pdf
-   *  \see http://cas.web.cern.ch/cas/Bulgaria-2010/Talks-web/Brandt-1-web.pdf
+   *  \see http://cas.web.cern.ch/sites/cas.web.cern.ch/files/lectures/bruges-2009/wolski-1.pdf
+   *  \see http://cas.web.cern.ch/sites/cas.web.cern.ch/files/lectures/varna-2010/brandt-1-web.pdf
    *  \see https://en.wikipedia.org/wiki/Multipole_magnet
    *
    *  \author  M.Frank

--- a/DDCore/include/DD4hep/FieldTypes.h
+++ b/DDCore/include/DD4hep/FieldTypes.h
@@ -132,7 +132,7 @@ namespace dd4hep {
    *  \f{eqnarray*}{
    *  B_y + i B_x &=& (b_4 +ia_4) (x^3 + 3ix^2y - 3xy^2 -iy^3)  \\
    *  B_y &=& b_4 x^3 - 3 b_4 x y^2 - 3 a_4 x^2 y + a_4 y^3     \\
-   *  B_x &=& 3 b_4 x^2 y + b_4 y^3 + a_4 x^3 - 3 a_4 x y^2     \\
+   *  B_x &=& 3 b_4 x^2 y - b_4 y^3 + a_4 x^3 - 3 a_4 x y^2     \\
    *  \f}
    *
    *  The defined field components only apply within the shape 'volume'.

--- a/DDCore/include/DD4hep/FieldTypes.h
+++ b/DDCore/include/DD4hep/FieldTypes.h
@@ -95,8 +95,8 @@ namespace dd4hep {
    *  The different momenta are given by:
    *
    *  \f{eqnarray*}{
-   *  B_y + i*B_x         &=& C_n * (x + iy)^{n-1}                        \\
-   *  B_sum = B_y + i B_x &=& Sum_{n=1..4} (b_n + ia_n) (x + iy)^{n-1}    \\
+   *  B_y + i*B_x         &=& ( 1/(n-1)! )* C_n * (x + iy)^{n-1}                        \\
+   *  B_sum = B_y + i B_x &=& Sum_{n=1..4} ( 1/(n-1)! )*(b_n + ia_n) (x + iy)^{n-1}    \\
    *  \f}
    *  With C_n being the complex multipole coefficients and
    *  b_n the "normal multipole coefficients" and a_n the "skew multipole coefficients".
@@ -122,17 +122,17 @@ namespace dd4hep {
    *  \li Sextupole (n=3):
    *
    *  \f{eqnarray*}{
-   *  B_y + i B_x &=& (b_3 +ia_3) (x^2 + 2ixy - y^2)    \\
-   *  B_y         &=& b_3 x^2 - b_3 y^2 - 2 a_3 xy      \\
-   *  B_x         &=& a_3 x^2 - a_3 y^2 + 2 b_3 xy      \\
+   *  B_y + i B_x &=& (1/2) * (b_3 +ia_3) (x^2 + 2ixy - y^2)    \\
+   *  B_y         &=& (1/2) * ( b_3 x^2 - b_3 y^2 - 2 a_3 xy)      \\
+   *  B_x         &=& (1/2) * (a_3 x^2 - a_3 y^2 + 2 b_3 xy)      \\
    *  \f}
    *
    *  \li Octopole (n=4):
    *
    *  \f{eqnarray*}{
-   *  B_y + i B_x &=& (b_4 +ia_4) (x^3 + 3ix^2y - 3xy^2 -iy^3)  \\
-   *  B_y &=& b_4 x^3 - 3 b_4 x y^2 - 3 a_4 x^2 y + a_4 y^3     \\
-   *  B_x &=& 3 b_4 x^2 y - b_4 y^3 + a_4 x^3 - 3 a_4 x y^2     \\
+   *  B_y + i B_x &=& (1/6) * (b_4 +ia_4) (x^3 + 3ix^2y - 3xy^2 -iy^3)  \\
+   *  B_y &=& (1/6) * (b_4 x^3 - 3 b_4 x y^2 - 3 a_4 x^2 y + a_4 y^3)     \\
+   *  B_x &=& (1/6) * (3 b_4 x^2 y - b_4 y^3 + a_4 x^3 - 3 a_4 x y^2)     \	\
    *  \f}
    *
    *  The defined field components only apply within the shape 'volume'.

--- a/DDCore/src/FieldTypes.cpp
+++ b/DDCore/src/FieldTypes.cpp
@@ -99,12 +99,12 @@ void MultipoleField::fieldComponents(const double* pos, double* field) {
     double y2 = y*y;
     switch(coefficents.size())  {
     case 4:      // Ocupole momentum
-      by +=  coefficents[3] * (x2*x - 3.0*x*y2) + skews[3]*(y2*y - 3.0*x2*y);
-      bx +=  coefficents[3] * (3.0*x2*y - y2*y) + skews[3]*(x2*x - 3.0*x*y2);
+      by += (1./6.) * ( coefficents[3] * (x2*x - 3.0*x*y2) + skews[3]*(y2*y - 3.0*x2*y) );
+      bx += (1./6.) * ( coefficents[3] * (3.0*x2*y - y2*y) + skews[3]*(x2*x - 3.0*x*y2) );
       [[fallthrough]];
     case 3:      // Sextupole momentum:
-      by +=  coefficents[2] * (x2 - y2) - skews[2] * 2.0 * xy;
-      bx +=  coefficents[2] * 2.0 * xy + skews[2] * (x2 - y2);
+      by +=  (1./2.) * ( coefficents[2] * (x2 - y2) - skews[2] * 2.0 * xy );
+      bx +=  (1./2.) * ( coefficents[2] * 2.0 * xy + skews[2] * (x2 - y2) );
       [[fallthrough]];
     case 2:      // Quadrupole momentum:
       bx += coefficents[1] * y + skews[1]*x;

--- a/DDCore/src/FieldTypes.cpp
+++ b/DDCore/src/FieldTypes.cpp
@@ -99,16 +99,16 @@ void MultipoleField::fieldComponents(const double* pos, double* field) {
     double y2 = y*y;
     switch(coefficents.size())  {
     case 4:      // Ocupole momentum
-      by +=  coefficents[3] * (x2*x - 3.0*x*y2) + skews[3]*(y2*y - 3.0*x*y2);
+      by +=  coefficents[3] * (x2*x - 3.0*x*y2) + skews[3]*(y2*y - 3.0*x2*y);
       bx +=  coefficents[3] * (3.0*x2*y - y2*y) + skews[3]*(x2*x - 3.0*x*y2);
       [[fallthrough]];
     case 3:      // Sextupole momentum:
-      by += -coefficents[2] * (x2 - y2) + skews[2] * 2.0 * xy;
+      by +=  coefficents[2] * (x2 - y2) - skews[2] * 2.0 * xy;
       bx +=  coefficents[2] * 2.0 * xy + skews[2] * (x2 - y2);
       [[fallthrough]];
     case 2:      // Quadrupole momentum:
-      bx += coefficents[1] * x - skews[1]*y;
-      by += coefficents[1] * y + skews[1]*x;
+      bx += coefficents[1] * y + skews[1]*x;
+      by += coefficents[1] * x - skews[1]*y;
       [[fallthrough]];
     case 1:      // Dipole momentum:
       bx += skews[0];


### PR DESCRIPTION
I believe there are bugs in the definition of the multipole fields (both in the code and the documentation).
I've compared to the definitions given in
https://dd4hep.web.cern.ch/dd4hep/reference/classdd4hep_1_1MultipoleField.html


BEGINRELEASENOTES
- correct coded expressions for quadrupole, sextupole and octopole fields.
- correct expression for octopole field in documentation
ENDRELEASENOTES