### PR TITLE
Add dictionaries and python interface  to DDRec

### DIFF
--- a/DDCond/CMakeLists.txt
+++ b/DDCond/CMakeLists.txt
@@ -17,7 +17,8 @@ dd4hep_package(    DDCond
 dd4hep_add_dictionary( G__DDCond
   SOURCES include/ROOT/Warnings.h
   src/ConditionsDictionary.h
-  LINKDEF include/ROOT/LinkDef.h )
+  LINKDEF include/ROOT/LinkDef.h
+  )
 
 #---DDCond library --------------------------------------------------------------
 dd4hep_add_package_library(DDCond

--- a/DDRec/CMakeLists.txt
+++ b/DDRec/CMakeLists.txt
@@ -1,4 +1,3 @@
-# $Id: $
 #==========================================================================
 #  AIDA Detector description implementation 
 #--------------------------------------------------------------------------
@@ -22,14 +21,15 @@ if(DD4HEP_USE_GEAR)
   add_definitions("-D DD4HEP_USE_GEAR")
 endif()
 
-#dd4hep_add_dictionary( G__DDRec
-#  SOURCES include/DDRec/*.h
-#  OPTIONAL [GEAR REQUIRED]
-#)  
+dd4hep_add_dictionary( G__DDRec
+  SOURCES ${DDCore_INCLUDE_DIRS}/include/ROOT/Warnings.h src/RecDictionary.h
+  LINKDEF include/ROOT/LinkDef.h
+)
 
 dd4hep_add_package_library(DDRec 
+  SOURCES include/ROOT/Warnings.h
   SOURCES        src/*.cpp
-#  GENERATED      G__DDRec.cxx
+  GENERATED      G__DDRec.cxx
   OPTIONAL       [GEAR COMPONENTS geartgeo SOURCES src/gear/DDGear.cpp DEFINITIONS DD4HEP_USE_GEAR ]
 )
 dd4hep_add_plugin(DDRecPlugins 
@@ -46,4 +46,5 @@ else()
     OPTIONAL [GEAR COMPONENTS geartgeo SOURCES src/convertToGear.cc DEFINITIONS DD4HEP_USE_GEAR] )
 endif()
 
+dd4hep_install_files(FILES python/*.py DESTINATION python)
 

--- a/DDRec/include/DDRec/CellIDPositionConverter.h
+++ b/DDRec/include/DDRec/CellIDPositionConverter.h
@@ -25,8 +25,11 @@ namespace dd4hep {
      */
 
     class CellIDPositionConverter {
-      
+#if defined(G__ROOT)
+      CellIDPositionConverter() = default ;
+#else
       CellIDPositionConverter() = delete ;
+#endif
       CellIDPositionConverter(const CellIDPositionConverter&) = delete ;
       void operator=(const CellIDPositionConverter&) = delete ;
       

--- a/DDRec/include/DDRec/SurfaceManager.h
+++ b/DDRec/include/DDRec/SurfaceManager.h
@@ -29,8 +29,11 @@ namespace dd4hep {
       SurfaceManager(Detector& theDetector);
 
       /// No default constructor
+#if defined(G__ROOT)
+      SurfaceManager() = default ;
+#else
       SurfaceManager() = delete ;
-
+#endif
       /// No copy constructor
       SurfaceManager(const SurfaceManager& copy) = delete;
       

--- a/DDRec/python/DDRec.py
+++ b/DDRec/python/DDRec.py
@@ -1,0 +1,93 @@
+#==========================================================================
+#  AIDA Detector description implementation 
+#--------------------------------------------------------------------------
+# Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+# All rights reserved.
+#
+# For the licensing terms see $DD4hepINSTALL/LICENSE.
+# For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+#
+#==========================================================================
+import logging
+import DD4hep as core
+
+def loadDDRec():
+  from ROOT import gSystem
+  result = gSystem.Load("libDDRec")
+  if result < 0:
+    raise Exception('DDG4.py: Failed to load the DDG4 library libDDRec: '+gSystem.GetErrorStr())
+  from ROOT import dd4hep as module
+  return module
+
+# We are nearly there ....
+name_space = __import__(__name__)
+def import_namespace_item(ns,nam):  
+  scope = getattr(name_space,ns)
+  attr  = getattr(scope,nam)
+  setattr(name_space,nam,attr)
+  return attr
+
+#---------------------------------------------------------------------------
+#
+try:
+  dd4hep = loadDDRec()
+  rec = dd4hep.rec
+except Exception as X:
+  logging.info('+--%-100s--+',100*'-')
+  logging.info('|  %-100s  |','Failed to load DDRec library:')
+  logging.info('|  %-100s  |',str(X))
+  logging.info('+--%-100s--+',100*'-')
+  exit(1)
+
+
+def import_rec():
+  import_namespace_item('rec','CellIDPositionConverter')
+
+  import_namespace_item('rec','FixedPadSizeTPCStruct')
+
+  import_namespace_item('rec','ZPlanarStruct')
+  import_namespace_item('rec','ZPlanarStruct::LayerLayout')
+
+  import_namespace_item('rec','ZDiskPetalsStruct')
+  import_namespace_item('rec','ZDiskPetalsStruct::LayerLayout')
+
+  import_namespace_item('rec','ConicalSupportStruct')
+
+  import_namespace_item('rec','LayeredCalorimeterStruct')
+  import_namespace_item('rec','LayeredCalorimeterStruct::Layer')
+
+  import_namespace_item('rec','NeighbourSurfacesStruct')
+  import_namespace_item('rec','DetectorSurfaces')
+
+  import_namespace_item('rec','IMaterial')
+  import_namespace_item('rec','ISurface')
+  import_namespace_item('rec','ICylinder')
+  import_namespace_item('rec','ICone')
+  import_namespace_item('rec','SurfaceType')
+  import_namespace_item('rec','MaterialData')
+  import_namespace_item('rec','MaterialManager')
+  import_namespace_item('rec','VolSurfaceBase')
+  import_namespace_item('rec','VolSurface')
+  import_namespace_item('rec','VolSurfaceList')
+  import_namespace_item('rec','VolPlaneImpl')
+  import_namespace_item('rec','VolCylinderImpl')
+  import_namespace_item('rec','VolConeImpl')
+  import_namespace_item('rec','Surface')
+  import_namespace_item('rec','CylinderSurface')
+  import_namespace_item('rec','ConeSurface')
+  import_namespace_item('rec','SurfaceList')
+  import_namespace_item('rec','Vector2D')
+  import_namespace_item('rec','Vector3D')
+  import_namespace_item('rec','SurfaceManager')
+
+  import_namespace_item('rec','StructExtension<FixedPadSizeTPCStruct>')
+  import_namespace_item('rec','StructExtension<ZPlanarStruct>')
+  import_namespace_item('rec','StructExtension<ZDiskPetalsStruct>')
+  import_namespace_item('rec','StructExtension<ConicalSupportStruct>')
+  import_namespace_item('rec','StructExtension<LayeredCalorimeterStruct>')
+  import_namespace_item('rec','StructExtension<NeighbourSurfacesStruct>')
+
+# Now instantiate the entire thing
+import_rec()
+std_list_ISurface   = core.std_list('ISurface*')
+std_list_VolSurface = core.std_list('VolSurface')

--- a/DDRec/python/DDRec.py
+++ b/DDRec/python/DDRec.py
@@ -17,7 +17,8 @@ def loadDDRec():
   if result < 0:
     raise Exception('DDG4.py: Failed to load the DDG4 library libDDRec: '+gSystem.GetErrorStr())
   from ROOT import dd4hep as module
-  return module
+  core.rec = module.rec
+  return module.rec
 
 # We are nearly there ....
 name_space = __import__(__name__)
@@ -30,8 +31,7 @@ def import_namespace_item(ns,nam):
 #---------------------------------------------------------------------------
 #
 try:
-  dd4hep = loadDDRec()
-  rec = dd4hep.rec
+  rec = loadDDRec()
 except Exception as X:
   logging.info('+--%-100s--+',100*'-')
   logging.info('|  %-100s  |','Failed to load DDRec library:')

--- a/DDRec/src/RecDictionary.h
+++ b/DDRec/src/RecDictionary.h
@@ -1,0 +1,108 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_REC_RECDICTIONARY_H
+#define DD4HEP_REC_RECDICTIONARY_H
+
+// Framework include files
+#include "DDRec/Material.h"
+#include "DDRec/ISurface.h"
+#include "DDRec/DetectorData.h"
+#include "DDRec/DetectorSurfaces.h"
+#include "DDRec/MaterialManager.h"
+#include "DDRec/CellIDPositionConverter.h"
+#include "DDRec/Surface.h"
+#include "DDRec/SurfaceManager.h"
+#include "DDRec/Vector3D.h"
+#include "DDRec/Vector2D.h"
+
+namespace {
+  class RecDictionary {};
+}
+
+// -------------------------------------------------------------------------
+// Regular dd4hep dictionaries
+// -------------------------------------------------------------------------
+#if defined(__CINT__) || defined(__MAKECINT__) || defined(__CLING__) || defined(__ROOTCLING__)
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ namespace dd4hep;
+#pragma link C++ namespace dd4hep::detail;
+#pragma link C++ namespace dd4hep::rec;
+
+using namespace dd4hep;
+using namespace dd4hep::rec;
+
+// DDRec/CellIDPositionConverter.h
+#pragma link C++ class CellIDPositionConverter+;
+
+
+// DDRec/DetectorData.h
+#pragma link C++ class FixedPadSizeTPCStruct+;
+
+#pragma link C++ class ZPlanarStruct+;
+#pragma link C++ class ZPlanarStruct::LayerLayout+;
+
+#pragma link C++ class ZDiskPetalsStruct+;
+#pragma link C++ class ZDiskPetalsStruct::LayerLayout+;
+
+#pragma link C++ class ConicalSupportStruct+;
+
+#pragma link C++ class LayeredCalorimeterStruct+;
+#pragma link C++ class LayeredCalorimeterStruct::Layer+;
+
+#pragma link C++ class NeighbourSurfacesStruct+;
+
+#pragma link C++ class StructExtension<FixedPadSizeTPCStruct>+;
+#pragma link C++ class StructExtension<ZPlanarStruct>+;
+#pragma link C++ class StructExtension<ZDiskPetalsStruct>+;
+#pragma link C++ class StructExtension<ConicalSupportStruct>+;
+#pragma link C++ class StructExtension<LayeredCalorimeterStruct>+;
+#pragma link C++ class StructExtension<NeighbourSurfacesStruct>+;
+
+// DDRec/DetectorSurfaces.h
+#pragma link C++ class DetectorSurfaces+;
+
+// DDRec/ISurface.h
+#pragma link C++ class IMaterial+;
+#pragma link C++ class ISurface+;
+#pragma link C++ class ICylinder+;
+#pragma link C++ class ICone+;
+#pragma link C++ class SurfaceType+;
+
+// DDRec/Material.h
+#pragma link C++ class MaterialData+;
+#pragma link C++ class MaterialManager+;
+#pragma link C++ class VolSurfaceBase+;
+#pragma link C++ class VolSurface+;
+#pragma link C++ class VolSurfaceList+;
+#pragma link C++ class std::list< VolSurface >+;
+#pragma link C++ class VolPlaneImpl+;
+#pragma link C++ class VolCylinderImpl+;
+#pragma link C++ class VolConeImpl+;
+//#pragma link C++ class VolSurfaceHandle+;
+#pragma link C++ class Surface+;
+#pragma link C++ class CylinderSurface+;
+#pragma link C++ class ConeSurface+;
+#pragma link C++ class SurfaceList+;
+#pragma link C++ class std::list< ISurface* >+;
+
+#pragma link C++ class Vector2D+;
+#pragma link C++ class Vector3D+;
+#pragma link C++ class SurfaceManager-;
+#pragma link C++ class std::multimap< unsigned long, ISurface*>+;
+
+#endif
+
+#endif /* DD4HEP_REC_RECDICTIONARY_H  */


### PR DESCRIPTION
Resolves #306 
Closes #312 
BEGINRELEASENOTES
- Add dictionaries to `DDRec`. 
  - Consequently add the python interface to access the exported classes.

ENDRELEASENOTES