### PR TITLE
Fix CLHEP compatibility for Geant4 10.4

### DIFF
--- a/.dd4hep-ci.d/compile_and_test.sh
+++ b/.dd4hep-ci.d/compile_and_test.sh
@@ -5,7 +5,7 @@ source /DD4hep/.dd4hep-ci.d/init_x86_64.sh
 cd /DD4hep
 mkdir build
 cd build
-cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib64/Geant4-10.3.3 -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" .. && \
+cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib64/Geant4-10.4.0 -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" .. && \
 ninja && \
 ninja install && \
 . ../bin/thisdd4hep.sh && \

--- a/.dd4hep-ci.d/coverity_scan.sh
+++ b/.dd4hep-ci.d/coverity_scan.sh
@@ -7,7 +7,7 @@ source /Package/.dd4hep-ci.d/init_x86_64.sh
 cd /Package
 mkdir build
 cd build
-cmake -D DD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -D DD4HEP_USE_LCIO=ON -D BUILD_TESTING=ON  -D Geant4_DIR=$G4INSTALL/lib64/Geant4-10.3.3 -D DD4HEP_USE_CXX11=ON -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" .. && \
+cmake -D DD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -D DD4HEP_USE_LCIO=ON -D BUILD_TESTING=ON  -D Geant4_DIR=$G4INSTALL/lib64/Geant4-10.4.0 -D DD4HEP_USE_CXX11=ON -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" .. && \
 export PATH=/cov-analysis-linux64/bin:$PATH && \
 cov-build --dir cov-int make -j4 && \
 tar czvf myproject.tgz cov-int

--- a/.dd4hep-ci.d/init_x86_64.sh
+++ b/.dd4hep-ci.d/init_x86_64.sh
@@ -103,7 +103,7 @@ export LD_LIBRARY_PATH="$XercesC_HOME/lib:$LD_LIBRARY_PATH"
 #--------------------------------------------------------------------------------
 #Determine which Geant4 version to use
 if [ -z ${GEANT4_VERSION} ]; then
-GEANT4_VERSION="10.03.p03"
+GEANT4_VERSION="10.04"
 fi
 
 export G4INSTALL=${CLICREPO}/software/Geant4/${GEANT4_VERSION}/${BUILD_FLAVOUR}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,7 @@ slc6-ggc7-Geant10.3:
   image: clicdp/slc6-base
   script:
     - export COMPILER_TYPE="gcc"
+    - export GEANT4_VERSION="10.03.p03"
     - source .dd4hep-ci.d/init_x86_64.sh
     - mkdir build
     - cd build
@@ -50,7 +51,7 @@ slc6-ggc7-Geant10.3:
     - ninja install
     - ctest --output-on-failure
 
-slc6-gcc7-Geant10.3-XERCESC:
+slc6-gcc7-Geant10.4-XERCESC:
   stage: build
   tags:
     - docker
@@ -75,17 +76,18 @@ slc6-gcc7-Geant10.3-XERCESC:
     - ctest --output-on-failure
 
 
-slc6-llvm5-Geant10.3:
+slc6-llvm5-Geant10.4:
   stage: build
   tags:
     - docker
   image: clicdp/slc6-base
   script:
     - export COMPILER_TYPE="llvm"
+    - export GEANT4_VERSION="10.04"
     - source .dd4hep-ci.d/init_x86_64.sh
     - mkdir build
     - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib64/Geant4-10.3.3 -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS ..
+    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib64/Geant4-10.4.0 -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS ..
     - ninja
     - ninja install
     - . ../bin/thisdd4hep.sh
@@ -105,6 +107,7 @@ slc6-llvm5-Geant10.3-XERCESC:
   image: clicdp/slc6-base
   script:
     - export COMPILER_TYPE="llvm"
+    - export GEANT4_VERSION="10.03.p03"
     - source .dd4hep-ci.d/init_x86_64.sh
     - mkdir build
     - cd build
@@ -121,11 +124,12 @@ slc6-llvm5-Geant10.3-XERCESC:
     - ninja install
     - ctest --output-on-failure
 
-mac1013-llvm90:
+mac1013-llvm90-Geant10.3:
   stage: build
   tags:
     - mac
   script:
+    - export GEANT4_VERSION="10.03.p03"
     - source .dd4hep-ci.d/init_x86_64.sh
     - mkdir build
     - cd build
@@ -142,15 +146,16 @@ mac1013-llvm90:
     - ninja install
     - ctest --output-on-failure
 
-mac1013-llvm90-XERCESC:
+mac1013-llvm90-Geant10.4-XERCESC:
   stage: build
   tags:
     - mac
   script:
+    - export GEANT4_VERSION="10.04"
     - source .dd4hep-ci.d/init_x86_64.sh
     - mkdir build
     - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib/Geant4-10.3.3 -DCMAKE_BUILD_TYPE=Release -DDD4HEP_USE_XERCESC=ON -DXERCESC_ROOT_DIR=${XercesC_HOME} -DROOT_DIR=$ROOTSYS ..
+    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib/Geant4-10.4.0 -DCMAKE_BUILD_TYPE=Release -DDD4HEP_USE_XERCESC=ON -DXERCESC_ROOT_DIR=${XercesC_HOME} -DROOT_DIR=$ROOTSYS ..
     - ninja
     - ninja install
     - . ../bin/thisdd4hep.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,10 +57,11 @@ slc6-gcc7-Geant10.3-XERCESC:
   image: clicdp/slc6-base
   script:
     - export COMPILER_TYPE="gcc"
+    - export GEANT4_VERSION="10.04"
     - source .dd4hep-ci.d/init_x86_64.sh
     - mkdir build
     - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib64/Geant4-10.3.3 -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release -DDD4HEP_USE_XERCESC=ON -DXERCESC_ROOT_DIR=${XercesC_HOME} -DROOT_DIR=$ROOTSYS ..
+    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib64/Geant4-10.4.0 -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release -DDD4HEP_USE_XERCESC=ON -DXERCESC_ROOT_DIR=${XercesC_HOME} -DROOT_DIR=$ROOTSYS ..
     - ninja
     - ninja install
     - . ../bin/thisdd4hep.sh

--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -92,9 +92,9 @@ if [ ${Geant4_DIR} ]; then
     if [ @GEANT4_USE_CLHEP@ ] ; then
 	dd4hep_add_library_path @CLHEP_LIBRARY_PATH@;
     fi;
-    export CLHEP_DIR=@CLHEP_ROOT_DIR@;
-    export CLHEP_ROOT_DIR=@CLHEP_ROOT_DIR@;
-    export CLHEP_LIBRARY_PATH=@CLHEP_LIBRARY_PATH@;
+    export CLHEP_DIR=@CLHEP_INCLUDE_DIR@/../;
+    export CLHEP_ROOT_DIR=@CLHEP_INCLUDE_DIR@/../;
+    export CLHEP_INCLUDE_DIR=@CLHEP_INCLUDE_DIR@;
     dd4hep_add_library_path ${G4LIB_DIR};
     unset G4ENV_INIT;
     unset G4LIB_DIR;

--- a/examples/CLICSiD/scripts/testDDPython.py
+++ b/examples/CLICSiD/scripts/testDDPython.py
@@ -3,6 +3,7 @@ from ROOT import gSystem
 import os, logging, platform
 if platform.system()=="Darwin":
   gSystem.SetDynamicPath(os.environ['DD4HEP_LIBRARY_PATH'])
+gSystem.Load('libglapi')
 gSystem.Load('libDDPython')
 from ROOT import dd4hep as Core
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Deduce CLHEP location from `CLHEP_INCLUDE_DIR` ( Fixes #314 )
- Add `gSystem.Load('libglapi')` to `testDDPython.py` which failed due to TLS issues on local machine
- Add Geant4 10.4 to test suite

ENDRELEASENOTES

It turn out that `CLHEP_INCLUDE_DIR` is the only consistent variable to deduce the actual location of CLHEP for different Geant4 versions (10.2, 10.3, 10.4)
