### PR TITLE
Use magFromXYZ instead of radiusFromXYZ to calculate Pseudorapidity

### DIFF
--- a/DDCore/include/DDSegmentation/SegmentationUtil.h
+++ b/DDCore/include/DDSegmentation/SegmentationUtil.h
@@ -40,7 +40,7 @@ inline double radiusFromXYZ(const Vector3D& position) {
 
 /// Calculates cosine of the polar angle theat from Cartesian coodinates
 inline double cosThetaFromXYZ(const Vector3D& position) {
-	return position.Z / radiusFromXYZ(position);
+	return position.Z / magFromXYZ(position);
 }
 
 /// calculates the polar angle theta from Cartesian coordinates


### PR DESCRIPTION
This PR resolves #342


BEGINRELEASENOTES
- Fix bug in calculating eta, introduced in #138 
  - use `magFromXYZ` instead of `radiusFromXYZ` to calculate pseudorapidity

ENDRELEASENOTES