### PR TITLE
DDCore: Add interface to allow URI blocking during file parsing

### DIFF
--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -109,6 +109,32 @@ namespace dd4hep {
   };
   typedef Solid_type<TGeoShape> Solid;
 
+  /// Class describing a shape-less solid shape
+  /**
+   *   For any further documentation please see the following ROOT documentation:
+   *   \see http://root.cern.ch/root/html/TGeoShapeAssembly.html
+   *
+   *
+   *   \author  M.Frank
+   *   \version 1.0
+   *   \ingroup DD4HEP_CORE
+   */
+  class ShapelessSolid: public Solid_type<TGeoShapeAssembly> {
+  public:
+    /// Default constructor
+    ShapelessSolid() = default;
+    /// Constructor to be used when passing an already created object
+    ShapelessSolid(const ShapelessSolid& e) = default;
+    /// Constructor to be used with an existing object
+    template <typename Q> ShapelessSolid(const Q* p) : Solid_type<TGeoShapeAssembly>(p) { }
+    /// Constructor to be used with an existing object
+    template <typename Q> ShapelessSolid(const Handle<Q>& e) : Solid_type<TGeoShapeAssembly>(e) { }
+    /// Constructor to create an anonymous new shapeless solid
+    ShapelessSolid(const std::string& name);
+    /// Assignment operator
+    ShapelessSolid& operator=(const ShapelessSolid& copy) = default;
+  };
+
   /// Class describing a box shape
   /**
    *   For any further documentation please see the following ROOT documentation:
@@ -211,12 +237,12 @@ namespace dd4hep {
     /// Constructor to be used when reading the already parsed polycone object
     template <typename Q> Polycone(const Handle<Q>& e) : Solid_type<Object>(e) { }
     /// Constructor to create a new polycone object
-    Polycone(double start, double delta);
+    Polycone(double startPhi, double deltaPhi);
     /// Constructor to create a new polycone object. Add at the same time all Z planes
-    Polycone(double start, double delta,
+    Polycone(double startPhi, double deltaPhi,
              const std::vector<double>& r, const std::vector<double>& z);
     /// Constructor to create a new polycone object. Add at the same time all Z planes
-    Polycone(double start, double delta,
+    Polycone(double startPhi, double deltaPhi,
              const std::vector<double>& rmin, const std::vector<double>& rmax, const std::vector<double>& z);
     /// Assignment operator
     Polycone& operator=(const Polycone& copy) = default;
@@ -752,11 +778,11 @@ namespace dd4hep {
   class ExtrudedPolygon : public Solid_type<TGeoXtru> {
   protected:
     /// Helper function to create the polyhedron
-    void make(const std::vector<double> & x,
-              const std::vector<double> & y,
-              const std::vector<double> & z,
-              const std::vector<double> & zx,
-              const std::vector<double> & zy,
+    void make(const std::vector<double> & pt_x,
+              const std::vector<double> & pt_y,
+              const std::vector<double> & sec_z,
+              const std::vector<double> & sec_x,
+              const std::vector<double> & sec_y,
               const std::vector<double> & zscale);
   public:
     /// Default constructor
@@ -768,11 +794,11 @@ namespace dd4hep {
     /// Constructor to be used when passing an already created object
     template <typename Q> ExtrudedPolygon(const Handle<Q>& e) : Solid_type<Object>(e) {  }
     /// Constructor to create a new object. 
-    ExtrudedPolygon(const std::vector<double> & x,
-                    const std::vector<double> & y,
-                    const std::vector<double> & z,
-                    const std::vector<double> & zx,
-                    const std::vector<double> & zy,
+    ExtrudedPolygon(const std::vector<double> & pt_x,
+                    const std::vector<double> & pt_y,
+                    const std::vector<double> & sec_z,
+                    const std::vector<double> & sec_x,
+                    const std::vector<double> & sec_y,
                     const std::vector<double> & zscale);
     /// Assignment operator
     ExtrudedPolygon& operator=(const ExtrudedPolygon& copy) = default;

--- a/DDCore/include/XML/UriReader.h
+++ b/DDCore/include/XML/UriReader.h
@@ -54,6 +54,11 @@ namespace dd4hep {
       virtual ~UriReader();
       /// Access to local context
       virtual UserContext* context() = 0;
+      /** Helpers for selective parsing  */
+      /// Add a blocked path entry
+      virtual void blockPath(const std::string&  /* path */)  {}
+      /// Check if a URI path is blocked
+      virtual bool isBlocked(const std::string& /* path */)  const  { return false; }
       /// Resolve a given URI to a string containing the data
       virtual bool load(const std::string& system_id, std::string& data);
       /// Resolve a given URI to a string containing the data with context
@@ -90,6 +95,11 @@ namespace dd4hep {
       virtual ~UriContextReader();
       /// Access to local context
       virtual UserContext* context()  override  {  return m_context;  }
+      /** Helpers for selective parsing  */
+      /// Add a blocked path entry
+      virtual void blockPath(const std::string& path)  override;
+      /// Check if a URI path is blocked
+      virtual bool isBlocked(const std::string& path)  const  override;
       /// Resolve a given URI to a string containing the data
       virtual bool load(const std::string& system_id, std::string& data)  override;
       /// Resolve a given URI to a string containing the data with context

--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -255,5 +255,5 @@ try:
 except:
   print 'WARNING: No units from TGeoUnit can be imported. This is normal for ROOT < 6.12.0'
   TGeoUnits = {}
-  def import_units():
+  def import_units(ns=None):
     return 0

--- a/DDCore/src/XML/UriReader.cpp
+++ b/DDCore/src/XML/UriReader.cpp
@@ -46,6 +46,16 @@ dd4hep::xml::UriContextReader::UriContextReader(const UriContextReader& copy)
 dd4hep::xml::UriContextReader::~UriContextReader()   {
 }
 
+/// Add a blocked path entry
+void dd4hep::xml::UriContextReader::blockPath(const std::string& path)  {
+  return m_reader->blockPath(path);
+}
+
+/// Check if a URI path is blocked
+bool dd4hep::xml::UriContextReader::isBlocked(const std::string& path)  const  {
+  return m_reader->isBlocked(path);
+}
+
 /// Resolve a given URI to a string containing the data
 bool dd4hep::xml::UriContextReader::load(const string& system_id, string& data)   {
   return m_reader->load(system_id, context(), data);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,8 +49,25 @@ dd4hep_enable_tests (
   AlignDet
   ClientTests
   Conditions
-  DDCMS
-  DDDB
   DDG4
   Persistency
-  SimpleDetector)
+  SimpleDetector
+  )
+#
+# XercesC dependent stuff
+if ( DD4HEP_USE_XERCESC )
+  dd4hep_print("|++> XercesC PRESENT. Building DDDB examples.")
+  dd4hep_enable_tests (DDDB)
+else()
+  dd4hep_print("|++> XercesC is not present. NOT building DDDB examples.")
+endif()
+#
+# CLHEP dependent stuff:
+find_package (CLHEP QUIET)
+string(FIND "${CLHEP_DIR}" "NOTFOUND" HaveDDCMS)
+if ( NOT ${HaveDDCMS} GREATER 0 )
+  dd4hep_print("|++> XercesC PRESENT. Building DDCMS examples.")
+  dd4hep_enable_tests (DDCMS)
+else()
+  dd4hep_print("|++> CLHEP is not present. NOT building DDCMS examples.")
+endif()

--- a/examples/DDCMS/CMakeLists.txt
+++ b/examples/DDCMS/CMakeLists.txt
@@ -50,7 +50,7 @@ dd4hep_add_test_reg( DDCMS_TestShapes
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDCMS.sh"
   EXEC_ARGS  geoPluginRun  -destroy -print WARNING -plugin DD4hep_XMLLoader 
   file:${CMAKE_CURRENT_SOURCE_DIR}/data/cms_test_solids.xml
-  REGEX_PASS "Request to process unknown shape para \\[Parallelepiped\\]"
+  REGEX_PASS "Request to process unknown shape 'para' \\[Parallelepiped\\]"
   REGEX_FAIL "Exception"
   REGEX_FAIL "FAILED"
   )

--- a/examples/DDCMS/CMakeLists.txt
+++ b/examples/DDCMS/CMakeLists.txt
@@ -45,6 +45,7 @@ dd4hep_install_dir( scripts DESTINATION ${DD4hep_DIR}/examples/DDCMS )
 #---Testing--------------------------------------------------------------------
 dd4hep_configure_scripts ( DDCMS DEFAULT_SETUP WITH_TESTS )
 #
+#
 #  Test CMS tracker detector construction
 dd4hep_add_test_reg( DDCMS_TestShapes
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDCMS.sh"

--- a/examples/DDCMS/CMakeLists.txt
+++ b/examples/DDCMS/CMakeLists.txt
@@ -46,6 +46,16 @@ dd4hep_install_dir( scripts DESTINATION ${DD4hep_DIR}/examples/DDCMS )
 dd4hep_configure_scripts ( DDCMS DEFAULT_SETUP WITH_TESTS )
 #
 #  Test CMS tracker detector construction
+dd4hep_add_test_reg( DDCMS_TestShapes
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDCMS.sh"
+  EXEC_ARGS  geoPluginRun  -destroy -print WARNING -plugin DD4hep_XMLLoader 
+  file:${CMAKE_CURRENT_SOURCE_DIR}/data/cms_test_solids.xml
+  REGEX_PASS "Request to process unknown shape para \\[Parallelepiped\\]"
+  REGEX_FAIL "Exception"
+  REGEX_FAIL "FAILED"
+  )
+#
+#  Test CMS tracker detector construction
 dd4hep_add_test_reg( DDCMS_LoadGeometry
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDCMS.sh"
   EXEC_ARGS  geoPluginRun

--- a/examples/DDCMS/data/cms_test_solids.xml
+++ b/examples/DDCMS/data/cms_test_solids.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug>
+    <debug_shapes/>
+    <debug_includes/>
+<!-- 
+    <debug_rotations/>
+    <debug_materials/>
+
+    <debug_volumes/>
+    <debug_constants/>
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+    <debug_visattr/>
+-->
+  </debug>
+  <open_geometry/>
+  <close_geometry/>
+
+  <ConstantsSection label="" eval="true">
+    <Constant name="world_x" value="5*m"/>
+    <Constant name="world_y" value="5*m"/>
+    <Constant name="world_z" value="5*m"/>
+    <Constant name="fm"      value="1e-12*m"/>
+    <Constant name="Air"     value="materials_Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials_Vacuum"  type="string"/>
+  </ConstantsSection>
+
+  <IncludeSection>
+    <Include ref="materials.xml"/>
+    <Include ref="testRotations.xml"/>
+    <Include ref="testSolids.xml"/>
+  </IncludeSection>
+</DDDefinition>

--- a/examples/DDCMS/data/testRotations.xml
+++ b/examples/DDCMS/data/testRotations.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../Schema/DDLSchema.xsd">
+
+  <RotationSection label="testRotations.xml">
+    <RotationByAxis name="z30" axis="z" angle="30*deg"/>
+    <RotationSequence name="z30x20">
+      <RotationByAxis axis="z" angle="30*deg"/>
+      <RotationByAxis axis="x" angle="20*deg"/>
+    </RotationSequence>
+    <RotationSequence name="x90y45">
+      <RotationByAxis axis="x" angle="90*deg"/>
+      <RotationByAxis axis="y" angle="45*deg"/>
+    </RotationSequence>
+    <RotationSequence name="x90y90">
+      <RotationByAxis axis="x" angle="90*deg"/>
+      <RotationByAxis axis="y" angle="90*deg"/>
+    </RotationSequence>
+    <RotationSequence name="x90y135">
+      <RotationByAxis axis="x" angle="90*deg"/>
+      <RotationByAxis axis="y" angle="135*deg"/>
+    </RotationSequence>
+    <RotationSequence name="x90y180">
+      <RotationByAxis axis="x" angle="90*deg"/>
+      <RotationByAxis axis="y" angle="180*deg"/>
+    </RotationSequence>
+    <RotationByAxis name="x90" axis="x" angle="90*deg"/>
+    <Rotation name="x90y45" phiX="0" thetaX="90*deg" phiY="90*deg" thetaY="90*deg" phiZ="0" thetaZ="0"/>
+    <Rotation name="cmsimIdentity" phiX="0" thetaX="90*deg" phiY="90*deg" thetaY="90*deg" phiZ="0" thetaZ="0"/>
+    <RotationByAxis name="newrotIdentity" axis="z" angle="0*deg"/> <!-- This seems silly -->
+    <ReflectionRotation name="180R" thetaX="90*deg" phiX="0*deg" thetaY="90*deg" phiY="90*deg" thetaZ="180*deg" phiZ="0*deg" />
+  </RotationSection>
+
+</DDDefinition>

--- a/examples/DDCMS/data/testSolids.xml
+++ b/examples/DDCMS/data/testSolids.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../Schema/DDLSchema.xsd">
+
+  <SolidSection label="testSolids.xml">
+    <Trapezoid name="trap1" alp1="10*deg" alp2="10*deg" bl1="50*cm" bl2="75*cm" dz="1*m" h1="20*cm" h2="40*cm" phi="30*deg" theta="30*deg" tl1="50*cm" tl2="75*cm"/>
+    <Trapezoid name="trap2" alp1="10*deg" alp2="10*deg" bl1="50*cm" bl2="75*cm" dz="1*m" h1="20*cm" h2="40*cm" tl1="50*cm" tl2="75*cm"/>
+    <PseudoTrap name="ptrap1" dx1="10" dx2="3" dy1="30" dy2="10" dz="30" radius="10" atMinusZ="false"/>
+    <PseudoTrap name="ptrap2" dx1="10" dx2="3" dy1="30" dy2="10" dz="30" radius="10" atMinusZ="true"/>
+    <Box name="box1" dx="10*cm" dy="10*cm" dz="10*cm"/>
+    <Cone name="cone1" dz="1*m" rMin1="50*cm" rMax1="100*cm" rMin2="75*cm" rMax2="125*cm" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Cone name="cone2" dz="1*m" rMin1="50*cm" rMax1="100*cm" rMin2="50*cm" rMax2="100*cm" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Cone name="cone2hole" dz="20*cm" rMin1="50*cm" rMax1="100*cm" rMin2="50*cm" rMax2="100*cm" startPhi="0*deg" deltaPhi="20*deg"/>
+    <!-- While using this as a test solid I found that there is a 
+problem with it.  Can a Polycone come to a point "in the real world?" -->
+    <Polycone name="pczsect" startPhi="0*deg" deltaPhi="360*deg">
+      <!-- see above comment ZSection z="1*m" rMin="50*cm" rMax="50*cm"/-->
+      <ZSection z="1*m" rMin="50*cm" rMax="55*cm"/>
+      <ZSection z="1.5*m" rMin="50*cm" rMax="60*cm"/>
+      <ZSection z="2*m" rMin="50*cm" rMax="75*cm"/>
+    </Polycone>
+
+    <Polycone name="pcrz" startPhi="0*deg" deltaPhi="360*deg">
+      <RZPoint r="50*cm" z="1*m"/>
+      <RZPoint r="60*cm" z="1.5*m"/>
+      <RZPoint r="75*cm" z="2*m"/>
+      <RZPoint r="50*cm" z="2.0001*m"/>
+    </Polycone>
+
+    <Polyhedra name="phzsect" numSide="18" startPhi="0*deg" deltaPhi="360*deg">
+      <ZSection z="1*m" rMin="50*cm" rMax="50*cm"/>
+      <ZSection z="1.5*m" rMin="50*cm" rMax="60*cm"/>
+      <ZSection z="2*m" rMin="50*cm" rMax="75*cm"/>
+    </Polyhedra>
+
+    <Polyhedra name="phrz" numSide="18" startPhi="0*deg" deltaPhi="360*deg">
+      <RZPoint r="50*cm" z="1*m"/>
+      <RZPoint r="60*cm" z="1.5*m"/>
+      <RZPoint r="75*cm" z="2*m"/>
+      <RZPoint r="50*cm" z="2.0001*m"/>
+    </Polyhedra>
+
+    <ExtrudedPolygon name="extrudedpgon">
+      <XYPoint x="-30*cm" y="-30*cm"/>
+      <XYPoint x="-30*cm" y=" 30*cm"/>
+      <XYPoint x=" 30*cm" y=" 30*cm"/>
+      <XYPoint x=" 30*cm" y="-30*cm"/>
+      <XYPoint x=" 15*cm" y="-30*cm"/>
+      <XYPoint x=" 15*cm" y=" 15*cm"/>
+      <XYPoint x="-15*cm" y=" 15*cm"/>
+      <XYPoint x="-15*cm" y="-30*cm"/>
+      <ZXYSection z="-60*cm" x="0*cm" y="30*cm" scale="0.8"/>
+      <ZXYSection z="-15*cm" x="0*cm" y="-30*cm" scale="1."/>
+      <ZXYSection z="10*cm" x="0*cm" y="0*cm" scale="0.6"/>
+      <ZXYSection z="60*cm" x="0*cm" y="30*cm" scale="1.2"/>
+    </ExtrudedPolygon>
+    <Trd1 name="trd1" dx1="1*m" dx2="1.3*m" dz="3*m" dy1="30*cm"/>
+    <Trd1 name="trd2" dx1="1*m" dx2="1.3*m" dz="3*m" dy1="30*cm" dy2="50*cm"/>
+    <Tube name="tube1" rMin="1*m" rMax="1.5*m" dz="1*m"/>
+    <Tubs name="tube2" rMin="1*m" rMax="2*m" dz="1*m" startPhi="30*deg" deltaPhi="150*deg"/>
+    <CutTubs name="cuttubs" rMin="1*m" rMax="2*m" dz="1*m" startPhi="30*deg" deltaPhi="150*deg" lx="0" ly="-0.7" lz="-0.71" tx="0.7" ty="0" tz="0.71"/>
+    <TruncTubs name="trunctubs1" zHalf="50*cm" rMin="20*cm" rMax="40*cm" startPhi="0*deg" deltaPhi="90*deg" cutAtStart="25*cm" cutAtDelta="35*cm" cutInside="true"/>
+    <ShapelessSolid name="momma"/>
+    <Box name="MotherOfAllBoxes" dx="10*m" dy="10*m" dz="10*m"/>
+    <Torus name="torus" innerRadius="7.5*cm" outerRadius="10*cm" torusRadius="30*cm" startPhi="0*deg" deltaPhi="360*deg"/>
+    <ReflectionSolid name="trd2mirror">
+      <rSolid name="trd2"/>
+    </ReflectionSolid>
+    <SubtractionSolid name="subsolid" firstSolid="cone2" secondSolid="cone2hole"/>
+    <SubtractionSolid name="subsolidOLD">
+        <rSolid name="cone2"/>
+        <rSolid name="cone2hole"/>
+        <rRotation name="testRotations:x90y45"/>
+    </SubtractionSolid>
+    <UnionSolid name="unionsolid" firstSolid="pcrz" secondSolid="cone1">
+      <Translation x="0" y="0" z="-1.0*m"/>
+    </UnionSolid>
+    <MultiUnionSolid name="multiunionsolid">
+      <rSolid name="pcrz"/>
+      <rSolid name="cone1"/>
+      <Translation x="0" y="0" z="-1.0*m"/>
+    </MultiUnionSolid>
+    <IntersectionSolid name="intsolid" firstSolid="cone1" secondSolid="cone2">
+      <RotationByAxis axis="y" angle="90*deg"/>
+      <Translation x="0" y="0" z="50*cm"/>
+    </IntersectionSolid>
+    <Sphere name="asphere" innerRadius="1.*cm" outerRadius="1.1*cm" startPhi="0*deg" deltaPhi="180*deg" startTheta="15*deg" deltaTheta="90*deg"/>
+    <Orb name="anorb" radius="1.*cm"/>
+    <EllipticalTube name="etube" xSemiAxis=".5*cm" ySemiAxis="1.*cm" zHeight="3.*cm"/>
+    <Ellipsoid name="anelipsoid" xSemiAxis=".5*cm" ySemiAxis="1.*cm" zSemiAxis="3.*cm" zBottomCut="0.*cm" zTopCut="1.5*cm"/>
+    <Ellipsoid name="unusedelipsoid" xSemiAxis=".5*cm" ySemiAxis="1.*cm" zSemiAxis="3.*cm"/>
+    <Parallelepiped name="para" xHalf="5.*cm" yHalf="6.*cm" zHalf="7.*cm" alpha="15*deg" theta="30*deg" phi="45*deg"/>
+  </SolidSection>
+</DDDefinition>

--- a/examples/DDCMS/include/DDCMS/DDCMS.h
+++ b/examples/DDCMS/include/DDCMS/DDCMS.h
@@ -77,6 +77,14 @@ namespace dd4hep {
         elt.setAttr(n,val);
         return elt.attr<T>(n);
       }
+      template <typename T> T attr(xml_elt_t elt,const xml_tag_t& n, T default_value) const   {
+        if ( elt.hasAttr(n) )   {
+          std::string val = real_name(elt.attr<std::string>(n));
+          elt.setAttr(n,val);
+          return elt.attr<T>(n);
+        }
+        return default_value;
+      }
       /// Add a new constant to the namespace
       void     addConstant(const std::string& name, const std::string& value, const std::string& type)  const;
       /// Add a new constant to the namespace as fully indicated by the name

--- a/examples/DDCMS/include/DDCMS/DDCMSTags.h
+++ b/examples/DDCMS/include/DDCMS/DDCMSTags.h
@@ -46,7 +46,6 @@ namespace dd4hep {
     UNICODE(atomicNumber);
     UNICODE(MaterialFraction);
 
-
     UNICODE(RotationSection);
     UNICODE(Rotation);
     UNICODE(rRotation);
@@ -57,16 +56,31 @@ namespace dd4hep {
     UNICODE(thetaZ);
     UNICODE(phiZ);
 
+    UNICODE(numSide);
+    
     UNICODE(TransformationSection);
     UNICODE(Transformation);
 
     UNICODE(SolidSection);
+
+    UNICODE(PseudoTrap);
+    UNICODE(dx1);
+    UNICODE(dy1);
+    UNICODE(dx2);
+    UNICODE(dy2);
+    UNICODE(atMinusZ);
 
     UNICODE(Box);
     UNICODE(dx);
     UNICODE(dy);
     UNICODE(dz);
 
+    UNICODE(Cone);
+    UNICODE(rMin1);
+    UNICODE(rMax1);
+    UNICODE(rMin2);
+    UNICODE(rMax2);
+    
     UNICODE(Tubs);
     UNICODE(rMin);
     UNICODE(rMax);
@@ -75,8 +89,26 @@ namespace dd4hep {
     
     UNICODE(Polycone);
     UNICODE(ZSection);
-    UNICODE(z);
 
+    UNICODE(ZXYSection);
+    UNICODE(XYPoint);
+    UNICODE(RZPoint);
+    UNICODE(scale);
+
+    UNICODE(CutTubs);
+    UNICODE(lx);
+    UNICODE(ly);
+    UNICODE(lz);
+    UNICODE(tx);
+    UNICODE(ty);
+    UNICODE(tz);
+
+    UNICODE(TruncTubs);
+    UNICODE(cutAtStart);
+    UNICODE(cutAtDelta);
+    UNICODE(cutInside);
+    UNICODE(zHalf);
+    
     UNICODE(Trapezoid);
     UNICODE(alp1);
     UNICODE(h1);
@@ -87,12 +119,28 @@ namespace dd4hep {
     UNICODE(bl2);
     UNICODE(tl2);
 
+    UNICODE(Sphere);
+    UNICODE(startTheta);
+    UNICODE(deltaTheta);
+    
+    UNICODE(Ellipsoid);
+    UNICODE(xSemiAxis);
+    UNICODE(ySemiAxis);
+    UNICODE(zSemiAxis);
+    UNICODE(zBottomCut);
+    UNICODE(zTopCut);
+    
+    UNICODE(EllipticalTube);
+    UNICODE(zHeight);
+    
     UNICODE(Torus);
     UNICODE(torusRadius);
     UNICODE(innerRadius);
     UNICODE(outerRadius);
     
     UNICODE(SubtractionSolid);
+    UNICODE(firstSolid);
+    UNICODE(secondSolid);
 
     UNICODE(LogicalPartSection);
     UNICODE(LogicalPart);

--- a/examples/DDCMS/src/plugins/DDDefinitions2Objects.cpp
+++ b/examples/DDCMS/src/plugins/DDDefinitions2Objects.cpp
@@ -81,11 +81,23 @@ namespace dd4hep {
     class logicalpart;
 
     class solidsection;
+    class extrudedpolygon;
+    class shapeless;
     class trapezoid;
+    class ellipsoid;
+    class ellipticaltube;
+    class pseudotrap;
+    class polyhedra;
     class polycone;
     class torus;
+    class trd1;
+    class trunctubs;
+    class cuttubs;
     class tubs;
+    class orb;
     class box;
+    class cone;
+    class sphere;
     class unionsolid;
     class intersectionsolid;
     class subtractionsolid;
@@ -139,16 +151,40 @@ namespace dd4hep {
   template <> void Converter<subtractionsolid>::operator()(xml_h element) const;
   /// Converter for <IntersectionSolid/> tags
   template <> void Converter<intersectionsolid>::operator()(xml_h element) const;
+  /// Converter for <PseudoTrap/> tags
+  template <> void Converter<pseudotrap>::operator()(xml_h element) const;
+  /// Converter for <ExtrudedPolygon/> tags
+  template <> void Converter<extrudedpolygon>::operator()(xml_h element) const;
+  /// Converter for <ShapelessSolid/> tags
+  template <> void Converter<shapeless>::operator()(xml_h element) const;
   /// Converter for <Trapezoid/> tags
   template <> void Converter<trapezoid>::operator()(xml_h element) const;
+  /// Converter for <Polyhedra/> tags
+  template <> void Converter<polyhedra>::operator()(xml_h element) const;
   /// Converter for <Polycone/> tags
   template <> void Converter<polycone>::operator()(xml_h element) const;
+  /// Converter for <Ellipsoid/> tags
+  template <> void Converter<ellipsoid>::operator()(xml_h element) const;
+  /// Converter for <EllipticalTube/> tags
+  template <> void Converter<ellipticaltube>::operator()(xml_h element) const;
   /// Converter for <Torus/> tags
   template <> void Converter<torus>::operator()(xml_h element) const;
   /// Converter for <Tubs/> tags
   template <> void Converter<tubs>::operator()(xml_h element) const;
+  /// Converter for <CutTubs/> tags
+  template <> void Converter<cuttubs>::operator()(xml_h element) const;
+  /// Converter for <TruncTubs/> tags
+  template <> void Converter<trunctubs>::operator()(xml_h element) const;
+  /// Converter for <Sphere/> tags
+  template <> void Converter<sphere>::operator()(xml_h element) const;
+  /// Converter for <Trd1/> tags
+  template <> void Converter<trd1>::operator()(xml_h element) const;
+  /// Converter for <Cone/> tags
+  template <> void Converter<cone>::operator()(xml_h element) const;
   /// Converter for <Box/> tags
   template <> void Converter<box>::operator()(xml_h element) const;
+  /// Converter for <Orb/> tags
+  template <> void Converter<orb>::operator()(xml_h element) const;
 
   /// Converter for <Algorithm/> tags
   template <> void Converter<algorithm>::operator()(xml_h element) const;
@@ -210,10 +246,34 @@ template <> void Converter<solidsection>::operator()(xml_h element) const   {
       Converter<box>(description,_ns.context,optional)(solid);
     else if ( tag == "Polycone" )
       Converter<polycone>(description,_ns.context,optional)(solid);
+    else if ( tag == "Polyhedra" )
+      Converter<polyhedra>(description,_ns.context,optional)(solid);
     else if ( tag == "Tubs" )
       Converter<tubs>(description,_ns.context,optional)(solid);
+    else if ( tag == "CutTubs" )
+      Converter<cuttubs>(description,_ns.context,optional)(solid);
+    else if ( tag == "TruncTubs" )
+      Converter<trunctubs>(description,_ns.context,optional)(solid);
+    else if ( tag == "Tube" )
+      Converter<tubs>(description,_ns.context,optional)(solid);
+    else if ( tag == "Trd1" )
+      Converter<trd1>(description,_ns.context,optional)(solid);
+    else if ( tag == "Cone" )
+      Converter<cone>(description,_ns.context,optional)(solid);
+    else if ( tag == "Sphere" )
+      Converter<sphere>(description,_ns.context,optional)(solid);
+    else if ( tag == "Ellipsoid" )
+      Converter<ellipsoid>(description,_ns.context,optional)(solid);
+    else if ( tag == "EllipticalTube" )
+      Converter<ellipticaltube>(description,_ns.context,optional)(solid);
+    else if ( tag == "Orb" )
+      Converter<orb>(description,_ns.context,optional)(solid);
     else if ( tag == "Torus" )
       Converter<torus>(description,_ns.context,optional)(solid);
+    else if ( tag == "PseudoTrap" )
+      Converter<pseudotrap>(description,_ns.context,optional)(solid);
+    else if ( tag == "ExtrudedPolygon" )
+      Converter<extrudedpolygon>(description,_ns.context,optional)(solid);
     else if ( tag == "Trapezoid" )
       Converter<trapezoid>(description,_ns.context,optional)(solid);
     else if ( tag == "UnionSolid" )
@@ -222,6 +282,8 @@ template <> void Converter<solidsection>::operator()(xml_h element) const   {
       Converter<subtractionsolid>(description,_ns.context,optional)(solid);
     else if ( tag == "IntersectionSolid" )
       Converter<intersectionsolid>(description,_ns.context,optional)(solid);
+    else if ( tag == "ShapelessSolid" )
+      Converter<shapeless>(description,_ns.context,optional)(solid);
     else  {
       string nam = xml_dim_t(solid).nameStr();
       printout(ERROR,"DDCMS","+++ Request to process unknown shape %s [%s]",
@@ -512,14 +574,19 @@ static void convert_boolean(ParsingContext* ctx, xml_h element)   {
   Solid       boolean;
   int cnt=0;
 
-  for(xml_coll_t c(element, _CMU(rSolid)); cnt<2 && c; ++c, ++cnt)
-    solids[cnt] = _ns.solid(c.attr<string>(_U(name)));
-
+  if ( e.hasChild(_CMU(rSolid)) )  {   // Old version
+    for(xml_coll_t c(element, _CMU(rSolid)); cnt<2 && c; ++c, ++cnt)
+      solids[cnt] = _ns.solid(c.attr<string>(_U(name)));
+  }
+  else  {
+    if ( (solids[0] = _ns.solid(e.attr<string>(_CMU(firstSolid)))).isValid() ) ++cnt;
+    if ( (solids[1] = _ns.solid(e.attr<string>(_CMU(secondSolid)))).isValid() ) ++cnt;
+  }
   if ( cnt != 2 )   {
-    except("DDCMS","+++ Failed to create blooean solid %s. Found only %d parts.",nam.c_str(), cnt);
+    except("DDCMS","+++ Failed to create boolean solid %s. Found only %d parts.",nam.c_str(), cnt);
   }
   printout(_ns.context->debug_placements ? ALWAYS : DEBUG, "DDCMS",
-           "+++ SubtractionSolid: %s Left: %-32s Right: %-32s",
+           "+++ BooleanSolid: %s Left: %-32s Right: %-32s",
            nam.c_str(), solids[0]->GetName(), solids[1]->GetName());
 
   if ( solids[0].isValid() && solids[1].isValid() )  {
@@ -556,15 +623,105 @@ template <> void Converter<polycone>::operator()(xml_h element) const {
   double deltaPhi = _ns.attr<double>(e,_CMU(deltaPhi));
   vector<double> z, rmin, rmax;
   
+  for(xml_coll_t zplane(element, _CMU(RZPoint)); zplane; ++zplane)   {
+    rmin.push_back(0.0);
+    rmax.push_back(_ns.attr<double>(zplane,_U(r)));
+    z.push_back(_ns.attr<double>(zplane,_U(z)));
+  }
   for(xml_coll_t zplane(element, _CMU(ZSection)); zplane; ++zplane)   {
     rmin.push_back(_ns.attr<double>(zplane,_CMU(rMin)));
     rmax.push_back(_ns.attr<double>(zplane,_CMU(rMax)));
-    z.push_back(_ns.attr<double>(zplane,_CMU(z)));
+    z.push_back(_ns.attr<double>(zplane,_U(z)));
   }
   printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
-           "+   Polycone: startPhi=%10.3f [rad] deltaPhi=%10.3f [rad]  %4ld z-planes",
+           "+   Polycone: startPhi=%8.3f [rad] deltaPhi=%8.3f [rad]  %4ld z-planes",
            startPhi, deltaPhi, z.size());
   _ns.addSolid(nam, Polycone(startPhi,deltaPhi,rmin,rmax,z));
+}
+
+/// Converter for <ExtrudedPolygon/> tags
+template <> void Converter<extrudedpolygon>::operator()(xml_h element) const  {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam      = e.nameStr();
+  vector<double> pt_x, pt_y, sec_x, sec_y, sec_z, sec_scale;
+  
+  for(xml_coll_t sec(element, _CMU(ZXYSection)); sec; ++sec)   {
+    sec_z.push_back(_ns.attr<double>(sec,_U(z)));
+    sec_x.push_back(_ns.attr<double>(sec,_U(x)));
+    sec_y.push_back(_ns.attr<double>(sec,_U(y)));
+    sec_scale.push_back(_ns.attr<double>(sec,_CMU(scale),1.0));
+  }
+  for(xml_coll_t pt(element, _CMU(XYPoint)); pt; ++pt)   {
+    pt_x.push_back(_ns.attr<double>(pt,_U(x)));
+    pt_y.push_back(_ns.attr<double>(pt,_U(y)));
+  }
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   ExtrudedPolygon: %4ld points %4ld zxy sections",
+           pt_x.size(), sec_z.size());
+  _ns.addSolid(nam,ExtrudedPolygon(pt_x,pt_y,sec_z,sec_x,sec_y,sec_scale));
+}
+
+/// Converter for <Polyhedra/> tags
+template <> void Converter<polyhedra>::operator()(xml_h element) const {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam      = e.nameStr();
+  double numSide  = _ns.attr<int>(e,_CMU(numSide));
+  double startPhi = _ns.attr<double>(e,_CMU(startPhi));
+  double deltaPhi = _ns.attr<double>(e,_CMU(deltaPhi));
+  vector<double> z, rmin, rmax;
+  
+  for(xml_coll_t zplane(element, _CMU(RZPoint)); zplane; ++zplane)   {
+    rmin.push_back(0.0);
+    rmax.push_back(_ns.attr<double>(zplane,_U(r)));
+    z.push_back(_ns.attr<double>(zplane,_U(z)));
+  }
+  for(xml_coll_t zplane(element, _CMU(ZSection)); zplane; ++zplane)   {
+    rmin.push_back(_ns.attr<double>(zplane,_CMU(rMin)));
+    rmax.push_back(_ns.attr<double>(zplane,_CMU(rMax)));
+    z.push_back(_ns.attr<double>(zplane,_U(z)));
+  }
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   Polyhedra:startPhi=%8.3f [rad] deltaPhi=%8.3f [rad]  %4d sides %4ld z-planes",
+           startPhi, deltaPhi, numSide, z.size());
+  _ns.addSolid(nam, Polyhedra(numSide,startPhi,deltaPhi,z,rmin,rmax));
+}
+
+/// Converter for <Sphere/> tags
+template <> void Converter<sphere>::operator()(xml_h element) const {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam      = e.nameStr();
+  double rinner   = _ns.attr<double>(e,_CMU(innerRadius));
+  double router   = _ns.attr<double>(e,_CMU(outerRadius));
+  double startPhi = _ns.attr<double>(e,_CMU(startPhi));
+  double deltaPhi = _ns.attr<double>(e,_CMU(deltaPhi));
+  double startTheta = _ns.attr<double>(e,_CMU(startTheta));
+  double deltaTheta = _ns.attr<double>(e,_CMU(deltaTheta));
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   Sphere:   r_inner=%8.3f [cm] r_outer=%8.3f [cm]"
+           " startPhi=%8.3f [rad] deltaPhi=%8.3f startTheta=%8.3f delteTheta=%8.3f [rad]",
+           rinner, router, startPhi, deltaPhi, startTheta, deltaTheta);
+  _ns.addSolid(nam, Sphere(rinner, router, startTheta, deltaTheta, startPhi, deltaPhi));
+}
+
+/// Converter for <Ellipsoid/> tags: Same as sphere, but with scale
+template <> void Converter<ellipsoid>::operator()(xml_h element) const   {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam  = e.nameStr();
+  double dx   = _ns.attr<double>(e,_CMU(xSemiAxis));
+  double dy   = _ns.attr<double>(e,_CMU(ySemiAxis));
+  double dz   = _ns.attr<double>(e,_CMU(zSemiAxis));
+  double zBot = _ns.attr<double>(e,_CMU(zBottomCut),0.0);
+  double zTop = _ns.attr<double>(e,_CMU(zTopCut),0.0);
+
+  printout(WARNING, "DDCMS",
+           "+   Ellipsoid UNSUPPORTED. %s REPLACED BY BOX "
+           " xSemiAxis=%8.3f ySemiAxis=%8.3f zSemiAxis=%8.3f zBottomCut=%8.3f zTopCut=%8.3f [cm]",
+           nam.c_str(), dx, dy, dz, zBot, zTop);
+  _ns.addSolid(nam, Box(1,1,1));
 }
 
 /// Converter for <Torus/> tags
@@ -578,10 +735,28 @@ template <> void Converter<torus>::operator()(xml_h element) const   {
   double startPhi = _ns.attr<double>(e,_CMU(startPhi));
   double deltaPhi = _ns.attr<double>(e,_CMU(deltaPhi));
   printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
-           "+   Torus:    r=%10.3f [cm] r_inner=%10.3f [cm] r_outer=%10.3f [cm]"
-           " startPhi=%10.3f [rad] deltaPhi=%10.3f [rad]",
+           "+   Torus:    r=%8.3f [cm] r_inner=%8.3f [cm] r_outer=%8.3f [cm]"
+           " startPhi=%8.3f [rad] deltaPhi=%8.3f [rad]",
            r, rinner, router, startPhi, deltaPhi);
   _ns.addSolid(nam, Torus(r, rinner, router, startPhi, deltaPhi));
+}
+
+/// Converter for <Pseudotrap/> tags
+template <> void Converter<pseudotrap>::operator()(xml_h element) const {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam      = e.nameStr();
+  double dx1      = _ns.attr<double>(e,_CMU(dx1));
+  double dy1      = _ns.attr<double>(e,_CMU(dy1));
+  double dx2      = _ns.attr<double>(e,_CMU(dx2));
+  double dy2      = _ns.attr<double>(e,_CMU(dy2));
+  double dz       = _ns.attr<double>(e,_U(dz));
+  double r        = _ns.attr<double>(e,_U(radius));
+  bool   atMinusZ = _ns.attr<bool>  (e,_CMU(atMinusZ));
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   Pseudotrap:  dz=%8.3f [cm] dx1:%.3f dy1:%.3f dx2=%.3f dy2=%.3f radius:%.3f atMinusZ:%s",
+           dz, dx1, dy1, dx2, dy2, r, yes_no(atMinusZ));
+  _ns.addSolid(nam, PseudoTrap(dx1, dx2, dy1, dy2, dz, r, atMinusZ));
 }
 
 /// Converter for <Trapezoid/> tags
@@ -598,12 +773,28 @@ template <> void Converter<trapezoid>::operator()(xml_h element) const {
   double bl2      = _ns.attr<double>(e,_CMU(bl2));
   double tl2      = _ns.attr<double>(e,_CMU(tl2));
   double h2       = _ns.attr<double>(e,_CMU(h2));
-  double phi      = _ns.attr<double>(e,_U(phi));
-  double theta    = _ns.attr<double>(e,_U(theta));
+  double phi      = _ns.attr<double>(e,_U(phi),0.0);
+  double theta    = _ns.attr<double>(e,_U(theta),0.0);
   printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
-           "+   Trapezoid:  dz=%10.3f [cm] alp1:%.3f bl1=%.3f tl1=%.3f alp2=%.3f bl2=%.3f tl2=%.3f h2=%.3f phi=%.3f theta=%.3f",
+           "+   Trapezoid:  dz=%8.3f [cm] alp1:%.3f bl1=%.3f tl1=%.3f alp2=%.3f bl2=%.3f tl2=%.3f h2=%.3f phi=%.3f theta=%.3f",
            dz, alp1, bl1, tl1, h1, alp2, bl2, tl2, h2, phi, theta);
   _ns.addSolid(nam, Trap(dz, theta, phi, h1, bl1, tl1, alp1, h2, bl2, tl2, alp2));
+}
+
+/// Converter for <Trd1/> tags
+template <> void Converter<trd1>::operator()(xml_h element) const {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam      = e.nameStr();
+  double dx1      = _ns.attr<double>(e,_CMU(dx1));
+  double dy1      = _ns.attr<double>(e,_CMU(dy1));
+  double dx2      = _ns.attr<double>(e,_CMU(dx2),0.0);
+  double dy2      = _ns.attr<double>(e,_CMU(dy2),0.0);
+  double dz       = _ns.attr<double>(e,_CMU(dz));
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   Trd1:       dz=%8.3f [cm] dx1:%.3f dy1:%.3f dx2:%.3f dy2:%.3f",
+           dz, dx1, dy1, dx2, dy2);
+  _ns.addSolid(nam, Trapezoid(dx1, dx2, dy1, dy2, dz));
 }
 
 /// Converter for <Tubs/> tags
@@ -614,12 +805,100 @@ template <> void Converter<tubs>::operator()(xml_h element) const {
   double dz       = _ns.attr<double>(e,_CMU(dz));
   double rmin     = _ns.attr<double>(e,_CMU(rMin));
   double rmax     = _ns.attr<double>(e,_CMU(rMax));
+  double startPhi = _ns.attr<double>(e,_CMU(startPhi),0.0);
+  double deltaPhi = _ns.attr<double>(e,_CMU(deltaPhi),2*M_PI);
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   Tubs:     dz=%8.3f [cm] rmin=%8.3f [cm] rmax=%8.3f [cm]"
+           " startPhi=%8.3f [rad] deltaPhi=%8.3f [rad]", dz, rmin, rmax, startPhi, deltaPhi);
+  _ns.addSolid(nam, Tube(rmin,rmax,dz,startPhi,deltaPhi));
+}
+
+/// Converter for <CutTubs/> tags
+template <> void Converter<cuttubs>::operator()(xml_h element) const {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam      = e.nameStr();
+  double dz       = _ns.attr<double>(e,_CMU(dz));
+  double rmin     = _ns.attr<double>(e,_CMU(rMin));
+  double rmax     = _ns.attr<double>(e,_CMU(rMax));
   double startPhi = _ns.attr<double>(e,_CMU(startPhi));
   double deltaPhi = _ns.attr<double>(e,_CMU(deltaPhi));
+  double lx       = _ns.attr<double>(e,_CMU(lx));
+  double ly       = _ns.attr<double>(e,_CMU(ly));
+  double lz       = _ns.attr<double>(e,_CMU(lz));
+  double tx       = _ns.attr<double>(e,_CMU(tx));
+  double ty       = _ns.attr<double>(e,_CMU(ty));
+  double tz       = _ns.attr<double>(e,_CMU(tz));
   printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
-           "+   Tubs:     dz=%10.3f [cm] rmin=%10.3f [cm] rmax=%10.3f [cm]"
-           " startPhi=%10.3f [rad] deltaPhi=%10.3f [rad]", dz, rmin, rmax, startPhi, deltaPhi);
-  _ns.addSolid(nam, Tube(rmin,rmax,dz,startPhi,deltaPhi));
+           "+   CutTube:  dz=%8.3f [cm] rmin=%8.3f [cm] rmax=%8.3f [cm]"
+           " startPhi=%8.3f [rad] deltaPhi=%8.3f [rad]...",
+           dz, rmin, rmax, startPhi, deltaPhi);
+  _ns.addSolid(nam, CutTube(rmin,rmax,dz,startPhi,deltaPhi,lx,ly,lz,tx,ty,tz));
+}
+
+/// Converter for <TruncTubs/> tags
+template <> void Converter<trunctubs>::operator()(xml_h element) const {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam        = e.nameStr();
+  double zhalf      = _ns.attr<double>(e,_CMU(zHalf));
+  double rmin       = _ns.attr<double>(e,_CMU(rMin));
+  double rmax       = _ns.attr<double>(e,_CMU(rMax));
+  double startPhi   = _ns.attr<double>(e,_CMU(startPhi));
+  double deltaPhi   = _ns.attr<double>(e,_CMU(deltaPhi));
+  double cutAtStart = _ns.attr<double>(e,_CMU(cutAtStart));
+  double cutAtDelta = _ns.attr<double>(e,_CMU(cutAtDelta));
+  bool   cutInside  = _ns.attr<bool>(e,_CMU(cutInside));
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   TruncTube:zHalf=%8.3f [cm] rmin=%8.3f [cm] rmax=%8.3f [cm]"
+           " startPhi=%8.3f [rad] deltaPhi=%8.3f [rad] atStart=%8.3f [cm] atDelta=%8.3f [cm] inside:%s",
+           zhalf, rmin, rmax, startPhi, deltaPhi, cutAtStart, cutAtDelta, yes_no(cutInside));
+  _ns.addSolid(nam, TruncatedTube(zhalf,rmin,rmax,startPhi,deltaPhi,cutAtStart,cutAtDelta,cutInside));
+}
+
+/// Converter for <EllipticalTube/> tags
+template <> void Converter<ellipticaltube>::operator()(xml_h element) const   {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam = e.nameStr();
+  double dx  = _ns.attr<double>(e,_CMU(xSemiAxis));
+  double dy  = _ns.attr<double>(e,_CMU(ySemiAxis));
+  double dz  = _ns.attr<double>(e,_CMU(zHeight));
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   EllipticalTube xSemiAxis=%8.3f [cm] ySemiAxis=%8.3f [cm] zHeight=%8.3f [cm]",dx,dy,dz);
+  _ns.addSolid(nam, EllipticalTube(dx,dy,dz));
+}
+
+/// Converter for <Cone/> tags
+template <> void Converter<cone>::operator()(xml_h element) const {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam      = e.nameStr();
+  double dz       = _ns.attr<double>(e,_CMU(dz));
+  double rmin1    = _ns.attr<double>(e,_CMU(rMin1));
+  double rmin2    = _ns.attr<double>(e,_CMU(rMin2));
+  double rmax1    = _ns.attr<double>(e,_CMU(rMax1));
+  double rmax2    = _ns.attr<double>(e,_CMU(rMax2));
+  double startPhi = _ns.attr<double>(e,_CMU(startPhi));
+  double deltaPhi = _ns.attr<double>(e,_CMU(deltaPhi));
+  double phi2     = startPhi + deltaPhi;
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   Cone:     dz=%8.3f [cm]"
+           " rmin1=%8.3f [cm] rmax1=%8.3f [cm]"
+           " rmin2=%8.3f [cm] rmax2=%8.3f [cm]"
+           " startPhi=%8.3f [rad] deltaPhi=%8.3f [rad]",
+           dz, rmin1, rmax1, rmin2, rmax2, startPhi, deltaPhi);
+  _ns.addSolid(nam, ConeSegment(dz,rmin1,rmax1,rmin2,rmax2,startPhi,phi2));
+}
+
+/// Converter for </> tags
+template <> void Converter<shapeless>::operator()(xml_h element) const {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam = e.nameStr();
+  printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
+           "+   Shapeless: THIS ONE CAN ONLY BE USED AT THE VOLUME LEVEL -> Assembly%s", nam.c_str());
+  _ns.addSolid(nam, Box(1,1,1));
 }
 
 /// Converter for <Box/> tags
@@ -631,8 +910,19 @@ template <> void Converter<box>::operator()(xml_h element) const {
   double dy  = _ns.attr<double>(e,_CMU(dy));
   double dz  = _ns.attr<double>(e,_CMU(dz));
   printout(_ns.context->debug_shapes ? ALWAYS : DEBUG, "DDCMS",
-           "+   Box:      dx=%10.3f [cm] dy=%10.3f [cm] dz=%10.3f [cm]", dx, dy, dz);
+           "+   Box:      dx=%8.3f [cm] dy=%8.3f [cm] dz=%8.3f [cm]", dx, dy, dz);
   _ns.addSolid(nam, Box(dx,dy,dz));
+}
+
+/// Converter for <Box/> tags
+template <> void Converter<orb>::operator()(xml_h element) const {
+  Namespace _ns(_param<ParsingContext>());
+  xml_dim_t e(element);
+  string nam = e.nameStr();
+  double r = _ns.attr<double>(e,_U(radius));
+  printout(WARNING, "DDCMS",
+           "+   Orb UNSUPPORTED. %s REPLACED BY BOX:      r=%8.3f [cm]", nam.c_str(), r);
+  _ns.addSolid(nam, Box(r,r,r));
 }
 
 /// DD4hep specific Converter for <Include/> tags: process only the constants

--- a/examples/DDCMS/src/plugins/DDDefinitions2Objects.cpp
+++ b/examples/DDCMS/src/plugins/DDDefinitions2Objects.cpp
@@ -286,7 +286,7 @@ template <> void Converter<solidsection>::operator()(xml_h element) const   {
       Converter<shapeless>(description,_ns.context,optional)(solid);
     else  {
       string nam = xml_dim_t(solid).nameStr();
-      printout(ERROR,"DDCMS","+++ Request to process unknown shape %s [%s]",
+      printout(ERROR,"DDCMS","+++ Request to process unknown shape '%s' [%s]",
                nam.c_str(), tag.c_str());
     }
   }
@@ -718,7 +718,7 @@ template <> void Converter<ellipsoid>::operator()(xml_h element) const   {
   double zTop = _ns.attr<double>(e,_CMU(zTopCut),0.0);
 
   printout(WARNING, "DDCMS",
-           "+   Ellipsoid UNSUPPORTED. %s REPLACED BY BOX "
+           "+   Ellipsoid UNSUPPORTED. '%s' REPLACED BY BOX "
            " xSemiAxis=%8.3f ySemiAxis=%8.3f zSemiAxis=%8.3f zBottomCut=%8.3f zTopCut=%8.3f [cm]",
            nam.c_str(), dx, dy, dz, zBot, zTop);
   _ns.addSolid(nam, Box(1,1,1));

--- a/examples/DDDB/CMakeLists.txt
+++ b/examples/DDDB/CMakeLists.txt
@@ -233,6 +233,7 @@ if (DD4HEP_USE_XERCESC)
     DDDB_DeVelo_Gaudi_LONGTEST
     DDDB_DeVelo_LONGTEST
     DDDB_extract_LONGTEST
-    REGEX_PASS "DDDB Database successfully removed" )
+    REGEX_PASS "DDDB Database successfully removed"
+  )
 
 endif()

--- a/examples/DDDB/include/DDDB/DDDBReader.h
+++ b/examples/DDDB/include/DDDB/DDDBReader.h
@@ -79,9 +79,9 @@ namespace dd4hep {
 
       /** Helpers for selective parsing  */
       /// Add a blocked path entry
-      void blockPath(const std::string& path);
+      virtual void blockPath(const std::string& path)  override;
       /// Check if a URI path is blocked
-      bool isBlocked(const std::string& path)  const;
+      virtual bool isBlocked(const std::string& path)  const  override;
       
     protected:
       /// File directory

--- a/examples/DDDB/include/Detector/DeVPSensor.h
+++ b/examples/DDDB/include/Detector/DeVPSensor.h
@@ -19,10 +19,10 @@
 #include <array>
 
 // Framework include files
+#include "Kernel/VPConstants.h"
 #include "Detector/DetectorElement.h"
 #include "Detector/DeStatic.h"
 #include "Detector/DeIOV.h"
-#include "Kernel/VPConstants.h"
 
 /// Gaudi namespace declaration
 namespace gaudi   {
@@ -161,9 +161,9 @@ namespace gaudi   {
     /// Standard constructors and assignment
     DE_CTORS_HANDLE(DeVPSensorElement,Base);
     /// Access to the static data. Does this need to be optionized???
-    static_t& staticData()  const    {  return access()->sensor_static;         }
-    bool isLeft()   const            {  return (ptr()->de_user&VP::LEFT) != 0;  }
-    bool isRight()   const           {  return (ptr()->de_user&VP::LEFT) == 0;  }
+    static_t& staticData()  const  {  return access()->sensor_static;            }
+    //bool isLeft()   const          {  return (ptr()->de_user & VP::RIGHT) == 0;  }
+    //bool isRight()   const         {  return (ptr()->de_user & VP::RIGHT) != 0;  }
   };
 
   /// For the full sensor object, we have to combine it with the geometry stuff:

--- a/examples/DDDB/src/plugins/CondDB2DDDB.cpp
+++ b/examples/DDDB/src/plugins/CondDB2DDDB.cpp
@@ -158,7 +158,7 @@ namespace dd4hep {
 
     public:
       Detector*   description = 0;
-      DDDBReader* resolver = 0;
+      xml::UriReader* resolver = 0;
       dddb*       geo = 0;
       Locals      locals;
       bool        check = true;
@@ -444,7 +444,7 @@ namespace dd4hep {
 
     void fixCatalogs(DDDBContext* context)  {
       dddb*       geo = context->geo;
-      DDDBReader* rdr = context->resolver;
+      xml::UriReader* rdr = context->resolver;
       for(dddb::Catalogs::iterator i=geo->catalogs.begin(); i!=geo->catalogs.end(); ++i)  {
         DDDBCatalog* det = (*i).second;
         for(dddb::Catalogs::iterator j=det->catalogrefs.begin(); j!=det->catalogrefs.end(); ++j)  {
@@ -1786,7 +1786,7 @@ namespace dd4hep {
       size_t hash = ref.find("#");
       if ( hash != 0 )  {
         try {
-          DDDBReader*        rdr       = context->resolver;
+          xml::UriReader*        rdr       = context->resolver;
           DDDBReaderContext* ctx       = (DDDBReaderContext*)rdr->context();
           string doc_path = element.ptr() ? reference_href(element,ref) : ref;
           if ( ref == ctx->match+"/Conditions/Online" )
@@ -1869,7 +1869,7 @@ namespace dd4hep {
                         DDDBHelper*  hlp, 
                         const std::string& doc_path,
                         const std::string& obj_path)  {
-      DDDBReader*         rdr     = hlp->reader<DDDBReader>();
+      xml::UriReader*         rdr     = hlp->reader<xml::UriReader>();
       DDDBReaderContext*  ctx     = (DDDBReaderContext*)rdr->context();
       DDDBDocument*       doc     = new DDDBDocument();
       doc->name                   = obj_path;

--- a/examples/DDDB/src/plugins/DeVeloServiceTest.cpp
+++ b/examples/DDDB/src/plugins/DeVeloServiceTest.cpp
@@ -78,7 +78,7 @@ namespace {
       /// Configure file based reader
       void configReader(long iov_start, long iov_end)   {
         try   {
-          const DetService::IOVType* iov_typ = m_service->iovType("epoch");
+          const IDetService::IOVType* iov_typ = m_service->iovType("epoch");
           dd4hep::IOV iov_range(iov_typ);
           iov_range.keyData.first  = iov_start;
           iov_range.keyData.second = iov_end;
@@ -102,9 +102,9 @@ namespace {
         m_de     = dd4hep::detail::tools::findElement(dsc, path);
         m_reader = helper->reader<dd4hep::DDDB::DDDBReader>();
         m_service.reset(new DetService(manager));
-        const DetService::IOVType* iov_typ = m_service->iovType("epoch");
-        dd4hep::IOV                iov(iov_typ,dd4hep::detail::makeTime(2018,1,1));
-        IDetService::Content       content = m_service->openContent("DDDB");
+        const IDetService::IOVType* iov_typ = m_service->iovType("epoch");
+        dd4hep::IOV                 iov(iov_typ,dd4hep::detail::makeTime(2018,1,1));
+        IDetService::Content        content = m_service->openContent("DDDB");
         configReader(dd4hep::detail::makeTime(2008,1,1), dd4hep::detail::makeTime(2018,12,31));
 
         cont.reset(new dd4hep::cond::ConditionsContent());


### PR DESCRIPTION

BEGINRELEASENOTES
- Examples: only build some examples depending on the availibility of dependencies.
- DDCore: Add interface to allow URI blocking during file parsing.
  Default is as now.
- DDCMS: Add conversion of new shapes.
ENDRELEASENOTES