### PR TITLE
Give the Detector object state, which depends on the geometry state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,13 @@ ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 ###############################################
 
 OPTION(BUILD_DOCS_ONLY "Build documentation only" OFF)
+OPTION(BUILD_DOCS "Build documentation" ON)
 
 # Add targets for Doxygen code reference and LaTeX User manual
 
-ADD_SUBDIRECTORY(doc)
+if (BUILD_DOCS)
+    ADD_SUBDIRECTORY(doc)
+ENDIF()
 
 # If only building docs, stop processing the rest of the CMake file:
 IF(BUILD_DOCS_ONLY)

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,12 @@
+//==========================================================================
+//  AIDA Detector description implementation (DD4hep)
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank et al.
+//
+//==========================================================================

--- a/DDRec/python/DDRec.py
+++ b/DDRec/python/DDRec.py
@@ -9,7 +9,7 @@
 #
 #==========================================================================
 import logging
-import DD4hep as core
+import dd4hep as core
 
 def loadDDRec():
   from ROOT import gSystem

--- a/DDRec/python/dumpDetectorData.py
+++ b/DDRec/python/dumpDetectorData.py
@@ -73,7 +73,7 @@ except ImportError,X:
   sys.exit(errno.ENOENT)
 
 try:
-  import DD4hep
+  import dd4hep
 except ImportError,X:
   logging.error('dd4hep python interface not accessible: %s',str(X))
   logging.error("%s",parser.format_help())
@@ -87,12 +87,12 @@ except ImportError,X:
   sys.exit(errno.ENOENT)
 #
 
-DD4hep.setPrintLevel(DD4hep.OutputLevel.ERROR)
+dd4hep.setPrintLevel(dd4hep.OutputLevel.ERROR)
 logging.info('+++%s\n+++ Loading compact geometry:%s\n+++%s',120*'=',opts.compact,120*'=')
 
 
 
-description = DD4hep.Detector.getInstance()
+description = dd4hep.Detector.getInstance()
 description.fromXML(opts.compact)
 
 


### PR DESCRIPTION
Replaced #369 

BEGINRELEASENOTES

*    Give the Detector object state, which depends on the geometry state.
*    Allow to disable building the documentation cmake option BUILD_DOCS.
    By default ON and backwards compatible. If set to OFF no doc shall be built.
    (not everybody has biber installed)
*    Move from DD4hep.py to dd4hep.py, since DD4hep.py has to disappear due to conflicts on MAC.

    ENDRELEASENOTES
