### PR TITLE
Fixed incorrect callback for Geant4FieldTrackingConstruction

### DIFF
--- a/DDG4/plugins/Geant4FieldTrackingSetup.cpp
+++ b/DDG4/plugins/Geant4FieldTrackingSetup.cpp
@@ -112,8 +112,8 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4FieldTrackingConstruction() {}
 
-      /// Phase action callback
-      void operator()();
+      /// Detector construction callback
+      void constructField(Geant4DetectorConstructionContext *ctxt);
 
     };
   }    // End namespace sim
@@ -284,8 +284,8 @@ Geant4FieldTrackingConstruction::Geant4FieldTrackingConstruction(Geant4Context* 
   declareProperty("largest_step",       largest_step = -1.0);
 }
 
-/// Post-track action callback
-void Geant4FieldTrackingConstruction::operator()()   {
+/// Detector construction callback
+void Geant4FieldTrackingConstruction::constructField(Geant4DetectorConstructionContext *) {
   execute(context()->detectorDescription());
   printout( INFO, "FieldSetup", "Geant4 magnetic field tracking configured.");
   printout( INFO, "FieldSetup", "G4MagIntegratorStepper:%s G4Mag_EqRhs:%s",


### PR DESCRIPTION
`Geant4FieldTrackingConstruction` overloads `operator()`, but should override `constructField()`.  This PR fixes this.

BEGINRELEASENOTES
- Geant4FieldTrackingConstruction now properly overrides `constructField()`

ENDRELEASENOTES