### PR TITLE
Fix bug found by Coverity

### DIFF
--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -637,8 +637,8 @@ void ExtrudedPolygon::make(const vector<double>& pt_x,
 ExtrudedPolygon::ExtrudedPolygon(const vector<double>& pt_x,
                                  const vector<double>& pt_y,
                                  const vector<double>& sec_z,
-                                 const vector<double>& sec_y,
                                  const vector<double>& sec_x,
+                                 const vector<double>& sec_y,
                                  const vector<double>& sec_scale)
 {
   make(pt_x, pt_y, sec_z, sec_x, sec_y, sec_scale);

--- a/DDCore/src/plugins/ShapePlugins.cpp
+++ b/DDCore/src/plugins/ShapePlugins.cpp
@@ -176,7 +176,7 @@ static Handle<TObject> create_ExtrudedPolygon(Detector&, xml_h element)   {
     pt_x.push_back(point.attr<double>(_U(x)));
     pt_y.push_back(point.attr<double>(_U(y)));
   }
-  return ExtrudedPolygon(pt_x, pt_y, sec_z, sec_x, sec_y, sec_scale);
+  return ExtrudedPolygon(pt_x, pt_y, sec_z, sec_y, sec_x, sec_scale);
 }
 DECLARE_XML_SHAPE(ExtrudedPolygon__shape_constructor,create_ExtrudedPolygon)
 

--- a/DDCore/src/plugins/ShapePlugins.cpp
+++ b/DDCore/src/plugins/ShapePlugins.cpp
@@ -176,7 +176,7 @@ static Handle<TObject> create_ExtrudedPolygon(Detector&, xml_h element)   {
     pt_x.push_back(point.attr<double>(_U(x)));
     pt_y.push_back(point.attr<double>(_U(y)));
   }
-  return ExtrudedPolygon(pt_x, pt_y, sec_z, sec_y, sec_x, sec_scale);
+  return ExtrudedPolygon(pt_x, pt_y, sec_z, sec_x, sec_y, sec_scale);
 }
 DECLARE_XML_SHAPE(ExtrudedPolygon__shape_constructor,create_ExtrudedPolygon)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix bug in variable order of `ExtrudedPolygon` (x<->y)

ENDRELEASENOTES
Resolves #386 