### PR TITLE
Remove duplicate ReleaseNotes.md entry

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -10,26 +10,6 @@
   - Fix bug in calculating eta, introduced in #138 
     - use `magFromXYZ` instead of `radiusFromXYZ` to calculate pseudorapidity
 
-* 2018-03-19 Marko Petric ([PR#338](https://github.com/AIDASoft/DD4hep/pull/338))
-  - Include fixes from Chris Burr for the alignments calculator.
-   - Add a small study for the LHCb upgrade defining reasonable detector element conditions for the Velo pixel detector using the DDCond derived condition mechanism.
-   - To be done: somehow get an example for this mechanism, which works outside Gaudi.
-
-* 2018-03-23 Markus Frank ([PR#340](https://github.com/AIDASoft/DD4hep/pull/340))
-  - Improvement for DDDB - case study to implement real-world detector elements.
-
-* 2018-03-28 Marko Petric ([PR#345](https://github.com/AIDASoft/DD4hep/pull/345))
-  - Remove `DDSurfaces` folder as it was merged in `DDRec`
-
-* 2018-03-28 Marko Petric ([PR#341](https://github.com/AIDASoft/DD4hep/pull/341))
-  - Remove top level `DDSegmentation` folder as it is not needed anymore
-
-# v01-07
-
-* 2018-03-26 Javier Cervantes Villanueva ([PR#343](https://github.com/AIDASoft/DD4hep/pull/343))
-  - Fix bug in calculating eta, introduced in #138 
-    - use `magFromXYZ` instead of `radiusFromXYZ` to calculate pseudorapidity
-
 * 2018-03-19 Frank Gaede ([PR#338](https://github.com/AIDASoft/DD4hep/pull/338))
   - Include fixes from Chris Burr for the alignments calculator.
    - Add a small study for the LHCb upgrade defining reasonable detector element conditions for the Velo pixel detector using the DDCond derived condition mechanism.


### PR DESCRIPTION
when creating the v01-07 tag somehow it was tagged twice
this
https://github.com/AIDASoft/DD4hep/commit/90d926c4df007d68786a02bccd1d37a08c25908b
and this
https://github.com/AIDASoft/DD4hep/commit/9a8bc58ab170ef192ac5914adcb51a72b1617f8e

If you want I can also rewrite the history...