### PR TITLE
Allow for out-of-source builds of DD4hep examples

### DIFF
--- a/DDCond/include/DDCond/ConditionsManager.h
+++ b/DDCond/include/DDCond/ConditionsManager.h
@@ -157,6 +157,14 @@ namespace dd4hep {
        */
       void pushUpdates() const;
 
+      /// Adopt cleanup handler. If a handler is registered, it is invoked at every "prepare" step
+      /** Note:
+       *  This may be convenient under certain circumstances, however at the expense of
+       *  more flexible approaches to perform the conditions data cleanup.
+       *  Any previously registered instance shall be deleted.
+       */
+      void adoptCleanup(ConditionsCleanup* cleaner)  const;
+      
       /// Invoke cache cleanup with user defined policy
       void clean(const ConditionsCleanup& cleaner)  const;
 

--- a/DDCond/include/DDCond/ConditionsManagerObject.h
+++ b/DDCond/include/DDCond/ConditionsManagerObject.h
@@ -86,16 +86,16 @@ namespace dd4hep {
       virtual ~ConditionsManagerObject();
 
       /// Access to the detector description instance
-      Detector& detectorDescription() const                    {  return m_detDesc;              }
+      Detector& detectorDescription() const {  return m_detDesc;              }
 
       /// Access to the data loader
-      ConditionsDataLoader* loader()  const {  return m_loader.get();      }
+      ConditionsDataLoader* loader()  const {  return m_loader.get();         }
 
       /// Access to load flag
-      bool doLoadConditions()  const        {  return m_doLoad;            }
+      bool doLoadConditions()  const        {  return m_doLoad;               }
 
       /// Access to flag to indicate if unloaded items should be saved to the slice (or not)
-      bool doOutputUnloaded()  const        {  return m_doOutputUnloaded;  }
+      bool doOutputUnloaded()  const        {  return m_doOutputUnloaded;     }
 
       /// Listener invocation when a condition is registered to the cache
       void onRegister(Condition condition);
@@ -163,6 +163,14 @@ namespace dd4hep {
 
       /// Prepare all updates to the clients with the defined IOV
       virtual Result prepare(const IOV& req_iov, ConditionsSlice& slice, ConditionUpdateUserContext* ctx=0) = 0;
+
+      /// Adopt cleanup handler. If a handler is registered, it is invoked at every "prepare" step
+      /** Note:
+       *  This may be convenient under certain circumstances, however at the expense of
+       *  more flexible approaches to perform the conditions data cleanup.
+       *  Any previously registered instance shall be deleted.
+       */
+      virtual void adoptCleanup(ConditionsCleanup* cleaner) = 0;
 
       /// Clean conditions, which are above the age limit.
       /** @return Number of conditions cleaned/removed from the IOV pool of the given type   */

--- a/DDCond/include/DDCond/Type1/Manager_Type1.h
+++ b/DDCond/include/DDCond/Type1/Manager_Type1.h
@@ -73,7 +73,9 @@ namespace dd4hep {
       dd4hep_mutex_t          m_poolLock;
       /// Reference to update conditions pool
       std::unique_ptr<UpdatePool>  m_updatePool;
-
+      /// Reference to the default conditions cleanup object (if registered)
+      std::unique_ptr<ConditionsCleanup> m_cleaner;
+      
     public:
       /// Managed pool of typed conditions indexed by IOV-type and IOV key
       TypedConditionPool      m_rawPool;
@@ -132,22 +134,25 @@ namespace dd4hep {
       virtual ConditionsPool* registerIOV(const IOVType& typ, IOV::Key key)  final;
 
       /// Access conditions multi IOV pool by iov type
-      ConditionsIOVPool* iovPool(const IOVType& type)  const  final;
+      virtual ConditionsIOVPool* iovPool(const IOVType& type)  const  final;
 
       /// Register new condition with the conditions store. Unlocked version, not multi-threaded
       virtual bool registerUnlocked(ConditionsPool& pool, Condition cond)  final;
 
+      /// Adopt cleanup handler. If a handler is registered, it is invoked at every "prepare" step
+      virtual void adoptCleanup(ConditionsCleanup* cleaner)  final;
+      
       /// Clean conditions, which are above the age limit.
       /** @return Number of conditions cleaned/removed from the IOV pool of the given type   */
-      int clean(const IOVType* typ, int max_age)  final;
+      virtual int clean(const IOVType* typ, int max_age)  final;
 
       /// Invoke cache cleanup with user defined policy
       /** @return pair<Number of pools cleared, Number of conditions cleaned up and removed> */
-      std::pair<int,int> clean(const ConditionsCleanup& cleaner)  final;
+      virtual std::pair<int,int> clean(const ConditionsCleanup& cleaner)  final;
 
       /// Full cleanup of all managed conditions.
       /** @return pair<Number of pools cleared, Number of conditions cleaned up and removed> */
-      std::pair<int,int> clear()  final;
+      virtual std::pair<int,int> clear()  final;
 
       /// Push all pending updates to the conditions store. 
       /** Note:

--- a/DDCond/src/ConditionsManager.cpp
+++ b/DDCond/src/ConditionsManager.cpp
@@ -240,6 +240,11 @@ bool ConditionsManager::registerUnlocked(ConditionsPool& pool, Condition cond)  
 void ConditionsManager::pushUpdates()  const {
 }
 
+/// Adopt cleanup handler. If a handler is registered, it is invoked at every "prepare" step
+void ConditionsManager::adoptCleanup(ConditionsCleanup* cleaner)  const   {
+  access()->adoptCleanup(cleaner);
+}
+
 /// Clean conditions, which are above the age limit.
 void ConditionsManager::clean(const IOVType* typ, int max_age)  const  {
   access()->clean(typ, max_age);

--- a/cmake/run_test_package.sh
+++ b/cmake/run_test_package.sh
@@ -7,8 +7,8 @@
 #
 
 #----- initialize environment for this package - including DD4hep 
-source @CMAKE_INSTALL_PREFIX@/bin/this@PackageName@.sh
-
+export DD4hepExamplesINSTALL=@CMAKE_INSTALL_PREFIX@;
+source @CMAKE_INSTALL_PREFIX@/bin/this@PackageName@.sh;
 #----- parse command line - first argument is the 
 #      test to run
 command=$1

--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -29,7 +29,7 @@ dd4hep_configure_scripts( AlignDet DEFAULT_SETUP WITH_TESTS)
 dd4hep_add_test_reg( AlignDet_Telescope_dump_geometry
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy 
-  -compact file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml 
+  -compact file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
   -plugin DD4hep_DetectorDump
   REGEX_PASS "/world/Telescope/module_9 NumDau\\:1 VolID\\:00000903 Place"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -39,7 +39,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_dump_geometry
 dd4hep_add_test_reg( AlignDet_Telescope_populate
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_populate 
-     -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 10
+     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 10
   REGEX_PASS "Summary          INFO  Processed a total 190 conditions \\(S:190,L:0,C:0,M:0\\) and \\(C:190,M:0\\) alignments. Created:200"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -48,8 +48,8 @@ dd4hep_add_test_reg( AlignDet_Telescope_populate
 dd4hep_add_test_reg( AlignDet_Telescope_read_xml
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml 
-     -input  file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml 
-     -deltas file:${DD4hep_DIR}/examples/Conditions/data/repository.xml 
+     -input  file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
+     -deltas file:${CMAKE_INSTALL_PREFIX}/examples/Conditions/data/repository.xml 
   REGEX_PASS "20 conditions in slice. \\(T:20,S:20,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -58,8 +58,8 @@ dd4hep_add_test_reg( AlignDet_Telescope_read_xml
 dd4hep_add_test_reg( AlignDet_Telescope_dump_xml
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml 
-  -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml 
-  -delta file:${DD4hep_DIR}/examples/Conditions/data/repository.xml 
+  -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
+  -delta file:${CMAKE_INSTALL_PREFIX}/examples/Conditions/data/repository.xml 
   -plugin DD4hep_ConditionsXMLRepositoryWriter -iov_type run -iov_value 1500
   REGEX_PASS "Summary: Converted 33 conditions. 0 conditions without recipe"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -69,8 +69,8 @@ dd4hep_add_test_reg( AlignDet_Telescope_dump_xml
 dd4hep_add_test_reg( AlignDet_Telescope_write_xml
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml 
-  -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml 
-  -delta file:${DD4hep_DIR}/examples/Conditions/data/repository.xml 
+  -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
+  -delta file:${CMAKE_INSTALL_PREFIX}/examples/Conditions/data/repository.xml 
   -plugin DD4hep_ConditionsXMLRepositoryWriter -iov_type run -iov_value 1500 -manager -output new_cond.xml
   REGEX_PASS "Successfully wrote 33 conditions \\(0 unconverted\\) to file: new_cond.xml"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -80,7 +80,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_write_xml
 dd4hep_add_test_reg( AlignDet_Telescope_stress
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_AlignmentExample_stress 
-      -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 20 -runs 111
+      -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 20 -runs 111
   REGEX_PASS "Summary: Total 4598 conditions used \\(S:4598,L:0,C:0,M:0\\) \\(A:380,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -89,8 +89,8 @@ dd4hep_add_test_reg( AlignDet_Telescope_stress
 dd4hep_add_test_reg( AlignDet_Telescope_align_new
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_align_telescope 
-     -input  file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml 
-     -setup  file:${DD4hep_DIR}/examples/Conditions/data/manager.xml 
+     -input  file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
+     -setup  file:${CMAKE_INSTALL_PREFIX}/examples/Conditions/data/manager.xml 
   REGEX_PASS "World transformation of: /world/Telescope/module_3/sensor  Tr:\\( 3.9e\\+02,       0,     4.9 \\[cm\\]\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -99,7 +99,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_align_new
 dd4hep_add_test_reg( AlignDet_Telescope_align_nominal
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_nominal
-     -input  file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml 
+     -input  file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
   REGEX_PASS "Printed 20, scanned 20 and computed a total of 20 alignments \\(C:20,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -108,7 +108,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_align_nominal
 dd4hep_add_test_reg( AlignDet_Telescope_readback_xml
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml
-  -input  file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
+  -input  file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
   -deltas file:./new_cond.xml
   REGEX_PASS "33 conditions in slice. \\(T:33,S:33,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -118,7 +118,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_readback_xml
 dd4hep_add_test_reg( AlignDet_CLICSiD_stress_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_AlignmentExample_stress 
-      -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 10 -runs 100
+      -input file:${CMAKE_INSTALL_PREFIX}/examples/CLICSiD/compact/compact.xml -iovs 10 -runs 100
   REGEX_PASS "Summary: Total 7352100 conditions used \\(S:7352100,L:0,C:0,M:0\\) \\(A:350100,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -127,7 +127,7 @@ dd4hep_add_test_reg( AlignDet_CLICSiD_stress_LONGTEST
 dd4hep_add_test_reg( AlignDet_CLICSiD_align_nominal_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_nominal
-     -input  file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml
+     -input  file:${CMAKE_INSTALL_PREFIX}/examples/CLICSiD/compact/compact.xml
   REGEX_PASS "Printed 35011, scanned 35011 and computed a total of 35011 alignments \\(C:35011,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -136,7 +136,7 @@ dd4hep_add_test_reg( AlignDet_CLICSiD_align_nominal_LONGTEST
 dd4hep_add_test_reg( AlignDet_AlephTPC_load
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun
-             -input file:${DD4hep_DIR}/examples/AlignDet/compact/AlephTPC.xml
+             -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/AlephTPC.xml
              -destroy -no-interpreter -plugin DD4hep_GlobalAlignmentInstall
   REGEX_PASS "189 nodes/ 24 volume UID's in Detector Geometry"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -146,10 +146,10 @@ dd4hep_add_test_reg( AlignDet_AlephTPC_load
 dd4hep_add_test_reg( AlignDet_AlephTPC_global_align
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun
-             -input file:${DD4hep_DIR}/examples/AlignDet/compact/AlephTPC.xml
+             -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/AlephTPC.xml
              -destroy -no-interpreter
              -plugin DD4hep_GlobalAlignmentInstall
-             -plugin DD4hep_XMLLoader file:${DD4hep_DIR}/examples/AlignDet/compact/AlephTPC_alignment.xml BUILD_DEFAULT
+             -plugin DD4hep_XMLLoader file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/AlephTPC_alignment.xml BUILD_DEFAULT
   REGEX_PASS "Successfully parsed XML: AlephTPC_alignment.xml"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -158,11 +158,11 @@ dd4hep_add_test_reg( AlignDet_AlephTPC_global_align
 dd4hep_add_test_reg( AlignDet_AlephTPC_global_reset
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun
-             -input file:${DD4hep_DIR}/examples/AlignDet/compact/AlephTPC.xml
+             -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/AlephTPC.xml
              -destroy -no-interpreter
              -plugin DD4hep_GlobalAlignmentInstall
-             -plugin DD4hep_XMLLoader file:${DD4hep_DIR}/examples/AlignDet/compact/AlephTPC_alignment.xml
-             -plugin DD4hep_XMLLoader file:${DD4hep_DIR}/examples/AlignDet/compact/AlephTPC_reset.xml
+             -plugin DD4hep_XMLLoader file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/AlephTPC_alignment.xml
+             -plugin DD4hep_XMLLoader file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/AlephTPC_reset.xml
   REGEX_PASS "Successfully parsed XML: AlephTPC_reset.xml"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )

--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -17,7 +17,8 @@ dd4hep_package ( CLICSiD MAJOR 0 MINOR 0 PATCH 1
   USES  [ROOT   REQUIRED COMPONENTS Geom] 
         [DD4hep REQUIRED COMPONENTS DDCore]
 )
-dd4hep_install_dir( compact scripts sim DESTINATION ${DD4hep_DIR}/examples/CLICSiD )
+set(CLICSiDEx_INSTALL         ${CMAKE_INSTALL_PREFIX}/examples/CLICSiD)
+dd4hep_install_dir( compact scripts sim DESTINATION ${CLICSiDEx_INSTALL} )
 #--------------------------------------------------------------------------
 if (DD4HEP_USE_GEANT4)
   find_package(Geant4 REQUIRED)
@@ -37,7 +38,7 @@ foreach ( typ description gdml vis )
   dd4hep_add_test_reg ( "CLICSiD_converter_${typ}_LONGTEST" 
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
     EXEC_ARGS  geoConverter -compact2${typ} 
-                            -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml
+                            -input file:${CLICSiDEx_INSTALL}/compact/compact.xml
                             -output file:CLICSiD.${typ}
     REGEX_PASS " Handled [1-9][0-9][0-9]+ volumes" )
 endforeach()
@@ -46,7 +47,7 @@ endforeach()
 dd4hep_add_test_reg( CLICSiD_check_geometry_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  python ${DD4hep_DIR}/python/checkGeometry.py
-                    --compact=file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml
+                    --compact=file:${CLICSiDEx_INSTALL}/compact/compact.xml
   # This takes too long                  --full=true --ntracks=10 --option=o --vx=0 --vy=0 --vz=0
   REGEX_PASS " Execution finished..." )
 #
@@ -54,7 +55,7 @@ dd4hep_add_test_reg( CLICSiD_check_geometry_LONGTEST
 dd4hep_add_test_reg( CLICSiD_check_overlaps_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  python ${DD4hep_DIR}/python/checkOverlaps.py 
-                    --compact=file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml
+                    --compact=file:${CLICSiDEx_INSTALL}/compact/compact.xml
                     --tolerance=0.1
   REGEX_PASS " Execution finished..." )
 #
@@ -65,7 +66,7 @@ if( "${ROOT_FIND_VERSION}" VERSION_GREATER "6.13.0" )
 # ROOT Geometry export to GDML
 dd4hep_add_test_reg( CLICSiD_GDML_export_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  geoPluginRun -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml -print WARNING -destroy -volmgr
+  EXEC_ARGS  geoPluginRun -input file:${CLICSiDEx_INSTALL}/compact/compact.xml -print WARNING -destroy -volmgr
              -plugin DD4hep_ROOTGDMLExtract -output EcalBarrel.gdml            -path /world/EcalBarrel
              -plugin DD4hep_ROOTGDMLExtract -output EcalEndcap.gdml            -path /world/EcalEndcap
              -plugin DD4hep_ROOTGDMLExtract -output HcalBarrel.gdml            -path /world/HcalBarrel 
@@ -84,7 +85,7 @@ dd4hep_add_test_reg( CLICSiD_GDML_export_LONGTEST
 # ROOT Geometry export to GDML
 dd4hep_add_test_reg( CLICSiD_GDML_import_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  geoPluginRun -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact_nocalo.xml -print WARNING -destroy -volmgr
+  EXEC_ARGS  geoPluginRun -input file:${CLICSiDEx_INSTALL}/compact/compact_nocalo.xml -print WARNING -destroy -volmgr
              -plugin DD4hep_ROOTGDMLParse    -input EcalBarrel.gdml            -path /world/EcalBarrel
              -plugin DD4hep_ROOTGDMLParse    -input EcalEndcap.gdml            -path /world/EcalEndcap
              -plugin DD4hep_ROOTGDMLParse    -input HcalBarrel.gdml            -path /world/HcalBarrel
@@ -111,7 +112,7 @@ if (DD4HEP_USE_GEANT4)
   foreach(script testDDPython CLICMagField CLICPhysics CLICRandom CLICSiDScan)
     dd4hep_add_test_reg( CLICSiD_DDG4_${script}_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-      EXEC_ARGS  python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/${script}.py
+      EXEC_ARGS  python ${CLICSiDEx_INSTALL}/scripts/${script}.py
       REQUIRES   DDG4 Geant4
       REGEX_PASS "TEST_PASSED"
       REGEX_FAIL "Exception;EXCEPTION;ERROR" )
@@ -121,7 +122,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_test_reg( CLICSiD_DDG4_g4material_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
     EXEC_ARGS  python ${DD4hep_DIR}/python/g4MaterialScan.py
-                      --compact=file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml 
+                      --compact=file:${CLICSiDEx_INSTALL}/compact/compact.xml 
                       "--position=0,0,0" "--direction=0,1,0"
     REQUIRES   DDG4 Geant4
     REGEX_PASS " Terminate Geant4 and delete associated actions." )
@@ -132,7 +133,7 @@ if (DD4HEP_USE_GEANT4)
     # Build AClick from the source file
     dd4hep_add_test_reg( CLICSiD_DDG4_${script}_as_AClick_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-      EXEC_ARGS  root.exe -b -x -n -q -l "${DD4hep_DIR}/examples/DDG4/examples/run.C(\"${DD4hep_DIR}/examples/CLICSiD/scripts/${script}\")"
+      EXEC_ARGS  root.exe -b -x -n -q -l "${DD4hep_DIR}/examples/DDG4/examples/run.C(\"${CLICSiDEx_INSTALL}/scripts/${script}\")"
       REQUIRES   DDG4 Geant4
       REGEX_PASS "UserEvent_1      INFO  Geant4TestEventAction> calling end.event_id=9"
       REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )

--- a/examples/CLICSiD/scripts/CLICSiDAClick.C
+++ b/examples/CLICSiD/scripts/CLICSiDAClick.C
@@ -1,4 +1,3 @@
-// $Id$
 //====================================================================
 //  AIDA Detector description implementation
 //--------------------------------------------------------------------
@@ -43,7 +42,7 @@ Geant4SensDetActionSequence* setupDetector(Geant4Kernel& kernel, const std::stri
 
 int setupG4_CINT(bool interactive)  {
   Geant4Kernel& kernel = Geant4Kernel::instance(Detector::getInstance());
-  string install_dir = getenv("DD4hepINSTALL");
+  string install_dir = getenv("DD4hepExamplesINSTALL");
   Phase p;
 
   kernel.loadGeometry(("file:"+install_dir+"/examples/CLICSiD/compact/compact.xml").c_str());

--- a/examples/CLICSiD/scripts/CLICSiDXML.C
+++ b/examples/CLICSiD/scripts/CLICSiDXML.C
@@ -26,7 +26,7 @@ using namespace std;
 using namespace dd4hep::sim::Setup;
 
 int setupG4_XML(bool interactive)  {
-  string install_dir = getenv("DD4hepINSTALL");
+  string install_dir = getenv("DD4hepExamplesINSTALL");
   string prefix = "file:"+install_dir+"/examples/";
   Kernel& kernel = Kernel::instance(dd4hep::Detector::getInstance());
   kernel.loadGeometry((prefix+"CLICSiD/compact/compact.xml").c_str());

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package ( ROOT REQUIRED COMPONENTS Geom GenVector )
 include(${ROOT_USE_FILE})
 #
 dd4hep_set_compiler_flags()
+SET( ENV{DD4hepExamplesINSTALL} ${CMAKE_INSTALL_PREFIX} )
 #
 dd4hep_configure_output()
 dd4hep_package ( dd4hepExample MAJOR 0 MINOR 15 PATCH 0 

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -23,7 +23,8 @@ dd4hep_add_plugin( ClientTests SOURCES src/*.cpp
   OPTIONAL       [BOOST SOURCES src_boost/*.cpp]
   )
 #
-dd4hep_install_dir( compact scripts ref DESTINATION ${DD4hep_DIR}/examples/ClientTests )
+set(ClientTestsEx_INSTALL         ${CMAKE_INSTALL_PREFIX}/examples/ClientTests)
+dd4hep_install_dir( compact scripts ref DESTINATION ${ClientTestsEx_INSTALL} )
 #--------------------------------------------------------------------------
 
 #--------------------------------------------------------------------------
@@ -34,7 +35,7 @@ dd4hep_configure_scripts( ClientTests DEFAULT_SETUP WITH_TESTS)
 dd4hep_add_test_reg( ClientTests_MiniTel_JSON_Dump
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun -destroy -plugin DD4hep_JsonDumper
-  ${CMAKE_CURRENT_SOURCE_DIR}/compact/MiniTel.json
+  ${ClientTestsEx_INSTALL}/compact/MiniTel.json
   REGEX_PASS "Successfully dumped json input"
   REGEX_FAIL "Exception"
   REGEX_FAIL "FAILED"
@@ -44,7 +45,7 @@ dd4hep_add_test_reg( ClientTests_MiniTel_JSON_Dump
 dd4hep_add_test_reg( ClientTests_MiniTel_JSON_Detector
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_XMLLoader
-  file:${CMAKE_CURRENT_SOURCE_DIR}/compact/MiniTel_json.xml
+  file:${ClientTestsEx_INSTALL}/compact/MiniTel_json.xml
   REGEX_PASS "Successfully processed JSON input"
   REGEX_FAIL "Exception"
   REGEX_FAIL "FAILED"
@@ -54,7 +55,7 @@ dd4hep_add_test_reg( ClientTests_MiniTel_JSON_Detector
 dd4hep_add_test_reg( ClientTests_DumpMaterials
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun
-  -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/MiniTel.xml
+  -input file:${ClientTestsEx_INSTALL}/compact/MiniTel.xml
   -volmgr -destroy -plugin DD4hep_MaterialTable -type xml
   REGEX_PASS "material name=\"PEEK\""
   REGEX_FAIL "Exception"
@@ -65,7 +66,7 @@ dd4hep_add_test_reg( ClientTests_DumpMaterials
 dd4hep_add_test_reg( ClientTests_DumpElements
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun
-  -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/MiniTel.xml
+  -input file:${ClientTestsEx_INSTALL}/compact/MiniTel.xml
   -volmgr -destroy -plugin DD4hep_ElementTable -type xml
   REGEX_PASS "formula=\"UUB\" name=\"UUB\""
   REGEX_FAIL "Exception"
@@ -77,7 +78,7 @@ dd4hep_add_test_reg( ClientTests_DumpElements
 dd4hep_add_test_reg( ClientTests_MultiPlace
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun
-  -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/SiBarrelMultiSensitiveLongVolID.xml -volmgr -destroy
+  -input file:${ClientTestsEx_INSTALL}/compact/SiBarrelMultiSensitiveLongVolID.xml -volmgr -destroy
   -plugin DD4hep_VolumeMgrTest SiTrackerBarrel
 
   REGEX_PASS "Volume:component1_1                                       IDDesc:OK  \\[S\\]  vid:00200668000000ff system:00ff barrel:0000 layer:0001 module:0033 sensor:0001"
@@ -88,7 +89,7 @@ dd4hep_add_test_reg( ClientTests_MultiPlace
 dd4hep_add_test_reg( ClientTests_Bitfield64_LongVoldID
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun
-  -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/SiBarrelMultiSensitiveLongVolID.xml -volmgr -destroy
+  -input file:${ClientTestsEx_INSTALL}/compact/SiBarrelMultiSensitiveLongVolID.xml -volmgr -destroy
   -plugin DD4hep_VolumeMgrTest SiTrackerBarrel
 
   REGEX_PASS "Volume:component1_1                                       IDDesc:OK  \\[S\\]  vid:00200668000000ff system:00ff barrel:0000 layer:0001 module:0033 sensor:0001"
@@ -99,7 +100,7 @@ dd4hep_add_test_reg( ClientTests_Bitfield64_LongVoldID
 dd4hep_add_test_reg( ClientTests_Bitfield64_BarrelSides
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun
-  -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/Bitfield_SidesTest.xml -volmgr -destroy
+  -input file:${ClientTestsEx_INSTALL}/compact/Bitfield_SidesTest.xml -volmgr -destroy
   -plugin DD4hep_DetectorVolumeDump
   -plugin DD4hep_VolumeDump volids
   -plugin DD4hep_VolumeMgrTest all
@@ -109,7 +110,7 @@ dd4hep_add_test_reg( ClientTests_Bitfield64_BarrelSides
 dd4hep_add_test_reg( ClientTests_Bitfield64_BarrelSides2
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun
-  -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/Bitfield_SidesTest2.xml -volmgr -destroy
+  -input file:${ClientTestsEx_INSTALL}/compact/Bitfield_SidesTest2.xml -volmgr -destroy
   -plugin DD4hep_DetectorVolumeDump
   -plugin DD4hep_VolumeDump volids
   -plugin DD4hep_VolumeMgrTest all
@@ -119,7 +120,7 @@ dd4hep_add_test_reg( ClientTests_Bitfield64_BarrelSides2
 dd4hep_add_test_reg( ClientTests_Check_Handle_Casts
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun
-  -volmgr -destroy -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/Check_Handles.xml
+  -volmgr -destroy -input file:${ClientTestsEx_INSTALL}/compact/Check_Handles.xml
   -plugin DD4hep_DetectorVolumeDump
   REGEX_PASS "|   164  casts PASSED     90 casts FAILED                         |")
 #
@@ -127,7 +128,7 @@ dd4hep_add_test_reg( ClientTests_Check_Handle_Casts
 dd4hep_add_test_reg( ClientTests_Save_ROOT_MiniTel_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun
-  -volmgr -destroy -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/MiniTel.xml
+  -volmgr -destroy -input file:${ClientTestsEx_INSTALL}/compact/MiniTel.xml
   -plugin DD4hep_Geometry2ROOT -output MiniTel_geometry.root
   REGEX_PASS "\\+\\+\\+ Successfully saved geometry data to file.")
 #
@@ -138,7 +139,7 @@ foreach (test Box Cone ConeSegment Tube ElTube
     Trap Trapezoid TruncatedTube ExtrudedPolygon)
   dd4hep_add_test_reg( ClientTests_Check_Shape_${test}
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-      EXEC_ARGS  geoDisplay file:${CMAKE_CURRENT_SOURCE_DIR}/compact/Check_Shape_${test}.xml -load -destroy
+      EXEC_ARGS  geoDisplay file:${ClientTestsEx_INSTALL}/compact/Check_Shape_${test}.xml -load -destroy
       REGEX_PASS "Shape verification SUCCESSFUL." )
 endforeach()
 #
@@ -152,7 +153,7 @@ foreach (test Assemblies BoxTrafos IronCylinder LheD_tracker MagnetFields Materi
   dd4hep_add_test_reg( ClientTests_volume_materials_${test}
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy
-      -input  file:${CMAKE_CURRENT_SOURCE_DIR}/compact/${test}.xml
+      -input  file:${ClientTestsEx_INSTALL}/compact/${test}.xml
       -plugin DD4hep_VolumeDump -materials
       REGEX_PASS "\\+\\+\\+ Checked [1-9][0-9]* materials in volume placements.   0 are BAD." )
             
@@ -161,7 +162,7 @@ foreach (test Assemblies BoxTrafos IronCylinder LheD_tracker MagnetFields Materi
     dd4hep_add_test_reg( ClientTests_converter_${type}_${test}
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  geoConverter -compact2${type}
-                              -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/${test}.xml
+                              -input file:${ClientTestsEx_INSTALL}/compact/${test}.xml
                               -output file:${test}.${type}
       REGEX_PASS " Handled [1-9][0-9]* volumes" )
   endforeach(type)
@@ -178,7 +179,7 @@ foreach (test Assemblies BoxTrafos LheD_tracker MagnetFields MiniTel SiliconBloc
   # Test material scans in [origine to 10 meters in y]
   dd4hep_add_test_reg( ClientTests_material_scan_${test}
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  materialScan file:${CMAKE_CURRENT_SOURCE_DIR}/compact/${test}.xml 0 0 0 0 10000 0
+    EXEC_ARGS  materialScan file:${ClientTestsEx_INSTALL}/compact/${test}.xml 0 0 0 0 10000 0
     REGEX_PASS " Average Material " )
   #
   # Geant4 material scan. From position=0,0,0 to end-of-world 
@@ -186,7 +187,7 @@ foreach (test Assemblies BoxTrafos LheD_tracker MagnetFields MiniTel SiliconBloc
     dd4hep_add_test_reg( ClientTests_g4material_scan_${test}_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  python ${DD4hep_DIR}/python/g4MaterialScan.py
-                        --compact=file:${CMAKE_CURRENT_SOURCE_DIR}/compact/${test}.xml
+                        --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
                         "--position=0,0,0" "--direction=0,1,0"
       REGEX_PASS " Terminate Geant4 and delete associated actions." )
   endif(DD4HEP_USE_GEANT4)
@@ -200,7 +201,7 @@ foreach (test BoxTrafos IronCylinder MiniTel SiliconBlock NestedSimple MultiColl
   dd4hep_add_test_reg( ClientTests_parse_xml_string_${test}
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  geoPluginRun -destroy -print WARNING
-          -plugin DD4hep_XML_InMemory -input ${CMAKE_CURRENT_SOURCE_DIR}/compact/${test}.xml
+          -plugin DD4hep_XML_InMemory -input ${ClientTestsEx_INSTALL}/compact/${test}.xml
           -plugin DD4hep_VolumeDump   -materials
       REGEX_PASS "\\+\\+\\+ Checked [1-9][0-9]* materials in volume placements.   0 are BAD." )
   #
@@ -208,7 +209,7 @@ foreach (test BoxTrafos IronCylinder MiniTel SiliconBlock NestedSimple MultiColl
   dd4hep_add_test_reg( ClientTests_check_geometry_${test}_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  python ${DD4hep_DIR}/python/checkGeometry.py
-                      --compact=file:${CMAKE_CURRENT_SOURCE_DIR}/compact/${test}.xml
+                      --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
                       --full=true --ntracks=10
     REGEX_PASS " Execution finished..." )
   #
@@ -216,7 +217,7 @@ foreach (test BoxTrafos IronCylinder MiniTel SiliconBlock NestedSimple MultiColl
   dd4hep_add_test_reg( ClientTests_check_overlaps_${test}_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  python ${DD4hep_DIR}/python/checkOverlaps.py 
-                      --compact=file:${CMAKE_CURRENT_SOURCE_DIR}/compact/${test}.xml
+                      --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
                       --tolerance=0.1
     REGEX_PASS " Execution finished..." )
 endforeach()
@@ -228,7 +229,7 @@ if (DD4HEP_USE_GEANT4)
   # Geant4 test if production cuts are processed
   dd4hep_add_test_reg( ClientTests_sim_MiniTel_prod_cuts
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/MiniTelRegions.py batch
+    EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/MiniTelRegions.py batch
     REQUIRES   DDG4 Geant4
     REGEX_PASS "minitel_region_1: Set cut  \\[gamma/0\\] = 5.000"
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
@@ -236,7 +237,7 @@ if (DD4HEP_USE_GEANT4)
   # Geant4 test if production cuts are processed
   dd4hep_add_test_reg( ClientTests_sim_MiniTel_limitset
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/MiniTelRegions.py batch
+    EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/MiniTelRegions.py batch
     REQUIRES   DDG4 Geant4
     REGEX_PASS "LimitSet:    Particle type: mu-                PDG: 13     : 3.000000"
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
@@ -244,7 +245,7 @@ if (DD4HEP_USE_GEANT4)
   # Test of an example user analysis creating an N-tuple instead of an output file with events
   dd4hep_add_test_reg( ClientTests_sim_UserAnalysis
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/MiniTelEnergyDeposits.py batch
+    EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/MiniTelEnergyDeposits.py batch
     REQUIRES   DDG4 Geant4
     REGEX_PASS "Entries :      200 "
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
@@ -252,7 +253,7 @@ if (DD4HEP_USE_GEANT4)
   # Test of an example user analysis creating an N-tuple instead of an output file with events
   dd4hep_add_test_reg( ClientTests_sim_TrackingRegion
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/TrackingRegion.py batch
+    EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/TrackingRegion.py batch
     REQUIRES   DDG4 Geant4
     REGEX_PASS "Placement tracking_volume_1 not converted \\[Veto'ed for simulation\\]"
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
@@ -261,7 +262,7 @@ if (DD4HEP_USE_GEANT4)
   foreach(script Assemblies LheD_tracker MiniTel NestedDetectors )
     dd4hep_add_test_reg( ClientTests_sim_${script}
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-      EXEC_ARGS  python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/${script}.py batch
+      EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/${script}.py batch
       REQUIRES   DDG4 Geant4
       REGEX_PASS NONE
       REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
@@ -271,8 +272,8 @@ if (DD4HEP_USE_GEANT4)
   foreach(script MultiCollections MultiSegmentations MultiSegmentCollections )
     dd4hep_add_test_reg( ClientTests_sim_${script}
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-      EXEC_ARGS  python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/MultiCollections.py 
-                        -compact ${CMAKE_CURRENT_SOURCE_DIR}/compact/${script}.xml -batch
+      EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/MultiCollections.py 
+                        -compact ${ClientTestsEx_INSTALL}/compact/${script}.xml -batch
       REQUIRES   DDG4 Geant4
       REGEX_PASS NONE
       REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )

--- a/examples/ClientTests/compact/Check_Shape_Box.xml
+++ b/examples/ClientTests/compact/Check_Shape_Box.xml
@@ -10,7 +10,7 @@
         <position x="30"  y="30"   z="30"/>
         <rotation x="0"   y="0"    z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Box.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Box.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Cone.xml
+++ b/examples/ClientTests/compact/Check_Shape_Cone.xml
@@ -10,7 +10,7 @@
         <position x="30"  y="30"   z="30"/>
         <rotation x="0"   y="0"    z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Cone.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Cone.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_ConeSegment.xml
+++ b/examples/ClientTests/compact/Check_Shape_ConeSegment.xml
@@ -15,7 +15,7 @@
         <position x="30*cm"  y="30*cm"   z="-80*cm"/>
         <rotation x="0"   y="0"    z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_ConeSegment.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_ConeSegment.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_CutTube.xml
+++ b/examples/ClientTests/compact/Check_Shape_CutTube.xml
@@ -13,7 +13,7 @@
         <position x="30"  y="30"   z="50"/>
         <rotation x="0"   y="pi/4" z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_CutTube.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_CutTube.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_ElTube.xml
+++ b/examples/ClientTests/compact/Check_Shape_ElTube.xml
@@ -10,7 +10,7 @@
         <position x="30"  y="30"   z="50"/>
         <rotation x="0"   y="0" z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_ElTube.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_ElTube.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_ExtrudedPolygon.xml
+++ b/examples/ClientTests/compact/Check_Shape_ExtrudedPolygon.xml
@@ -21,7 +21,7 @@
           <section z="60*cm" x="0*cm" y="30*cm" scale="1.2"/>
         </shape>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_ExtrudedPolygon.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_ExtrudedPolygon.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Hyperboloid.xml
+++ b/examples/ClientTests/compact/Check_Shape_Hyperboloid.xml
@@ -10,7 +10,7 @@
         <position x="30*cm" y="30*cm" z="30*cm"/>
         <rotation x="0"     y="0"     z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Hyperboloid.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Hyperboloid.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Paraboloid.xml
+++ b/examples/ClientTests/compact/Check_Shape_Paraboloid.xml
@@ -10,7 +10,7 @@
         <position x="30*cm" y="30*cm" z="30*cm"/>
         <rotation x="0"     y="0"     z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Paraboloid.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Paraboloid.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Polycone.xml
+++ b/examples/ClientTests/compact/Check_Shape_Polycone.xml
@@ -21,7 +21,7 @@
         <position x="30"  y="30"   z="30"/>
         <rotation x="0"   y="0"    z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Polycone.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Polycone.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_PseudoTrap.xml
+++ b/examples/ClientTests/compact/Check_Shape_PseudoTrap.xml
@@ -19,7 +19,7 @@
         <rotation x="0"      y="0"     z="0"/>
       </check>
 -->
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_PseudoTrap.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_PseudoTrap.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Sphere.xml
+++ b/examples/ClientTests/compact/Check_Shape_Sphere.xml
@@ -10,7 +10,7 @@
         <position x="30"  y="30"   z="30"/>
         <rotation x="0"   y="0"    z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Sphere.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Sphere.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Torus.xml
+++ b/examples/ClientTests/compact/Check_Shape_Torus.xml
@@ -10,7 +10,7 @@
         <position x="30"  y="30"   z="30"/>
         <rotation x="0"   y="0"    z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Torus.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Torus.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Trap.xml
+++ b/examples/ClientTests/compact/Check_Shape_Trap.xml
@@ -12,7 +12,7 @@
         <position x="30*cm"  y="30*cm" z="50*cm"/>
         <rotation x="0"      y="0"     z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Trap.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Trap.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Trapezoid.xml
+++ b/examples/ClientTests/compact/Check_Shape_Trapezoid.xml
@@ -10,7 +10,7 @@
         <position x="30"  y="30" z="50"/>
         <rotation x="0"   y="0"  z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Trapezoid.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Trapezoid.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_TruncatedTube.xml
+++ b/examples/ClientTests/compact/Check_Shape_TruncatedTube.xml
@@ -54,7 +54,7 @@
       </check>
 -->
 
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_TruncatedTube.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_TruncatedTube.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Tube.xml
+++ b/examples/ClientTests/compact/Check_Shape_Tube.xml
@@ -16,7 +16,7 @@
         <position x="30"  y="30"   z="-50"/>
         <rotation x="0"   y="0" z="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepINSTALL}/examples/ClientTests/ref/Ref_Tube.txt" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Tube.txt" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/ClientTests/scripts/Assemblies.py
+++ b/examples/ClientTests/scripts/Assemblies.py
@@ -10,7 +10,7 @@ from SystemOfUnits import *
 """
 def run():
   kernel = DDG4.Kernel()
-  install_dir = os.environ['DD4hepINSTALL']
+  install_dir = os.environ['DD4hepExamplesINSTALL']
   kernel.loadGeometry("file:"+install_dir+"/examples/ClientTests/compact/Assemblies.xml")
   #
   geant4 = DDG4.Geant4(kernel,tracker='Geant4TrackerCombineAction')

--- a/examples/ClientTests/scripts/LheD_tracker.py
+++ b/examples/ClientTests/scripts/LheD_tracker.py
@@ -17,7 +17,7 @@ def run():
   kernel = DDG4.Kernel()
   description = kernel.detectorDescription()
   
-  install_dir = os.environ['DD4hepINSTALL']
+  install_dir = os.environ['DD4hepExamplesINSTALL']
   kernel.loadGeometry("file:"+install_dir+"/examples/ClientTests/compact/LheD_tracker.xml")
 
   DDG4.importConstants(description,debug=False)

--- a/examples/ClientTests/scripts/MiniTelSetup.py
+++ b/examples/ClientTests/scripts/MiniTelSetup.py
@@ -9,7 +9,7 @@ import os, time, DDG4TestSetup
 """
 class Setup(DDG4TestSetup.Setup):
   def __init__(self):
-    install_dir = os.environ['DD4hepINSTALL']
+    install_dir = os.environ['DD4hepExamplesINSTALL']
     DDG4TestSetup.Setup.__init__(self, "file:"+install_dir+"/examples/ClientTests/compact/MiniTel.xml")
 
   def configure(self):

--- a/examples/ClientTests/scripts/MultiCollections.py
+++ b/examples/ClientTests/scripts/MultiCollections.py
@@ -14,7 +14,7 @@ from SystemOfUnits import *
 def run():
   batch = False
   kernel = DDG4.Kernel()
-  install_dir = os.environ['DD4hepINSTALL']
+  install_dir = os.environ['DD4hepExamplesINSTALL']
   geometry = "file:"+install_dir+"/examples/ClientTests/compact/MultiCollections.xml"
   kernel.setOutputLevel('Geant4Converter',Output.DEBUG)
   kernel.setOutputLevel('Gun',Output.INFO)

--- a/examples/ClientTests/scripts/MultiSegmentCollections.py
+++ b/examples/ClientTests/scripts/MultiSegmentCollections.py
@@ -14,7 +14,7 @@ from SystemOfUnits import *
 def run():
   batch = False
   kernel = DDG4.Kernel()
-  install_dir = os.environ['DD4hepINSTALL']
+  install_dir = os.environ['DD4hepExamplesINSTALL']
   geometry = "file:"+install_dir+"/examples/ClientTests/compact/MultiSegmentCollections.xml"
   kernel.setOutputLevel('Geant4Converter',Output.DEBUG)
   kernel.setOutputLevel('Gun',Output.INFO)

--- a/examples/ClientTests/scripts/NestedDetectors.py
+++ b/examples/ClientTests/scripts/NestedDetectors.py
@@ -13,7 +13,7 @@ from SystemOfUnits import *
 """
 def run():
   kernel = DDG4.Kernel()
-  install_dir = os.environ['DD4hepINSTALL']
+  install_dir = os.environ['DD4hepExamplesINSTALL']
   kernel.setOutputLevel('Geant4Converter',Output.DEBUG)
   kernel.setOutputLevel('Gun',Output.INFO)
   kernel.loadGeometry("file:"+install_dir+"/examples/ClientTests/compact/NestedDetectors.xml")

--- a/examples/ClientTests/scripts/SiliconBlock.py
+++ b/examples/ClientTests/scripts/SiliconBlock.py
@@ -15,7 +15,7 @@ from SystemOfUnits import *
 """
 def run():
   kernel = DDG4.Kernel()
-  install_dir = os.environ['DD4hepINSTALL']
+  install_dir = os.environ['DD4hepExamplesINSTALL']
   kernel.loadGeometry("file:"+install_dir+"/examples/ClientTests/compact/SiliconBlock.xml")
 
   DDG4.importConstants(kernel.detectorDescription(),debug=False)

--- a/examples/ClientTests/scripts/TrackingRegion.py
+++ b/examples/ClientTests/scripts/TrackingRegion.py
@@ -12,7 +12,7 @@ import os, sys, time, DDG4
 """
 def run():
   kernel = DDG4.Kernel()
-  install_dir = os.environ['DD4hepINSTALL']
+  install_dir = os.environ['DD4hepExamplesINSTALL']
   kernel.loadGeometry("file:"+install_dir+"/examples/ClientTests/compact/TrackingRegion.xml")
   geant4 = DDG4.Geant4(kernel,tracker='Geant4TrackerCombineAction')
   # Configure field

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -29,8 +29,8 @@ dd4hep_configure_scripts ( Conditions DEFAULT_SETUP WITH_TESTS )
 dd4hep_add_test_reg( Conditions_Telescope_cond_dump_by_pool
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy 
-  -compact file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml 
-  -plugin DD4hep_ConditionsXMLRepositoryParser file:${DD4hep_DIR}/examples/Conditions/data/repository.xml 
+  -compact file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
+  -plugin DD4hep_ConditionsXMLRepositoryParser file:${CMAKE_INSTALL_PREFIX}/examples/Conditions/data/repository.xml 
   -plugin DD4hep_ConditionsDump
   REGEX_PASS "Data\\(Translation-Rotation-Pivot\\): \\[\\( 0 , 0 , 1 \\), \\{phi\\(Z angle\\): 3.14159   theta\\(Y angle\\): 0   psi\\(X angle\\): 0\\}, \\( 0 , 0 , 0 \\)\\]"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -40,8 +40,8 @@ dd4hep_add_test_reg( Conditions_Telescope_cond_dump_by_pool
 dd4hep_add_test_reg( Conditions_Telescope_cond_dump_by_detelement
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy 
-  -compact file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml 
-  -plugin DD4hep_ConditionsXMLRepositoryParser file:${DD4hep_DIR}/examples/Conditions/data/repository.xml 
+  -compact file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
+  -plugin DD4hep_ConditionsXMLRepositoryParser file:${CMAKE_INSTALL_PREFIX}/examples/Conditions/data/repository.xml 
   -plugin DD4hep_DetElementConditionsDump
   REGEX_PASS "Path\\:/world/Telescope/module_9#alignment"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -51,7 +51,7 @@ dd4hep_add_test_reg( Conditions_Telescope_cond_dump_by_detelement
 dd4hep_add_test_reg( Conditions_Telescope_populate
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_populate
-      -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 5
+      -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 5
   REGEX_PASS "Accessed a total of 800 conditions \\(S:   500,L:     0,C:   300,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -60,7 +60,7 @@ dd4hep_add_test_reg( Conditions_Telescope_populate
 dd4hep_add_test_reg( Conditions_Telescope_stress
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress 
-    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 10 -runs 20
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 10 -runs 20
   REGEX_PASS "\\+  Accessed a total of 3200 conditions \\(S:  2660,L:     0,C:   540,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -69,7 +69,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress
 dd4hep_add_test_reg( Conditions_Telescope_stress2
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress2 
-    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 10
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 10
   REGEX_PASS "\\+  Accessed a total of 1600 conditions \\(S:  1000,L:     0,C:   600,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -78,7 +78,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress2
 dd4hep_add_test_reg( Conditions_Telescope_MT_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_MT 
-    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 30 -runs 10 -threads 1
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 30 -runs 10 -threads 1
   REGEX_PASS "\\+  Accessed a total of 286400 conditions \\(S:268400,L:     0,C: 18000,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -87,7 +87,7 @@ dd4hep_add_test_reg( Conditions_Telescope_MT_LONGTEST
 dd4hep_add_test_reg( Conditions_Telescope_root_save
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_save
-    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml -iovs 30
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 30
     -conditions TelescopeConditions.root
   REGEX_PASS "\\+ Successfully saved 14400 condition to file."
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -97,7 +97,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_save
 dd4hep_add_test_reg( Conditions_Telescope_root_load_iov
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_load
-    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore iovpool
   DEPENDS Conditions_Telescope_root_save
   REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
@@ -108,7 +108,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_iov
 dd4hep_add_test_reg( Conditions_Telescope_root_load_usr
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_load
-    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore userpool
   DEPENDS Conditions_Telescope_root_save
   REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
@@ -119,7 +119,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_usr
 dd4hep_add_test_reg( Conditions_Telescope_root_load_pool
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_load
-    -input file:${DD4hep_DIR}/examples/AlignDet/compact/Telescope.xml
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore condpool
   DEPENDS Conditions_Telescope_root_save
   REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
@@ -130,7 +130,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_pool
 dd4hep_add_test_reg( Conditions_CLICSiD_stress_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress 
-    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 10 -runs 100
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/CLICSiD/compact/compact.xml -iovs 10 -runs 100
   REGEX_PASS "\\+  Accessed a total of 28008800 conditions \\(S:26958470,L:     0,C:1050330,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -139,7 +139,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_stress2_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress2 
-    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 20
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/CLICSiD/compact/compact.xml -iovs 20
   REGEX_PASS "\\+  Accessed a total of 5601760 conditions \\(S:3501100,L:     0,C:2100660,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -148,7 +148,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress2_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_MT_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_MT 
-    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -runs 2 -threads 1
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/CLICSiD/compact/compact.xml -iovs 3 -runs 2 -threads 1
   REGEX_PASS "\\+  Accessed a total of 9522992 conditions \\(S:8892794,L:     0,C:630198,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -157,7 +157,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_MT_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_root_save_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_save
-    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/CLICSiD/compact/compact.xml -iovs 3
     -conditions CLICSiDConditions.root
   REGEX_PASS "\\+ Successfully saved 2520792 condition to file."
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -167,7 +167,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_save_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_root_load_iov_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_load
-    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore iovpool
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore iovpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
   REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"
@@ -178,7 +178,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_iov_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_root_load_usr_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_load
-    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore userpool
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore userpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
   REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"
@@ -189,7 +189,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_usr_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_root_load_cond_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_load
-    -input file:${DD4hep_DIR}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore condpool
+    -input file:${CMAKE_INSTALL_PREFIX}/examples/CLICSiD/compact/compact.xml -iovs 3 -restore condpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
   REGEX_PASS "\\+  Accessed a total of 840264 conditions \\(S:840264,L:     0,C:     0,M:0\\)"

--- a/examples/DDCodex/CMakeLists.txt
+++ b/examples/DDCodex/CMakeLists.txt
@@ -25,8 +25,8 @@ dd4hep_add_plugin(DDCodexPlugins
 )
 #
 #
-dd4hep_install_dir( compact python DESTINATION ${DD4hep_DIR}/examples/DDCodex )
-dd4hep_install_files(FILES Upgrade.root DESTINATION ${DD4hep_DIR}/examples/DDCodex )
+dd4hep_install_dir( compact python DESTINATION ${CMAKE_INSTALL_PREFIX}/examples/DDCodex )
+dd4hep_install_files(FILES Upgrade.root DESTINATION ${CMAKE_INSTALL_PREFIX}/examples/DDCodex )
 #--------------------------------------------------------------------------
 #
 dd4hep_configure_scripts ( DDCodex DEFAULT_SETUP WITH_TESTS )

--- a/examples/DDDB/scripts/extract_dddb.sh
+++ b/examples/DDDB/scripts/extract_dddb.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #==========================================================================
 #  AIDA Detector description implementation 
 #--------------------------------------------------------------------------
@@ -23,7 +22,7 @@ if test -n "$USER"; then
 else
     target=/tmp;
 fi;
-source=${DD4hepINSTALL}/examples/DDDB/DDDB.tar.gz;
+source=${DD4hepExamplesINSTALL}/examples/DDDB/DDDB.tar.gz;
 clean="NO";
 #
 # Check for arguments:

--- a/examples/DDG4/CMakeLists.txt
+++ b/examples/DDG4/CMakeLists.txt
@@ -37,7 +37,7 @@ if (DD4HEP_USE_GEANT4)
     )
   #
   #
-  dd4hep_install_dir(data DESTINATION ${DD4hep_DIR}/examples/DDG4 )
+  dd4hep_install_dir(data DESTINATION ${CMAKE_INSTALL_PREFIX}/examples/DDG4 )
   #
   dd4hep_configure_scripts (DDG4 DEFAULT_SETUP WITH_TESTS)
   #
@@ -45,7 +45,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_test_reg( test_DDG4_HepMC_reader
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
     EXEC_ARGS  python ${DD4hep_DIR}/examples/DDG4/examples/readHEPMC.py
-                      ${DD4hep_DIR}/examples/DDG4/data/hepmc_geant4.dat
+                      ${CMAKE_INSTALL_PREFIX}/examples/DDG4/data/hepmc_geant4.dat
     REQUIRES   DDG4 Geant4
     REGEX_PASS "EventReaderHepMC::moveToEvent INFO  Current event number: 9")
 endif()

--- a/examples/LHeD/CMakeLists.txt
+++ b/examples/LHeD/CMakeLists.txt
@@ -17,7 +17,8 @@ dd4hep_package ( LHeD MAJOR 0 MINOR 0 PATCH 1
   USES           [ROOT   REQUIRED COMPONENTS Geom GenVector MathCore] 
                  [DD4hep REQUIRED COMPONENTS DDRec DDCore DDCond DDAlign]
   )
-dd4hep_install_dir( src compact scripts sim DESTINATION ${DD4hep_DIR}/examples/LHeD )
+set(LHeDEx_INSTALL         ${CMAKE_INSTALL_PREFIX}/examples/LHeD)
+dd4hep_install_dir( src compact scripts sim DESTINATION ${LHeDEx_INSTALL} )
 #-----------------------------------------------------------------------------------
 set(LIBRARY_OUTPUT_PATH    ${PROJECT_BINARY_DIR}/lib)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
@@ -41,7 +42,7 @@ foreach ( typ description gdml vis )
   dd4hep_add_test_reg ( "LHeD_converter_${typ}_LONGTEST" 
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
     EXEC_ARGS  geoConverter -compact2${typ} 
-                            -input file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml
+                            -input file:${LHeDEx_INSTALL}/compact/compact.xml
                             -output file:LHeD.${typ}
     REGEX_PASS " Handled [1-9][0-9][0-9]+ volumes" )
 endforeach()
@@ -50,7 +51,7 @@ endforeach()
 dd4hep_add_test_reg( LHeD_check_geometry_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
   EXEC_ARGS  python ${DD4hep_DIR}/python/checkGeometry.py
-                    --compact=file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml
+                    --compact=file:${LHeDEx_INSTALL}/compact/compact.xml
   # This takes too long                  --full=true --ntracks=10 --option=o --vx=0 --vy=0 --vz=0
   REGEX_PASS " Execution finished..." )
 #
@@ -58,7 +59,7 @@ dd4hep_add_test_reg( LHeD_check_geometry_LONGTEST
 dd4hep_add_test_reg( LHeD_check_overlaps_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
   EXEC_ARGS  python ${DD4hep_DIR}/python/checkOverlaps.py 
-                    --compact=file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml
+                    --compact=file:${LHeDEx_INSTALL}/compact/compact.xml
                     --tolerance=0.1
   REGEX_PASS " Execution finished..." )
 #
@@ -70,7 +71,7 @@ if (DD4HEP_USE_GEANT4)
   foreach(script LHeDMagField LHeDPhysics LHeDRandom LHeDScan)
     dd4hep_add_test_reg( LHeD_DDG4_${script}_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
-      EXEC_ARGS  python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/${script}.py
+      EXEC_ARGS  python ${LHeDEx_INSTALL}/scripts/${script}.py
       REQUIRES   DDG4 Geant4
       REGEX_PASS "TEST_PASSED"
       REGEX_FAIL "Exception;EXCEPTION;ERROR" )
@@ -80,7 +81,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_test_reg( LHeD_DDG4_g4material_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
     EXEC_ARGS  python ${DD4hep_DIR}/python/g4MaterialScan.py
-                      --compact=file:${CMAKE_CURRENT_SOURCE_DIR}/compact/compact.xml 
+                      --compact=file:${LHeDEx_INSTALL}/compact/compact.xml 
                       "--position=0,0,0" "--direction=0,1,0"
     REQUIRES   DDG4 Geant4
     REGEX_PASS " Terminate Geant4 and delete associated actions." )
@@ -91,7 +92,7 @@ if (DD4HEP_USE_GEANT4)
     # Build ACLick from the source file
     dd4hep_add_test_reg( LHeD_DDG4_${script}_as_ACLick_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
-      EXEC_ARGS  root.exe -b -x -n -q -l "${CMAKE_CURRENT_SOURCE_DIR}/scripts/run.C(\"${DD4hep_DIR}/examples/LHeD/scripts/${script}\")"
+      EXEC_ARGS  root.exe -b -x -n -q -l "${LHeDEx_INSTALL}/scripts/run.C(\"${LHeDEx_INSTALL}/scripts/${script}\")"
       REQUIRES   DDG4 Geant4
       REGEX_PASS "UserEvent_1      INFO  Geant4TestEventAction> calling end.event_id=9"
       REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )

--- a/examples/LHeD/CMakeLists.txt
+++ b/examples/LHeD/CMakeLists.txt
@@ -63,7 +63,6 @@ dd4hep_add_test_reg( LHeD_check_overlaps_LONGTEST
                     --tolerance=0.1
   REGEX_PASS " Execution finished..." )
 #
-#
 #---Geant4 Testsing-----------------------------------------------------------------
 #
 if (DD4HEP_USE_GEANT4)

--- a/examples/LHeD/CMakeLists.txt
+++ b/examples/LHeD/CMakeLists.txt
@@ -63,6 +63,7 @@ dd4hep_add_test_reg( LHeD_check_overlaps_LONGTEST
                     --tolerance=0.1
   REGEX_PASS " Execution finished..." )
 #
+#
 #---Geant4 Testsing-----------------------------------------------------------------
 #
 if (DD4HEP_USE_GEANT4)

--- a/examples/LHeD/compact/compact_Lhe_dip_sol_ell.xml
+++ b/examples/LHeD/compact/compact_Lhe_dip_sol_ell.xml
@@ -36,7 +36,7 @@
     </includes>
 
     <define>
-        <constant name="Lhe_Detector_dir" value="${DD4hepINSTALL}/examples/LHeD/" type="string"/>;
+        <constant name="Lhe_Detector_dir" value="${DD4hepExamplesINSTALL}/examples/LHeD/" type="string"/>;
         <constant name="world_side" value="20.*m"/>
         <constant name="world_x" value="world_side"/>
         <constant name="world_y" value="world_side"/>

--- a/examples/LHeD/scripts/LHeD.py
+++ b/examples/LHeD/scripts/LHeD.py
@@ -11,7 +11,7 @@ class LHeD:
  
   def loadGeometry(self):
     import os
-    install_dir = os.environ['DD4hepINSTALL']
+    install_dir = os.environ['DD4hepExamplesINSTALL']
     self.kernel.loadGeometry("file:"+install_dir+"/examples/LHeD/compact/compact_Lhe_dip_sol_ell.xml")
     return self
 

--- a/examples/LHeD/scripts/LHeDACLick.C
+++ b/examples/LHeD/scripts/LHeDACLick.C
@@ -44,7 +44,7 @@ Geant4SensDetActionSequence* setupDetector(Geant4Kernel& kernel, const std::stri
 
 int setupG4_CINT(bool interactive)  {
   Geant4Kernel& kernel = Geant4Kernel::instance(Detector::getInstance());
-  string install_dir = getenv("DD4hepINSTALL");
+  string install_dir = getenv("DD4hepExamplesINSTALL");
   Phase p;
 
   kernel.loadGeometry(("file:"+install_dir+"/examples/LHeD/compact/compact.xml").c_str());

--- a/examples/LHeD/scripts/LHeDScan.py
+++ b/examples/LHeD/scripts/LHeDScan.py
@@ -11,7 +11,7 @@ def run():
 
   logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
   kernel = DDG4.Kernel()
-  install_dir = os.environ['DD4hepINSTALL']
+  install_dir = os.environ['DD4hepExamplesINSTALL']
   kernel.loadGeometry("file:"+install_dir+"/examples/LHeD/compact/compact.xml")
   DDG4.Core.setPrintFormat("%-32s %6s %s")
   geant4 = DDG4.Geant4(kernel)

--- a/examples/LHeD/scripts/LHeDXML.C
+++ b/examples/LHeD/scripts/LHeDXML.C
@@ -27,7 +27,7 @@ using namespace dd4hep::sim;
 using namespace dd4hep::sim::Setup;
 
 int setupG4_XML(bool interactive)  {
-  string install_dir = getenv("DD4hepINSTALL");
+  string install_dir = getenv("DD4hepExamplesINSTALL");
   string prefix = "file:"+install_dir+"/examples/";
   Kernel& kernel = Kernel::instance(dd4hep::Detector::getInstance());
   kernel.loadGeometry((prefix+"LHeD/compact/compact.xml").c_str());

--- a/examples/LHeD/scripts/run.C
+++ b/examples/LHeD/scripts/run.C
@@ -9,7 +9,7 @@
 void run(const char* macro)  {
   int status;
   char cmd[1024];
-  const char* dd4hep_install = getenv("DD4hepINSTALL");
+  const char* dd4hep_install = getenv("DD4hepExamplesINSTALL");
   const char* dd4hep = getenv("DD4hep");
   if ( dd4hep_install )  {
     ::sprintf(cmd,".L %s/examples/LHeD/scripts/initAClick.C+",dd4hep_install);

--- a/examples/SimpleDetector/CMakeLists.txt
+++ b/examples/SimpleDetector/CMakeLists.txt
@@ -21,7 +21,7 @@ dd4hep_package (SimpleDetector MAJOR 0 MINOR 0 PATCH 1
 
 #-----------------------------------------------------------------------------------
 dd4hep_add_plugin(SimpleDetector SOURCES src/*.cpp)
-dd4hep_install_dir(compact DESTINATION ${DD4hep_DIR}/examples/ClientTests)
+dd4hep_install_dir(compact DESTINATION ${CMAKE_INSTALL_PREFIX}/examples/ClientTests)
 #-----------------------------------------------------------------------------------
 dd4hep_configure_scripts(SimpleDetector DEFAULT_SETUP WITH_TESTS)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Support out-of-source builds of DD4hep examples.
  Comes with an expense: A new environment DD4hepExamplesINSTALL.
  has to be defined to support internal file accesses and loads.
  The builds were also checked with read-only installation directories.
  Solves issue https://github.com/AIDASoft/DD4hep/issues/382
- Smallish improvement to the ConditionsManager.
ENDRELEASENOTES