### PR TITLE
bug fix in Geant4EventReaderGuineaPig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - COMPILER=llvm
 
 before_install:
-  - wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+  - wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
   - sudo dpkg -i cvmfs-release-latest_all.deb
   - sudo apt-get update
   - sudo apt-get install cvmfs cvmfs-config-default

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,3 +1,11 @@
+# v01-07-02
+
+* 2018-06-26 Frank Gaede ([PR#413](https://github.com/AIDASoft/DD4hep/pull/413)
+  - bug fix in Geant4EventReaderGuineaPig
+    - fix ignoring input lines with 'nan'
+    - did not work on SL6 w/ gcc
+
+
 # v01-07-01
 
 * 2018-05-17 Frank Gaede


### PR DESCRIPTION
BEGINRELEASENOTES
- bug fix in Geant4EventReaderGuineaPig
     - fix ignoring input lines with 'nan'
    - did not work on SL6 w/ gcc


ENDRELEASENOTES