### PR TITLE
 Fix DetElement cloning mechanism 

### DIFF
--- a/DDCore/include/DD4hep/DetElement.h
+++ b/DDCore/include/DD4hep/DetElement.h
@@ -296,6 +296,9 @@ namespace dd4hep {
     /// Assignment operator
     DetElement& operator=(const DetElement& e) = default;
 
+    /// Clone (Deep copy) the DetElement structure
+    DetElement clone(int flag) const;
+
     /// Clone (Deep copy) the DetElement structure with a new name
     DetElement clone(const std::string& new_name) const;
 

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -339,9 +339,12 @@ namespace dd4hep {
     /// Legacy: Constructor to create a new identifiable tube object with attribute initialization
     Tube(const std::string& nam, double rmin, double rmax, double dz, double deltaPhi)
     {  make(nam, rmin, rmax, dz, 0, deltaPhi);             }
+    /// Legacy: Constructor to create a new identifiable tube object with attribute initialization
+    Tube(const std::string& nam, double rmin, double rmax, double dz, double startPhi, double deltaPhi)
+    {  make(nam, rmin, rmax, dz, startPhi, startPhi+deltaPhi); }
     /// Constructor to create a new anonymous tube object with attribute initialization
-    template <typename RMIN, typename RMAX, typename Z, typename DELTAPHI>
-    Tube(const RMIN& rmin, const RMAX& rmax, const Z& dz, const DELTAPHI& deltaPhi)
+    template <typename RMIN, typename RMAX, typename Z, typename DELTAPHI=double>
+    Tube(const RMIN& rmin, const RMAX& rmax, const Z& dz, const DELTAPHI& deltaPhi = 2.0*M_PI)
     {  make("", _toDouble(rmin), _toDouble(rmax), _toDouble(dz), 0, _toDouble(deltaPhi));   }
     /// Assignment operator
     Tube& operator=(const Tube& copy) = default;

--- a/DDCore/include/XML/VolumeBuilder.h
+++ b/DDCore/include/XML/VolumeBuilder.h
@@ -144,6 +144,7 @@ namespace dd4hep {
         typedef std::map<std::string,std::pair<Handle_t,Transform3D> > Transformations;
         Detector&             description;
         Handle_t              x_det;
+        int                   id = -1;
         DetElement            detector;
         SensitiveDetector     sensitive;
         DetectorBuildType     buildType;
@@ -165,7 +166,7 @@ namespace dd4hep {
                       Handle_t x_parent,
                       SensitiveDetector sd=SensitiveDetector());
         /// Default constructor
-        ~VolumeBuilder() {}
+        virtual ~VolumeBuilder() {}
         /// Inhibit move assignment
         VolumeBuilder& operator=(VolumeBuilder&& copy) = delete;
         /// Inhibit copy assignment

--- a/DDCore/src/DetElement.cpp
+++ b/DDCore/src/DetElement.cpp
@@ -252,14 +252,29 @@ DetElement& DetElement::add(DetElement sdet) {
   throw runtime_error("dd4hep: DetElement::add: Self is not defined [Invalid Handle]");
 }
 
+/// Clone (Deep copy) the DetElement structure
+DetElement DetElement::clone(int flg) const   {
+  Object* o = access();
+  Object* n = o->clone(o->id, flg);
+  n->SetName(o->GetName());
+  n->SetTitle(o->GetTitle());
+  return DetElement(n);
+}
+
 DetElement DetElement::clone(const string& new_name) const {
   Object* o = access();
-  return DetElement(o->clone(o->id, COPY_NONE), new_name, o->GetTitle());
+  Object* n = o->clone(o->id, COPY_NONE);
+  n->SetName(new_name.c_str());
+  n->SetTitle(o->GetTitle());
+  return DetElement(n);
 }
 
 DetElement DetElement::clone(const string& new_name, int new_id) const {
   Object* o = access();
-  return DetElement(o->clone(new_id, COPY_NONE), new_name, o->GetTitle());
+  Object* n = o->clone(new_id, COPY_NONE);
+  n->SetName(new_name.c_str());
+  n->SetTitle(o->GetTitle());
+  return DetElement(n);
 }
 
 /// Access to the ideal physical volume of this detector element

--- a/DDCore/src/DetectorInterna.cpp
+++ b/DDCore/src/DetectorInterna.cpp
@@ -107,9 +107,9 @@ DetElementObject* DetElementObject::clone(int new_id, int flg) const {
   obj->survey      = AlignmentCondition();
   obj->parent      = DetElement();
   if ( (flg & DetElement::COPY_PLACEMENT) == DetElement::COPY_PLACEMENT )  {
-    obj->placement  = placement;
-    obj->idealPlace = idealPlace;
-    obj->placementPath = placementPath;
+    obj->placement     = placement;
+    obj->idealPlace    = idealPlace;
+    obj->placementPath = "";
   }
   // This implicitly assumes that the children do not access the parent's extensions!
   obj->ObjectExtensions::clear();
@@ -117,16 +117,17 @@ DetElementObject* DetElementObject::clone(int new_id, int flg) const {
 
   obj->children.clear();
   for (const auto& i : children )  {
-    const NamedObject* pc = i.second.ptr();
     const DetElementObject& d = i.second._data();
-    DetElement child(d.clone(d.id, DetElement::COPY_PLACEMENT), pc->GetName(), pc->GetTitle());
-    pair<DetElement::Children::iterator, bool> r = obj->children.insert(make_pair(child.name(), child));
+    DetElement c = d.clone(d.id, DetElement::COPY_PLACEMENT);
+    c->SetName(d.GetName());
+    c->SetTitle(d.GetTitle());
+    pair<DetElement::Children::iterator, bool> r = obj->children.insert(make_pair(c.name(), c));
     if (r.second) {
-      child._data().parent = obj;
+      c._data().parent = obj;
     }
     else {
-      throw runtime_error("dd4hep: DetElement::copy: Element " + string(child.name()) +
-                          " is already present [Double-Insert]");
+      except("DetElement","+++ DetElement::copy: Element %s is already "
+             "present [Double-Insert]", c.name());
     }
   }
   return obj;

--- a/DDCore/src/XML/VolumeBuilder.cpp
+++ b/DDCore/src/XML/VolumeBuilder.cpp
@@ -35,7 +35,8 @@ VolumeBuilder::VolumeBuilder(Detector& dsc, xml_h x_parent, SensitiveDetector sd
   if ( x_det )   {
     xml_det_t c(x_det);
     string name = c.nameStr();
-    detector = DetElement(name, c.id());
+    id          = c.id();
+    detector = DetElement(name, id);
   }
   buildType = description.buildType();
 }
@@ -180,6 +181,9 @@ size_t VolumeBuilder::buildShapes(xml_h handle)    {
         except("VolumeBuilder","+++ Failed to create shape %s of type: %s",
                nam.c_str(), type.c_str());
       }
+      if ( debug )  {
+        printout(ALWAYS,"VolumeBuilder","+++ Building shape  from XML: %s",nam.c_str());
+      }
       shapes.insert(make_pair(nam,make_pair(c,solid)));
       continue;
     }
@@ -229,7 +233,7 @@ size_t VolumeBuilder::buildVolumes(xml_h handle)    {
         vol.setSensitiveDetector(sensitive);
       }
       if ( debug )  {
-        printout(ALWAYS,"VolumeBuilder","+++ Building volume %s",nam.c_str());
+        printout(ALWAYS,"VolumeBuilder","+++ Building volume from XML: %s",nam.c_str());
       }
       continue;
     }
@@ -314,14 +318,14 @@ VolumeBuilder& VolumeBuilder::placeDaughters(DetElement parent, Volume vol, xml_
         pv = vol.placeVolume((*iv).second.second, tr);
       }
       if ( (attr=c.attr_nothrow(_U(element))) )  {
-        int id = parent.id();
+        int parent_id = parent.id();
         string elt = c.attr<string>(attr);
         attr = c.attr_nothrow(_U(id));
         if ( attr )   {
           id = c.attr<int>(attr);
           elt += c.attr<string>(attr);
         }
-        DetElement de(parent,elt,id);
+        DetElement de(parent,elt,parent_id);
         de.setPlacement(pv);
       }
     }

--- a/DDParsers/src/Evaluator/setStdMath.cpp
+++ b/DDParsers/src/Evaluator/setStdMath.cpp
@@ -2,6 +2,7 @@
 // ----------------------------------------------------------------------
 
 #include "Evaluator/Evaluator.h"
+#include <limits>
 
 #ifdef DD4HEP_NONE
 /// Utility namespace to support TGeo units.
@@ -84,6 +85,10 @@ namespace dd4hep  {
       setVariable("rad",    units::radian );
       setVariable("degree", units::degree );
       setVariable("deg",    units::degree );
+      setVariable("int:epsilon",    std::numeric_limits<int>::epsilon());
+      setVariable("long:epsilon",   std::numeric_limits<long>::epsilon());
+      setVariable("float:epsilon",  std::numeric_limits<float>::epsilon());
+      setVariable("double:epsilon", std::numeric_limits<double>::epsilon());
 
       //   S E T   S T A N D A R D   F U N C T I O N S
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed the DetElement cloning mechanism it to properly replicate DetElement trees.
  - Tested with one LHCb upgrade detector.
- Added numeric epsilon to the default math dictionary of the expression evaluator:
  ```cpp
  int:epsilon  --> std::numeric_limits<int>::epsilon()
  long:epsilon  --> std::numeric_limits<long>::epsilon()
  float:epsilon  --> std::numeric_limits<float>::epsilon()
  double:epsilon  --> std::numeric_limits<double>::epsilon()
  ```
ENDRELEASENOTES