### PR TITLE
add include <memory> in VolumeAssembly_geo.cpp

### DIFF
--- a/DDDetectors/src/VolumeAssembly_geo.cpp
+++ b/DDDetectors/src/VolumeAssembly_geo.cpp
@@ -18,6 +18,7 @@
 #include "DD4hep/Printout.h"
 #include "XML/VolumeBuilder.h"
 #include "XML/Utilities.h"
+#include <memory>
 
 using namespace std;
 using namespace dd4hep;


### PR DESCRIPTION

BEGINRELEASENOTES
- fix for gcc49
      - add include <memory> in VolumeAssembly_geo.cpp

ENDRELEASENOTES