### PR TITLE
Add shape constructor for regular trapezoids (TGeoTrd1)

### DIFF
--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -707,18 +707,20 @@ namespace dd4hep {
     /// Constructor to be used when passing an already created object
     template <typename Q> Sphere(const Handle<Q>& e) : Solid_type<Object>(e) {  }
     /// Constructor to create a new anonymous object with attribute initialization
-    Sphere(double rmin, double rmax, double theta = 0., double delta_theta = M_PI, double phi = 0.0, double delta_phi = 2. * M_PI)
+    Sphere(double rmin,        double rmax,
+           double theta = 0.0, double delta_theta = M_PI,
+           double phi   = 0.0, double delta_phi   = 2. * M_PI)
     {  make(rmin, rmax, theta, delta_theta, phi, delta_phi);     }
     /// Constructor to create a new anonymous object with generic attribute initialization
     template<typename RMIN,         typename RMAX,
              typename THETA=double, typename DELTA_THETA=double,
              typename PHI=double,   typename DELTA_PHI=double>
-    Sphere(RMIN rmin, RMAX rmax,
-           THETA theta = 0., DELTA_THETA delta_theta = M_PI,
-           PHI phi = 0.0, DELTA_PHI delta_phi = 2. * M_PI)  {
+    Sphere(RMIN  rmin,         RMAX        rmax,
+           THETA theta = 0.0,  DELTA_THETA delta_theta = M_PI,
+           PHI   phi   = 0.0,  DELTA_PHI   delta_phi   = 2. * M_PI)  {
       make(_toDOuble(rmin),  _toDouble(rmax),
            _toDouble(theta), _toDouble(delta_theta),
-           _toDouble(phi),   _toDouble(delta_theta));
+           _toDouble(phi),   _toDouble(delta_phi));
     }
     /// Assignment operator
     Sphere& operator=(const Sphere& copy) = default;

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -709,10 +709,10 @@ namespace dd4hep {
     /// Constructor to create a new anonymous object with attribute initialization
     Sphere(double rmin, double rmax, double theta = 0., double delta_theta = M_PI, double phi = 0.0, double delta_phi = 2. * M_PI)
     {  make(rmin, rmax, theta, delta_theta, phi, delta_phi);     }
+    /// Constructor to create a new anonymous object with generic attribute initialization
     template<typename RMIN,         typename RMAX,
              typename THETA=double, typename DELTA_THETA=double,
              typename PHI=double,   typename DELTA_PHI=double>
-    /// Constructor to create a new anonymous object with attribute initialization
     Sphere(RMIN rmin, RMAX rmax,
            THETA theta = 0., DELTA_THETA delta_theta = M_PI,
            PHI phi = 0.0, DELTA_PHI delta_phi = 2. * M_PI)  {

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -296,13 +296,16 @@ namespace dd4hep {
     /// Constructor to be used when reading the already parsed ConeSegment object
     template <typename Q> ConeSegment(const Handle<Q>& e) : Solid_type<Object>(e) {  }
     /// Constructor to create a new ConeSegment object
-    ConeSegment(double dz, double rmin1, double rmax1, double rmin2, double rmax2, double phi1 = 0.0, double phi2 = 2.0 * M_PI);
+    ConeSegment(double dz, double rmin1, double rmax1,
+                double rmin2, double rmax2,
+                double phi1 = 0.0, double phi2 = 2.0 * M_PI);
     /// Assignment operator
     ConeSegment& operator=(const ConeSegment& copy) = default;
 
     /// Set the cone segment dimensions
     ConeSegment& setDimensions(double dz, double rmin1, double rmax1,
-                               double rmin2, double rmax2, double phi1 = 0.0, double phi2 = 2.0 * M_PI);
+                               double rmin2, double rmax2,
+                               double phi1 = 0.0, double phi2 = 2.0 * M_PI);
   };
 #if 0
   /// Intermediate class to overcome drawing probles with the TGeoTubeSeg
@@ -571,7 +574,43 @@ namespace dd4hep {
     PseudoTrap& operator=(const PseudoTrap& copy) = default;
   };
 
-  /// Class describing a Trapezoid shape
+  /// Class describing a Trd1 shape
+  /**
+   *   For any further documentation please see the following ROOT documentation:
+   *   \see http://root.cern.ch/root/html/TGeoTrd1.html
+   *
+   *
+   *   \author  M.Frank
+   *   \version 1.0
+   *   \ingroup DD4HEP_CORE
+   */
+  class Trd1: public Solid_type<TGeoTrd1> {
+  private:
+    /// Internal helper method to support object construction
+    void make(double x1, double x2, double y, double z);
+
+  public:
+    /// Default constructor
+    Trd1() = default;
+    /// Constructor to be used when passing an already created object
+    Trd1(const Trd1& e) = default;
+    /// Constructor to be used with an existing object
+    template <typename Q> Trd1(const Q* p) : Solid_type<Object>(p) { }
+    /// Constructor to be used when passing an already created object
+    template <typename Q> Trd1(const Handle<Q>& e) : Solid_type<Object>(e) { }
+    /// Constructor to create a new anonymous object with attribute initialization
+    Trd1(double x1, double x2, double y, double z);
+    /// Constructor to create a new anonymous object with attribute initialization
+    template <typename X1,typename X2,typename Y,typename Z>
+    Trd1(X1 x1, X2 x2, Y y, Z z)
+    { make(_toDouble(x1),_toDouble(x2),_toDouble(y),_toDouble(z)); }
+    /// Assignment operator
+    Trd1& operator=(const Trd1& copy) = default;
+    /// Set the Trd1 dimensions
+    Trd1& setDimensions(double x1, double x2, double y, double z);
+  };
+  
+  /// Class describing a Trd2 shape
   /**
    *   For any further documentation please see the following ROOT documentation:
    *   \see http://root.cern.ch/root/html/TGeoTrd2.html
@@ -581,32 +620,34 @@ namespace dd4hep {
    *   \version 1.0
    *   \ingroup DD4HEP_CORE
    */
-  class Trapezoid: public Solid_type<TGeoTrd2> {
+  class Trd2: public Solid_type<TGeoTrd2> {
   private:
     /// Internal helper method to support object construction
     void make(double x1, double x2, double y1, double y2, double z);
 
   public:
     /// Default constructor
-    Trapezoid() = default;
+    Trd2() = default;
     /// Constructor to be used when passing an already created object
-    Trapezoid(const Trapezoid& e) = default;
+    Trd2(const Trd2& e) = default;
     /// Constructor to be used with an existing object
-    template <typename Q> Trapezoid(const Q* p) : Solid_type<Object>(p) { }
+    template <typename Q> Trd2(const Q* p) : Solid_type<Object>(p) { }
     /// Constructor to be used when passing an already created object
-    template <typename Q> Trapezoid(const Handle<Q>& e) : Solid_type<Object>(e) { }
+    template <typename Q> Trd2(const Handle<Q>& e) : Solid_type<Object>(e) { }
     /// Constructor to create a new anonymous object with attribute initialization
-    Trapezoid(double x1, double x2, double y1, double y2, double z);
+    Trd2(double x1, double x2, double y1, double y2, double z);
     /// Constructor to create a new anonymous object with attribute initialization
     template <typename X1,typename X2,typename Y1,typename Y2,typename Z>
-    Trapezoid(X1 x1, X2 x2, Y1 y1, Y2 y2, Z z)
+    Trd2(X1 x1, X2 x2, Y1 y1, Y2 y2, Z z)
     { make(_toDouble(x1),_toDouble(x2),_toDouble(y1),_toDouble(y2),_toDouble(z)); }
     /// Assignment operator
-    Trapezoid& operator=(const Trapezoid& copy) = default;
-    /// Set the Trapezoid dimensions
-    Trapezoid& setDimensions(double x1, double x2, double y1, double y2, double z);
+    Trd2& operator=(const Trd2& copy) = default;
+    /// Set the Trd2 dimensions
+    Trd2& setDimensions(double x1, double x2, double y1, double y2, double z);
   };
-
+  /// Shortcut name definition
+  typedef Trd2 Trapezoid;
+  
   /// Class describing a Torus shape
   /**
    *   For any further documentation please see the following ROOT documentation:
@@ -653,6 +694,9 @@ namespace dd4hep {
    *   \ingroup DD4HEP_CORE
    */
   class Sphere: public Solid_type<TGeoSphere> {
+  protected:
+    /// Constructor function to be used when creating a new object with attribute initialization
+    void make(double rmin, double rmax, double theta, double delta_theta, double phi, double delta_phi);
   public:
     /// Default constructor
     Sphere() = default;
@@ -663,7 +707,19 @@ namespace dd4hep {
     /// Constructor to be used when passing an already created object
     template <typename Q> Sphere(const Handle<Q>& e) : Solid_type<Object>(e) {  }
     /// Constructor to create a new anonymous object with attribute initialization
-    Sphere(double rmin, double rmax, double theta = 0., double delta_theta = M_PI, double phi = 0.0, double delta_phi = 2. * M_PI);
+    Sphere(double rmin, double rmax, double theta = 0., double delta_theta = M_PI, double phi = 0.0, double delta_phi = 2. * M_PI)
+    {  make(rmin, rmax, theta, delta_theta, phi, delta_phi);     }
+    template<typename RMIN,         typename RMAX,
+             typename THETA=double, typename DELTA_THETA=double,
+             typename PHI=double,   typename DELTA_PHI=double>
+    /// Constructor to create a new anonymous object with attribute initialization
+    Sphere(RMIN rmin, RMAX rmax,
+           THETA theta = 0., DELTA_THETA delta_theta = M_PI,
+           PHI phi = 0.0, DELTA_PHI delta_phi = 2. * M_PI)  {
+      make(_toDOuble(rmin),  _toDouble(rmax),
+           _toDouble(theta), _toDouble(delta_theta),
+           _toDouble(phi),   _toDouble(delta_theta));
+    }
     /// Assignment operator
     Sphere& operator=(const Sphere& copy) = default;
     /// Set the Sphere dimensions
@@ -681,6 +737,8 @@ namespace dd4hep {
    *   \ingroup DD4HEP_CORE
    */
   class Paraboloid: public Solid_type<TGeoParaboloid> {
+    /// Constructor function to create a new anonymous object with attribute initialization
+    void make(double r_low, double r_high, double delta_z);
   public:
     /// Default constructor
     Paraboloid() = default;
@@ -691,7 +749,12 @@ namespace dd4hep {
     /// Constructor to be used when passing an already created object
     template <typename Q> Paraboloid(const Handle<Q>& e) : Solid_type<Object>(e) { }
     /// Constructor to create a new anonymous object with attribute initialization
-    Paraboloid(double r_low, double r_high, double delta_z);
+    Paraboloid(double r_low, double r_high, double delta_z)
+    {  make(r_low, r_high, delta_z);  }
+    /// Constructor to create a new anonymous object with attribute initialization
+    template<typename R_LOW, typename R_HIGH, typename DELTA_Z>
+    Paraboloid(R_LOW r_low, R_HIGH r_high, DELTA_Z delta_z)
+    {  make(_toDouble(r_low), _toDouble(r_high), _toDouble(delta_z));  }
     /// Assignment operator
     Paraboloid& operator=(const Paraboloid& copy) = default;
     /// Set the Paraboloid dimensions
@@ -709,6 +772,8 @@ namespace dd4hep {
    *   \ingroup DD4HEP_CORE
    */
   class Hyperboloid: public Solid_type<TGeoHype> {
+    /// Constructor function to create a new anonymous object with attribute initialization
+    void make(double rin, double stin, double rout, double stout, double dz);
   public:
     /// Default constructor
     Hyperboloid() = default;
@@ -719,7 +784,14 @@ namespace dd4hep {
     /// Constructor to be used when passing an already created object
     template <typename Q> Hyperboloid(const Handle<Q>& e) : Solid_type<Object>(e) {   }
     /// Constructor to create a new anonymous object with attribute initialization
-    Hyperboloid(double rin, double stin, double rout, double stout, double dz);
+    Hyperboloid(double rin, double stin, double rout, double stout, double dz)   {
+      make(rin, stin, rout, stout, dz);
+    }
+    /// Constructor to create a new anonymous object with attribute initialization
+    template <typename RIN, typename STIN, typename ROUT, typename STOUT, typename DZ>
+    Hyperboloid(RIN rin, STIN stin, ROUT rout, STOUT stout, DZ dz)  {
+      make(_toDouble(rin), _toDouble(stin), _toDouble(rout), _toDouble(stout), _toDouble(dz));
+    }
     /// Assignment operator
     Hyperboloid& operator=(const Hyperboloid& copy) = default;
     /// Set the Hyperboloid dimensions

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -523,24 +523,41 @@ Cone& Cone::setDimensions(double z, double rmin1, double rmax1, double rmin2, do
 }
 
 /// Constructor to create a new anonymous object with attribute initialization
-Trapezoid::Trapezoid(double x1, double x2, double y1, double y2, double z)   {
+Trd1::Trd1(double x1, double x2, double y, double z)   {
+  make(x1,x2,y,z);
+}
+
+/// Constructor to be used when creating a new object with attribute initialization
+void Trd1::make(double x1, double x2, double y, double z) {
+  _assign(new TGeoTrd1(x1, x2, y, z ), "", "trd2", true);
+}
+
+/// Set the Trd1 dimensions
+Trd1& Trd1::setDimensions(double x1, double x2, double y, double z) {
+  double params[] = { x1, x2, y, z  };
+  _setDimensions(params);
+  return *this;
+}
+
+/// Constructor to create a new anonymous object with attribute initialization
+Trd2::Trd2(double x1, double x2, double y1, double y2, double z)   {
   make(x1,x2,y1,y2,z);
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void Trapezoid::make(double x1, double x2, double y1, double y2, double z) {
+void Trd2::make(double x1, double x2, double y1, double y2, double z) {
   _assign(new TGeoTrd2(x1, x2, y1, y2, z ), "", "trd2", true);
 }
 
-/// Set the Trapezoid dimensions
-Trapezoid& Trapezoid::setDimensions(double x1, double x2, double y1, double y2, double z) {
+/// Set the Trd2 dimensions
+Trd2& Trd2::setDimensions(double x1, double x2, double y1, double y2, double z) {
   double params[] = { x1, x2, y1, y2, z  };
   _setDimensions(params);
   return *this;
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-Paraboloid::Paraboloid(double r_low, double r_high, double delta_z) {
+void Paraboloid::make(double r_low, double r_high, double delta_z) {
   _assign(new TGeoParaboloid(r_low, r_high, delta_z ), "", "paraboloid", true);
 }
 
@@ -552,7 +569,7 @@ Paraboloid& Paraboloid::setDimensions(double r_low, double r_high, double delta_
 }
 
 /// Constructor to create a new anonymous object with attribute initialization
-Hyperboloid::Hyperboloid(double rin, double stin, double rout, double stout, double dz) {
+void Hyperboloid::make(double rin, double stin, double rout, double stout, double dz) {
   _assign(new TGeoHype(rin, stin/units::deg, rout, stout/units::deg, dz), "", "hyperboloid", true);
 }
 
@@ -563,8 +580,8 @@ Hyperboloid& Hyperboloid::setDimensions(double rin, double stin, double rout, do
   return *this;
 }
 
-/// Constructor to be used when creating a new object with attribute initialization
-Sphere::Sphere(double rmin, double rmax, double theta, double delta_theta, double phi, double delta_phi) {
+/// Constructor function to be used when creating a new object with attribute initialization
+void Sphere::make(double rmin, double rmax, double theta, double delta_theta, double phi, double delta_phi) {
   _assign(new TGeoSphere(rmin, rmax,
                          theta/units::deg, delta_theta/units::deg,
                          phi/units::deg, delta_phi/units::deg), "", "sphere", true);

--- a/DDCore/src/plugins/ShapePlugins.cpp
+++ b/DDCore/src/plugins/ShapePlugins.cpp
@@ -175,13 +175,22 @@ static Handle<TObject> create_PseudoTrap(Detector&, xml_h element)   {
 }
 DECLARE_XML_SHAPE(PseudoTrap__shape_constructor,create_PseudoTrap)
 
-static Handle<TObject> create_Trapezoid(Detector&, xml_h element)   {
+static Handle<TObject> create_Trd1(Detector&, xml_h element)   {
   xml_dim_t e(element);
-  Solid solid = Trapezoid(e.x1(),e.x2(),e.y1(),e.y2(),e.z(0.0));
+  Solid solid = Trd1(e.x1(),e.x2(),e.y(),e.z(0.0));
   if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
   return solid;
 }
-DECLARE_XML_SHAPE(Trapezoid__shape_constructor,create_Trapezoid)
+DECLARE_XML_SHAPE(Trd1__shape_constructor,create_Trd1)
+
+static Handle<TObject> create_Trd2(Detector&, xml_h element)   {
+  xml_dim_t e(element);
+  Solid solid = Trd2(e.x1(),e.x2(),e.y1(),e.y2(),e.z(0.0));
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  return solid;
+}
+DECLARE_XML_SHAPE(Trapezoid__shape_constructor,create_Trd2)
+DECLARE_XML_SHAPE(Trd2__shape_constructor,create_Trd2)
 
 static Handle<TObject> create_Torus(Detector&, xml_h element)   {
   xml_dim_t e(element);

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -164,7 +164,7 @@ dd4hep_add_test_reg( ClientTests_Save_ROOT_MiniTel_LONGTEST
 foreach (test Box Cone ConeSegment Tube ElTube
     CutTube Hyperboloid Paraboloid
     Polycone PseudoTrap Sphere Torus
-    Trap Trapezoid TruncatedTube ExtrudedPolygon)
+    Trap Trd1 Trd2 TruncatedTube ExtrudedPolygon)
   dd4hep_add_test_reg( ClientTests_Check_Shape_${test}
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  geoDisplay file:${ClientTestsEx_INSTALL}/compact/Check_Shape_${test}.xml -load -destroy

--- a/examples/ClientTests/compact/Check_Shape_Trd1.xml
+++ b/examples/ClientTests/compact/Check_Shape_Trd1.xml
@@ -1,0 +1,21 @@
+<lccdd>
+  <includes>
+    <gdmlFile ref="CheckShape.xml"/>
+  </includes>
+
+  <detectors>
+    <detector id="1" name="Shape_Trd1" type="DD4hep_TestShape_Creator">
+      <check vis="Shape1_vis">
+        <shape type="Trd1" z="80*cm" x1="25*cm" x2="50*cm" y="20*cm"/>
+        <position x="30"  y="30" z="50"/>
+        <rotation x="-pi/4"   y="pi/4"  z="pi/8"/>
+      </check>
+      <check vis="Shape2_vis">
+        <shape type="Trd1" z="120*cm" x1="44*cm" x2="10*cm" y="5*cm"/>
+        <position x="-30"  y="30" z="-100"/>
+        <rotation x="pi/2"   y="0"  z="pi/8"/>
+      </check>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Trd1.txt" create="CheckShape_create"/>
+    </detector>
+  </detectors>
+</lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Trd2.xml
+++ b/examples/ClientTests/compact/Check_Shape_Trd2.xml
@@ -1,0 +1,16 @@
+<lccdd>
+  <includes>
+    <gdmlFile ref="CheckShape.xml"/>
+  </includes>
+
+  <detectors>
+    <detector id="1" name="Shape_Trd2" type="DD4hep_TestShape_Creator">
+      <check vis="Shape1_vis">
+        <shape type="Trd2" z="30*cm" x1="30*cm" x2="50*cm" y1="15*cm" y2="30*cm"/>
+        <position x="30"  y="30" z="50"/>
+        <rotation x="0"   y="0"  z="0"/>
+      </check>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Trd2.txt" create="CheckShape_create"/>
+    </detector>
+  </detectors>
+</lccdd>

--- a/examples/ClientTests/ref/Ref_Trd1.txt
+++ b/examples/ClientTests/ref/Ref_Trd1.txt
@@ -1,0 +1,22 @@
+ShapeCheck[0] TGeoTrd1         8 Mesh-points:
+TGeoTrd1         Trd1 N(mesh)=8  N(vert)=8  N(seg)=12  N(pols)=6
+TGeoTrd1         0   Local  ( -25.00,  -20.00,  -80.00) Global ( -37.49,  -22.11,   37.55)
+TGeoTrd1         1   Local  ( -25.00,   20.00,  -80.00) Global ( -48.31,   11.68,   19.07)
+TGeoTrd1         2   Local  (  25.00,   20.00,  -80.00) Global ( -15.65,    2.11,  -17.55)
+TGeoTrd1         3   Local  (  25.00,  -20.00,  -80.00) Global (  -4.82,  -31.68,    0.93)
+TGeoTrd1         4   Local  ( -50.00,  -20.00,   80.00) Global (  59.32,   62.67,  135.87)
+TGeoTrd1         5   Local  ( -50.00,   20.00,   80.00) Global (  48.49,   96.46,  117.39)
+TGeoTrd1         6   Local  (  50.00,   20.00,   80.00) Global ( 113.82,   77.33,   44.13)
+TGeoTrd1         7   Local  (  50.00,  -20.00,   80.00) Global ( 124.64,   43.54,   62.61)
+TGeoTrd1         Bounding box:  dx=  50.00 dy=  20.00 dz=  80.00 Origin: x=   0.00 y=   0.00 z=   0.00
+ShapeCheck[1] TGeoTrd1         8 Mesh-points:
+TGeoTrd1         Trd1 N(mesh)=8  N(vert)=8  N(seg)=12  N(pols)=6
+TGeoTrd1         0   Local  ( -44.00,   -5.00, -120.00) Global ( -68.74,  150.00, -121.46)
+TGeoTrd1         1   Local  ( -44.00,    5.00, -120.00) Global ( -72.56,  150.00, -112.22)
+TGeoTrd1         2   Local  (  44.00,    5.00, -120.00) Global (   8.74,  150.00,  -78.54)
+TGeoTrd1         3   Local  (  44.00,   -5.00, -120.00) Global (  12.56,  150.00,  -87.78)
+TGeoTrd1         4   Local  ( -10.00,   -5.00,  120.00) Global ( -37.33,  -90.00, -108.45)
+TGeoTrd1         5   Local  ( -10.00,    5.00,  120.00) Global ( -41.15,  -90.00,  -99.21)
+TGeoTrd1         6   Local  (  10.00,    5.00,  120.00) Global ( -22.67,  -90.00,  -91.55)
+TGeoTrd1         7   Local  (  10.00,   -5.00,  120.00) Global ( -18.85,  -90.00, -100.79)
+TGeoTrd1         Bounding box:  dx=  44.00 dy=   5.00 dz= 120.00 Origin: x=   0.00 y=   0.00 z=   0.00

--- a/examples/ClientTests/ref/Ref_Trd2.txt
+++ b/examples/ClientTests/ref/Ref_Trd2.txt
@@ -1,5 +1,5 @@
 ShapeCheck[0] TGeoTrd2         8 Mesh-points:
-TGeoTrd2         Trapezoid N(mesh)=8  N(vert)=8  N(seg)=12  N(pols)=6
+TGeoTrd2         Trd2 N(mesh)=8  N(vert)=8  N(seg)=12  N(pols)=6
 TGeoTrd2         0   Local  ( -30.00,  -15.00,  -30.00) Global (   0.00,   15.00,   20.00)
 TGeoTrd2         1   Local  ( -30.00,   15.00,  -30.00) Global (   0.00,   45.00,   20.00)
 TGeoTrd2         2   Local  (  30.00,   15.00,  -30.00) Global (  60.00,   45.00,   20.00)


### PR DESCRIPTION

BEGINRELEASENOTES
# Add shape constructor for regular trapezoids (TGeoTrd1).

See also issue: https://github.com/AIDASoft/DD4hep/issues/460.
Trd2 cannot be divided the same way as Trd1 shapes. Hence the addition became necessary.
Due to the imprecise name of Trapezoid the names Trd1 and Trd2 (aka old Trapezoid) are favored.
The usage of Trapezoid is supported for backwards compatibility using a typedef.
ENDRELEASENOTES