### PR TITLE
Harmonize argument names in Shapes.h with their actual functionality 

### DIFF
--- a/DDCore/include/DD4hep/Conditions.h
+++ b/DDCore/include/DD4hep/Conditions.h
@@ -332,7 +332,9 @@ namespace dd4hep {
     /// Operator less (for map insertions) using hash value
     bool operator<(const Condition::key_type compare)  const;
     /// Automatic conversion to the hashed representation of the key object
-    operator Condition::key_type () const             {  return hash;     }
+    operator Condition::key_type () const   {  return hash;     }
+    /// Conversion to string
+    std::string toString()  const;
   };
 
   /// Constructor from detector element key and item sub-key

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -298,14 +298,14 @@ namespace dd4hep {
     /// Constructor to create a new ConeSegment object
     ConeSegment(double dz, double rmin1, double rmax1,
                 double rmin2, double rmax2,
-                double phi1 = 0.0, double phi2 = 2.0 * M_PI);
+                double startPhi = 0.0, double endPhi = 2.0 * M_PI);
     /// Assignment operator
     ConeSegment& operator=(const ConeSegment& copy) = default;
 
     /// Set the cone segment dimensions
     ConeSegment& setDimensions(double dz, double rmin1, double rmax1,
                                double rmin2, double rmax2,
-                               double phi1 = 0.0, double phi2 = 2.0 * M_PI);
+                               double startPhi = 0.0, double endPhi = 2.0 * M_PI);
   };
 #if 0
   /// Intermediate class to overcome drawing probles with the TGeoTubeSeg
@@ -332,7 +332,7 @@ namespace dd4hep {
   class Tube: public Solid_type<TGeoTubeSeg> {
   protected:
     /// Internal helper method to support object construction
-    void make(const std::string& nam, double rmin, double rmax, double z, double startPhi, double deltaPhi);
+    void make(const std::string& nam, double rmin, double rmax, double z, double startPhi, double endPhi);
 
   public:
     /// Default constructor
@@ -345,30 +345,30 @@ namespace dd4hep {
     template <typename Q> Tube(const Handle<Q>& e) : Solid_type<Object>(e) {  }
     /// Constructor to create a new anonymous tube object with attribute initialization
     Tube(double rmin, double rmax, double dz)
-    {   make("", rmin, rmax, dz, 0, 2*M_PI);               }
+    {   make("", rmin, rmax, dz, 0, 2*M_PI);                   }
     /// Constructor to create a new anonymous tube object with attribute initialization
-    Tube(double rmin, double rmax, double dz, double deltaPhi)
-    {   make("", rmin, rmax, dz, 0, deltaPhi);             }
+    Tube(double rmin, double rmax, double dz, double endPhi)
+    {   make("", rmin, rmax, dz, 0, endPhi);                   }
     /// Constructor to create a new anonymous tube object with attribute initialization
-    Tube(double rmin, double rmax, double dz, double startPhi, double deltaPhi)
-    {   make("", rmin, rmax, dz, startPhi, deltaPhi);      }
+    Tube(double rmin, double rmax, double dz, double startPhi, double endPhi)
+    {   make("", rmin, rmax, dz, startPhi, endPhi);            }
     /// Legacy: Constructor to create a new identifiable tube object with attribute initialization
     Tube(const std::string& nam, double rmin, double rmax, double dz)
-    {   make(nam, rmin, rmax, dz, 0, 2*M_PI);              }
+    {   make(nam, rmin, rmax, dz, 0, 2*M_PI);                  }
     /// Legacy: Constructor to create a new identifiable tube object with attribute initialization
-    Tube(const std::string& nam, double rmin, double rmax, double dz, double deltaPhi)
-    {  make(nam, rmin, rmax, dz, 0, deltaPhi);             }
+    Tube(const std::string& nam, double rmin, double rmax, double dz, double endPhi)
+    {  make(nam, rmin, rmax, dz, 0, endPhi);                   }
     /// Legacy: Constructor to create a new identifiable tube object with attribute initialization
-    Tube(const std::string& nam, double rmin, double rmax, double dz, double startPhi, double deltaPhi)
-    {  make(nam, rmin, rmax, dz, startPhi, startPhi+deltaPhi); }
+    Tube(const std::string& nam, double rmin, double rmax, double dz, double startPhi, double endPhi)
+    {  make(nam, rmin, rmax, dz, startPhi, endPhi);            }
     /// Constructor to create a new anonymous tube object with attribute initialization
-    template <typename RMIN, typename RMAX, typename Z, typename DELTAPHI=double>
-    Tube(const RMIN& rmin, const RMAX& rmax, const Z& dz, const DELTAPHI& deltaPhi = 2.0*M_PI)
-    {  make("", _toDouble(rmin), _toDouble(rmax), _toDouble(dz), 0, _toDouble(deltaPhi));   }
+    template <typename RMIN, typename RMAX, typename Z, typename ENDPHI=double>
+    Tube(const RMIN& rmin, const RMAX& rmax, const Z& dz, const ENDPHI& endPhi = 2.0*M_PI)
+    {  make("", _toDouble(rmin), _toDouble(rmax), _toDouble(dz), 0, _toDouble(endPhi));   }
     /// Assignment operator
     Tube& operator=(const Tube& copy) = default;
     /// Set the tube dimensions
-    Tube& setDimensions(double rmin, double rmax, double dz, double startPhi=0.0, double deltaPhi=2*M_PI);
+    Tube& setDimensions(double rmin, double rmax, double dz, double startPhi=0.0, double endPhi=2*M_PI);
   };
 
   /// Class describing a tube shape of a section of a cut tube segment
@@ -383,7 +383,7 @@ namespace dd4hep {
   class CutTube: public Solid_type<TGeoCtub> {
   protected:
     /// Internal helper method to support object construction
-    void make(double rmin, double rmax, double dz, double phi1, double phi2,
+    void make(double rmin, double rmax, double dz, double startPhi, double endPhi,
               double lx, double ly, double lz, double tx, double ty, double tz);
 
   public:
@@ -396,7 +396,7 @@ namespace dd4hep {
     /// Constructor to assign an object
     template <typename Q> CutTube(const Handle<Q>& e) : Solid_type<Object>(e) {  }
     /// Legacy: Constructor to create a new identifiable tube object with attribute initialization
-    CutTube(double rmin, double rmax, double dz, double phi1, double phi2,
+    CutTube(double rmin, double rmax, double dz, double startPhi, double endPhi,
             double lx, double ly, double lz, double tx, double ty, double tz);
     /// Assignment operator
     CutTube& operator=(const CutTube& copy) = default;
@@ -660,7 +660,7 @@ namespace dd4hep {
   class Torus: public Solid_type<TGeoTorus> {
   private:
     /// Internal helper method to support object construction
-    void make(double r, double rmin, double rmax, double phi, double delta_phi);
+    void make(double r, double rmin, double rmax, double startPhi, double deltaPhi);
   public:
     /// Default constructor
     Torus() = default;
@@ -671,16 +671,16 @@ namespace dd4hep {
     /// Constructor to be used when passing an already created object
     template <typename Q> Torus(const Handle<Q>& e) : Solid_type<Object>(e) {  }
     /// Constructor to create a new anonymous object with attribute initialization
-    template<typename R, typename RMIN, typename RMAX, typename PHI, typename DELTA_PHI>
-    Torus(R r, RMIN rmin, RMAX rmax, PHI phi=M_PI, DELTA_PHI delta_phi = 2.*M_PI)
-    {   make(_toDouble(r),_toDouble(rmin),_toDouble(rmax),_toDouble(phi),_toDouble(delta_phi));  }
+    template<typename R, typename RMIN, typename RMAX, typename STARTPHI, typename DELTAPHI>
+    Torus(R r, RMIN rmin, RMAX rmax, STARTPHI startPhi=M_PI, DELTAPHI deltaPhi = 2.*M_PI)
+    {   make(_toDouble(r),_toDouble(rmin),_toDouble(rmax),_toDouble(startPhi),_toDouble(deltaPhi));  }
     /// Constructor to create a new anonymous object with attribute initialization
-    Torus(double r, double rmin, double rmax, double phi=M_PI, double delta_phi = 2.*M_PI)
-    {   make(r,rmin,rmax,phi,delta_phi);  }
+    Torus(double r, double rmin, double rmax, double startPhi=M_PI, double deltaPhi = 2.*M_PI)
+    {   make(r, rmin, rmax, startPhi, deltaPhi);  }
     /// Assignment operator
     Torus& operator=(const Torus& copy) = default;
     /// Set the Torus dimensions
-    Torus& setDimensions(double r, double rmin, double rmax, double phi, double delta_phi);
+    Torus& setDimensions(double r, double rmin, double rmax, double startPhi, double deltaPhi);
   };
 
   /// Class describing a sphere shape
@@ -696,7 +696,9 @@ namespace dd4hep {
   class Sphere: public Solid_type<TGeoSphere> {
   protected:
     /// Constructor function to be used when creating a new object with attribute initialization
-    void make(double rmin, double rmax, double theta, double delta_theta, double phi, double delta_phi);
+    void make(double rmin,       double rmax,
+              double startTheta, double endTheta,
+              double startPhi,   double endPhi);
   public:
     /// Default constructor
     Sphere() = default;
@@ -707,25 +709,27 @@ namespace dd4hep {
     /// Constructor to be used when passing an already created object
     template <typename Q> Sphere(const Handle<Q>& e) : Solid_type<Object>(e) {  }
     /// Constructor to create a new anonymous object with attribute initialization
-    Sphere(double rmin,        double rmax,
-           double theta = 0.0, double delta_theta = M_PI,
-           double phi   = 0.0, double delta_phi   = 2. * M_PI)
-    {  make(rmin, rmax, theta, delta_theta, phi, delta_phi);     }
+    Sphere(double rmin,            double rmax,
+           double startTheta= 0.0, double endTheta = M_PI,
+           double startPhi  = 0.0, double endPhi   = 2. * M_PI)
+    {  make(rmin, rmax, startTheta, endTheta, startPhi, endPhi);     }
     /// Constructor to create a new anonymous object with generic attribute initialization
-    template<typename RMIN,         typename RMAX,
-             typename THETA=double, typename DELTA_THETA=double,
-             typename PHI=double,   typename DELTA_PHI=double>
-    Sphere(RMIN  rmin,         RMAX        rmax,
-           THETA theta = 0.0,  DELTA_THETA delta_theta = M_PI,
-           PHI   phi   = 0.0,  DELTA_PHI   delta_phi   = 2. * M_PI)  {
-      make(_toDOuble(rmin),  _toDouble(rmax),
-           _toDouble(theta), _toDouble(delta_theta),
-           _toDouble(phi),   _toDouble(delta_phi));
+    template<typename RMIN,              typename RMAX,
+             typename STARTTHETA=double, typename ENDTHETA=double,
+             typename STARTPHI=double,   typename ENDPHI=double>
+    Sphere(RMIN  rmin,                   RMAX     rmax,
+           STARTTHETA startTheta = 0.0,  ENDTHETA endTheta = M_PI,
+           STARTPHI   startPhi   = 0.0,  ENDPHI   endPhi   = 2. * M_PI)  {
+      make(_toDOuble(rmin),       _toDouble(rmax),
+           _toDouble(startTheta), _toDouble(endTheta),
+           _toDouble(startPhi),   _toDouble(endPhi));
     }
     /// Assignment operator
     Sphere& operator=(const Sphere& copy) = default;
     /// Set the Sphere dimensions
-    Sphere& setDimensions(double rmin, double rmax, double theta, double delta_theta, double phi, double delta_phi);
+    Sphere& setDimensions(double rmin,       double rmax,
+                          double startTheta, double endTheta,
+                          double startPhi,   double endPhi);
   };
 
   /// Class describing a Paraboloid shape

--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -395,6 +395,8 @@ namespace dd4hep {
     const Volume& setSolid(const Solid& s) const;
     /// Access to Solid (Shape)
     Solid solid() const;
+    /// Access the bounding box of the volume (if available)
+    Box boundingBox() const;
 
     /// Set the volume's material
     const Volume& setMaterial(const Material& m) const;

--- a/DDCore/src/Conditions.cpp
+++ b/DDCore/src/Conditions.cpp
@@ -267,3 +267,17 @@ Condition::itemkey_type ConditionKey::itemCode(const char* value)  {
 Condition::itemkey_type ConditionKey::itemCode(const std::string& value)   {
   return detail::hash32(value);
 }
+
+/// Conversion to string
+string ConditionKey::toString()  const    {
+  dd4hep::ConditionKey::KeyMaker key(hash);
+  char text[64];
+  ::snprintf(text,sizeof(text),"%08X-%08X",key.values.det_key, key.values.item_key);
+#if !defined(DD4HEP_MINIMAL_CONDITIONS)
+  stringstream str;
+  str << "(" << name << ") " << text;
+  return str.str();
+#endif
+  return text;
+}
+

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -354,7 +354,7 @@ Polycone::Polycone(double startPhi, double deltaPhi, const vector<double>& r, co
   params.push_back(r.size());
   for (size_t i = 0; i < r.size(); ++i) {
     params.push_back(z[i] );
-    params.push_back(0.0 );
+    params.push_back(0.0  );
     params.push_back(r[i] );
   }
   _assign(new TGeoPcon(&params[0]), "", "polycone", true);
@@ -386,48 +386,45 @@ void Polycone::addZPlanes(const vector<double>& rmin, const vector<double>& rmax
 
 /// Constructor to be used when creating a new cone segment object
 ConeSegment::ConeSegment(double dz, 
-			 double rmin1, double rmax1,
-			 double rmin2, double rmax2,
-			 double phi1, double phi2)
+                         double rmin1,     double rmax1,
+                         double rmin2,     double rmax2,
+                         double startPhi,  double endPhi)
 {
-  _assign(new TGeoConeSeg(dz, rmin1, rmax1, rmin2, rmax2, phi1/units::deg, phi2/units::deg), "", "cone_segment", true);
+  _assign(new TGeoConeSeg(dz, rmin1, rmax1, rmin2, rmax2, startPhi/units::deg, endPhi/units::deg), "", "cone_segment", true);
 }
 
 /// Set the cone segment dimensions
 ConeSegment& ConeSegment::setDimensions(double dz, 
-					double rmin1, double rmax1,
-					double rmin2, double rmax2,
-					double phi1,  double phi2) {
-  double params[] = { dz, rmin1, rmax1, rmin2, rmax2, phi1/units::deg, phi2/units::deg };
+                                        double rmin1, double rmax1,
+                                        double rmin2, double rmax2,
+                                        double startPhi,  double endPhi) {
+  double params[] = { dz, rmin1, rmax1, rmin2, rmax2, startPhi/units::deg, endPhi/units::deg };
   _setDimensions(params);
   return *this;
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void Tube::make(const string& nam, double rmin, double rmax, double z, double startPhi, double deltaPhi) {
-  _assign(new TGeoTubeSeg(rmin,rmax,z,startPhi/units::deg,deltaPhi/units::deg),nam,"tube",true);
-  //_assign(new MyConeSeg(), nam, "tube", true);
-  //setDimensions(rmin, rmax, z, startPhi, deltaPhi);
+void Tube::make(const string& nam, double rmin, double rmax, double z, double startPhi, double endPhi) {
+  _assign(new TGeoTubeSeg(rmin,rmax,z,startPhi/units::deg,endPhi/units::deg),nam,"tube",true);
 }
 
 /// Set the tube dimensions
-Tube& Tube::setDimensions(double rmin, double rmax, double z, double startPhi, double deltaPhi) {
-  double params[] = {rmin,rmax,z,startPhi/units::deg,deltaPhi/units::deg};
-  //double params[] = { z, rmin, rmax, rmin, rmax, startPhi/units::deg,deltaPhi/units::deg };
+Tube& Tube::setDimensions(double rmin, double rmax, double z, double startPhi, double endPhi) {
+  double params[] = {rmin,rmax,z,startPhi/units::deg,endPhi/units::deg};
   _setDimensions(params);
   return *this;
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-CutTube::CutTube(double rmin, double rmax, double dz, double phi1, double phi2,
+CutTube::CutTube(double rmin, double rmax, double dz, double startPhi, double endPhi,
                  double lx, double ly, double lz, double tx, double ty, double tz)  {
-  make(rmin,rmax,dz,phi1/units::deg,phi2/units::deg,lx,ly,lz,tx,ty,tz);
+  make(rmin,rmax,dz,startPhi/units::deg,endPhi/units::deg,lx,ly,lz,tx,ty,tz);
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void CutTube::make(double rmin, double rmax, double dz, double phi1, double phi2,
+void CutTube::make(double rmin, double rmax, double dz, double startPhi, double endPhi,
                    double lx, double ly, double lz, double tx, double ty, double tz)  {
-  _assign(new TGeoCtub(rmin,rmax,dz,phi1,phi2,lx,ly,lz,tx,ty,tz),"","cuttube",true);
+  _assign(new TGeoCtub(rmin,rmax,dz,startPhi,endPhi,lx,ly,lz,tx,ty,tz),"","cuttube",true);
 }
 
 /// Constructor to create a truncated tube object with attribute initialization
@@ -515,7 +512,7 @@ void Cone::make(double z, double rmin1, double rmax1, double rmin2, double rmax2
   _assign(new TGeoCone(z, rmin1, rmax1, rmin2, rmax2 ), "", "cone", true);
 }
 
-/// Set the box dimensions (startPhi=0.0, deltaPhi=2*pi)
+/// Set the box dimensions (startPhi=0.0, endPhi=2*pi)
 Cone& Cone::setDimensions(double z, double rmin1, double rmax1, double rmin2, double rmax2) {
   double params[] = { z, rmin1, rmax1, rmin2, rmax2  };
   _setDimensions(params);
@@ -581,27 +578,27 @@ Hyperboloid& Hyperboloid::setDimensions(double rin, double stin, double rout, do
 }
 
 /// Constructor function to be used when creating a new object with attribute initialization
-void Sphere::make(double rmin, double rmax, double theta, double delta_theta, double phi, double delta_phi) {
+void Sphere::make(double rmin, double rmax, double startTheta, double endTheta, double startPhi, double endPhi) {
   _assign(new TGeoSphere(rmin, rmax,
-                         theta/units::deg, delta_theta/units::deg,
-                         phi/units::deg, delta_phi/units::deg), "", "sphere", true);
+                         startTheta/units::deg, endTheta/units::deg,
+                         startPhi/units::deg,   endPhi/units::deg), "", "sphere", true);
 }
 
 /// Set the Sphere dimensions
-Sphere& Sphere::setDimensions(double rmin, double rmax, double theta, double delta_theta, double phi, double delta_phi) {
-  double params[] = { rmin, rmax, theta, delta_theta/units::deg, phi/units::deg, delta_phi/units::deg };
+Sphere& Sphere::setDimensions(double rmin, double rmax, double startTheta, double endTheta, double startPhi, double endPhi) {
+  double params[] = { rmin, rmax, startTheta, endTheta/units::deg, startPhi/units::deg, endPhi/units::deg };
   _setDimensions(params);
   return *this;
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void Torus::make(double r, double rmin, double rmax, double phi, double delta_phi) {
-  _assign(new TGeoTorus(r, rmin, rmax, phi/units::deg, delta_phi/units::deg), "", "torus", true);
+void Torus::make(double r, double rmin, double rmax, double startPhi, double deltaPhi) {
+  _assign(new TGeoTorus(r, rmin, rmax, startPhi/units::deg, deltaPhi/units::deg), "", "torus", true);
 }
 
 /// Set the Torus dimensions
-Torus& Torus::setDimensions(double r, double rmin, double rmax, double phi, double delta_phi) {
-  double params[] = { r, rmin, rmax, phi/units::deg, delta_phi/units::deg };
+Torus& Torus::setDimensions(double r, double rmin, double rmax, double startPhi, double deltaPhi) {
+  double params[] = { r, rmin, rmax, startPhi/units::deg, deltaPhi/units::deg };
   _setDimensions(params);
   return *this;
 }

--- a/DDCore/src/Volumes.cpp
+++ b/DDCore/src/Volumes.cpp
@@ -873,6 +873,20 @@ Solid Volume::solid() const {
   return Solid((*this)->GetShape());
 }
 
+/// Access the bounding box of the volume (if available)
+Box Volume::boundingBox() const {
+  Box box = this->solid();
+  if ( box.isValid() )   {
+    return box;
+  }
+  else if ( !isValid() )   {
+    except("dd4hep","Volume: Cannot access the bounding box of an invalid volume [Invalid Handle]!");
+  }
+  except("dd4hep","Volume: Cannot access the bounding box an object of type: %s shape: %s",
+         this->ptr()->IsA()->GetName(), this->ptr()->GetShape()->IsA()->GetName());
+  return box;
+}
+
 /// Set the regional attributes to the volume
 const Volume& Volume::setRegion(const Detector& description, const string& nam) const {
   if (!nam.empty()) {

--- a/DDCore/src/XML/VolumeBuilder.cpp
+++ b/DDCore/src/XML/VolumeBuilder.cpp
@@ -126,7 +126,7 @@ Solid VolumeBuilder::makeShape(xml_h handle)   {
     auto is = shapes.find(nam);
     if ( is != shapes.end() )  {
       except("VolumeBuilder","+++ The named shape %s is already known to this builder unit. "
-             "Cannot be overridded.",nam.c_str());
+             "Cannot be overridden.",nam.c_str());
     }
   }
   /// Was it veto'ed before ?
@@ -196,7 +196,7 @@ size_t VolumeBuilder::buildShapes(xml_h handle)    {
       continue;
     }
     except("VolumeBuilder","+++ Shape %s is already known to this builder unit. "
-           "Cannot be overridded.",nam.c_str());
+           "Cannot be overridden.",nam.c_str());
   }
   return shapes.size()-len;
 }

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -253,6 +253,7 @@ template <> void Converter<Debug>::operator()(xml_h e) const {
     else if ( nam.substr(0,6) == "limits" ) s_debug_limits       = (0 != val);
     else if ( nam.substr(0,6) == "segmen" ) s_debug_segmentation = (0 != val);
     else if ( nam.substr(0,6) == "consta" ) s_debug_constants    = (0 != val);
+    else if ( nam.substr(0,6) == "define" ) s_debug_constants    = (0 != val);
     else if ( nam.substr(0,6) == "includ" ) s_debug_include      = (0 != val);
   }
 }

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -116,7 +116,7 @@ DECLARE_CONSTRUCTOR(Detector_constructor,create_description_instance)
  */
 static long display(Detector& description, int argc, char** argv) {
   TGeoManager& mgr = description.manager();
-  int vislevel = 4, visopt = 1;
+  int vislevel = 6, visopt = 1;
   string detector = "/world";
   const char* opt = "ogl";
   for(int i = 0; i < argc && argv[i]; ++i)  {

--- a/UtilityApps/src/display.cpp
+++ b/UtilityApps/src/display.cpp
@@ -18,16 +18,23 @@
 int main(int argc,char** argv)  {
   std::vector<const char*> av;
   std::string level, visopt, opt;
+  bool dry = false;
   for(int i=0; i<argc; ++i)  {
-    if      ( strncmp(argv[i],"-visopt",4) == 0 )  visopt = argv[i];
-    else if ( strncmp(argv[i],"-level", 4)  == 0 ) level  = argv[i];
-    else if ( strncmp(argv[i],"-option",4) == 0 )  opt    = argv[i];
+    if ( i==1 && argv[i][0] != '-' ) av.push_back("-input");
+    if      ( strncmp(argv[i],"-load",4)   == 0 ) dry = true, av.push_back(argv[i]);
+    else if ( strncmp(argv[i],"-dry",4)    == 0 ) dry = true, av.push_back(argv[i]);
+    else if ( strncmp(argv[i],"-visopt",4) == 0 ) visopt = argv[i];
+    else if ( strncmp(argv[i],"-level", 4) == 0 ) level  = argv[i];
+    else if ( strncmp(argv[i],"-option",4) == 0 ) opt    = argv[i];
     else av.push_back(argv[i]);
   }
-  av.push_back("-plugin");
-  av.push_back("-DD4hep_GeometryDisplay");
-  if ( !opt.empty()    ) av.push_back("-opt"),    av.push_back(opt.c_str());
-  if ( !level.empty()  ) av.push_back("-level"),  av.push_back(level.c_str());
-  if ( !visopt.empty() ) av.push_back("-visopt"), av.push_back(visopt.c_str());
+  if ( !dry )   {
+    av.push_back("-interactive");
+    av.push_back("-plugin");
+    av.push_back("DD4hep_GeometryDisplay");
+    if ( !opt.empty()    ) av.push_back("-opt"),    av.push_back(opt.c_str());
+    if ( !level.empty()  ) av.push_back("-level"),  av.push_back(level.c_str());
+    if ( !visopt.empty() ) av.push_back("-visopt"), av.push_back(visopt.c_str());
+  }
   return dd4hep::execute::main_plugins("DD4hep_GeometryDisplay", av.size(), (char**)&av[0]);
 }

--- a/UtilityApps/src/display.cpp
+++ b/UtilityApps/src/display.cpp
@@ -16,5 +16,18 @@
 
 //______________________________________________________________________________
 int main(int argc,char** argv)  {
-  return main_default("DD4hep_GeometryDisplay",argc,argv);
+  std::vector<const char*> av;
+  std::string level, visopt, opt;
+  for(int i=0; i<argc; ++i)  {
+    if      ( strncmp(argv[i],"-visopt",4) == 0 )  visopt = argv[i];
+    else if ( strncmp(argv[i],"-level", 4)  == 0 ) level  = argv[i];
+    else if ( strncmp(argv[i],"-option",4) == 0 )  opt    = argv[i];
+    else av.push_back(argv[i]);
+  }
+  av.push_back("-plugin");
+  av.push_back("-DD4hep_GeometryDisplay");
+  if ( !opt.empty()    ) av.push_back("-opt"),    av.push_back(opt.c_str());
+  if ( !level.empty()  ) av.push_back("-level"),  av.push_back(level.c_str());
+  if ( !visopt.empty() ) av.push_back("-visopt"), av.push_back(visopt.c_str());
+  return dd4hep::execute::main_plugins("DD4hep_GeometryDisplay", av.size(), (char**)&av[0]);
 }

--- a/UtilityApps/src/plugin_runner.cpp
+++ b/UtilityApps/src/plugin_runner.cpp
@@ -16,102 +16,18 @@
 
 // Framework include files
 #include "run_plugin.h"
-#include <memory>
-
-using namespace std;
-
-//______________________________________________________________________________
-namespace {
-  void usage() {
-    cout <<
-      "geoPluginRun -opt [-opt]                                                \n"
-      "        -input  <file>  [OPTIONAL]  Specify geometry input file.        \n"
-      "        -plugin <name>  <args> [args] [-end-plugin]                     \n"
-      "                        [REQUIRED]  Plugin to be executed and applied.  \n"
-      "        -plugin <name>  <args> [args] -end-plugin                       \n"
-      "                        [OPTIONAL]  Next plugin with arguments.         \n";
-    print_default_args() << endl;
-    ::exit(EINVAL);
-  }
-
-  //______________________________________________________________________________
-  int invoke_plugin_runner(int argc,char** argv)  {
-    Args arguments;
-    arguments.interpreter = false;
-    
-    for(int i=1; i<argc;++i) {
-      if ( argv[i][0]=='-' ) {
-        if ( arguments.handle(i,argc,argv) )
-          continue;
-      }
-      else {
-        usage();
-      }
-    }
-    if ( !arguments.ui && !arguments.interpreter && arguments.plugins.empty() )  {
-      usage();
-    }
-    unique_ptr<TRint> interpreter;
-    dd4hep::Detector& description = dd4hep_instance();
-    // Load compact files if required by plugin
-    if ( !arguments.geo_files.empty() )   {
-      load_compact(description, arguments);
-    }
-    else  {
-      cout << "geoPluginRun: No geometry input supplied. "
-           << "No geometry will be loaded." << endl;
-    }
-    // Attach UI instance if requested to ease interaction from the ROOT prompt
-    if ( arguments.ui )  {
-      run_plugin(description,"DD4hep_InteractiveUI",0,0);
-    }
-    // Create volume manager and populate it required
-    if ( arguments.volmgr  )   {
-      run_plugin(description,"DD4hep_VolumeManager",0,0);
-    }
-    if ( arguments.interpreter )  {
-      pair<int, char**> a(0,0);
-      interpreter.reset(new TRint("geoPluginRun", &a.first, a.second));
-    }
-    // Execute plugin
-    for(size_t i=0; i<arguments.plugins.size(); ++i)   {
-      vector<const char*>& plug = arguments.plugins[i];
-      int num_args = int(plug.size())-2;
-      long result = run_plugin(description,plug[0], num_args,(char**)&plug[1]);
-      if ( result == EINVAL )   {
-        cout << "geoPluginRun: FAILED to execute dd4hep plugin: '" << plug[0] 
-                  << "' with args (" << num_args << ") :[ ";
-        for(size_t j = 1; j < plug.size(); ++j)   {
-          if ( plug[j] ) cout << plug[j] << " ";
-        }
-        cout << "]" << endl;
-        usage();
-      }
-      cout << "geoPluginRun: Executed dd4hep plugin: '" << plug[0]
-                << "' with args (" << num_args << ") :[ ";
-      for(size_t j=1; j<plug.size(); ++j)   {
-        if ( plug[j] ) cout << plug[j] << " ";
-      }
-      cout << "]" << endl << flush;
-    }
-    if ( interpreter )  {
-      interpreter->Run();
-    }
-    if ( arguments.destroy ) delete &description;
-    return 0;
-  }
-}
+#include <cerrno>
 
 /// Main entry point as a program
 int main(int argc, char** argv)   {
   try  {
-    return invoke_plugin_runner(argc, argv);
+    return dd4hep::execute::invoke_plugin_runner("", argc, argv);
   }
-  catch(const exception& e)  {
-    cout << "geoPluginRun: Got uncaught exception: " << e.what() << endl;
+  catch(const std::exception& e)  {
+    std::cout << "geoPluginRun: Got uncaught exception: " << e.what() << std::endl;
   }
   catch (...)  {
-    cout << "geoPluginRun: Got UNKNOWN uncaught exception." << endl;
+    std::cout << "geoPluginRun: Got UNKNOWN uncaught exception." << std::endl;
   }
   return EINVAL;    
 }

--- a/UtilityApps/src/run_plugin.h
+++ b/UtilityApps/src/run_plugin.h
@@ -301,7 +301,11 @@ namespace dd4hep  {
           usage_plugin_runner();
         }
       }
-      if ( !arguments.ui && !arguments.interpreter && arguments.plugins.empty() )  {
+      if ( !arguments.dry_run &&
+           !arguments.ui      &&
+           !arguments.interpreter &&
+           arguments.plugins.empty() )
+      {
         usage_plugin_runner();
       }
       std::unique_ptr<TRint> interpreter;
@@ -365,7 +369,7 @@ namespace dd4hep  {
           std::cout << "The geometry was loaded. Application now exiting." << std::endl;
         }
       }
-      if ( interpreter )  {
+      if ( !arguments.dry_run && interpreter.get() )  {
         interpreter->Run();
       }
       if ( arguments.destroy ) delete &description;

--- a/UtilityApps/src/teve_display.cpp
+++ b/UtilityApps/src/teve_display.cpp
@@ -155,7 +155,7 @@ DECLARE_APPLY(DD4hepTEveDisplay,teve_display)
 //=====================================================================================================================
 
 int main(int argc,char** argv)  {
-  return main_default("DD4hepTEveDisplay",argc,argv);
+  return dd4hep::execute::main_default("DD4hepTEveDisplay",argc,argv);
 }
 
 //=====================================================================================================================

--- a/examples/ClientTests/compact/CheckShape.xml
+++ b/examples/ClientTests/compact/CheckShape.xml
@@ -49,8 +49,9 @@
   <display>
     <vis name="InvisibleNoDaughters"      showDaughters="false" visible="false"/>
     <vis name="InvisibleWithDaughters"    showDaughters="true"  visible="false"/>
-    <vis name="Shape1_vis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
-    <vis name="Shape2_vis" alpha="1.0" r="0" g="1" b="0" showDaughters="true" visible="true"/>
-    <vis name="Shape3_vis" alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
+    <vis name="Shape1_vis_20" alpha="0.2" r="0.9" g="0.8" b="0.8" showDaughters="true" visible="true"/>
+    <vis name="Shape1_vis"    alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+    <vis name="Shape2_vis"    alpha="1.0" r="0" g="1" b="0" showDaughters="true" visible="true"/>
+    <vis name="Shape3_vis"    alpha="1.0" r="0" g="0" b="1" showDaughters="true" visible="true"/>
   </display>
 </lccdd>


### PR DESCRIPTION

BEGINRELEASENOTES
# Harmonize argument names in Shapes.h with their actual functionality 
For many shapes in DD4hep/Shapes.h the argument names were misleading:
very often deltaPhi was mentioned, whereas the code actually used instead
of (phi, deltaphi) the input arguments to the ROOT constructors (startPhi,endPhi)
or (phi1, phi2).  Wherever ROOT uses (startPhi,endPhi) the argument names were changed accordingly.
Please note:
a bug was found in the legacy constructor:
    /// Legacy: Constructor to create a new identifiable tube object with attribute initialization
    Tube(const std::string& nam, double rmin, double rmax, double dz, double startPhi, double endPhi)
(which is probably not used by anyone....).
Here opposite to all other constructors delta_phi was used as such - in contradiction to other constructors of the same class. This was rectified.


ENDRELEASENOTES