### PR TITLE
add #include <memory> to run_plugin.h

### DIFF
--- a/UtilityApps/src/run_plugin.h
+++ b/UtilityApps/src/run_plugin.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include <cerrno>
 #include <string>
+#include <memory>
 
 //________________________________________________________________________________
 #include "TRint.h"


### PR DESCRIPTION

BEGINRELEASENOTES
- add #include <memory> to run_plugin.h
        - needed for std::unique_ptr and gcc49

ENDRELEASENOTES