### PR TITLE
Add make_unique instance creator for Detector

### DIFF
--- a/DDCore/include/DD4hep/DetElement.h
+++ b/DDCore/include/DD4hep/DetElement.h
@@ -383,6 +383,8 @@ namespace dd4hep {
 
     /// Access to the logical volume of the detector element's placement
     Volume volume() const;
+    /// Access to the shape of the detector element's placement
+    Solid solid() const;
 
     /// Access to the physical volume of this detector element
     /** This is the current placement value of the detector eleemnt.

--- a/DDCore/include/DD4hep/Detector.h
+++ b/DDCore/include/DD4hep/Detector.h
@@ -34,6 +34,7 @@
 #include <vector>
 #include <string>
 #include <cstdio>
+#include <memory>
 
 // Forward declarations
 class TGeoManager;
@@ -313,6 +314,9 @@ namespace dd4hep {
     static Detector& getInstance(const std::string& name="default");
     /// Destroy the singleton instance
     static void destroyInstance(const std::string& name="default");
+    /// Unique creation without internal registration
+    static std::unique_ptr<Detector> make_unique(const std::string& name);
+
   };
 
   /*

--- a/DDCore/src/DetElement.cpp
+++ b/DDCore/src/DetElement.cpp
@@ -321,6 +321,11 @@ Volume DetElement::volume() const {
   return access()->placement.volume();
 }
 
+/// Access to the shape of the detector element's placement
+Solid DetElement::solid() const    {
+  return volume()->GetShape();
+}
+
 DetElement& DetElement::setVisAttributes(const Detector& description, const string& nam, const Volume& vol) {
   vol.setVisAttributes(description, nam);
   return *this;

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -118,6 +118,11 @@ string dd4hep::versionString(){
   return vs;
 }
 
+unique_ptr<Detector> Detector::make_unique(const std::string& name)   {
+  Detector* description = new DetectorImp(name);
+  return unique_ptr<Detector>(description);
+}
+
 Detector& Detector::getInstance(const std::string& name)   {
   lock_guard<recursive_mutex> lock(s_instances.lock);
   Detector* description = s_instances.get(name);

--- a/UtilityApps/src/display.cpp
+++ b/UtilityApps/src/display.cpp
@@ -21,12 +21,12 @@ int main(int argc,char** argv)  {
   bool dry = false;
   for(int i=0; i<argc; ++i)  {
     if ( i==1 && argv[i][0] != '-' ) av.push_back("-input");
-    if      ( strncmp(argv[i],"-load",4)     == 0 ) dry = true, av.push_back(argv[i]);
-    else if ( strncmp(argv[i],"-dry",4)      == 0 ) dry = true, av.push_back(argv[i]);
-    else if ( strncmp(argv[i],"-visopt",4)   == 0 ) visopt   = argv[++i];
-    else if ( strncmp(argv[i],"-level", 4)   == 0 ) level    = argv[++i];
-    else if ( strncmp(argv[i],"-option",4)   == 0 ) opt      = argv[++i];
-    else if ( strncmp(argv[i],"-detector",4) == 0 ) detector = argv[++i];
+    if      ( strncmp(argv[i],"-load-only",4) == 0 ) dry = true, av.push_back(argv[i]);
+    else if ( strncmp(argv[i],"-dry-run",4)   == 0 ) dry = true, av.push_back(argv[i]);
+    else if ( strncmp(argv[i],"-visopt",4)    == 0 ) visopt   = argv[++i];
+    else if ( strncmp(argv[i],"-level", 4)    == 0 ) level    = argv[++i];
+    else if ( strncmp(argv[i],"-option",4)    == 0 ) opt      = argv[++i];
+    else if ( strncmp(argv[i],"-detector",4)  == 0 ) detector = argv[++i];
     else av.push_back(argv[i]);
   }
   if ( !dry )   {


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix bug in geoDisplay to allow passing the volume display depth as an argument
- Add a static creator to the Detector class to create non-traced instances:
   std::unique_ptr<Detector> Detector::make_unique(const std::string& name);
   It is the users responsibility to release the allocated resources and to avoid
   clashed with existing TGeoManager instances.
-  Allow direct access to the solid instance of the DetElements's placement.

ENDRELEASENOTES