### PR TITLE
DDRec: extensions for sorting policy

### DIFF
--- a/DDRec/include/DDRec/DetectorData.h
+++ b/DDRec/include/DDRec/DetectorData.h
@@ -485,6 +485,12 @@ namespace dd4hep {
 
     std::ostream& operator<<( std::ostream& io , const NeighbourSurfacesData& d ) ;
 
+    struct MapStringDoubleStruct {
+      std::map<std::string, double> doubleParameters{};
+    };
+    using DoubleParameters = StructExtension<MapStringDoubleStruct>;
+
+    std::ostream& operator<<( std::ostream& io , const DoubleParameters& d ) ;
 
   } /* namespace rec */
 } /* namespace dd4hep */

--- a/DDRec/include/DDRec/Surface.h
+++ b/DDRec/include/DDRec/Surface.h
@@ -551,6 +551,9 @@ namespace dd4hep {
       /// The VolSurface attched to the volume.
       VolSurface volSurface() const { return _volSurf ; }
 
+      /// The DetElement belonging to the surface volume
+      DetElement detElement() const { return _det; }
+
 
       //==== geometry ====
       

--- a/DDRec/src/DetectorData.cpp
+++ b/DDRec/src/DetectorData.cpp
@@ -199,6 +199,20 @@ namespace dd4hep {
       io <<  "   sameLayer.size() : " << d.sameLayer.size() << std::endl ; 
       return io ;
     }
+
+
+    std::ostream& operator<<(std::ostream& io, const DoubleParameters& d) {
+      boost::io::ios_base_all_saver ifs(io);
+      io <<  " --DoubleParameters: "  << std::scientific << std::endl ;
+      for (auto const& thePair: d.doubleParameters) {
+        io <<  "    "
+           << std::setw(40) << thePair.first << ":"
+           << std::setw(14) << thePair.second
+           << std::endl;
+      }
+      return io ;
+    }
+
  
 
   } // namespace


### PR DESCRIPTION
To set the sorting policy we need to access the DetElement directly from the surface. The passive Surfaces are not part of the VolumeManager and cannot be looked up there. As the surface already holds the DetElement it is easiest to simply allow one to access it.

Then we can add an extension which stores the sortingPolicy calculated in a plugin. For this purpose we also add an Extension to hold arbitrary float values identified by a string.

BEGINRELEASENOTES
- DDRec: Surface: add accessor to DetElement member
- DDRec: DetectorData: add Extension holding a map of String to Doubles

ENDRELEASENOTES