### PR TITLE
Birks Law bug fix

### DIFF
--- a/DDG4/src/Geant4StepHandler.cpp
+++ b/DDG4/src/Geant4StepHandler.cpp
@@ -121,7 +121,11 @@ double Geant4StepHandler::birkAttenuation() const    {
 #endif
 
 #if G4VERSION_NUMBER >= 1003
-  s_emSaturation.InitialiseG4Saturation();
+  static bool s_initialised = false;
+  if(not s_initialised) {
+      s_emSaturation.InitialiseG4Saturation();
+      s_initialised = true;
+  }
 #endif
 
   double energyDeposition = step->GetTotalEnergyDeposit();

--- a/DDG4/src/Geant4StepHandler.cpp
+++ b/DDG4/src/Geant4StepHandler.cpp
@@ -1,5 +1,5 @@
 //==========================================================================
-//  AIDA Detector description implementation 
+//  AIDA Detector description implementation
 //--------------------------------------------------------------------------
 // Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
 // All rights reserved.
@@ -119,6 +119,10 @@ double Geant4StepHandler::birkAttenuation() const    {
   static G4EmSaturation s_emSaturation();
   s_emSaturation.SetVerbose(1);
 #endif
+
+#if G4VERSION_NUMBER >= 1003
+  s_emSaturation.InitialiseG4Saturation();
+#else
 
   double energyDeposition = step->GetTotalEnergyDeposit();
   double length = step->GetStepLength();

--- a/DDG4/src/Geant4StepHandler.cpp
+++ b/DDG4/src/Geant4StepHandler.cpp
@@ -122,7 +122,7 @@ double Geant4StepHandler::birkAttenuation() const    {
 
 #if G4VERSION_NUMBER >= 1003
   s_emSaturation.InitialiseG4Saturation();
-#else
+#endif
 
   double energyDeposition = step->GetTotalEnergyDeposit();
   double length = step->GetStepLength();


### PR DESCRIPTION
Due to a complete change in geant4 versions over 10.03, the class [G4EmSaturation](https://github.com/Geant4/geant4/blob/v10.3.2/source/processes/electromagnetic/utils/include/G4EmSaturation.hh) needs to be initialized via `InitialiseG4Saturation()`. This sets the default birks coefficients that are in geant4. If this method is not called, the birks law does not work as the coefficient is set to 0.

BEGINRELEASENOTES
- Added Initialization of G4EmSaturation to initialize birks coefficients - for g4 version > 10.03

ENDRELEASENOTES