### PR TITLE
Please see description in the release notes

### DIFF
--- a/DDCond/include/DDCond/ConditionsContent.h
+++ b/DDCond/include/DDCond/ConditionsContent.h
@@ -154,7 +154,7 @@ namespace dd4hep {
       addDependency(ConditionDependency* dep);
       /// Add a new conditions dependency (Built internally from arguments)
       std::pair<Condition::key_type, ConditionDependency*>
-      addDependency(DetElement de, Condition::itemkey_type item, ConditionUpdateCall* callback);
+      addDependency(DetElement de, Condition::itemkey_type item, std::shared_ptr<ConditionUpdateCall> callback);
     };
 
     template <> inline

--- a/DDCond/src/ConditionsContent.cpp
+++ b/DDCond/src/ConditionsContent.cpp
@@ -139,7 +139,7 @@ ConditionsContent::addDependency(ConditionDependency* dep)
 std::pair<Condition::key_type, ConditionDependency*>
 ConditionsContent::addDependency(DetElement de,
                                  Condition::itemkey_type item,
-                                 ConditionUpdateCall* callback)
+                                 std::shared_ptr<ConditionUpdateCall> callback)
 {
   ConditionDependency* dep = new ConditionDependency(de, item, callback);
   return addDependency(dep);

--- a/DDCond/src/plugins/ConditionsUserPool.cpp
+++ b/DDCond/src/plugins/ConditionsUserPool.cpp
@@ -491,11 +491,11 @@ namespace {
     typedef pair<const Condition::key_type,ConditionsLoadInfo* >     Info;
     typedef pair<const Condition::key_type,Condition>                Cond2;
     
-    bool operator()(const Dep& a,const Cond& b) const { return a.first < b.first; }
-    bool operator()(const Cond& a,const Dep& b) const { return a.first < b.first; }
+    bool operator()(const Dep& a,const Cond& b) const   { return a.first < b.first; }
+    bool operator()(const Cond& a,const Dep& b) const   { return a.first < b.first; }
 
-    bool operator()(const Info& a,const Cond& b) const { return a.first < b.first; }
-    bool operator()(const Cond& a,const Info& b) const { return a.first < b.first; }
+    bool operator()(const Info& a,const Cond& b) const  { return a.first < b.first; }
+    bool operator()(const Cond& a,const Info& b) const  { return a.first < b.first; }
 
     bool operator()(const Info& a,const Cond2& b) const { return a.first < b.first; }
     bool operator()(const Cond2& a,const Info& b) const { return a.first < b.first; }

--- a/DDCore/include/DD4hep/Conditions.h
+++ b/DDCore/include/DD4hep/Conditions.h
@@ -137,6 +137,8 @@ namespace dd4hep {
 
     /// Default constructor
     Condition() = default;
+    /// Move constructor
+    Condition(Condition&& c) = default;
     /// Copy constructor
     Condition(const Condition& c) = default;
     /// Initializing constructor
@@ -149,7 +151,9 @@ namespace dd4hep {
     Condition(const std::string& name, const std::string& type);
     /// Initializing constructor for a pure, undecorated conditions object with payload buffer
     Condition(const std::string& name, const std::string& type, size_t memory);
-    /// Assignment operator
+    /// Assignment move operator
+    Condition& operator=(Condition&& c) = default;
+    /// Assignment copy operator
     Condition& operator=(const Condition& c) = default;
 
     /// Output method

--- a/DDCore/include/DD4hep/DetElement.h
+++ b/DDCore/include/DD4hep/DetElement.h
@@ -51,9 +51,16 @@ namespace dd4hep {
     SensitiveDetector(Object* obj_pointer)
       : Handle<SensitiveDetectorObject>(obj_pointer) {      }
 
+    /// Move from named handle
+    SensitiveDetector(Handle<SensitiveDetectorObject>&& sd)
+      : Handle<SensitiveDetectorObject>(sd) {      }
+
     /// Copy from named handle
     SensitiveDetector(const Handle<SensitiveDetectorObject>& sd)
       : Handle<SensitiveDetectorObject>(sd) {      }
+
+    /// Move from handle
+    SensitiveDetector(SensitiveDetector&& sd) = default;
 
     /// Copy from handle
     SensitiveDetector(const SensitiveDetector& sd) = default;
@@ -65,7 +72,10 @@ namespace dd4hep {
     /// Constructor for a new sensitive detector element
     SensitiveDetector(const std::string& name, const std::string& type = "sensitive");
 
-    /// Assignment operator
+    /// Assignment move operator
+    SensitiveDetector& operator=(SensitiveDetector&& sd)  = default;
+
+    /// Assignment copy operator
     SensitiveDetector& operator=(const SensitiveDetector& sd)  = default;
 
     /// Access the type of the sensitive detector
@@ -253,6 +263,9 @@ namespace dd4hep {
     /// Default constructor
     DetElement() = default;
 
+    /// Constructor to move handle
+    DetElement(DetElement&& e) = default;
+
     /// Constructor to copy handle
     DetElement(const DetElement& e) = default;
 
@@ -281,6 +294,11 @@ namespace dd4hep {
     /// Constructor for a new subdetector element
     DetElement(DetElement parent, const std::string& name, int id);
 
+    /// Assignment move operator
+    DetElement& operator=(DetElement&& sd)  = default;
+    /// Assignment copy operator
+    DetElement& operator=(const DetElement& e) = default;
+
     /// Additional data accessor
     Object& _data() const {
       return object<Object>();
@@ -295,9 +313,6 @@ namespace dd4hep {
     bool operator ==(const DetElement e) const {
       return ptr() == e.ptr();
     }
-
-    /// Assignment operator
-    DetElement& operator=(const DetElement& e) = default;
 
     /// Clone (Deep copy) the DetElement structure
     DetElement clone(int flag) const;

--- a/DDCore/include/DD4hep/Detector.h
+++ b/DDCore/include/DD4hep/Detector.h
@@ -286,7 +286,7 @@ namespace dd4hep {
     /// Stupid legacy method
     virtual void dump() const = 0;
     /// Manipulate geometry using factory converter
-    virtual long apply(const char* factory, int argc, char** argv) = 0;
+    virtual long apply(const char* factory, int argc, char** argv)  const = 0;
 
     /// Add an extension object to the detector element (low level member function)
     virtual void* addUserExtension(unsigned long long int key, ExtensionEntry* entry) = 0;

--- a/DDCore/include/DD4hep/Handle.h
+++ b/DDCore/include/DD4hep/Handle.h
@@ -97,6 +97,8 @@ namespace dd4hep {
     /// Default constructor
     Handle() = default;
     /// Copy constructor
+    Handle(Handle<T>&& element) = default;
+    /// Copy constructor
     Handle(const Handle<T>& element) = default;
     /// Initializing constructor from pointer
     Handle(T* element) : m_element(element)   {            }
@@ -108,7 +110,9 @@ namespace dd4hep {
     template <typename Q> Handle(const Handle<Q>& element)
       : m_element(element.m_element ? detail::safe_cast<T>::cast(element.m_element) : 0)
     {             }
-    /// Assignment operator
+    /// Assignment move operator
+    Handle<T>& operator=(Handle<T>&& element) = default;
+    /// Assignment copy operator
     Handle<T>& operator=(const Handle<T>& element) = default;
     /// Boolean operator == used for RB tree insertions
     bool operator==(const Handle<T>& element)  const {

--- a/DDCore/include/DD4hep/Readout.h
+++ b/DDCore/include/DD4hep/Readout.h
@@ -41,9 +41,14 @@ namespace dd4hep {
     Readout() = default;
 
     /// Copy Constructor from object
+    Readout(Readout&& e) = default;
+
+    /// Copy Constructor from object
     Readout(const Readout& e) = default;
 
 #ifndef __CINT__
+    /// Move constructor from handle
+    Readout(Handle<ReadoutObject>&& e) : Handle<Object>(e) { }
     /// Copy Constructor from handle
     Readout(const Handle<ReadoutObject>& e) : Handle<Object>(e) { }
 #endif
@@ -53,6 +58,9 @@ namespace dd4hep {
 
     /// Initializing constructor
     Readout(const std::string& name);
+
+    /// Assignment move operator
+    Readout& operator=(Readout&& ro) = default;
 
     /// Assignment operator
     Readout& operator=(const Readout& ro) = default;

--- a/DDCore/include/DD4hep/Segmentations.h
+++ b/DDCore/include/DD4hep/Segmentations.h
@@ -44,15 +44,21 @@ namespace dd4hep {
     Segmentation(const std::string& type, const std::string& name, const BitFieldCoder* decoder);
     /// Default constructor
     Segmentation() = default;
-    /// Copy Constructor from object
+    /// Move Constructor
+    Segmentation(Segmentation&& e) = default;
+    /// Copy Constructor
     Segmentation(const Segmentation& e) = default;
 #ifndef __CINT__
+    /// Move Constructor from handle
+    Segmentation(Handle<Object>&& e) : Handle<Object>(e) { }
     /// Copy Constructor from handle
     Segmentation(const Handle<Object>& e) : Handle<Object>(e) { }
 #endif
     /// Constructor to be used when reading the already parsed object
     template <typename Q> Segmentation(const Handle<Q>& e) : Handle<Object>(e) { }
-    /// Assignment operator
+    /// Move Assignment operator
+    Segmentation& operator=(Segmentation&& seg) = default;
+    /// Copy Assignment operator
     Segmentation& operator=(const Segmentation& seg) = default;
     /// Access flag for hit positioning
     bool useForHitPosition() const;

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -93,15 +93,21 @@ namespace dd4hep {
 
     /// Default constructor for uninitialized object
     Solid_type() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move constructor
+    Solid_type(Solid_type&& e) = default;
+    /// Copy constructor
     Solid_type(const Solid_type& e) = default;
     /// Direct assignment using the implementation pointer
     Solid_type(T* p) : Handle<T>(p) {  }
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor from handle
+    Solid_type(Handle<T>&& e) : Handle<T>(e) {  }
+    /// Copy Constructor from handle
     Solid_type(const Handle<T>& e) : Handle<T>(e) {  }
     /// Constructor to be used when passing an already created object: need to check pointers
     template <typename Q> Solid_type(const Handle<Q>& e) : Handle<T>(e) {  }
-    /// Assignment operator
+    /// Assignment move operator
+    Solid_type& operator=(Solid_type&& copy) = default;
+    /// Assignment copy operator
     Solid_type& operator=(const Solid_type& copy) = default;
 
     /// Access to shape name
@@ -121,6 +127,8 @@ namespace dd4hep {
     T* operator->() const {
       return this->m_element;
     }
+    /// Access the dimensions of the shape: inverse of the setDimensions member function
+    std::vector<double> dimensions();
     /// Conversion to string for pretty print
     std::string toString(int precision=2) const   {
       return toStringSolid(this->m_element,precision);
@@ -145,7 +153,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     ShapelessSolid() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move constructor from handle
+    ShapelessSolid(ShapelessSolid&& e) = default;
+    /// Copy constructor from handle
     ShapelessSolid(const ShapelessSolid& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> ShapelessSolid(const Q* p) : Solid_type<TGeoShapeAssembly>(p) { }
@@ -153,7 +163,9 @@ namespace dd4hep {
     template <typename Q> ShapelessSolid(const Handle<Q>& e) : Solid_type<TGeoShapeAssembly>(e) { }
     /// Constructor to create an anonymous new shapeless solid
     ShapelessSolid(const std::string& name);
-    /// Assignment operator
+    /// Move Assignment operator
+    ShapelessSolid& operator=(ShapelessSolid&& copy) = default;
+    /// Copy Assignment operator
     ShapelessSolid& operator=(const ShapelessSolid& copy) = default;
   };
 
@@ -175,11 +187,13 @@ namespace dd4hep {
   public:
     /// Default constructor
     Box() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move constructor
+    Box(Box&& e) = default;
+    /// Copy constructor
     Box(const Box& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Box(const Q* p) : Solid_type<TGeoBBox>(p) { }
-    /// Constructor to be used with an existing object
+    /// Copy Constructor to be used with an existing object handle
     template <typename Q> Box(const Handle<Q>& e) : Solid_type<TGeoBBox>(e) { }
 
     /// Constructor to create an anonymous new box object (retrieves name from volume)
@@ -198,7 +212,9 @@ namespace dd4hep {
     Box(const std::string& name, const X& x_val, const Y& y_val, const Z& z_val)
     { make(name.c_str(), _toDouble(x_val), _toDouble(y_val), _toDouble(z_val));  }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Box& operator=(Box&& copy) = default;
+    /// Copy Assignment operator
     Box& operator=(const Box& copy) = default;
     /// Set the box dimensions
     Box& setDimensions(double x_val, double y_val, double z_val);
@@ -228,7 +244,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     HalfSpace() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    HalfSpace(HalfSpace&& e) = default;
+    /// Copy Constructor
     HalfSpace(const HalfSpace& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> HalfSpace(const Q* p) : Solid_type<Object>(p) { }
@@ -243,7 +261,9 @@ namespace dd4hep {
     HalfSpace(const std::string& nam, const double* const point, const double* const normal)
     { make(nam.c_str(), point, normal);    }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    HalfSpace& operator=(HalfSpace&& copy) = default;
+    /// Copy Assignment operator
     HalfSpace& operator=(const HalfSpace& copy) = default;
   };
 
@@ -269,7 +289,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Polycone() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move constructor
+    Polycone(Polycone&& e) = default;
+    /// Copy constructor
     Polycone(const Polycone& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Polycone(const Q* p) : Solid_type<Object>(p) {  }
@@ -294,8 +316,11 @@ namespace dd4hep {
     Polycone(const std::string& name, double startPhi, double deltaPhi,
              const std::vector<double>& rmin, const std::vector<double>& rmax, const std::vector<double>& z);
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Polycone& operator=(Polycone&& copy) = default;
+    /// Copy Assignment operator
     Polycone& operator=(const Polycone& copy) = default;
+
     /// Add Z-planes to the Polycone
     void addZPlanes(const std::vector<double>& rmin, const std::vector<double>& rmax, const std::vector<double>& z);
   };
@@ -316,7 +341,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     ConeSegment() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    ConeSegment(ConeSegment&& e) = default;
+    /// Copy Constructor
     ConeSegment(const ConeSegment& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> ConeSegment(const Q* p) : Solid_type<Object>(p) {  }
@@ -331,7 +358,9 @@ namespace dd4hep {
     ConeSegment(const std::string& name, double dz, double rmin1, double rmax1,
                 double rmin2, double rmax2, double startPhi = 0.0, double endPhi = 2.0 * M_PI);
 
-    /// Assignment operator
+    /// Move Assignment operator
+    ConeSegment& operator=(ConeSegment&& copy) = default;
+    /// Copy Assignment operator
     ConeSegment& operator=(const ConeSegment& copy) = default;
     /// Set the cone segment dimensions
     ConeSegment& setDimensions(double dz, double rmin1, double rmax1,
@@ -368,7 +397,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Tube() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Tube(Tube&& e) = default;
+    /// Copy Constructor
     Tube(const Tube& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Tube(const Q* p) : Solid_type<Object>(p) {  }
@@ -399,7 +430,9 @@ namespace dd4hep {
     Tube(const RMIN& rmin, const RMAX& rmax, const Z& dz, const ENDPHI& endPhi = 2.0*M_PI)
     {  make("", _toDouble(rmin), _toDouble(rmax), _toDouble(dz), 0, _toDouble(endPhi));   }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Tube& operator=(Tube&& copy) = default;
+    /// Copy Assignment operator
     Tube& operator=(const Tube& copy) = default;
     /// Set the tube dimensions
     Tube& setDimensions(double rmin, double rmax, double dz, double startPhi=0.0, double endPhi=2*M_PI);
@@ -424,7 +457,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     CutTube() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    CutTube(CutTube&& e) = default;
+    /// Copy Constructor
     CutTube(const CutTube& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> CutTube(const Q* p) : Solid_type<Object>(p) {  }
@@ -440,7 +475,9 @@ namespace dd4hep {
             double rmin, double rmax, double dz, double startPhi, double endPhi,
             double lx, double ly, double lz, double tx, double ty, double tz);
 
-    /// Assignment operator
+    /// Move Assignment operator
+    CutTube& operator=(CutTube&& copy) = default;
+    /// Copy Assignment operator
     CutTube& operator=(const CutTube& copy) = default;
   };
 
@@ -464,7 +501,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     TruncatedTube() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    TruncatedTube(TruncatedTube&& e) = default;
+    /// Copy Constructor
     TruncatedTube(const TruncatedTube& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> TruncatedTube(const Q* p) : Solid_type<Object>(p) {  }
@@ -480,7 +519,9 @@ namespace dd4hep {
                   double zhalf, double rmin, double rmax, double startPhi, double deltaPhi,
                   double cutAtStart, double cutAtDelta, bool cutInside);
 
-    /// Assignment operator
+    /// Move Assignment operator
+    TruncatedTube& operator=(TruncatedTube&& copy) = default;
+    /// Copy Assignment operator
     TruncatedTube& operator=(const TruncatedTube& copy) = default;
   };
   
@@ -504,7 +545,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     EllipticalTube() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    EllipticalTube(EllipticalTube&& e) = default;
+    /// Copy Constructor
     EllipticalTube(const EllipticalTube& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> EllipticalTube(const Q* p) : Solid_type<Object>(p) {   }
@@ -526,7 +569,9 @@ namespace dd4hep {
     EllipticalTube(const std::string& nam, const A& a, const B& b, const DZ& dz)
     {  make(nam, _toDouble(a), _toDouble(b), _toDouble(dz));   }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    EllipticalTube& operator=(EllipticalTube&& copy) = default;
+    /// Copy Assignment operator
     EllipticalTube& operator=(const EllipticalTube& copy) = default;
     /// Set the tube dimensions
     EllipticalTube& setDimensions(double a, double b, double dz);
@@ -548,7 +593,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Cone() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Cone(Cone&& e) = default;
+    /// Copy Constructor
     Cone(const Cone& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Cone(const Q* p) : Solid_type<Object>(p) { }
@@ -571,7 +618,9 @@ namespace dd4hep {
     Cone(const std::string& nam, const Z& z, const RMIN1& rmin1, const RMAX1& rmax1, const RMIN2& rmin2, const RMAX2& rmax2)
     {     make(nam, _toDouble(z), _toDouble(rmin1), _toDouble(rmax1), _toDouble(rmin2), _toDouble(rmax2)); }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Cone& operator=(Cone&& copy) = default;
+    /// Copy Assignment operator
     Cone& operator=(const Cone& copy) = default;
     /// Set the box dimensions
     Cone& setDimensions(double z, double rmin1, double rmax1, double rmin2, double rmax2);
@@ -593,7 +642,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Trap() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Trap(Trap&& e) = default;
+    /// Copy Constructor
     Trap(const Trap& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Trap(const Q* p) : Solid_type<Object>(p) { }
@@ -624,7 +675,9 @@ namespace dd4hep {
     Trap(const std::string& nam, PZ pz, PY py, PX px, PLTX pLTX)
     { make(nam, _toDouble(pz),_toDouble(py),_toDouble(px),_toDouble(pLTX)); }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Trap& operator=(Trap&& copy) = default;
+    /// Copy Assignment operator
     Trap& operator=(const Trap& copy) = default;
     /// Set the trap dimensions
     Trap& setDimensions(double z, double theta, double phi,
@@ -648,7 +701,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     PseudoTrap() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    PseudoTrap(PseudoTrap&& e) = default;
+    /// Copy Constructor
     PseudoTrap(const PseudoTrap& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> PseudoTrap(const Q* p) : Solid_type<Object>(p) { }
@@ -666,7 +721,9 @@ namespace dd4hep {
                double radius, bool minusZ)
     {  make(nam, x1, x2, y1, y2, z, radius, minusZ);    }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    PseudoTrap& operator=(PseudoTrap&& copy) = default;
+    /// Copy Assignment operator
     PseudoTrap& operator=(const PseudoTrap& copy) = default;
   };
 
@@ -688,7 +745,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Trd1() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Trd1(Trd1&& e) = default;
+    /// Copy Constructor
     Trd1(const Trd1& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Trd1(const Q* p) : Solid_type<Object>(p) { }
@@ -711,7 +770,9 @@ namespace dd4hep {
     Trd1(const std::string& nam, X1 x1, X2 x2, Y y, Z z)
     { make(nam, _toDouble(x1),_toDouble(x2),_toDouble(y),_toDouble(z)); }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Trd1& operator=(Trd1&& copy) = default;
+    /// Copy Assignment operator
     Trd1& operator=(const Trd1& copy) = default;
     /// Set the Trd1 dimensions
     Trd1& setDimensions(double x1, double x2, double y, double z);
@@ -735,7 +796,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Trd2() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Trd2(Trd2&& e) = default;
+    /// Copy Constructor
     Trd2(const Trd2& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Trd2(const Q* p) : Solid_type<Object>(p) { }
@@ -758,7 +821,9 @@ namespace dd4hep {
     Trd2(const std::string& nam, X1 x1, X2 x2, Y1 y1, Y2 y2, Z z)
     { make(nam, _toDouble(x1),_toDouble(x2),_toDouble(y1),_toDouble(y2),_toDouble(z)); }
 
-    /// Assignment operator
+    /// Copy Assignment operator
+    Trd2& operator=(Trd2&& copy) = default;
+    /// Move Assignment operator
     Trd2& operator=(const Trd2& copy) = default;
     /// Set the Trd2 dimensions
     Trd2& setDimensions(double x1, double x2, double y1, double y2, double z);
@@ -782,7 +847,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Torus() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Torus(Torus&& e) = default;
+    /// Copy Constructor
     Torus(const Torus& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Torus(const Q* p) : Solid_type<Object>(p) { }
@@ -805,7 +872,9 @@ namespace dd4hep {
     Torus(const std::string& nam, double r, double rmin, double rmax, double startPhi=M_PI, double deltaPhi = 2.*M_PI)
     {   make(nam, r, rmin, rmax, startPhi, deltaPhi);  }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Torus& operator=(Torus&& copy) = default;
+    /// Copy Assignment operator
     Torus& operator=(const Torus& copy) = default;
     /// Set the Torus dimensions
     Torus& setDimensions(double r, double rmin, double rmax, double startPhi, double deltaPhi);
@@ -831,7 +900,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Sphere() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Sphere(Sphere&& e) = default;
+    /// Copy Constructor
     Sphere(const Sphere& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Sphere(const Q* p) : Solid_type<Object>(p) { }
@@ -876,7 +947,9 @@ namespace dd4hep {
            _toDouble(startPhi),   _toDouble(endPhi));
     }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Sphere& operator=(Sphere&& copy) = default;
+    /// Copy Assignment operator
     Sphere& operator=(const Sphere& copy) = default;
     /// Set the Sphere dimensions
     Sphere& setDimensions(double rmin,       double rmax,
@@ -900,7 +973,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Paraboloid() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Paraboloid(Paraboloid&& e) = default;
+    /// Copy Constructor
     Paraboloid(const Paraboloid& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Paraboloid(const Q* p) : Solid_type<Object>(p) { }
@@ -923,7 +998,9 @@ namespace dd4hep {
     Paraboloid(const std::string& nam, R_LOW r_low, R_HIGH r_high, DELTA_Z delta_z)
     {  make(nam, _toDouble(r_low), _toDouble(r_high), _toDouble(delta_z));  }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Paraboloid& operator=(Paraboloid&& copy) = default;
+    /// Copy Assignment operator
     Paraboloid& operator=(const Paraboloid& copy) = default;
     /// Set the Paraboloid dimensions
     Paraboloid& setDimensions(double r_low, double r_high, double delta_z);
@@ -945,7 +1022,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Hyperboloid() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Hyperboloid(Hyperboloid&& e) = default;
+    /// Copy Constructor
     Hyperboloid(const Hyperboloid& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Hyperboloid(const Q* p) : Solid_type<Object>(p) {  }
@@ -968,7 +1047,9 @@ namespace dd4hep {
     Hyperboloid(const std::string& nam, RIN rin, STIN stin, ROUT rout, STOUT stout, DZ dz)
     { make(nam, _toDouble(rin), _toDouble(stin), _toDouble(rout), _toDouble(stout), _toDouble(dz));  }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    Hyperboloid& operator=(Hyperboloid&& copy) = default;
+    /// Copy Assignment operator
     Hyperboloid& operator=(const Hyperboloid& copy) = default;
     /// Set the Hyperboloid dimensions
     Hyperboloid& setDimensions(double rin, double stin, double rout, double stout, double dz);
@@ -990,7 +1071,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     PolyhedraRegular() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    PolyhedraRegular(PolyhedraRegular&& e) = default;
+    /// Copy Constructor
     PolyhedraRegular(const PolyhedraRegular& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> PolyhedraRegular(const Q* p) : Solid_type<Object>(p) {  }
@@ -1016,7 +1099,9 @@ namespace dd4hep {
     /// Constructor to create a new object. Phi(start)=0, deltaPhi=2PI, Z-planes a zplanes[0] and zplanes[1]
     PolyhedraRegular(const std::string& nam, int nsides, double rmin, double rmax, double zplanes[2])
     { make(nam, nsides, rmin, rmax, zplanes[0], zplanes[1], 0, 2.0*M_PI);  }
-    /// Assignment operator
+    /// Move Assignment operator
+    PolyhedraRegular& operator=(PolyhedraRegular&& copy) = default;
+    /// Copy Assignment operator
     PolyhedraRegular& operator=(const PolyhedraRegular& copy) = default;
   };
 
@@ -1039,7 +1124,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     Polyhedra() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    Polyhedra(Polyhedra&& e) = default;
+    /// Copy Constructor
     Polyhedra(const Polyhedra& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> Polyhedra(const Q* p) : Solid_type<Object>(p) {  }
@@ -1067,7 +1154,9 @@ namespace dd4hep {
     Polyhedra(const std::string& nam, int nsides, double start, double delta,
               const std::vector<double>& z, const std::vector<double>& rmin, const std::vector<double>& rmax)
     {  make(nam, nsides, start, delta, z, rmin, rmax);   }
-    /// Assignment operator
+    /// Move Assignment operator
+    Polyhedra& operator=(Polyhedra&& copy) = default;
+    /// Copy Assignment operator
     Polyhedra& operator=(const Polyhedra& copy) = default;
   };
 
@@ -1093,7 +1182,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     ExtrudedPolygon() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    ExtrudedPolygon(ExtrudedPolygon&& e) = default;
+    /// Copy Constructor
     ExtrudedPolygon(const ExtrudedPolygon& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> ExtrudedPolygon(const Q* p) : Solid_type<Object>(p) {  }
@@ -1118,7 +1209,9 @@ namespace dd4hep {
                     const std::vector<double> & sec_y,
                     const std::vector<double> & zscale)
     {  make(nam, pt_x, pt_y, sec_z, sec_x, sec_y, zscale);   }
-    /// Assignment operator
+    /// Move Assignment operator
+    ExtrudedPolygon& operator=(ExtrudedPolygon&& copy) = default;
+    /// Copy Assignment operator
     ExtrudedPolygon& operator=(const ExtrudedPolygon& copy) = default;
   };
 
@@ -1138,7 +1231,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     EightPointSolid() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    EightPointSolid(EightPointSolid&& e) = default;
+    /// Copy Constructor
     EightPointSolid(const EightPointSolid& e) = default;
     /// Constructor to be used with an existing object
     template <typename Q> EightPointSolid(const Q* p) : Solid_type<Object>(p) { }
@@ -1153,7 +1248,9 @@ namespace dd4hep {
     EightPointSolid(const std::string& nam, double dz, const double* vertices)
     { make(nam, dz, vertices);   }
 
-    /// Assignment operator
+    /// Move Assignment operator
+    EightPointSolid& operator=(EightPointSolid&& copy) = default;
+    /// Copy Assignment operator
     EightPointSolid& operator=(const EightPointSolid& copy) = default;
   };
 
@@ -1170,14 +1267,18 @@ namespace dd4hep {
   protected:
     /// Default constructor
     BooleanSolid() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    BooleanSolid(BooleanSolid&& b) = default;
+    /// Copy Constructor
     BooleanSolid(const BooleanSolid& b) = default;
       
   public:
     /// Constructor to be used when passing an already created object
     template <typename Q>
     BooleanSolid(const Handle<Q>& e) : Solid_type<Object>(e) { }
-    /// Assignment operator
+    /// Move Assignment operator
+    BooleanSolid& operator=(BooleanSolid&& copy) = default;
+    /// Copy Assignment operator
     BooleanSolid& operator=(const BooleanSolid& copy) = default;
   };
 
@@ -1195,7 +1296,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     SubtractionSolid() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    SubtractionSolid(SubtractionSolid&& e) = default;
+    /// Copy Constructor
     SubtractionSolid(const SubtractionSolid& e) = default;
     /// Constructor to be used when passing an already created object
     template <typename Q> SubtractionSolid(const Handle<Q>& e) : BooleanSolid(e) {  }
@@ -1221,7 +1324,9 @@ namespace dd4hep {
     SubtractionSolid(const std::string& name, const Solid& shape1, const Solid& shape2, const Rotation3D& rot);
     /// Constructor to create a new identified object. Placement by a generic transformation within the mother
     SubtractionSolid(const std::string& name, const Solid& shape1, const Solid& shape2, const Transform3D& pos);
-    /// Assignment operator
+    /// Move Assignment operator
+    SubtractionSolid& operator=(SubtractionSolid&& copy) = default;
+    /// Copy Assignment operator
     SubtractionSolid& operator=(const SubtractionSolid& copy) = default;
   };
 
@@ -1239,7 +1344,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     UnionSolid() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    UnionSolid(UnionSolid&& e) = default;
+    /// Copy Constructor
     UnionSolid(const UnionSolid& e) = default;
     /// Constructor to be used when passing an already created object
     template <typename Q> UnionSolid(const Handle<Q>& e) : BooleanSolid(e) { }
@@ -1265,7 +1372,9 @@ namespace dd4hep {
     UnionSolid(const std::string& name, const Solid& shape1, const Solid& shape2, const Rotation3D& rot);
     /// Constructor to create a new identified object. Placement by a generic transformation within the mother
     UnionSolid(const std::string& name, const Solid& shape1, const Solid& shape2, const Transform3D& pos);
-    /// Assignment operator
+    /// Move Assignment operator
+    UnionSolid& operator=(UnionSolid&& copy) = default;
+    /// Copy Assignment operator
     UnionSolid& operator=(const UnionSolid& copy) = default;
   };
 
@@ -1283,7 +1392,9 @@ namespace dd4hep {
   public:
     /// Default constructor
     IntersectionSolid() = default;
-    /// Constructor to be used when passing an already created object
+    /// Move Constructor
+    IntersectionSolid(IntersectionSolid&& e) = default;
+    /// Copy Constructor
     IntersectionSolid(const IntersectionSolid& e) = default;
     /// Constructor to be used when passing an already created object
     template <typename Q> IntersectionSolid(const Handle<Q>& e) : BooleanSolid(e) { }
@@ -1309,7 +1420,9 @@ namespace dd4hep {
     IntersectionSolid(const std::string& name, const Solid& shape1, const Solid& shape2, const Rotation3D& rot);
     /// Constructor to create a new identified object. Placement by a generic transformation within the mother
     IntersectionSolid(const std::string& name, const Solid& shape1, const Solid& shape2, const Transform3D& pos);
-    /// Assignment operator
+    /// Move Assignment operator
+    IntersectionSolid& operator=(IntersectionSolid&& copy) = default;
+    /// Copy Assignment operator
     IntersectionSolid& operator=(const IntersectionSolid& copy) = default;
   };
 

--- a/DDCore/include/DD4hep/VolumeManager.h
+++ b/DDCore/include/DD4hep/VolumeManager.h
@@ -146,7 +146,7 @@ namespace dd4hep {
      *  Please see enum PopulateFlags for further info.
      *  No action whatsoever is performed here, if the detector element is not valid.
      */
-    VolumeManager(Detector& description,
+    VolumeManager(const Detector& description,
                   const std::string& name,
                   DetElement         world = DetElement(),
                   Readout            ro    = Readout(),
@@ -155,7 +155,7 @@ namespace dd4hep {
     VolumeManager(DetElement subdetector, Readout ro);
 
     /// static accessor calling DD4hepVolumeManagerPlugin if necessary
-    static VolumeManager getVolumeManager(Detector& description);
+    static VolumeManager getVolumeManager(const Detector& description);
 
     /// Assignment operator
     VolumeManager& operator=(const VolumeManager& m) = default;

--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -111,13 +111,21 @@ namespace dd4hep {
     VolIDs volIDs;
     /// Default constructor
     PlacedVolumeExtension();
+    /// Default move
+    PlacedVolumeExtension(PlacedVolumeExtension&& copy);
     /// Copy constructor
     PlacedVolumeExtension(const PlacedVolumeExtension& c);
     /// Default destructor
     virtual ~PlacedVolumeExtension();
+    /// No move assignment
+    PlacedVolumeExtension& operator=(PlacedVolumeExtension&& copy)  {
+      magic  = std::move(copy.magic);
+      volIDs = std::move(copy.volIDs);
+      return *this;
+    }
     /// Assignment operator
     PlacedVolumeExtension& operator=(const PlacedVolumeExtension& c) {
-      magic = c.magic;
+      magic  = c.magic;
       volIDs = c.volIDs;
       return *this;
     }
@@ -163,6 +171,8 @@ namespace dd4hep {
 
     /// Default constructor
     PlacedVolume() = default;
+    /// Move constructor
+    PlacedVolume(PlacedVolume&& e) = default;
     /// Copy assignment
     PlacedVolume(const PlacedVolume& e) = default;
     /// Copy assignment from other handle type
@@ -170,11 +180,14 @@ namespace dd4hep {
     /// Constructor taking implementation object pointer
     PlacedVolume(const TGeoNode* e) : Handle<TGeoNode>(e) {  }
     /// Assignment operator (must match copy constructor)
+    PlacedVolume& operator=(PlacedVolume&& v)  = default;
+    /// Assignment operator (must match copy constructor)
     PlacedVolume& operator=(const PlacedVolume& v)  = default;
+
     /// Check if placement is properly instrumented
     Object* data() const;
-    /// Add identifier
-    PlacedVolume& addPhysVolID(const std::string& name, int value);
+    /// Access the copy number of this placement within its mother
+    int copyNumber() const;
     /// Volume material
     Material material() const;
     /// Logical volume of this placement
@@ -187,6 +200,8 @@ namespace dd4hep {
     Position position()  const;
     /// Access to the volume IDs
     const PlacedVolumeExtension::VolIDs& volIDs() const;
+    /// Add identifier
+    PlacedVolume& addPhysVolID(const std::string& name, int value);
     /// String dump
     std::string toString() const;
   };
@@ -221,10 +236,18 @@ namespace dd4hep {
     /// Reference to the sensitive detector
     Handle<NamedObject> sens_det;
     
-    /// Default constructor
-    VolumeExtension();
     /// Default destructor
     virtual ~VolumeExtension();
+    /// Default constructor
+    VolumeExtension();
+    /// No move
+    VolumeExtension(VolumeExtension&& copy) = delete;
+    /// No copy
+    VolumeExtension(const VolumeExtension& copy) = delete;
+    /// No move assignment
+    VolumeExtension& operator=(VolumeExtension&& copy) = delete;
+    /// No copy assignment
+    VolumeExtension& operator=(const VolumeExtension& copy) = delete;
     /// Copy the object
     void copy(const VolumeExtension& c) {
       magic      = c.magic;
@@ -277,6 +300,8 @@ namespace dd4hep {
   public:
     /// Default constructor
     Volume() = default;
+    /// Move from handle
+    Volume(Volume&& v) = default;
     /// Copy from handle
     Volume(const Volume& v) = default;
     /// Copy from handle
@@ -286,10 +311,17 @@ namespace dd4hep {
 
     /// Constructor to be used when creating a new geometry tree.
     Volume(const std::string& name);
+    /// Constructor to be used when creating a new geometry tree. Sets also title
+    Volume(const std::string& name, const std::string& title);
 
     /// Constructor to be used when creating a new geometry tree. Also sets materuial and solid attributes
     Volume(const std::string& name, const Solid& s, const Material& m);
 
+    /// Constructor to be used when creating a new geometry tree. Also sets materuial and solid attributes
+    Volume(const std::string& name, const std::string& title, const Solid& s, const Material& m);
+
+    /// Assignment operator (must match move constructor)
+    Volume& operator=(Volume&& a)  = default;
     /// Assignment operator (must match copy constructor)
     Volume& operator=(const Volume& a)  = default;
 
@@ -359,6 +391,11 @@ namespace dd4hep {
     /// Test the user flag bit
     bool testFlagBit(unsigned int bit)   const;
     
+    /// Set the volume's option value
+    void setOption(const std::string& opt) const;
+    /// Access the volume's option value
+    std::string option() const;
+
     /// Attach attributes to the volume
     const Volume& setAttributes(const Detector& description, const std::string& region, const std::string& limits,
                                 const std::string& vis) const;

--- a/DDCore/include/XML/config.h
+++ b/DDCore/include/XML/config.h
@@ -26,13 +26,14 @@
 // C/C++ include files
 #include <cstdlib>
 #include <cstdint>
+#include <uchar.h>
 
 #ifndef  __TIXML__
 // This is the absolute minimal include necessary to comply with XercesC
 // Not includuing this file leads to clashes in XmlChar aka XMLCh in XercesC.
 //
 // We do not load here many dependencies. This simply sets up primitive types.
-//#include <xercesc/util/Xerces_autoconf_config.hpp>
+#include <xercesc/util/Xerces_autoconf_config.hpp>
 #endif
 
 /// Namespace for the AIDA detector description toolkit
@@ -48,8 +49,13 @@ namespace dd4hep {
     typedef std::size_t XmlSize_t;
 #ifdef  __TIXML__
     typedef char XmlChar;
+#elif defined(XERCES_XMLCH_T)
+    /// Use the definition from the autoconf header of Xerces:
+    typedef XERCES_XMLCH_T XmlChar;
 #else
-    typedef uint16_t /* XERCES_XMLCH_T */ XmlChar;
+    // These only work for very specific XercesC implementations:
+    typedef char16_t       XmlChar;
+    //typedef unsigned short XmlChar;
 #endif
   }
 }

--- a/DDCore/include/XML/config.h
+++ b/DDCore/include/XML/config.h
@@ -25,13 +25,14 @@
 
 // C/C++ include files
 #include <cstdlib>
+#include <cstdint>
 
 #ifndef  __TIXML__
 // This is the absolute minimal include necessary to comply with XercesC
 // Not includuing this file leads to clashes in XmlChar aka XMLCh in XercesC.
 //
 // We do not load here many dependencies. This simply sets up primitive types.
-#include <xercesc/util/Xerces_autoconf_config.hpp>
+//#include <xercesc/util/Xerces_autoconf_config.hpp>
 #endif
 
 /// Namespace for the AIDA detector description toolkit
@@ -48,7 +49,7 @@ namespace dd4hep {
 #ifdef  __TIXML__
     typedef char XmlChar;
 #else
-    typedef XERCES_XMLCH_T XmlChar;
+    typedef uint16_t /* XERCES_XMLCH_T */ XmlChar;
 #endif
   }
 }

--- a/DDCore/include/XML/config.h
+++ b/DDCore/include/XML/config.h
@@ -49,12 +49,11 @@ namespace dd4hep {
     typedef std::size_t XmlSize_t;
 #ifdef  __TIXML__
     typedef char XmlChar;
-#elif defined(XERCES_XMLCH_T)
+#else
     /// Use the definition from the autoconf header of Xerces:
     typedef XERCES_XMLCH_T XmlChar;
-#else
     // These only work for very specific XercesC implementations:
-    typedef char16_t       XmlChar;
+    //typedef char16_t       XmlChar;
     //typedef unsigned short XmlChar;
 #endif
   }

--- a/DDCore/include/XML/config.h
+++ b/DDCore/include/XML/config.h
@@ -26,7 +26,6 @@
 // C/C++ include files
 #include <cstdlib>
 #include <cstdint>
-#include <uchar.h>
 
 #ifndef  __TIXML__
 // This is the absolute minimal include necessary to comply with XercesC

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -698,7 +698,7 @@ void DetectorImp::dump() const {
 }
 
 /// Manipulate geometry using facroy converter
-long DetectorImp::apply(const char* factory_type, int argc, char** argv) {
+long DetectorImp::apply(const char* factory_type, int argc, char** argv)   const   {
   string fac = factory_type;
   try {
     long result = PluginService::Create<long>(fac, (Detector*) this, argc, argv);

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -701,10 +701,11 @@ void DetectorImp::dump() const {
 long DetectorImp::apply(const char* factory_type, int argc, char** argv)   const   {
   string fac = factory_type;
   try {
-    long result = PluginService::Create<long>(fac, (Detector*) this, argc, argv);
+    Detector* thisPtr = const_cast<DetectorImp*>(this);
+    long result = PluginService::Create<long>(fac, thisPtr, argc, argv);
     if (0 == result) {
       PluginDebug dbg;
-      result = PluginService::Create<long>(fac, (Detector*) this, argc, argv);
+      result = PluginService::Create<long>(fac, thisPtr, argc, argv);
       if ( 0 == result )  {
         throw runtime_error("dd4hep: apply-plugin: Failed to locate plugin " +
                             fac + ". " + dbg.missingFactory(fac));

--- a/DDCore/src/DetectorImp.h
+++ b/DDCore/src/DetectorImp.h
@@ -112,7 +112,7 @@ namespace dd4hep {
     virtual void dump() const  override;
 
     /// Manipulate geometry using facroy converter
-    virtual long apply(const char* factory, int argc, char** argv)  override;
+    virtual long apply(const char* factory, int argc, char** argv)  const  override;
 
     /// Open the geometry at startup.
     virtual void init()  override;

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -78,7 +78,7 @@ namespace {
           pars.emplace_back(sh->GetYOffset(i));
           pars.emplace_back(sh->GetScale(i));
         }
-        return move(pars);
+        return pars;
       }
       else if (shape->IsA() == TGeoPgon::Class()) {
         const TGeoPgon* sh = (const TGeoPgon*) shape;
@@ -88,7 +88,7 @@ namespace {
           pars.emplace_back(sh->GetRmin(i));
           pars.emplace_back(sh->GetRmax(i));
         }
-        return move(pars);
+        return pars;
       }
       else if (shape->IsA() == TGeoPcon::Class()) {
         const TGeoPcon* sh = (const TGeoPcon*) shape;
@@ -98,7 +98,7 @@ namespace {
           pars.emplace_back(sh->GetRmin(i));
           pars.emplace_back(sh->GetRmax(i));
         }
-        return move(pars);
+        return pars;
       }
       else if (shape->IsA() == TGeoCone::Class()) {
         const TGeoCone* sh = (const TGeoCone*) shape;
@@ -133,7 +133,7 @@ namespace {
           pars.emplace_back(vertices[i*2]);
           pars.emplace_back(vertices[i*2]+1);
         }
-        return move(pars);
+        return pars;
       }
       else if (shape->IsA() == TGeoCompositeShape::Class()) {
         const TGeoCompositeShape* sh = (const TGeoCompositeShape*) shape;
@@ -159,7 +159,7 @@ namespace {
         pars.insert(pars.end(), right_par.begin(), right_par.end());
         pars.insert(pars.end(), right_rot, right_rot+9);
         pars.insert(pars.end(), right_tr, right_tr+3);
-        return move(pars);
+        return pars;
       }
       else  {
         printout(ERROR,"Solid","Failed to access dimensions for shape of type:%s.",

--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -63,19 +63,19 @@ namespace dd4hep {
       typedef PlacedVolume::VolIDs     VolIDs;
       typedef pair<VolumeID, VolumeID> Encoding;
       /// Reference to the Detector instance
-      Detector&     m_detDesc;
+      const Detector& m_detDesc;
       /// Reference to the volume manager to be populated
-      VolumeManager m_volManager;
+      VolumeManager   m_volManager;
       /// Set of already added entries
-      set<VolumeID> m_entries;
+      set<VolumeID>   m_entries;
       /// Debug flag
-      bool          m_debug    = false;
+      bool            m_debug    = false;
       /// Node counter
-      size_t        m_numNodes = 0;
+      size_t          m_numNodes = 0;
 
     public:
       /// Default constructor
-      VolumeManager_Populator(Detector& description, VolumeManager vm)
+      VolumeManager_Populator(const Detector& description, VolumeManager vm)
         : m_detDesc(description), m_volManager(vm)
       {
         m_debug = (0 != ::getenv("DD4HEP_VOLMGR_DEBUG"));
@@ -343,7 +343,7 @@ const TGeoHMatrix& VolumeManagerContext::toElement()  const   {
 }
 
 /// Initializing constructor to create a new object
-VolumeManager::VolumeManager(Detector& description, const string& nam, DetElement elt, Readout ro, int flags) {
+VolumeManager::VolumeManager(const Detector& description, const string& nam, DetElement elt, Readout ro, int flags) {
   printout(INFO, "VolumeManager", " - populating volume ids - be patient ..."  );
   size_t node_count = 0;
   Object* obj_ptr = new Object();
@@ -368,7 +368,7 @@ VolumeManager::VolumeManager(DetElement sub_detector, Readout ro)  {
   assign(obj_ptr, sub_detector.name(), "VolumeManager");
 }
 
-VolumeManager VolumeManager::getVolumeManager(Detector& description) {
+VolumeManager VolumeManager::getVolumeManager(const Detector& description) {
   if( not description.volumeManager().isValid() ) {
     description.apply("DD4hepVolumeManager", 0, 0);
   }

--- a/DDCore/src/XML/XMLElements.cpp
+++ b/DDCore/src/XML/XMLElements.cpp
@@ -12,6 +12,18 @@
 //==========================================================================
 
 // Framework include files
+#ifdef DD4HEP_USE_TINYXML
+#include "XML/tinyxml.h"
+#else
+#include <xercesc/util/Xerces_autoconf_config.hpp>
+#include "xercesc/util/XMLString.hpp"
+#include "xercesc/dom/DOMElement.hpp"
+#include "xercesc/dom/DOMDocument.hpp"
+#include "xercesc/dom/DOMNodeList.hpp"
+#include "xercesc/dom/DOM.hpp"
+#include "XML/config.h"
+#endif
+
 #include "XML/Evaluator.h"
 #include "XML/XMLElements.h"
 #include "XML/Printout.h"
@@ -53,7 +65,6 @@ namespace {
 #define _XE(x)  Xml(x).xe
 
 #ifdef DD4HEP_USE_TINYXML
-#include "XML/tinyxml.h"
 #define ELEMENT_NODE_TYPE TiXmlNode::ELEMENT
 #define getTagName          Value
 #define getTextContent      GetText
@@ -108,11 +119,6 @@ size_t dd4hep::xml::XmlString::length(const char* p)  {
 }
 
 #else
-#include "xercesc/util/XMLString.hpp"
-#include "xercesc/dom/DOMElement.hpp"
-#include "xercesc/dom/DOMDocument.hpp"
-#include "xercesc/dom/DOMNodeList.hpp"
-#include "xercesc/dom/DOM.hpp"
 #define ELEMENT_NODE_TYPE xercesc::DOMNode::ELEMENT_NODE
 
 /// Union to ease castless object access when using XercesC

--- a/DDG4/include/DDG4/Geant4AssemblyVolume.h
+++ b/DDG4/include/DDG4/Geant4AssemblyVolume.h
@@ -49,7 +49,7 @@ namespace dd4hep {
       }
 
       /// Default destructor
-      virtual ~Geant4AssemblyVolume() {
+      ~Geant4AssemblyVolume()   {
       }
 
       //std::vector<G4AssemblyTriplet>& triplets()  { return fTriplets; }

--- a/DDG4/include/DDG4/Geant4Converter.h
+++ b/DDG4/include/DDG4/Geant4Converter.h
@@ -57,10 +57,10 @@ namespace dd4hep {
       PrintLevel outputLevel;
 
       /// Initializing Constructor
-      Geant4Converter(Detector& description);
+      Geant4Converter(const Detector& description);
 
       /// Initializing Constructor
-      Geant4Converter(Detector& description, PrintLevel level);
+      Geant4Converter(const Detector& description, PrintLevel level);
 
       /// Standard destructor
       virtual ~Geant4Converter();

--- a/DDG4/include/DDG4/Geant4Mapping.h
+++ b/DDG4/include/DDG4/Geant4Mapping.h
@@ -34,14 +34,14 @@ namespace dd4hep {
      */
     class Geant4Mapping: public detail::GeoHandlerTypes {
     protected:
-      Detector& m_detDesc;
+      const Detector& m_detDesc;
       Geant4GeometryInfo* m_dataPtr;
 
       /// When resolving pointers, we must check for the validity of the data block
       void checkValidity() const;
     public:
       /// Initializing Constructor
-      Geant4Mapping(Detector& description);
+      Geant4Mapping(const Detector& description);
 
       /// Standard destructor
       virtual ~Geant4Mapping();
@@ -50,7 +50,7 @@ namespace dd4hep {
       static Geant4Mapping& instance();
 
       /// Accesor to the Detector instance
-      Detector& detectorDescription() const {
+      const Detector& detectorDescription() const {
         return m_detDesc;
       }
 

--- a/DDG4/include/DDG4/Geant4VolumeManager.h
+++ b/DDG4/include/DDG4/Geant4VolumeManager.h
@@ -53,7 +53,7 @@ namespace dd4hep {
       static const VolumeID NonExisting = 0ULL;
 
       /// Initializing constructor. The tree will automatically be built if possible
-      Geant4VolumeManager(Detector& description, Geant4GeometryInfo* info);
+      Geant4VolumeManager(const Detector& description, Geant4GeometryInfo* info);
       /// Default constructor
       Geant4VolumeManager() = default;
       /// Constructor to be used when reading the already parsed object

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -269,7 +269,7 @@ namespace {
 }
 
 /// Initializing Constructor
-Geant4Converter::Geant4Converter(Detector& description_ref)
+Geant4Converter::Geant4Converter(const Detector& description_ref)
   : Geant4Mapping(description_ref), checkOverlaps(true) {
   this->Geant4Mapping::init();
   m_propagateRegions = true;
@@ -277,7 +277,7 @@ Geant4Converter::Geant4Converter(Detector& description_ref)
 }
 
 /// Initializing Constructor
-Geant4Converter::Geant4Converter(Detector& description_ref, PrintLevel level)
+Geant4Converter::Geant4Converter(const Detector& description_ref, PrintLevel level)
   : Geant4Mapping(description_ref), checkOverlaps(true) {
   this->Geant4Mapping::init();
   m_propagateRegions = true;

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -1042,7 +1042,8 @@ void Geant4Converter::handleProperties(Detector::Properties& prp) const {
     const Detector::PropertyValues& vals = prp[nam];
     string type = vals.find("type")->second;
     string tag = type + "_Geant4_action";
-    long result = PluginService::Create<long>(tag, &m_detDesc, hdlr, &vals);
+    Detector* detPtr = const_cast<Detector*>(&m_detDesc);
+    long result = PluginService::Create<long>(tag, detPtr, hdlr, &vals);
     if (0 == result) {
       throw runtime_error("Failed to locate plugin to interprete files of type"
                           " \"" + tag + "\" - no factory:" + type);

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -197,7 +197,7 @@ void Geant4AssemblyVolume::imprint(Geant4GeometryInfo& info,
 
       // Register the physical volume created by us so we can delete it later
       //
-      fPVStore.push_back( pvPlaced.first );
+      //fPVStore.push_back( pvPlaced.first );
       info.g4VolumeImprints[vol].push_back(make_pair(new_chain,pvPlaced.first));
 #if 0
       cout << " Assembly:Parent:" << parent->GetName() << " " << node->GetName()

--- a/DDG4/src/Geant4Mapping.cpp
+++ b/DDG4/src/Geant4Mapping.cpp
@@ -24,7 +24,7 @@ using namespace dd4hep;
 using namespace std;
 
 /// Initializing Constructor
-Geant4Mapping::Geant4Mapping(Detector& description_ref)
+Geant4Mapping::Geant4Mapping(const Detector& description_ref)
   : m_detDesc(description_ref), m_dataPtr(0) {
 }
 
@@ -73,7 +73,7 @@ void Geant4Mapping::attach(Geant4GeometryInfo* data_ptr) {
 Geant4VolumeManager Geant4Mapping::volumeManager() const {
   if ( m_dataPtr ) {
     if ( m_dataPtr->g4Paths.empty() ) {
-      VolumeManager::getVolumeManager(m_detDesc);
+      //VolumeManager::getVolumeManager(m_detDesc);
       return Geant4VolumeManager(m_detDesc, m_dataPtr);
     }
     return Geant4VolumeManager(Handle < Geant4GeometryInfo > (m_dataPtr));

--- a/DDG4/src/Geant4VolumeManager.cpp
+++ b/DDG4/src/Geant4VolumeManager.cpp
@@ -44,14 +44,14 @@ namespace {
     typedef vector<const TGeoNode*> Chain;
     typedef map<VolumeID,Geant4GeometryInfo::Geant4PlacementPath> Registries;
     /// Reference to the Detector instance
-    Detector& m_detDesc;
+    const Detector& m_detDesc;
     /// Set of already added entries
     Registries m_entries;
     /// Reference to Geant4 translation information
     Geant4GeometryInfo& m_geo;
 
     /// Default constructor
-    Populator(Detector& description, Geant4GeometryInfo& g)
+    Populator(const Detector& description, Geant4GeometryInfo& g)
       : m_detDesc(description), m_geo(g) {
     }
 
@@ -185,7 +185,7 @@ namespace {
 }
 
 /// Initializing constructor. The tree will automatically be built if possible
-Geant4VolumeManager::Geant4VolumeManager(Detector& description, Geant4GeometryInfo* info)
+Geant4VolumeManager::Geant4VolumeManager(const Detector& description, Geant4GeometryInfo* info)
   : Handle<Geant4GeometryInfo>(info), m_isValid(false) {
   if (info && info->valid && info->g4Paths.empty()) {
     Populator p(description, *info);

--- a/examples/Conditions/src/ConditionExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionExampleObjects.cpp
@@ -114,16 +114,13 @@ void ConditionUpdate3::resolve(Condition target, ConditionUpdateContext& context
 ConditionsDependencyCreator::ConditionsDependencyCreator(ConditionsContent& c, PrintLevel p)
   : OutputLevel(p), content(c)
 {
-  call1 = new ConditionUpdate1(printLevel);
-  call2 = new ConditionUpdate2(printLevel);
-  call3 = new ConditionUpdate3(printLevel);
+  call1 = std::shared_ptr<ConditionUpdateCall>(new ConditionUpdate1(printLevel));
+  call2 = std::shared_ptr<ConditionUpdateCall>(new ConditionUpdate2(printLevel));
+  call3 = std::shared_ptr<ConditionUpdateCall>(new ConditionUpdate3(printLevel));
 }
 
 /// Destructor
 ConditionsDependencyCreator::~ConditionsDependencyCreator()  {
-  detail::releasePtr(call1);
-  detail::releasePtr(call2);
-  detail::releasePtr(call3);
 }
 
 /// Callback to process a single detector element
@@ -132,12 +129,12 @@ int ConditionsDependencyCreator::operator()(DetElement de, int)  const  {
   ConditionKey      target1(de,"derived_data/derived_1");
   ConditionKey      target2(de,"derived_data/derived_2");
   ConditionKey      target3(de,"derived_data/derived_3");
-  DependencyBuilder build_1(de, target1.item_key(), call1->addRef());
-  DependencyBuilder build_2(de, target2.item_key(), call2->addRef());
-  DependencyBuilder build_3(de, target3.item_key(), call3->addRef());
-  //DependencyBuilder build_1(de, "derived_data/derived_1", call1->addRef());
-  //DependencyBuilder build_2(de, "derived_data/derived_2", call2->addRef());
-  //DependencyBuilder build_3(de, "derived_data/derived_3", call3->addRef());
+  DependencyBuilder build_1(de, target1.item_key(), call1);
+  DependencyBuilder build_2(de, target2.item_key(), call2);
+  DependencyBuilder build_3(de, target3.item_key(), call3);
+  //DependencyBuilder build_1(de, "derived_data/derived_1", call1);
+  //DependencyBuilder build_2(de, "derived_data/derived_2", call2);
+  //DependencyBuilder build_3(de, "derived_data/derived_3", call3);
 
   // Compute the derived stuff
   build_1.add(key);

--- a/examples/Conditions/src/ConditionExampleObjects.h
+++ b/examples/Conditions/src/ConditionExampleObjects.h
@@ -148,7 +148,7 @@ namespace dd4hep {
       /// Content object to be filled
       ConditionsContent&   content;
       /// Three different update call types
-      ConditionUpdateCall *call1, *call2, *call3;
+      std::shared_ptr<ConditionUpdateCall> call1, call2, call3;
       /// Constructor
       ConditionsDependencyCreator(ConditionsContent& c, PrintLevel p);
       /// Destructor

--- a/examples/DDDB/src/plugins/DDDBDerivedCondTest.cpp
+++ b/examples/DDDB/src/plugins/DDDBDerivedCondTest.cpp
@@ -283,9 +283,9 @@ namespace  {
                 ConditionKey target1(de,cond->name+"/derived_1");
                 ConditionKey target2(de,cond->name+"/derived_2");
                 ConditionKey target3(de,cond->name+"/derived_3");
-                DependencyBuilder build_1(de, cond->name+"/derived_1", new ConditionUpdate1(m_context));
-                DependencyBuilder build_2(de, cond->name+"/derived_2", new ConditionUpdate2(m_context));
-                DependencyBuilder build_3(de, cond->name+"/derived_3", new ConditionUpdate3(m_context));
+                DependencyBuilder build_1(de, cond->name+"/derived_1", make_shared<ConditionUpdate1>(m_context));
+                DependencyBuilder build_2(de, cond->name+"/derived_2", make_shared<ConditionUpdate2>(m_context));
+                DependencyBuilder build_3(de, cond->name+"/derived_3", make_shared<ConditionUpdate3>(m_context));
                 build_1.add(key);
 
                 build_2.add(key);

--- a/examples/DDDB/src/plugins/DeVeloServiceTest.cpp
+++ b/examples/DDDB/src/plugins/DeVeloServiceTest.cpp
@@ -118,12 +118,12 @@ namespace {
         dd4hep::DetectorScanner(dd4hep::detElementsCollector(elts), m_de);    
         dd4hep::cond::DependencyBuilder align_builder(dsc.world(),
                                                       Keys::alignmentsComputedKey,
-                                                      new DeAlignmentCall(m_de));
+                                                      make_shared<DeAlignmentCall>(m_de));
         auto* dep = align_builder.release();
         dep->target.hash = Keys::alignmentsComputedKey;
         m_service->addContent(content, dep);
 
-        std::unique_ptr<DeVeloStaticConditionCall> static_update(new DeVeloStaticConditionCall());
+        auto static_update = make_shared<DeVeloStaticConditionCall>();
         for(const auto& e : elts)   {
           dd4hep::DetElement de = e.first;
           dd4hep::DDDB::DDDBCatalog* cat = de.extension<dd4hep::DDDB::DDDBCatalog>();
@@ -147,16 +147,15 @@ namespace {
             }
           }
 
-          dd4hep::cond::DependencyBuilder static_builder(de, Keys::staticKey, static_update->addRef());
+          dd4hep::cond::DependencyBuilder static_builder(de, Keys::staticKey, static_update);
           m_service->addContent(content, static_builder.release());
 
-          dd4hep::cond::ConditionUpdateCall* call = (e.first == m_de)
-            ? new DeVeloConditionCall(de, cat, m_context.get())
-            : new DeVeloIOVConditionCall(de, cat, m_context.get());
+          shared_ptr<dd4hep::cond::ConditionUpdateCall> call = ( e.first == m_de )
+            ? make_shared<DeVeloConditionCall>(de, cat, m_context.get())
+            : make_shared<DeVeloIOVConditionCall>(de, cat, m_context.get());
           dd4hep::cond::DependencyBuilder iov_builder(de, Keys::deKey, call);
           m_service->addContent(content, iov_builder.release());
         }
-        static_update.release()->release();
         m_service->closeContent(content);
         manager.clear();
       }


### PR DESCRIPTION

BEGINRELEASENOTES
-  Use shared_ptr instead of home made ref counting for ConditionUpdateCalls
-  Implement construction parameter access for solids. 
   This one is a bit tricky: Some shapes (ShapeAssembly, Boolean shapes) had no such parameters.
    Added them as the sequence of the basic shape parameters + the corresponding matrices.
    To be seen.
-  Add move constructors to handles 
-  Improve const-ness of detector object in DDG4 
ENDRELEASENOTES