### PR TITLE
Update macros check for powerpc

### DIFF
--- a/DDCore/src/Primitives.cpp
+++ b/DDCore/src/Primitives.cpp
@@ -25,7 +25,7 @@
 #include <cstring>
 #include <map>
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__powerpc64__)
 #include <cxxabi.h>
 #ifndef __APPLE__
 typedef abi::__class_type_info class_t;


### PR DESCRIPTION
We currently apply a patch https://github.com/cms-sw/cmsdist/blob/c1e2d7ab02f957e01e7325ecf1259eb8f06b0e8d/dd4hep-add-ppc64-macro-check.patch so that we get into that condition and include that header when building on ppc64. So if it's reasonable I propose to get this in

BEGINRELEASENOTES
- Added powerpc macros check to include header cxxabi.h

ENDRELEASENOTES