### PR TITLE
Add Higgs PDG code 25 to rejected codes for DDSim simulation

### DIFF
--- a/DDG4/python/DDSim/Helper/Physics.py
+++ b/DDG4/python/DDSim/Helper/Physics.py
@@ -13,7 +13,7 @@ class Physics( ConfigHelper ):
     self.list ="FTFP_BERT"
     self.decays = True
     self._pdgfile = None
-    self._rejectPDGs = {1,2,3,4,5,6,21,23,24}
+    self._rejectPDGs = {1,2,3,4,5,6,21,23,24,25}
 
   @property
   def rejectPDGs( self ):


### PR DESCRIPTION
If you had Higgs decays and you were using DDSim you got the error

```
ParticleHandler  ERROR +++ ERROR: Geant4 particle for track:1 last known is:1 -- is gluon or quark!
ParticleHandler  ERROR +++ ERROR(2): Geant4 particle for track:1 last known is:1 -- is gluon or quark!
```
this is due to missing PDG code of the Higgs in the rejectPDGs

BEGINRELEASENOTES
- Add Higgs PDG code 25 to rejected codes for DDSim simulation

ENDRELEASENOTES