### PR TITLE
Add properties to Geant4GDMLWriteAction

### DIFF
--- a/DDG4/include/DDG4/Geant4UIManager.h
+++ b/DDG4/include/DDG4/Geant4UIManager.h
@@ -60,6 +60,8 @@ namespace dd4hep {
       std::string m_visSetup;
       /// Property: Array of macro files to be chained
       std::vector<std::string> m_commands;
+      /// Property: Array of macro files to be chained and executed AFTER running
+      std::vector<std::string> m_postRunCommands;
       /// Property: Array of commands to be chained
       std::vector<std::string> m_macros;
       /// Property: New prompt if the user wants to change it. (Default is do nothing)

--- a/DDG4/plugins/Geant4GDMLWriteAction.cpp
+++ b/DDG4/plugins/Geant4GDMLWriteAction.cpp
@@ -144,7 +144,7 @@ void Geant4GDMLWriteAction::writeGDML()   {
   unique_ptr<G4GDMLParser> parser(new G4GDMLParser());
   parser->SetRegionExport(m_exportRegions != 0);
   parser->SetEnergyCutsExport(m_exportEnergyCuts != 0);
-#if G4VERSION_NUMBER>=1020
+#if G4VERSION_NUMBER>=1030
   parser->SetSDExport(m_exportSensitiveDetectors != 0);
 #endif
   info("+++ Writing GDML file: %s", m_output.c_str());

--- a/DDG4/plugins/Geant4GDMLWriteAction.cpp
+++ b/DDG4/plugins/Geant4GDMLWriteAction.cpp
@@ -90,6 +90,7 @@ namespace dd4hep {
 
 // Geant 4 includes
 #include "G4GDMLParser.hh"
+#include "G4Version.hh"
 
 // C/C++ include files
 #include <sys/types.h>
@@ -143,7 +144,9 @@ void Geant4GDMLWriteAction::writeGDML()   {
   unique_ptr<G4GDMLParser> parser(new G4GDMLParser());
   parser->SetRegionExport(m_exportRegions != 0);
   parser->SetEnergyCutsExport(m_exportEnergyCuts != 0);
+#if G4VERSION_NUMBER>=1020
   parser->SetSDExport(m_exportSensitiveDetectors != 0);
+#endif
   info("+++ Writing GDML file: %s", m_output.c_str());
   parser->Write(m_output, context()->world());
 }

--- a/DDG4/src/Geant4UIManager.cpp
+++ b/DDG4/src/Geant4UIManager.cpp
@@ -152,14 +152,8 @@ void Geant4UIManager::start() {
     context()->kernel().runManager().BeamOn(numEvent);
   } catch (DD4hep_End_Of_File& e) {
     printout(INFO,"Geant4UIManager","++ End of file reached, ending run...");
+    context()->kernel().runManager().RunTermination();
   }
-  // Execute the chained command statements
-  for(const auto& c : m_postRunCommands)  {
-    printout(INFO,"Geant4UIManager","++ Executing Command statement:%s",c.c_str());
-    mgr->ApplyCommand(c.c_str());
-    executed_statements = true;
-  }
-  context()->kernel().runManager().RunTermination();
 }
 
 /// Stop and release resources

--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -119,12 +119,12 @@ if (DD4HEP_USE_GEANT4)
   endforeach(script)
   #
   # Write GDML from Geant4 using UI
-  #dd4hep_add_test_reg( CLICSiD_DDG4_GDML_LONGTEST
-  #    COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  #    EXEC_ARGS  python ${CLICSiDEx_INSTALL}/scripts/CLIC_GDML.py
-  #    REQUIRES   DDG4 Geant4
-  #    REGEX_PASS "G4GDML. Writing 'CLICSiD.gdml' done !"
-  #    REGEX_FAIL "Exception;EXCEPTION;ERROR" )
+  dd4hep_add_test_reg( CLICSiD_DDG4_GDML_LONGTEST
+      COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
+      EXEC_ARGS  python ${CLICSiDEx_INSTALL}/scripts/CLIC_GDML.py
+      REQUIRES   DDG4 Geant4
+      REGEX_PASS "G4GDML. Writing 'CLICSiD.gdml' done !"
+      REGEX_FAIL "Exception;EXCEPTION;ERROR" )
   #
   # Material scan
   dd4hep_add_test_reg( CLICSiD_DDG4_g4material_scan_LONGTEST

--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -119,12 +119,12 @@ if (DD4HEP_USE_GEANT4)
   endforeach(script)
   #
   # Write GDML from Geant4 using UI
-  dd4hep_add_test_reg( CLICSiD_DDG4_GDML_LONGTEST
-      COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-      EXEC_ARGS  python ${CLICSiDEx_INSTALL}/scripts/CLIC_GDML.py
-      REQUIRES   DDG4 Geant4
-      REGEX_PASS "G4GDML. Writing 'CLICSiD.gdml' done !"
-      REGEX_FAIL "Exception;EXCEPTION;ERROR" )
+  #dd4hep_add_test_reg( CLICSiD_DDG4_GDML_LONGTEST
+  #    COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
+  #    EXEC_ARGS  python ${CLICSiDEx_INSTALL}/scripts/CLIC_GDML.py
+  #    REQUIRES   DDG4 Geant4
+  #    REGEX_PASS "G4GDML. Writing 'CLICSiD.gdml' done !"
+  #    REGEX_FAIL "Exception;EXCEPTION;ERROR" )
   #
   # Material scan
   dd4hep_add_test_reg( CLICSiD_DDG4_g4material_scan_LONGTEST

--- a/examples/CLICSiD/scripts/CLIC_G4Gun.py
+++ b/examples/CLICSiD/scripts/CLIC_G4Gun.py
@@ -40,7 +40,6 @@ def run():
   merger.enableUI()
   kernel.generatorAction().adopt(merger)
 
-
   # And handle the simulation particles.
   part = DDG4.GeneratorAction(kernel,"Geant4ParticleHandler/ParticleHandler")
   kernel.generatorAction().adopt(part)
@@ -52,11 +51,6 @@ def run():
   user.enableUI()
   part.adopt(user)
   #
-  # Setup the GDML writer action
-  writer = DDG4.Action(kernel,'Geant4GDMLWriteAction/Writer')
-  writer.enableUI()
-  kernel.registerGlobalAction(writer)
-
   sid.setupDetectors()
   sid.setupPhysics('QGSP_BERT')
   sid.test_config()

--- a/examples/CLICSiD/scripts/CLIC_G4Gun.py
+++ b/examples/CLICSiD/scripts/CLIC_G4Gun.py
@@ -51,6 +51,11 @@ def run():
   user.TrackingVolume_Rmax = DDG4.EcalBarrel_rmin
   user.enableUI()
   part.adopt(user)
+  #
+  # Setup the GDML writer action
+  writer = DDG4.Action(kernel,'Geant4GDMLWriteAction/Writer')
+  writer.enableUI()
+  kernel.registerGlobalAction(writer)
 
   sid.setupDetectors()
   sid.setupPhysics('QGSP_BERT')

--- a/examples/CLICSiD/scripts/CLIC_GDML.py
+++ b/examples/CLICSiD/scripts/CLIC_GDML.py
@@ -7,6 +7,7 @@
 
 """
 def run():
+  from g4units import *
   import logging, CLICSid, DDG4
   from DDG4 import OutputLevel as Output
   
@@ -22,15 +23,29 @@ def run():
   writer = DDG4.Action(kernel,'Geant4GDMLWriteAction/Writer')
   writer.enableUI()
   kernel.registerGlobalAction(writer)
+  sid.setupPhysics('QGSP_BERT')
   #
+  gen = sid.geant4.setupGun('Gun','pi-',10*GeV,Standalone=True)
   # Now initialize. At the Geant4 command prompt we can write the geometry:
   # Idle> /ddg4/Writer/write
-  # or by configuring the UI: 
+  # or by configuring the UI using ui.Commands
+  #
+  # Please note: The Geant4 physics list must be initialized BEFORE
+  # invoking the writer with options. Otherwise the particle definitions
+  # are missing!
+  # If you ONLY want to dump the geometry to GDML you must call
+  # /run/beamOn 0
+  # before writing the GDML file!
+  # You also need to setup a minimal generation action like:
+  # sid.geant4.setupGun('Gun','pi-',10*GeV,Standalone=True)
+  #
   ui.Commands = [
+    '/run/beamOn 0',
     '/ddg4/Writer/Output CLICSiD.gdml',
     '/ddg4/Writer/OverWrite 1',
     '/ddg4/Writer/write'
     ]
+  kernel.NumEvents = 0
   kernel.configure()
   kernel.initialize()
   kernel.run()


### PR DESCRIPTION
Add properties to Geant4GDMLWriteAction to steer writing of regions, cuts and sensitive detectors. Resolves #507.

BEGINRELEASENOTES
* Geant4GDMLWriteAction:
  * Add properties to Geant4GDMLWriteAction to steer writing of regions, cuts and sensitive detectors. See github issue #507
    * Property: Export region information to the GDML: ExportRegions, default: True
    * Property: Export energy cut information to the GDML: ExportEnergyCuts, default: True
    * Property: Export sensitive detector information to the GDML: ExportSensitiveDetectors, default: True
  * **Note: The Geant4 physics list must be initialized BEFORE invoking the writer with options. Otherwise the particle definitions are missing! If you ONLY want to dump the geometry to GDML you must call**
    ```
       /run/beamOn 0
    ```
    before writing the GDML file!
    You also need to setup a minimal generation action like:
     ```py
     sid.geant4.setupGun('Gun','pi-',10*GeV,Standalone=True)
     ```
ENDRELEASENOTES