### PR TITLE
Remove Too Many Decays

### DIFF
--- a/DDG4/plugins/Geant4ExtraParticles.cpp
+++ b/DDG4/plugins/Geant4ExtraParticles.cpp
@@ -154,10 +154,8 @@ void Geant4ExtraParticles::constructProcess(Constructor& ctor) {
       if (pdef->GetPDGCharge() != 0) {
         pmgr->AddProcess(new G4hMultipleScattering(), -1,  1, 1); //multiple scattering
         pmgr->AddProcess(new G4hIonisation(),  -1,  2, 2); // ionisation
-        pmgr->AddProcess(new G4Decay(),   -1, -1, 2); // decay 
       } else {
-        //	pmgr->AddProcess(new G4hMultipleScattering(), -1,  1, 1); // multiple scattering
-        pmgr->AddProcess(new G4Decay(),   -1, -1, 2); // decay 
+        //nothing to do
       }
     }
   }

--- a/DDG4/plugins/Geant4ExtraParticles.cpp
+++ b/DDG4/plugins/Geant4ExtraParticles.cpp
@@ -28,32 +28,20 @@
 #include "G4PhysicalConstants.hh"
 #include "G4Version.hh"
 
-#include "DDG4/Factories.h"
 #include <fstream>
 #include <sstream>
 #include <string>
 
-
-#include "G4RunManager.hh"
-
 using namespace dd4hep::sim;
 
 Geant4ExtraParticles::Geant4ExtraParticles(Geant4Context* ctxt, const std::string& nam)
-  : Geant4PhysicsConstructor(ctxt, nam), m_decay(0), m_ionise(0), m_scatter(0)
+  : Geant4PhysicsConstructor(ctxt, nam)
 {
   declareProperty("pdgfile", m_pdgfile);
 }
 
-Geant4ExtraParticles::~Geant4ExtraParticles()   {
-  detail::deletePtr(m_decay);
-  detail::deletePtr(m_ionise);
-  detail::deletePtr(m_scatter);
-}
+Geant4ExtraParticles::~Geant4ExtraParticles() {}
 
-// bool Geant4ExtraParticles::FileExists() {
-//   std::ifstream pdgFile( m_pdgfile.c_str(), std::ifstream::in );
-//   return pdgFile.is_open();
-// }
 
 void Geant4ExtraParticles::constructParticle(Constructor& ) {
   if (m_pdgfile.empty()) return;
@@ -159,36 +147,17 @@ void Geant4ExtraParticles::constructParticle(Constructor& ) {
 
 void Geant4ExtraParticles::constructProcess(Constructor& ctor) {
   G4ParticleTable::G4PTblDicIterator* ParticleIterator = ctor.particleIterator();
-#if G4VERSION_NUMBER < 940
-  if ( 0 == _scatter ) _scatter=new G4hMultipleScattering();
-  if ( 0 == _ionise ) _ionise=new G4hIonisation()
-  if ( 0 == _decay ) _decay=new G4Decay()
-#endif
   while((*ParticleIterator)()) {
     G4ParticleDefinition* pdef = ParticleIterator->value();
     G4ProcessManager* pmgr = pdef->GetProcessManager();
     if (pdef->GetParticleType() == "extra") {
       if (pdef->GetPDGCharge() != 0) {
-#if G4VERSION_NUMBER < 940
-        pmgr->AddProcess(_scatter, -1,  1, 1); // multiple scattering
-        pmgr->AddProcess(_ionise,  -1,  2, 2); // ionisation
-        pmgr->AddProcess(_decay,   -1, -1, 2); // decay
-#else
         pmgr->AddProcess(new G4hMultipleScattering(), -1,  1, 1); //multiple scattering
         pmgr->AddProcess(new G4hIonisation(),  -1,  2, 2); // ionisation
         pmgr->AddProcess(new G4Decay(),   -1, -1, 2); // decay 
-#endif
-
       } else {
-
-#if G4VERSION_NUMBER < 940
-        pmgr->AddProcess(_scatter=new G4hMultipleScattering(), -1,  1, 1); // multiple scattering
-        pmgr->AddProcess(_decay=new G4Decay(),   -1, -1, 2); // decay
-#else
         //	pmgr->AddProcess(new G4hMultipleScattering(), -1,  1, 1); // multiple scattering
         pmgr->AddProcess(new G4Decay(),   -1, -1, 2); // decay 
-#endif
-
       }
     }
   }

--- a/DDG4/plugins/Geant4ExtraParticles.h
+++ b/DDG4/plugins/Geant4ExtraParticles.h
@@ -40,9 +40,6 @@ namespace dd4hep {
 
     private:
       std::string m_pdgfile;    
-      G4Decay* m_decay; 	 
-      G4hIonisation* m_ionise; 	 
-      G4hMultipleScattering* m_scatter;
     };
   }
 }

--- a/DDG4/python/DDSim/Helper/Physics.py
+++ b/DDG4/python/DDSim/Helper/Physics.py
@@ -11,7 +11,7 @@ class Physics( ConfigHelper ):
     super(Physics, self).__init__()
     self._rangecut = 0.7*mm
     self.list ="FTFP_BERT"
-    self.decays = True
+    self._decays = False
     self._pdgfile = None
     self._rejectPDGs = {1,2,3,4,5,6,21,23,24,25}
     self._zeroTimePDGs = {11, 13, 15, 17}
@@ -77,6 +77,16 @@ class Physics( ConfigHelper ):
       raise RuntimeError( "PDGFile: %s not found" % os.path.abspath( val ) )
     self._pdgfile = os.path.abspath( val )
 
+  @property
+  def decays(self):
+    """If true, add decay processes for all particles.
+
+    Only enable when creating a physics list not based on an existing Geant4 list!
+    """
+    return self._decays
+  @decays.setter
+  def decays(self, val):
+    self._decays = val
 
   def setupPhysics( self, kernel, name=None):
     seq = kernel.physicsList()

--- a/DDG4/python/DDSim/Helper/Physics.py
+++ b/DDG4/python/DDSim/Helper/Physics.py
@@ -10,7 +10,7 @@ class Physics( ConfigHelper ):
   def __init__( self ):
     super(Physics, self).__init__()
     self._rangecut = 0.7*mm
-    self.list ="FTFP_BERT"
+    self._list = "FTFP_BERT"
     self._decays = False
     self._pdgfile = None
     self._rejectPDGs = {1,2,3,4,5,6,21,23,24,25}
@@ -87,6 +87,14 @@ class Physics( ConfigHelper ):
   @decays.setter
   def decays(self, val):
     self._decays = val
+
+  @property
+  def list(self):
+    """The name of the Geant4 Physics list."""
+    return self._list
+  @list.setter
+  def list(self, val):
+    self._list = val
 
   def setupPhysics( self, kernel, name=None):
     seq = kernel.physicsList()


### PR DESCRIPTION
As we require Geant4 10.2.2 we don't have to keep this code for geant4 before 940

BEGINRELEASENOTES
- Gean4ExtraParticles: no longer add decay process to extra particles, this is done by Geant4  solves #513 
- ddsim: disable physics.decays by default. This should only be enabled if completely new physics lists are created solves #513 

ENDRELEASENOTES