### PR TITLE
Update CI on Macs

### DIFF
--- a/.dd4hep-ci.d/init_mac.sh
+++ b/.dd4hep-ci.d/init_mac.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+if [ "$(uname)" == "Darwin" ]; then
+    if [ $(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}') == "10.14" ]; then
+        OS=mac1014
+        COMPILER_TYPE=clang
+        COMPILER_VERSION=clang100
+    else
+        echo "Bootstrap only works on macOS Mojave (10.14)"
+        exit 1
+    fi
+else
+    echo "This script is only meant for Mac"
+    exit 1
+fi
+
+# Determine is you have CVMFS installed
+if [ ! -d "/cvmfs" ]; then
+    echo "No CVMFS detected, please install it."
+    exit 1
+fi
+
+if [ ! -d "/cvmfs/clicdp.cern.ch" ]; then
+    echo "No clicdp CVMFS repository detected, please add it."
+    exit 1
+fi
+
+# Choose build type
+if [ -z ${BUILD_TYPE} ]; then
+    BUILD_TYPE=opt
+fi
+
+
+# General variables
+CLICREPO=/cvmfs/clicdp.cern.ch
+BUILD_FLAVOUR=x86_64-${OS}-${COMPILER_VERSION}-${BUILD_TYPE}
+
+#--------------------------------------------------------------------------------
+#     CMake
+#--------------------------------------------------------------------------------
+
+export CMAKE_HOME=${CLICREPO}/software/CMake/3.14.3/${BUILD_FLAVOUR}
+export PATH=${CMAKE_HOME}/bin:$PATH
+
+#--------------------------------------------------------------------------------
+#     Python
+#--------------------------------------------------------------------------------
+
+export PYTHONDIR=${CLICREPO}/software/Python/2.7.16/${BUILD_FLAVOUR}
+export PATH=${PYTHONDIR}/bin:$PATH
+export DYLD_LIBRARY_PATH="${PYTHONDIR}/lib:$DYLD_LIBRARY_PATH"
+
+#--------------------------------------------------------------------------------
+#     ROOT
+#--------------------------------------------------------------------------------
+
+export ROOTSYS=${CLICREPO}/software/ROOT/6.18.00/${BUILD_FLAVOUR}
+export PYTHONPATH="$ROOTSYS/lib:$PYTHONPATH"
+export PATH="$ROOTSYS/bin:$PATH"
+export DYLD_LIBRARY_PATH="$ROOTSYS/lib:$DYLD_LIBRARY_PATH"
+
+#--------------------------------------------------------------------------------
+#     XercesC
+#--------------------------------------------------------------------------------
+
+export XercesC_HOME=${CLICREPO}/software/Xerces-C/3.1.3/${BUILD_FLAVOUR}
+export PATH="$XercesC_HOME/bin:$PATH"
+export DYLD_LIBRARY_PATH="$XercesC_HOME/lib:$DYLD_LIBRARY_PATH"
+
+
+#--------------------------------------------------------------------------------
+#     Geant4
+#--------------------------------------------------------------------------------
+
+export G4INSTALL=${CLICREPO}/software/Geant4/10.05.p01/${BUILD_FLAVOUR}
+export G4LIB=$G4INSTALL/lib/Geant4-10.5.1/
+export G4ENV_INIT="${G4INSTALL}/bin/geant4.sh"
+export G4SYSTEM="Linux-g++"
+
+
+#--------------------------------------------------------------------------------
+#     Boost
+#--------------------------------------------------------------------------------
+
+export BOOST_ROOT=${CLICREPO}/software/Boost/1.70.0/${BUILD_FLAVOUR}
+export DYLD_LIBRARY_PATH="${BOOST_ROOT}/lib:$DYLD_LIBRARY_PATH"
+
+#--------------------------------------------------------------------------------
+#     Ninja
+#--------------------------------------------------------------------------------
+
+export Ninja_HOME=${CLICREPO}/software/Ninja/1.9.0/${BUILD_FLAVOUR}
+export PATH="$Ninja_HOME:$PATH"
+
+#--------------------------------------------------------------------------------
+#     LCIO
+#--------------------------------------------------------------------------------
+
+export LCIO=${CLICREPO}/software/LCIO/2.12.1/${BUILD_FLAVOUR}/
+export CMAKE_PREFIX_PATH="$LCIO:$CMAKE_PREFIX_PATH"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,16 +124,15 @@ slc6-llvm5-Geant10.3-XERCESC:
     - ninja install
     - ctest --output-on-failure
 
-mac1013-llvm90-Geant10.3:
+mac1014-clang100-Geant10.5:
   stage: build
   tags:
     - mac
   script:
-    - export GEANT4_VERSION="10.03.p03"
-    - source .dd4hep-ci.d/init_x86_64.sh
+    - source .dd4hep-ci.d/init_mac.sh
     - mkdir build
     - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib/Geant4-10.3.3 -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS ..
+    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib/Geant4-10.5.1 -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release -DROOT_DIR=$ROOTSYS -DCMAKE_CXX_STANDARD=17 ..
     - ninja
     - ninja install
     - . ../bin/thisdd4hep.sh
@@ -146,16 +145,15 @@ mac1013-llvm90-Geant10.3:
     - ninja install
     - ctest --output-on-failure
 
-mac1013-llvm90-Geant10.4-XERCESC:
+mac1014-clang100-Geant10.5-XERCESC:
   stage: build
   tags:
     - mac
   script:
-    - export GEANT4_VERSION="10.04"
-    - source .dd4hep-ci.d/init_x86_64.sh
+    - source .dd4hep-ci.d/init_mac.sh
     - mkdir build
     - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib/Geant4-10.4.0 -DCMAKE_BUILD_TYPE=Release -DDD4HEP_USE_XERCESC=ON -DXERCESC_ROOT_DIR=${XercesC_HOME} -DROOT_DIR=$ROOTSYS ..
+    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DGeant4_DIR=$G4INSTALL/lib/Geant4-10.5.1 -DCMAKE_BUILD_TYPE=Release -DDD4HEP_USE_XERCESC=ON -DXERCESC_ROOT_DIR=${XercesC_HOME} -DROOT_DIR=$ROOTSYS -DCMAKE_CXX_STANDARD=17 ..
     - ninja
     - ninja install
     - . ../bin/thisdd4hep.sh

--- a/DDCore/include/DD4hep/Memory.h
+++ b/DDCore/include/DD4hep/Memory.h
@@ -29,8 +29,6 @@
 // C/C++ include files
 #include <memory>
 
-// Use std::auto_ptr<T> instead of std::unique_ptr<T>
-#define DD4HEP_DD4HEP_PTR_AUTO
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep  {

--- a/DDCore/include/DD4hep/Memory.h
+++ b/DDCore/include/DD4hep/Memory.h
@@ -45,21 +45,9 @@ namespace dd4hep  {
    *   \ingroup DD4HEP_CORE
    */
   template <typename T> class dd4hep_ptr
-  //#if defined(DD4HEP_NEVER) && __cplusplus >= 201103L && ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
-#if !defined(DD4HEP_DD4HEP_PTR_AUTO) && __cplusplus >= 201103L && ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
     : public std::unique_ptr<T>  {
-  public:
-    typedef std::unique_ptr<T> base_t;
-#else
-      : public std::auto_ptr<T>  {
     public:
-        typedef std::auto_ptr<T> base_t;
-        void swap(base_t& c) {
-          this->base_t::operator=(base_t(c.release()));
-        }
-        /// Constructor from copy
-        dd4hep_ptr(dd4hep_ptr<T>& c) : base_t(c) {}
-#endif
+        typedef std::unique_ptr<T> base_t;
     public:
         /// Default Constructor.
         dd4hep_ptr() : base_t() {}

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -109,7 +109,6 @@ namespace {
            << "**************************************************** \n"
            << endl ;
 
-      set_unexpected(std::unexpected);
       set_terminate(std::terminate);
       // this provokes ROOT seg fault and stack trace (comment out to avoid it)
       exit(1) ;
@@ -161,7 +160,6 @@ DetectorImp::DetectorImp(const string& name)
   TGeoUnit::setUnitType(TGeoUnit::kTGeant4Units);
 #endif
   SetTitle("DD4hep detector description object");
-  set_unexpected( description_unexpected );
   set_terminate( description_unexpected );
   InstanceCount::increment(this);
   //if ( gGeoManager ) delete gGeoManager;

--- a/DDG4/include/DDG4/DDG4Dict.h
+++ b/DDG4/include/DDG4/DDG4Dict.h
@@ -70,11 +70,6 @@ using namespace std;
 #pragma link C++ class dd4hep::dd4hep_ptr<dd4hep::sim::DataExtension>;
 #pragma link C++ class dd4hep::dd4hep_ptr<dd4hep::sim::ParticleExtension>;
 
-#ifdef DD4HEP_DD4HEP_PTR_AUTO
-#pragma link C++ class dd4hep::dd4hep_ptr<dd4hep::sim::DataExtension>::base_t;
-#pragma link C++ class dd4hep::dd4hep_ptr<dd4hep::sim::ParticleExtension>::base_t;
-#endif
-
 #pragma link C++ class dd4hep::sim::Geant4Particle+;
 #pragma link C++ class vector<dd4hep::sim::Geant4Particle*>+;
 #pragma link C++ class map<int,dd4hep::sim::Geant4Particle*>+;

--- a/DDG4/include/DDG4/Geant4Data.h
+++ b/DDG4/include/DDG4/Geant4Data.h
@@ -124,11 +124,7 @@ namespace dd4hep {
       /// Original Geant 4 track identifier of the creating track (debugging)
       long g4ID = -1;
       /// User data extension if required
-#ifdef DD4HEP_DD4HEP_PTR_AUTO
-      dd4hep_ptr<DataExtension> extension;
-#else
       dd4hep_ptr<DataExtension> extension;   //! not persisten. ROOT cannot handle
-#endif
 
       /// Utility class describing the monte carlo contribution of a given particle to a hit.
       /**

--- a/DDG4/include/DDG4/Geant4Particle.h
+++ b/DDG4/include/DDG4/Geant4Particle.h
@@ -127,11 +127,7 @@ namespace dd4hep {
       Particles daughters;
 
       /// User data extension if required
-#ifdef DD4HEP_DD4HEP_PTR_AUTO
-      dd4hep_ptr<ParticleExtension> extension;
-#else
       dd4hep_ptr<ParticleExtension> extension;   //! not persisten. ROOT cannot handle
-#endif
       const G4VProcess *process = 0;             //! not persistent
       /// Default constructor
       Geant4Particle();

--- a/DDG4/include/DDG4/Geant4Vertex.h
+++ b/DDG4/include/DDG4/Geant4Vertex.h
@@ -56,11 +56,7 @@ namespace dd4hep {
       /// The list of incoming particles
       Particles in;
       /// User data extension if required
-#ifdef DD4HEP_DD4HEP_PTR_AUTO
-      dd4hep_ptr<VertexExtension> extension;
-#else
       dd4hep_ptr<VertexExtension> extension;   //! not persistent: ROOT cannot handle yet
-#endif
       /// Default constructor
       Geant4Vertex();
       /// Copy constructor

--- a/DDG4/python/DDG4Dict.C
+++ b/DDG4/python/DDG4Dict.C
@@ -241,9 +241,6 @@ typedef dd4hep::sim::Geant4ActionCreation Geant4ActionCreation;
 #pragma link C++ class dd4hep::dd4hep_ptr<dd4hep::sim::VertexExtension>+;
 #pragma link C++ class dd4hep::dd4hep_ptr<dd4hep::sim::PrimaryExtension>+;
 #pragma link C++ class dd4hep::dd4hep_ptr<dd4hep::sim::Geant4InputAction::Particles>;
-#ifdef DD4HEP_DD4HEP_PTR_AUTO
-#pragma link C++ class dd4hep::dd4hep_ptr<dd4hep::sim::Geant4InputAction::Particles>::base_t;
-#endif
 
 // Basic stuff
 #pragma link C++ class dd4hep::sim::Geant4ActionCreation;

--- a/GaudiPluginService/src/PluginService.cpp
+++ b/GaudiPluginService/src/PluginService.cpp
@@ -49,14 +49,14 @@ namespace {
 static inline std::string &ltrim(std::string &s) {
         s.erase(s.begin(),
                 std::find_if(s.begin(), s.end(),
-                             std::not1(std::ptr_fun<int, int>(std::isspace))));
+                             [](int c) {return !std::isspace(c);}));
         return s;
 }
 
 // trim from end
 static inline std::string &rtrim(std::string &s) {
         s.erase(std::find_if(s.rbegin(), s.rend(),
-                             std::not1(std::ptr_fun<int, int>(std::isspace)))
+                             [](int c) {return !std::isspace(c);})
                                        .base(),
                 s.end());
         return s;


### PR DESCRIPTION
BEGINRELEASENOTES
- Update CI to macOS Mojave 10.14
- Make `PluginService.cpp` C++17 compliant (addresses partially #525)
  - replace `ptr_fun` with `lambda`
- Remove deprecated code that uses `auto_prt`
- Remove deprecated `set_unexpected` from  `DetectorImp.cpp`
- Remove code associated to `DD4HEP_DD4HEP_PTR_AUTO`
ENDRELEASENOTES