### PR TITLE
Improve material scans. Add copyright statements to DDRec 

### DIFF
--- a/DDG4/src/Geant4SensitiveDetector.cpp
+++ b/DDG4/src/Geant4SensitiveDetector.cpp
@@ -218,8 +218,8 @@ long long Geant4SensitiveDetector::getVolumeID(G4Step* aStep) {
 }
 
 
-long long Geant4SensitiveDetector::getCellID(G4Step* s) {
-  StepHandler h(s);
+long long Geant4SensitiveDetector::getCellID(G4Step* step) {
+  StepHandler h(step);
   Geant4VolumeManager volMgr = Geant4Mapping::instance().volumeManager();
   VolumeID            volID  = volMgr.volumeID(h.preTouchable());
   Segmentation        seg    = m_readout.segmentation();

--- a/DDRec/include/DDRec/CellIDPositionConverter.h
+++ b/DDRec/include/DDRec/CellIDPositionConverter.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef CellIDPositionConverter_H_
 #define CellIDPositionConverter_H_
 

--- a/DDRec/include/DDRec/DDGear.h
+++ b/DDRec/include/DDRec/DDGear.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef DDGear_H
 #define DDGear_H
 

--- a/DDRec/include/DDRec/DetectorData.h
+++ b/DDRec/include/DDRec/DetectorData.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef rec_DetectorData_H_
 #define rec_DetectorData_H_
 

--- a/DDRec/include/DDRec/DetectorSurfaces.h
+++ b/DDRec/include/DDRec/DetectorSurfaces.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef rec_DetectorSurfaces_H_
 #define rec_DetectorSurfaces_H_
 

--- a/DDRec/include/DDRec/IMaterial.h
+++ b/DDRec/include/DDRec/IMaterial.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef DDRec_IMaterial_H_
 #define DDRec_IMaterial_H_
 

--- a/DDRec/include/DDRec/ISurface.h
+++ b/DDRec/include/DDRec/ISurface.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef DDRec_ISurface_H
 #define DDRec_ISurface_H
 

--- a/DDRec/include/DDRec/Material.h
+++ b/DDRec/include/DDRec/Material.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef rec_Material_H
 #define rec_Material_H
 

--- a/DDRec/include/DDRec/MaterialManager.h
+++ b/DDRec/include/DDRec/MaterialManager.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef rec_MaterialManager_H_
 #define rec_MaterialManager_H_
 
@@ -15,7 +27,8 @@ class TGeoManager ;
 namespace dd4hep {
   namespace rec {
 
-    typedef std::vector< std::pair< Material, double > > MaterialVec ;
+    typedef std::vector< std::pair< Material, double > >     MaterialVec;
+    typedef std::vector< std::pair< PlacedVolume, double > > PlacementVec;
     
     /** Material manager provides access to the material properties of the detector.
      *  Material can be accessed either for a given point or as a list of materials along a straight
@@ -45,12 +58,19 @@ namespace dd4hep {
        *  are ignored. Avoid calling this method in inner loops as the computation is not cheap. Ideally the result should be cached,
        *  for example as an averaged material @see createAveragedMaterial().
        */
-      const MaterialVec& materialsBetween(const Vector3D& p0, const Vector3D& p1 , double epsilon=1e-4 ) ;
+      const MaterialVec& materialsBetween(const Vector3D& p0, const Vector3D& p1 , double epsilon=1e-4 );
 
+      /** Get a vector with all the placements between the two points p0 and p1
+       */
+      const PlacementVec& placementsBetween(const Vector3D& p0, const Vector3D& p1 , double epsilon=1e-4 );
+      
       /** Get the material at the given position.
        */
       const Material& materialAt(const Vector3D& pos );
 
+      /** Get the placed volume at the given position.
+       */
+      PlacedVolume placementAt(const Vector3D& pos );
 
       /** Create a material with averaged properties from all materials in the list. 
        *  A and Z are averaged by relative number of atoms(molecules), rho is averaged by relative volume
@@ -59,32 +79,30 @@ namespace dd4hep {
       MaterialData createAveragedMaterial( const MaterialVec& materials ) ;
 
     protected :
-
-      //cached materials
+      /// Cached materials
       MaterialVec  _mV ;
-      Material _m ;
-
-      // cached last points
-      Vector3D _p0 , _p1, _pos ;
-
+      Material     _m ;
+      /// Cached nodes
+      PlacedVolume _pv;
+      PlacementVec _placeV;
+      /// cached last points
+      Vector3D     _p0 , _p1, _pos ;
+      /// Reference to the TGeoManager
       TGeoManager* _tgeoMgr ;
     };
 
-   
     /// dump Material operator 
     inline std::ostream& operator<<( std::ostream& os , const Material& m ) {
       os << "  " << m.name() << " Z: " << m.Z() << " A: " << m.A() << " density: " << m.density() 
-	 << " radiationLength: "  <<  m.radLength() 
-	 << " interactionLength: " << m.intLength() ;
+         << " radiationLength: "  <<  m.radLength() 
+         << " interactionLength: " << m.intLength() ;
       return os ;
     }
     
-
     /// dump MaterialVec operator 
     inline std::ostream& operator<<( std::ostream& os , const MaterialVec& m ) {
-
       for( unsigned i=0,n=m.size() ; i<n ; ++i ) {
-	os << "  material: " << m[i].first << " thickness: " << m[i].second << std::endl ; 
+        os << "  material: " << m[i].first << " thickness: " << m[i].second << std::endl ; 
       }
       return os ;
     }

--- a/DDRec/include/DDRec/MaterialScan.h
+++ b/DDRec/include/DDRec/MaterialScan.h
@@ -29,6 +29,21 @@ namespace dd4hep {
 
     /// Class to perform material scans along a straight line
     /**
+     *  Examples: from DDDetectors/compact/SiD.xml
+     *  $> materialScan file:checkout/DDDetectors/compact/SiD.xml -interactive
+     *
+     *  1) Simple scan:
+     *     root [0] gMaterialScan->print(5,5,0,5,5,400)
+     *  2) Scan a given subdetector:
+     *     root [0] de=gDD4hepUI->instance()->detector("LumiCal");
+     *     root [1] gMaterialScan->setDetector(de);
+     *     root [2] gMaterialScan->print(5,5,0,5,5,400)
+     *  3) Scan by material:
+     *     root [0] gMaterialScan->setMaterial("Silicon");
+     *     root [1] gMaterialScan->print(5,5,0,5,5,400)
+     *  4) Scan by region:
+     *     root [0] gMaterialScan->setRegion("SiTrackerBarrelRegion");
+     *     root [1] gMaterialScan->print(0,0,0,100,100,0)
      *
      *  \author  M.Frank
      *  \version 1.0
@@ -38,10 +53,11 @@ namespace dd4hep {
     private:
       
       /// Reference to detector setup
-      Detector& m_detector;
+      Detector&                        m_detector;
       /// Material manager
       std::unique_ptr<MaterialManager> m_materialMgr;  //!
-
+      /// Local cache: subdetector placements
+      std::set<const TGeoNode*>        m_placements;
       /// Default constructor
       MaterialScan();
  
@@ -53,8 +69,20 @@ namespace dd4hep {
       /// Default destructor
       virtual ~MaterialScan();
 
-      /// Set a specific detector volume to limit the scan
+      /// Set a specific detector volume to limit the scan (resets other selection criteria)
       void setDetector(DetElement detector);
+      /// Set a specific detector volume to limit the scan (resets other selection criteria)
+      void setDetector(const char* detector);
+
+      /// Set a specific volume material to limit the scan (resets other selection criteria)
+      void setMaterial(const char* material);
+      /// Set a specific volume material to limit the scan (resets other selection criteria)
+      void setMaterial(Material material);
+
+      /// Set a specific region to limit the scan (resets other selection criteria)
+      void setRegion(const char* region);
+      /// Set a specific region to limit the scan (resets other selection criteria)
+      void setRegion(Region region);
 
       /// Scan along a line and store the matrials internally
       const MaterialVec& scan(double x0, double y0, double z0, double x1, double y1, double z1, double epsilon=1e-4)  const;

--- a/DDRec/include/DDRec/Surface.h
+++ b/DDRec/include/DDRec/Surface.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef rec_Surface_H
 #define rec_Surface_H
 

--- a/DDRec/include/DDRec/SurfaceHelper.h
+++ b/DDRec/include/DDRec/SurfaceHelper.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef rec_SurfaceHelper_H_
 #define rec_SurfaceHelper_H_
 

--- a/DDRec/include/DDRec/SurfaceManager.h
+++ b/DDRec/include/DDRec/SurfaceManager.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef rec_SurfaceManager_H_
 #define rec_SurfaceManager_H_
 

--- a/DDRec/include/DDRec/Vector2D.h
+++ b/DDRec/include/DDRec/Vector2D.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef DDRec_Vector2D_h
 #define DDRec_Vector2D_h 1
 

--- a/DDRec/include/DDRec/Vector3D.h
+++ b/DDRec/include/DDRec/Vector3D.h
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #ifndef DDRec_Vector3D_h
 #define DDRec_Vector3D_h 1
 

--- a/DDRec/src/CellIDPositionConverter.cpp
+++ b/DDRec/src/CellIDPositionConverter.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 
 #include "DDRec/CellIDPositionConverter.h"
 

--- a/DDRec/src/DetectorData.cpp
+++ b/DDRec/src/DetectorData.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DDRec/DetectorData.h"
 
 #include <boost/io/ios_state.hpp>

--- a/DDRec/src/DetectorSurfaces.cpp
+++ b/DDRec/src/DetectorSurfaces.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DDRec/DetectorSurfaces.h"
 
 namespace dd4hep {

--- a/DDRec/src/MaterialScan.cpp
+++ b/DDRec/src/MaterialScan.cpp
@@ -141,11 +141,11 @@ void MaterialScan::setMaterial(Material material)   {
   struct PvCollector  {
     Material material;
     std::set<const TGeoNode*>& cont;
-    PvCollector(Material m, std::set<const TGeoNode*>& c) : material(m), cont(c) {}
+    PvCollector(Material mat, std::set<const TGeoNode*>& c) : material(mat), cont(c) {}
     void operator()(TGeoNode* pv)    {
-      Volume   v = pv->GetVolume();
-      Material m = v.material();
-      if ( m.ptr() == material.ptr() )  {
+      Volume   vol = pv->GetVolume();
+      Material mat = vol.material();
+      if ( mat.ptr() == material.ptr() )  {
         cont.insert(pv);
       }
       for (Int_t idau = 0, ndau = pv->GetNdaughters(); idau < ndau; ++idau)

--- a/DDRec/src/MaterialScan.cpp
+++ b/DDRec/src/MaterialScan.cpp
@@ -46,11 +46,121 @@ MaterialScan::~MaterialScan()    {
 }
 
 
+/// Set a specific region to limit the scan (resets the subdetector selection)
+void MaterialScan::setRegion(const char* region)   {
+  Region reg;
+  if ( region )   {
+    reg = m_detector.region(region);
+  }
+  setRegion(reg);
+}
+
+/// Set a specific region to limit the scan (resets the subdetector selection)
+void MaterialScan::setRegion(Region region)   {
+  struct PvCollector  {
+    Region rg;
+    std::set<const TGeoNode*>& cont;
+    PvCollector(Region r, std::set<const TGeoNode*>& c) : rg(r), cont(c) {}
+    void collect(TGeoNode* pv)    {
+      cont.insert(pv);
+      for (Int_t idau = 0, ndau = pv->GetNdaughters(); idau < ndau; ++idau)
+        collect(pv->GetDaughter(idau));
+    }
+    void operator()(TGeoNode* pv)    {
+      Volume v = pv->GetVolume();
+      Region r = v.region();
+      if ( r.isValid() )  {
+        collect(pv);
+        return;
+      }
+      for (Int_t idau = 0, ndau = pv->GetNdaughters(); idau < ndau; ++idau)
+        (*this)(pv->GetDaughter(idau));
+    }
+  };
+  m_placements.clear();
+  if ( region.isValid() )   {
+    PvCollector coll(region, m_placements);
+    coll(m_detector.world().placement().ptr());
+    printout(ALWAYS,"MaterialScan","+++ Set new scanning region to: %s [%ld placements]",
+             region.name(), m_placements.size());
+  }
+  else   {
+    printout(ALWAYS,"MaterialScan","+++ No region restrictions set. Back to full scanning mode.");
+  }
+}
+
+/// Set a specific detector volume to limit the scan
+void MaterialScan::setDetector(const char* detector)   {
+  DetElement det;
+  if ( detector )   {
+    det = m_detector.detector(detector);
+  }
+  setDetector(det);
+}
+
 /// Set a specific detector volume to limit the scan
 void MaterialScan::setDetector(DetElement detector)   {
+  struct PvCollector  {
+    std::set<const TGeoNode*>& cont;
+    PvCollector(std::set<const TGeoNode*>& c) : cont(c) {}
+    void operator()(TGeoNode* pv)    {
+      cont.insert(pv);
+      for (Int_t idau = 0, ndau = pv->GetNdaughters(); idau < ndau; ++idau) {
+        TGeoNode* daughter = pv->GetDaughter(idau);
+        (*this)(daughter);
+      }
+    }
+  };
   if ( detector.isValid() )   {
-    printout(ALWAYS,"MaterialScan","+++ Set new scanning volume to: %s",detector.path().c_str());
-    m_materialMgr.reset(new MaterialManager(detector.volume()));
+    PlacedVolume pv = detector.placement();
+    m_placements.clear();
+    if ( pv.isValid() )  {
+      PvCollector coll(m_placements);
+      coll(pv.ptr());
+    }
+    printout(ALWAYS,"MaterialScan","+++ Set new scanning volume to: %s [%ld placements]",
+             detector.path().c_str(), m_placements.size());
+  }
+  else   {
+    printout(ALWAYS,"MaterialScan","+++ No subdetector restrictions set. Back to full scanning mode.");
+    m_placements.clear();
+  }
+}
+
+/// Set a specific volume material to limit the scan
+void MaterialScan::setMaterial(const char* material)   {
+  Material mat;
+  if ( material )   {
+    mat = m_detector.material(material);
+  }
+  setMaterial(mat);
+}
+
+/// Set a specific volume material to limit the scan
+void MaterialScan::setMaterial(Material material)   {
+  struct PvCollector  {
+    Material material;
+    std::set<const TGeoNode*>& cont;
+    PvCollector(Material m, std::set<const TGeoNode*>& c) : material(m), cont(c) {}
+    void operator()(TGeoNode* pv)    {
+      Volume   v = pv->GetVolume();
+      Material m = v.material();
+      if ( m.ptr() == material.ptr() )  {
+        cont.insert(pv);
+      }
+      for (Int_t idau = 0, ndau = pv->GetNdaughters(); idau < ndau; ++idau)
+        (*this)(pv->GetDaughter(idau));
+    }
+  };
+  m_placements.clear();
+  if ( material.isValid() )   {
+    PvCollector coll(material, m_placements);
+    coll(m_detector.world().placement().ptr());
+    printout(ALWAYS,"MaterialScan","+++ Set new scanning material to: %s [%ld placements]",
+             material.name(), m_placements.size());
+  }
+  else   {
+    printout(ALWAYS,"MaterialScan","+++ No material restrictions set. Back to full scanning mode.");
   }
 }
 
@@ -62,12 +172,12 @@ const MaterialVec& MaterialScan::scan(double x0, double y0, double z0, double x1
 
 /// Scan along a line and print the materials traversed
 void MaterialScan::print(const Vector3D& p0, const Vector3D& p1, double epsilon)  const    {
-  const auto& materials = m_materialMgr->materialsBetween(p0, p1, epsilon);
+  const auto& placements = m_materialMgr->placementsBetween(p0, p1, epsilon);
   auto& matMgr = *m_materialMgr;
   Vector3D end, direction;
   double sum_x0 = 0;
   double sum_lambda = 0;
-  double path_length = 0;
+  double path_length = 0, total_length = 0;
   const char* fmt1 = " | %5d %-20s %3.0f %8.3f %8.4f %11.4f  %11.4f %10.3f %8.2f %11.6f %11.6f  (%7.2f,%7.2f,%7.2f)\n";
   const char* fmt2 = " | %5d %-20s %3.0f %8.3f %8.4f %11.6g  %11.6g %10.3f %8.2f %11.6f %11.6f  (%7.2f,%7.2f,%7.2f)\n";
   const char* line = " +--------------------------------------------------------------------------------------------------------------------------------------------------\n";
@@ -80,16 +190,30 @@ void MaterialScan::print(const Vector3D& p0, const Vector3D& p1, double epsilon)
   ::printf(" | Num. \\  %-11s   Number/Z   Mass/A  Density    Length       Length    Thickness   Length      X0        Lambda      Endpoint  \n","Name");
   ::printf(" | Layer \\ %-11s            [g/mole]  [g/cm3]     [cm]        [cm]          [cm]      [cm]     [cm]        [cm]     (     cm,     cm,     cm)\n","");
   ::printf("%s",line);
-
-  for( unsigned i=0,n=materials.size();i<n;++i){
-    TGeoMaterial* mat =  materials[i].first->GetMaterial();
-    double length = materials[i].second;
-    double nx0 = length / mat->GetRadLen();
-    sum_x0 += nx0;
+  MaterialVec materials;
+  for( unsigned i=0,n=placements.size(); i<n; ++i){
+    TGeoNode*  pv  = placements[i].first.ptr();
+    double length  = placements[i].second;
+    total_length  += length;
+    end = p0 + total_length * direction;
+    if ( !m_placements.empty() && m_placements.find(pv) == m_placements.end() )  {
+#if 0
+      ::printf("%p %s  %s  %s\n",
+               placements[i].first.ptr(),
+               placements[i].first->GetName(),
+               placements[i].first->GetVolume()->GetName(),
+               placements[i].first->GetMedium()->GetName());
+#endif
+      continue;
+    }
+    TGeoMaterial* mat = placements[i].first->GetMedium()->GetMaterial();
+    double nx0     = length / mat->GetRadLen();
     double nLambda = length / mat->GetIntLen();
-    sum_lambda += nLambda;
-    path_length += length;
-    end = p0 + path_length * direction;
+
+    sum_x0        += nx0;
+    sum_lambda    += nLambda;
+    path_length   += length;
+    materials.push_back(std::make_pair(placements[i].first->GetMedium(),length));
     const char* fmt = mat->GetRadLen() >= 1e5 ? fmt2 : fmt1;
     ::printf(fmt, i+1, mat->GetName(), mat->GetZ(), mat->GetA(),
              mat->GetDensity(), mat->GetRadLen(), mat->GetIntLen(), 
@@ -99,7 +223,6 @@ void MaterialScan::print(const Vector3D& p0, const Vector3D& p1, double epsilon)
   printf("%s",line);
   const MaterialData& avg = matMgr.createAveragedMaterial(materials);
   const char* fmt = avg.radiationLength() >= 1e5 ? fmt2 : fmt1;
-  end = p0 + path_length * direction;
   ::printf(fmt,0,"Average Material",avg.Z(),avg.A(),avg.density(), 
            avg.radiationLength(), avg.interactionLength(),
            path_length, path_length, 

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DDRec/Surface.h"
 #include "DD4hep/detail/DetectorInterna.h"
 #include "DD4hep/Memory.h"

--- a/DDRec/src/SurfaceHelper.cpp
+++ b/DDRec/src/SurfaceHelper.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DDRec/SurfaceHelper.h"
 
 #include "DDRec/DetectorSurfaces.h"

--- a/DDRec/src/SurfaceManager.cpp
+++ b/DDRec/src/SurfaceManager.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DDRec/SurfaceManager.h"
 
 #include "DDRec/SurfaceHelper.h"

--- a/DDRec/src/convertToGear.cc
+++ b/DDRec/src/convertToGear.cc
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DD4hep/Detector.h"
 #include "DD4hep/DD4hepUnits.h"
 #include "DD4hep/Fields.h"

--- a/DDRec/src/gear/DDGear.cpp
+++ b/DDRec/src/gear/DDGear.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DDRec/DDGear.h"
 
 #include "DD4hep/Detector.h"

--- a/DDRec/src/gear/createGearForCLIC.cpp
+++ b/DDRec/src/gear/createGearForCLIC.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DD4hep/Detector.h"
 #include "DD4hep/Factories.h"
 #include "DD4hep/DD4hepUnits.h" 

--- a/DDRec/src/gear/createGearForILD.cpp
+++ b/DDRec/src/gear/createGearForILD.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DD4hep/Detector.h"
 #include "DD4hep/Factories.h"
 #include "DD4hep/DD4hepUnits.h" 

--- a/DDRec/src/gear/createGearForSiD.cpp
+++ b/DDRec/src/gear/createGearForSiD.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DD4hep/Detector.h"
 #include "DD4hep/Factories.h"
 #include "DD4hep/DD4hepUnits.h" 

--- a/DDRec/src/plugins/createSurfaceManager.cpp
+++ b/DDRec/src/plugins/createSurfaceManager.cpp
@@ -1,3 +1,15 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : F.Gaede
+//
+//==========================================================================
 #include "DD4hep/Detector.h"
 #include "DD4hep/Factories.h"
 #include "DD4hep/Printout.h"


### PR DESCRIPTION

BEGINRELEASENOTES

* Allow for various material scan types from the root interactove prompt

       Examples: from DDDetectors/compact/SiD.xml
       $> materialScan file:checkout/DDDetectors/compact/SiD.xml -interactive
     
       1) Simple scan:
          root [0] gMaterialScan->print(5,5,0,5,5,400)
       2) Scan a given subdetector:
          root [0] de=gDD4hepUI->instance()->detector("LumiCal");
          root [1] gMaterialScan->setDetector(de);
          root [2] gMaterialScan->print(5,5,0,5,5,400)
       3) Scan by material:
          root [0] gMaterialScan->setMaterial("Silicon");
          root [1] gMaterialScan->print(5,5,0,5,5,400)
       4) Scan by region:
          root [0] gMaterialScan->setRegion("SiTrackerBarrelRegion");
          root [1] gMaterialScan->print(0,0,0,100,100,0)

* Added copyright notices to the DDRec files.

ENDRELEASENOTES