### PR TITLE
Fix shadows and problem in mac examples CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -140,7 +140,7 @@ mac1014-clang100-Geant10.5:
     - cd ../examples/
     - mkdir build
     - cd build
-    - cmake -GNinja ..
+    - cmake -DBoost_NO_BOOST_CMAKE=ON -GNinja ..
     - ninja
     - ninja install
     - ctest --output-on-failure
@@ -161,7 +161,7 @@ mac1014-clang100-Geant10.5-XERCESC:
     - cd ../examples/
     - mkdir build
     - cd build
-    - cmake -GNinja -DXERCESC_ROOT_DIR=${XercesC_HOME} ..
+    - cmake -GNinja -DBoost_NO_BOOST_CMAKE=ON -DXERCESC_ROOT_DIR=${XercesC_HOME} ..
     - ninja
     - ninja install
     - ctest --output-on-failure

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -498,8 +498,8 @@ template <> void Converter<Material>::operator()(xml_h e) const {
       xml_elt_t p = properties;
       if ( p.hasAttr(_U(ref)) )   {
         string ref = p.attr<string>(_U(ref));
-        TGDMLMatrix* m = mgr.GetGDMLMatrix(ref.c_str());
-        if ( m )  {
+        TGDMLMatrix* gdmlMat = mgr.GetGDMLMatrix(ref.c_str());
+        if ( gdmlMat )  {
           string prop_nam = p.attr<string>(_U(name));
           mat->AddProperty(prop_nam.c_str(), ref.c_str());
           printout(s_debug.materials ? ALWAYS : DEBUG, "Compact",

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -280,10 +280,10 @@ static long root_dump_gdml_tables(Detector& description, int /* argc */, char** 
   TObjArrayIter arr(c);
   printout(INFO,"Dump_GDMLTables","+++ Dumping known GDML tables from TGeoManager.");
   for(TObject* i = arr.Next(); i; i=arr.Next())   {
-    TGDMLMatrix* m = (TGDMLMatrix*)i;
-    num_elements += (m->GetRows()*m->GetCols());
+    TGDMLMatrix* gdmlMat = (TGDMLMatrix*)i;
+    num_elements += (gdmlMat->GetRows()*gdmlMat->GetCols());
     ++num_tables;
-    m->Print();
+    gdmlMat->Print();
   }
 #endif
   printout(INFO,"Dump_GDMLTables",
@@ -310,9 +310,9 @@ static long root_dump_optical_surfaces(Detector& description, int /* argc */, ch
   TObjArrayIter arr(c);
   printout(ALWAYS,"Dump_OpticalSurfaces","+++ Dumping known Optical Surfaces from TGeoManager.");
   for(TObject* i = arr.Next(); i; i=arr.Next())   {
-    TGeoOpticalSurface* m = (TGeoOpticalSurface*)i;
+    TGeoOpticalSurface* optSurt = (TGeoOpticalSurface*)i;
     ++num_surfaces;
-    m->Print();
+    optSurt->Print();
   }
 #endif
   printout(ALWAYS,"Dump_OpticalSurfaces",
@@ -338,9 +338,9 @@ static long root_dump_skin_surfaces(Detector& description, int /* argc */, char*
   TObjArrayIter arr(c);
   printout(ALWAYS,"Dump_SkinSurfaces","+++ Dumping known Skin Surfaces from TGeoManager.");
   for(TObject* i = arr.Next(); i; i=arr.Next())   {
-    TGeoSkinSurface* m = (TGeoSkinSurface*)i;
+    TGeoSkinSurface* skinSurf = (TGeoSkinSurface*)i;
     ++num_surfaces;
-    m->Print();
+    skinSurf->Print();
   }
 #endif
   printout(ALWAYS,"Dump_SkinSurfaces",
@@ -366,9 +366,9 @@ static long root_dump_border_surfaces(Detector& description, int /* argc */, cha
   TObjArrayIter arr(c);
   printout(ALWAYS,"Dump_BorderSurfaces","+++ Dumping known Border Surfaces from TGeoManager.");
   for(TObject* i = arr.Next(); i; i=arr.Next())   {
-    TGeoBorderSurface* m = (TGeoBorderSurface*)i;
+    TGeoBorderSurface* bordSurt = (TGeoBorderSurface*)i;
     ++num_surfaces;
-    m->Print();
+    bordSurt->Print();
   }
 #endif
   printout(ALWAYS,"Dump_BorderSurfaces",

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,6 +22,9 @@
 # M.Frank, CERN, 2015:  Adapt to new cmake scripts
 #==========================================================================
 cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+if (POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW) # CMake 3.12
+endif ()
 
 project( DD4hep_Examples )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove shadow warnings related to code interfacing only ROOT 6.18
- Add `DBoost_NO_BOOST_CMAKE=ON` to examples cmake call as it is necessary now
- Set CMP0074 policy to NEW if can be set

ENDRELEASENOTES