### PR TITLE
Add Python 3 CI

### DIFF
--- a/.dd4hep-ci.d/init_x86_64.sh
+++ b/.dd4hep-ci.d/init_x86_64.sh
@@ -43,10 +43,14 @@ fi
 
 
 # General variables
-LCGREPO=/cvmfs/sft.cern.ch/lcg/releases/LCG_96
+if [ -z ${LCG_RELEASE} ]; then
+    LCG_RELEASE="LCG_96"
+fi
+
+LCGREPO=/cvmfs/sft.cern.ch/lcg/releases/${LCG_RELEASE}
 BUILD_FLAVOUR=x86_64-${OS}-${COMPILER_VERSION}-${BUILD_TYPE}
 
-export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/views/LCG_96/${BUILD_FLAVOUR}/lib64:/cvmfs/sft.cern.ch/lcg/views/LCG_96/${BUILD_FLAVOUR}/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/views/${LCG_RELEASE}/${BUILD_FLAVOUR}/lib64:/cvmfs/sft.cern.ch/lcg/views/${LCG_RELEASE}/${BUILD_FLAVOUR}/lib:$LD_LIBRARY_PATH
 
 #--------------------------------------------------------------------------------
 #     Compiler
@@ -69,8 +73,11 @@ export PATH=${CMAKE_HOME}/bin:$PATH
 #--------------------------------------------------------------------------------
 #     Python
 #--------------------------------------------------------------------------------
-
-export PYTHONDIR=${LCGREPO}/Python/2.7.16/${BUILD_FLAVOUR}
+if [[ $LCG_RELEASE =~ "python3" ]]; then
+    export PYTHONDIR=${LCGREPO}/Python/3.6.5/${BUILD_FLAVOUR}
+else
+    export PYTHONDIR=${LCGREPO}/Python/2.7.16/${BUILD_FLAVOUR}
+fi
 export PATH=${PYTHONDIR}/bin:$PATH
 export LD_LIBRARY_PATH=${PYTHONDIR}/lib:${LD_LIBRARY_PATH}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,6 +69,30 @@ centos7-gcc8-Geant10.5-XERCESC:
     - ninja install
     - ctest --output-on-failure
 
+centos7-gcc8-Geant10.5-Python3:
+  allow_failure: true
+  stage: build
+  tags:
+    - docker
+  image: clicdp/cc7-lcg
+  script:
+    - export LCG_RELEASE="LCG_96python3"
+    - source .dd4hep-ci.d/init_x86_64.sh
+    - mkdir build
+    - cd build
+    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 ..
+    - ninja
+    - ninja install
+    - . ../bin/thisdd4hep.sh
+    - ctest --output-on-failure -j4
+    - cd ../examples/
+    - mkdir build
+    - cd build
+    - cmake -GNinja -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_CXX_STANDARD=17  ..
+    - ninja
+    - ninja install
+    - ctest --output-on-failure
+
 
 centos7-clang8-Geant10.5-XERCESC:
   stage: build


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a Python 3 pipeline to the CI (currently set to `allow_failure`)

ENDRELEASENOTES