### PR TITLE
Fix unit conversion for optical surface properties

### DIFF
--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -499,6 +499,10 @@ namespace dd4hep {
    *   No real correspondance to TGeo. In principle it's a boolean Solid based on a tube.
    *   \see http://cmssdt.cern.ch/lxr/source/DetectorDescription/Core/src/TruncTubs.h
    *
+   *   The Solid::dimension() and Solid::setDimension() calls for the TruncatedTube
+   *   deliver/expect the parameters in the same order as the constructor:
+   *   (zhalf, rmin, rmax, startPhi, deltaPhi, cutAtStart, cutAtDelta, cutInside)
+   *
    *   \author  M.Frank
    *   \version 1.0
    *   \ingroup DD4HEP_CORE
@@ -702,6 +706,10 @@ namespace dd4hep {
    *   No real correspondance to TGeo. In principle it's a boolean Solid based on a tube.
    *   \see http://cmssdt.cern.ch/lxr/source/DetectorDescription/Core/src/PseudoTrap.h
    *
+   *   The Solid::dimension() and Solid::setDimension() calls for the PseudoTrap
+   *   deliver/expect the parameters in the same order as the constructor:
+   *   (x1, x2, y1, y2, z, radius, minusZ)
+   *
    *   \author  M.Frank
    *   \version 1.0
    *   \ingroup DD4HEP_CORE
@@ -729,8 +737,8 @@ namespace dd4hep {
     /// Constructor to create a new identified object with attribute initialization
     PseudoTrap(const std::string& nam,
                double x1, double x2,
-               double y1, double y2, double z,
-               double radius, bool minusZ)
+               double y1, double y2,
+               double z,  double radius, bool minusZ)
     {  this->make(nam, x1, x2, y1, y2, z, radius, minusZ);    }
 
     /// Move Assignment operator

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -638,22 +638,23 @@ void DetectorImp::init() {
     Constant     vac_const = getRefChild(m_define, "Vacuum", false);
     Box          worldSolid;
     
-    m_materialAir    = material(air_const.isValid() ? air_const->GetTitle() : "Air");
     m_materialVacuum = material(vac_const.isValid() ? vac_const->GetTitle() : "Vacuum");
 
     m_worldVol = m_manager->GetTopVolume();
     if ( m_worldVol.isValid() )   {
-      worldSolid = m_worldVol.solid();
+      worldSolid    = m_worldVol.solid();
+      m_materialAir = m_worldVol.material();
       printout(INFO,"Detector", "*********** Use Top Node from manager as "
-               "world volume [%s].  BBox: %4.0f %4.0f %4.0f",
-               worldSolid->IsA()->GetName(),
+               "world volume [%s].  Material: %s BBox: %4.0f %4.0f %4.0f",
+               worldSolid->IsA()->GetName(), m_materialAir.name(),
                worldSolid->GetDX(), worldSolid->GetDY(), worldSolid->GetDZ());
     }
     else   {
       /// Construct the top level world element
       Solid parallelWorldSolid = Box("world_x", "world_y", "world_z");
-      worldSolid = Box("world_x", "world_y", "world_z");
-      m_worldVol = Volume("world_volume", worldSolid, m_materialAir);
+      worldSolid    = Box("world_x", "world_y", "world_z");
+      m_materialAir = material(air_const.isValid() ? air_const->GetTitle() : "Air");
+      m_worldVol    = Volume("world_volume", worldSolid, m_materialAir);
       parallelWorldSolid->SetName("parallel_world_solid");
       printout(INFO,"Detector","*********** Created World volume with size: %4.0f %4.0f %4.0f",
                worldSolid->GetDX(), worldSolid->GetDY(), worldSolid->GetDZ());

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -718,10 +718,10 @@ namespace dd4hep {
             except("PseudoTrap","+++ Incompatible change of parameters.");
           }
           ((TGeoTranslation*)right_matrix)->SetTranslation(0,0,displacement);
-          stringstream params;
-          params << x1 << " " << x2 << " " << y1 << " " << y2 << " " << z << " "
-                 << r << " " << char(atMinusZ ? '1' : '0') << " ";
-          right_matrix->SetTitle(params.str().c_str());
+          stringstream str;
+          str << x1 << " " << x2 << " " << y1 << " " << y2 << " " << z << " "
+              << r << " " << char(atMinusZ ? '1' : '0') << " ";
+          right_matrix->SetTitle(str.str().c_str());
           return;
         }
         // In general TGeoCompositeShape instances have an empty SetDimension call


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix unit conversion for optical surface properties. The units of the property tables were not converted from TGeo to Geant4. See dicussion in issue https://github.com/AIDASoft/DD4hep/issues/440
- If an external world volume is supplied, the material `Air` is deduced from this solid (only used by CMS).

ENDRELEASENOTES