### PR TITLE
Implement isA() operation on solids. Add TGeoCtub translation to Geant4.

### DIFF
--- a/DDCore/include/DD4hep/ConditionDerived.h
+++ b/DDCore/include/DD4hep/ConditionDerived.h
@@ -342,6 +342,8 @@ namespace dd4hep {
       ConditionDependency(DetElement de, const std::string& item, std::shared_ptr<ConditionUpdateCall> call);
       /// Initializing constructor used by builder
       ConditionDependency(DetElement de, Condition::itemkey_type item_key, std::shared_ptr<ConditionUpdateCall> call);
+      /// Initializing constructor used by builder
+      ConditionDependency(Condition::detkey_type det_key, Condition::itemkey_type item_key, std::shared_ptr<ConditionUpdateCall> call);
       /// Default constructor
       ConditionDependency();
       /// Access the dependency key

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -28,10 +28,8 @@
 #endif
 // ROOT include files
 #include "TGeoCone.h"
-#include "TGeoParaboloid.h"
 #include "TGeoPgon.h"
 #include "TGeoPcon.h"
-#include "TGeoSphere.h"
 #include "TGeoArb8.h"
 #include "TGeoTrd1.h"
 #include "TGeoTrd2.h"
@@ -40,7 +38,9 @@
 #include "TGeoXtru.h"
 #include "TGeoHype.h"
 #include "TGeoTorus.h"
+#include "TGeoSphere.h"
 #include "TGeoHalfSpace.h"
+#include "TGeoParaboloid.h"
 #include "TGeoCompositeShape.h"
 #include "TGeoShapeAssembly.h"
 #ifdef __GNUC__
@@ -64,6 +64,12 @@ namespace dd4hep {
   
   /// Set the shape dimensions (As for the TGeo shape, but angles in rad rather than degrees)
   void set_shape_dimensions(TGeoShape* shape, const std::vector<double>& params);
+
+  /// Type check of various shapes. Result like dynamic_cast. Compare with python's isinstance(obj,type)
+  template <typename SOLID> bool isInstance(const Handle<TGeoShape>& solid);
+  /// Type check of various shapes. Do not allow for polymorphism. Types must match exactly
+  template <typename SOLID> bool isA(const Handle<TGeoShape>& solid);
+  
 
   ///  Base class for Solid (shape) objects
   /**
@@ -148,9 +154,6 @@ namespace dd4hep {
   };
   typedef Solid_type<TGeoShape> Solid;
 
-  /// Type check of various shapes.
-  template <typename SOLID> bool instanceOf(const Handle<TGeoShape>& solid);
-  
   /// Class describing a shape-less solid shape
   /**
    *   For any further documentation please see the following ROOT documentation:
@@ -379,16 +382,7 @@ namespace dd4hep {
                                double rmin2, double rmax2,
                                double startPhi = 0.0, double endPhi = 2.0 * M_PI);
   };
-#if 0
-  /// Intermediate class to overcome drawing probles with the TGeoTubeSeg
-  class MyConeSeg: public TGeoConeSeg {
-  public:
-    MyConeSeg() : TGeoConeSeg(0.0,0.0,0.0,0.0,0.0,0.0,0.0) { }
-    virtual ~MyConeSeg() { }
-    double GetRmin() const {        return GetRmin1();      }
-    double GetRmax() const {        return GetRmax1();      }
-  };
-#endif
+
   /// Class describing a tube shape of a section of a tube
   /**
    *   TGeoTube - cylindrical tube class. It takes 3 parameters :

--- a/DDCore/src/ConditionDerived.cpp
+++ b/DDCore/src/ConditionDerived.cpp
@@ -140,6 +140,15 @@ ConditionDependency::ConditionDependency(Condition::key_type  key,
 }
 
 /// Initializing constructor
+ConditionDependency::ConditionDependency(Condition::detkey_type det_key,
+                                         Condition::itemkey_type item_key,
+                                         std::shared_ptr<ConditionUpdateCall> call)
+  : m_refCount(0), target(det_key, item_key), callback(std::move(call))
+{
+  InstanceCount::increment(this);
+}
+
+/// Initializing constructor
 ConditionDependency::ConditionDependency(DetElement              de,
                                          Condition::itemkey_type item_key,
                                          std::shared_ptr<ConditionUpdateCall> call)
@@ -172,7 +181,8 @@ ConditionDependency::ConditionDependency()
 }
 
 /// Default destructor
-ConditionDependency::~ConditionDependency()  {
+ConditionDependency::~ConditionDependency()
+{
   InstanceCount::decrement(this);
 }
 

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -43,77 +43,136 @@ namespace units = dd4hep;
 
 namespace dd4hep {
   static bool check_shape_type(const Handle<TGeoShape>& solid, const TClass* cl)   {
-    if ( solid.isValid() )   {
-      return solid->IsA() == cl;
-    }
-    return false;
+    return solid.isValid() && solid->IsA() == cl;
   }
 
-  /// Type check of various shapes.
-  template <typename SOLID> bool instanceOf(const Handle<TGeoShape>& solid)   {
-    if ( solid.isValid() )   {
-      return solid->IsA() == SOLID::Object::Class();
-    }
-    return false;
+  /// Type check of various shapes. Result like dynamic_cast. Compare with python's isinstance(obj,type)
+  template <typename SOLID> bool isInstance(const Handle<TGeoShape>& solid)   {
+    return check_shape_type(solid, SOLID::Object::Class());
   }
-  template bool instanceOf<Box>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<ShapelessSolid>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<HalfSpace>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<ConeSegment>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Tube>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<CutTube>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<EllipticalTube>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Cone>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Trap>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Trd1>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Trd2>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Torus>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Sphere>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Paraboloid>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Hyperboloid>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<PolyhedraRegular>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<Polyhedra>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<ExtrudedPolygon>(const Handle<TGeoShape>& solid);
-  template bool instanceOf<BooleanSolid>(const Handle<TGeoShape>& solid);
-  template <> bool instanceOf<Polycone>(const Handle<TGeoShape>& solid)   {
+  template bool isInstance<Box>(const Handle<TGeoShape>& solid);
+  template bool isInstance<ShapelessSolid>(const Handle<TGeoShape>& solid);
+  template bool isInstance<HalfSpace>(const Handle<TGeoShape>& solid);
+  template bool isInstance<ConeSegment>(const Handle<TGeoShape>& solid);
+  template bool isInstance<CutTube>(const Handle<TGeoShape>& solid);
+  template bool isInstance<EllipticalTube>(const Handle<TGeoShape>& solid);
+  template bool isInstance<Trap>(const Handle<TGeoShape>& solid);
+  template bool isInstance<Trd1>(const Handle<TGeoShape>& solid);
+  template bool isInstance<Trd2>(const Handle<TGeoShape>& solid);
+  template bool isInstance<Torus>(const Handle<TGeoShape>& solid);
+  template bool isInstance<Sphere>(const Handle<TGeoShape>& solid);
+  template bool isInstance<Paraboloid>(const Handle<TGeoShape>& solid);
+  template bool isInstance<Hyperboloid>(const Handle<TGeoShape>& solid);
+  template bool isInstance<PolyhedraRegular>(const Handle<TGeoShape>& solid);
+  template bool isInstance<Polyhedra>(const Handle<TGeoShape>& solid);
+  template bool isInstance<ExtrudedPolygon>(const Handle<TGeoShape>& solid);
+  template bool isInstance<BooleanSolid>(const Handle<TGeoShape>& solid);
+
+  template <> bool isInstance<Cone>(const Handle<TGeoShape>& solid)  {
+    return check_shape_type(solid, TGeoConeSeg::Class())
+      ||   check_shape_type(solid, TGeoCone::Class());
+  }
+  template <> bool isInstance<Tube>(const Handle<TGeoShape>& solid)  {
+    return check_shape_type(solid, TGeoTubeSeg::Class())
+      ||   check_shape_type(solid, TGeoCtub::Class());
+  }
+  template <> bool isInstance<Polycone>(const Handle<TGeoShape>& solid)   {
     return check_shape_type(solid, TGeoPcon::Class())
       ||   check_shape_type(solid, TGeoPgon::Class());
   }
-  template <> bool instanceOf<EightPointSolid>(const Handle<TGeoShape>& solid)   {
+  template <> bool isInstance<EightPointSolid>(const Handle<TGeoShape>& solid)   {
     if ( solid.isValid() )   {
       TClass* c = solid->IsA();
-      return c==TGeoTrap::Class() || c==TGeoArb8::Class() || c==TGeoGtra::Class();
+      return c==TGeoArb8::Class() || c==TGeoTrap::Class() || c==TGeoGtra::Class();
     }
     return false;
   }
-  template <> bool instanceOf<TruncatedTube>(const Handle<TGeoShape>& solid)   {
+  template <> bool isInstance<TruncatedTube>(const Handle<TGeoShape>& solid)   {
     if ( solid.isValid() )   {
       return solid->IsA() == TGeoCompositeShape::Class()
         &&   ::strcmp(solid->GetTitle(), TRUNCATEDTUBE_TAG) == 0;
     }
     return false;
   }
-  template <> bool instanceOf<PseudoTrap>(const Handle<TGeoShape>& solid)   {
+  template <> bool isInstance<PseudoTrap>(const Handle<TGeoShape>& solid)   {
     if ( solid.isValid() )   {
       return solid->IsA() == TGeoCompositeShape::Class()
         &&   ::strcmp(solid->GetTitle(), PSEUDOTRAP_TAG) == 0;
     }
     return false;
   }
-  template <> bool instanceOf<SubtractionSolid>(const Handle<TGeoShape>& solid)   {
+  template <> bool isInstance<SubtractionSolid>(const Handle<TGeoShape>& solid)   {
     TGeoCompositeShape* sh = (TGeoCompositeShape*)solid.ptr();
     return sh && sh->IsA() == TGeoCompositeShape::Class()
       &&   sh->GetBoolNode()->GetBooleanOperator() == TGeoBoolNode::kGeoSubtraction;
   }
-  template <> bool instanceOf<UnionSolid>(const Handle<TGeoShape>& solid)   {
+  template <> bool isInstance<UnionSolid>(const Handle<TGeoShape>& solid)   {
     TGeoCompositeShape* sh = (TGeoCompositeShape*)solid.ptr();
     return sh && sh->IsA() == TGeoCompositeShape::Class()
       &&   sh->GetBoolNode()->GetBooleanOperator() == TGeoBoolNode::kGeoUnion;
   }
-  template <> bool instanceOf<IntersectionSolid>(const Handle<TGeoShape>& solid)   {
+  template <> bool isInstance<IntersectionSolid>(const Handle<TGeoShape>& solid)   {
     TGeoCompositeShape* sh = (TGeoCompositeShape*)solid.ptr();
     return sh && sh->IsA() == TGeoCompositeShape::Class()
       &&   sh->GetBoolNode()->GetBooleanOperator() == TGeoBoolNode::kGeoIntersection;
+  }
+
+  /// Type check of various shapes. Do not allow for polymorphism. Types must match exactly
+  template <typename SOLID> bool isA(const Handle<TGeoShape>& solid)   {
+    return check_shape_type(solid, SOLID::Object::Class());
+  }
+  template bool isA<Box>(const Handle<TGeoShape>& solid);
+  template bool isA<ShapelessSolid>(const Handle<TGeoShape>& solid);
+  template bool isA<HalfSpace>(const Handle<TGeoShape>& solid);
+  template bool isA<Cone>(const Handle<TGeoShape>& solid);
+  template bool isA<ConeSegment>(const Handle<TGeoShape>& solid);
+  template bool isA<Tube>(const Handle<TGeoShape>& solid);
+  template bool isA<CutTube>(const Handle<TGeoShape>& solid);
+  template bool isA<EllipticalTube>(const Handle<TGeoShape>& solid);
+  template bool isA<Trap>(const Handle<TGeoShape>& solid);
+  template bool isA<Trd1>(const Handle<TGeoShape>& solid);
+  template bool isA<Trd2>(const Handle<TGeoShape>& solid);
+  template bool isA<Torus>(const Handle<TGeoShape>& solid);
+  template bool isA<Sphere>(const Handle<TGeoShape>& solid);
+  template bool isA<Paraboloid>(const Handle<TGeoShape>& solid);
+  template bool isA<Hyperboloid>(const Handle<TGeoShape>& solid);
+  template bool isA<PolyhedraRegular>(const Handle<TGeoShape>& solid);
+  template bool isA<Polyhedra>(const Handle<TGeoShape>& solid);
+  template bool isA<ExtrudedPolygon>(const Handle<TGeoShape>& solid);
+  template bool isA<Polycone>(const Handle<TGeoShape>& solid);
+  template bool isA<EightPointSolid>(const Handle<TGeoShape>& solid);
+
+  template <> bool isA<TruncatedTube>(const Handle<TGeoShape>& solid)   {
+    if ( solid.isValid() )   {
+      return solid->IsA() == TGeoCompositeShape::Class()
+        &&   ::strcmp(solid->GetTitle(), TRUNCATEDTUBE_TAG) == 0;
+    }
+    return false;
+  }
+  template <> bool isA<PseudoTrap>(const Handle<TGeoShape>& solid)   {
+    if ( solid.isValid() )   {
+      return solid->IsA() == TGeoCompositeShape::Class()
+        &&   ::strcmp(solid->GetTitle(), PSEUDOTRAP_TAG) == 0;
+    }
+    return false;
+  }
+  template <> bool isA<SubtractionSolid>(const Handle<TGeoShape>& solid)   {
+    TGeoCompositeShape* sh = (TGeoCompositeShape*)solid.ptr();
+    return sh && sh->IsA() == TGeoCompositeShape::Class()
+      &&   sh->GetBoolNode()->GetBooleanOperator() == TGeoBoolNode::kGeoSubtraction
+      &&    ::strcmp(solid->GetTitle(), SUBTRACTION_TAG) == 0;
+  }
+  template <> bool isA<UnionSolid>(const Handle<TGeoShape>& solid)   {
+    TGeoCompositeShape* sh = (TGeoCompositeShape*)solid.ptr();
+    return sh && sh->IsA() == TGeoCompositeShape::Class()
+      &&   sh->GetBoolNode()->GetBooleanOperator() == TGeoBoolNode::kGeoUnion
+      &&    ::strcmp(solid->GetTitle(), UNION_TAG) == 0;
+  }
+  template <> bool isA<IntersectionSolid>(const Handle<TGeoShape>& solid)   {
+    TGeoCompositeShape* sh = (TGeoCompositeShape*)solid.ptr();
+    return sh && sh->IsA() == TGeoCompositeShape::Class()
+      &&   sh->GetBoolNode()->GetBooleanOperator() == TGeoBoolNode::kGeoIntersection
+      &&    ::strcmp(solid->GetTitle(), INTERSECTION_TAG) == 0;
   }
 }
 
@@ -267,7 +326,7 @@ namespace dd4hep {
         TGeoMatrix* right_matrix  = boolean->GetRightMatrix();
         TGeoShape*  left_solid    = boolean->GetLeftShape();
         TGeoShape*  right_solid   = boolean->GetRightShape();
-        if ( instanceOf<TruncatedTube>(solid) )   {
+        if ( isInstance<TruncatedTube>(solid) )   {
           stringstream params(right_matrix->GetTitle());
           vector<double> pars;
           pars.reserve(8);
@@ -350,7 +409,7 @@ namespace dd4hep {
               cutAtStart, cutAtDelta, cutInside ? 1.0 : 0.0 };
 #endif
         }
-        else if ( instanceOf<PseudoTrap>(solid) )   {
+        else if ( isInstance<PseudoTrap>(solid) )   {
           stringstream params(right_matrix->GetTitle());
           vector<double> pars;
           pars.reserve(7);
@@ -368,11 +427,11 @@ namespace dd4hep {
           }
           return pars;
         }
-        else if ( instanceOf<SubtractionSolid>(solid) )   {
+        else if ( isInstance<SubtractionSolid>(solid) )   {
         }
-        else if ( instanceOf<UnionSolid>(solid) )   {
+        else if ( isInstance<UnionSolid>(solid) )   {
         }
-        else if ( instanceOf<IntersectionSolid>(solid) )   {
+        else if ( isInstance<IntersectionSolid>(solid) )   {
         }
         
         TGeoBoolNode::EGeoBoolType oper = boolean->GetBooleanOperator();
@@ -607,7 +666,7 @@ namespace dd4hep {
         TGeoMatrix* right_matrix  = boolean->GetRightMatrix();
         TGeoShape*  left_solid    = boolean->GetLeftShape();
         TGeoShape*  right_solid   = boolean->GetRightShape();
-        if ( instanceOf<TruncatedTube>(solid) )   {
+        if ( isInstance<TruncatedTube>(solid) )   {
           TGeoTubeSeg* tubs = (TGeoTubeSeg*)left_solid;
           TGeoBBox*    box  = (TGeoBBox*)right_solid;
           double zhalf = params[0];
@@ -664,7 +723,7 @@ namespace dd4hep {
           combi->SetTranslation(xBox, 0, 0);
           return;
         }
-        else if ( instanceOf<PseudoTrap>(solid) )   {
+        else if ( isInstance<PseudoTrap>(solid) )   {
           double x1 = params[0];
           double x2 = params[1];
           double y1 = params[2];
@@ -742,11 +801,11 @@ namespace dd4hep {
           return;
         }
         // In general TGeoCompositeShape instances have an empty SetDimension call
-        else if ( instanceOf<SubtractionSolid>(solid) )   {
+        else if ( isInstance<SubtractionSolid>(solid) )   {
         }
-        else if ( instanceOf<UnionSolid>(solid) )   {
+        else if ( isInstance<UnionSolid>(solid) )   {
         }
-        else if ( instanceOf<IntersectionSolid>(solid) )   {
+        else if ( isInstance<IntersectionSolid>(solid) )   {
         }
 #ifdef DIMENSION_DEBUG
         throw runtime_error("Composite shape. setDimensions is not implemented!");

--- a/DDCore/src/plugins/ShapePlugins.cpp
+++ b/DDCore/src/plugins/ShapePlugins.cpp
@@ -546,55 +546,55 @@ static Ref_t create_shape(Detector& description, xml_h e, Ref_t /* sens */)  {
              shape.typeStr().c_str());
     bool instance_test = false;
     if ( 0 == strcasecmp(solid->GetTitle(),"box") )
-      instance_test = instanceOf<Box>(solid);
+      instance_test = isInstance<Box>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Tube") )
-      instance_test = instanceOf<Tube>(solid);
+      instance_test = isInstance<Tube>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"CutTube") )
-      instance_test = instanceOf<CutTube>(solid);
+      instance_test = isInstance<CutTube>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Cone") )
-      instance_test = instanceOf<Cone>(solid);
+      instance_test = isInstance<Cone>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Trap") )
-      instance_test = instanceOf<Trap>(solid);
+      instance_test = isInstance<Trap>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Trd1") )
-      instance_test = instanceOf<Trd1>(solid);
+      instance_test = isInstance<Trd1>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Trd2") )
-      instance_test = instanceOf<Trd2>(solid);
+      instance_test = isInstance<Trd2>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Torus") )
-      instance_test = instanceOf<Torus>(solid);
+      instance_test = isInstance<Torus>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Sphere") )
-      instance_test = instanceOf<Sphere>(solid);
+      instance_test = isInstance<Sphere>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"HalfSpace") )
-      instance_test = instanceOf<HalfSpace>(solid);
+      instance_test = isInstance<HalfSpace>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"ConeSegment") )
-      instance_test = instanceOf<ConeSegment>(solid);
+      instance_test = isInstance<ConeSegment>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Paraboloid") )
-      instance_test = instanceOf<Paraboloid>(solid);
+      instance_test = isInstance<Paraboloid>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Hyperboloid") )
-      instance_test = instanceOf<Hyperboloid>(solid);
+      instance_test = isInstance<Hyperboloid>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"PolyhedraRegular") )
-      instance_test = instanceOf<PolyhedraRegular>(solid);
+      instance_test = isInstance<PolyhedraRegular>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Polyhedra") )
-      instance_test = instanceOf<Polyhedra>(solid);
+      instance_test = isInstance<Polyhedra>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"EllipticalTube") )
-      instance_test = instanceOf<EllipticalTube>(solid);
+      instance_test = isInstance<EllipticalTube>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"ExtrudedPolygon") )
-      instance_test = instanceOf<ExtrudedPolygon>(solid);
+      instance_test = isInstance<ExtrudedPolygon>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"Polycone") )
-      instance_test = instanceOf<Polycone>(solid);
+      instance_test = isInstance<Polycone>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"EightPointSolid") )
-      instance_test = instanceOf<EightPointSolid>(solid);
+      instance_test = isInstance<EightPointSolid>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"SubtractionSolid") )
-      instance_test = instanceOf<SubtractionSolid>(solid);
+      instance_test = isInstance<SubtractionSolid>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"UnionSolid") )
-      instance_test = instanceOf<UnionSolid>(solid);
+      instance_test = isInstance<UnionSolid>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"IntersectionSolid") )
-      instance_test = instanceOf<IntersectionSolid>(solid);
+      instance_test = isInstance<IntersectionSolid>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"TruncatedTube") )
-      instance_test = instanceOf<TruncatedTube>(solid);
+      instance_test = isInstance<TruncatedTube>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),"PseudoTrap") )
-      instance_test = instanceOf<PseudoTrap>(solid);
+      instance_test = isInstance<PseudoTrap>(solid);
 
-    if ( !instance_test || ::strcasecmp(shape.typeStr().c_str(),solid->GetTitle()) )   {
+    if ( !instance_test || ::strcasecmp(shape.typeStr().c_str(),solid->GetTitle()) != 0 )   {
       printout(ERROR,"TestShape","BAD shape type: %s <-> %s Instance test: %s",
                shape.typeStr().c_str(), solid->GetTitle(),
                instance_test ? "OK" : "FAILED");
@@ -712,11 +712,11 @@ void* shape_mesh_verifier(Detector& description, int argc, char** argv)    {
     for (Int_t ipv=0, npv=v->GetNdaughters(); ipv < npv; ipv++) {
       PlacedVolume place = v->GetNode(ipv);
       Solid solid = place.volume().solid();
-      if ( instanceOf<TruncatedTube>(solid) )   {
+      if ( isInstance<TruncatedTube>(solid) )   {
         auto params = solid.dimensions();
         solid.setDimensions(params);
       }
-      else if ( instanceOf<PseudoTrap>(solid) )   {
+      else if ( isInstance<PseudoTrap>(solid) )   {
         auto params = solid.dimensions();
         solid.setDimensions(params);
       }

--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -136,7 +136,7 @@ namespace dd4hep {
       z.reserve(nz);
       polygon.reserve(nz);
       for(size_t i=0; i<nz; ++i)   {
-        z.emplace_back(G4ExtrudedSolid::ZSection(sh->GetZ(i) * CM_2_MM,
+        z.emplace_back(sh->GetZ(i) * CM_2_MM,
                                                  {sh->GetXOffset(i), sh->GetYOffset(i)},
                                                  sh->GetScale(i));
         polygon.emplace_back(sh->GetX(i) * CM_2_MM,sh->GetY(i) * CM_2_MM);

--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -124,7 +124,7 @@ namespace dd4hep {
       TGeoArb8* sh = (TGeoArb8*) shape;
       Double_t* vtx_xy = sh->GetVertices();
       for ( size_t i=0; i<8; ++i, vtx_xy +=2 )
-        vertices.emplace_back(G4TwoVector(vtx_xy[0] * CM_2_MM,vtx_xy[1] * CM_2_MM));
+        vertices.emplace_back(vtx_xy[0] * CM_2_MM, vtx_xy[1] * CM_2_MM);
       return new G4GenericTrap(sh->GetName(), sh->GetDz() * CM_2_MM, vertices);
     }
 

--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -138,7 +138,7 @@ namespace dd4hep {
       for(size_t i=0; i<nz; ++i)   {
         z.emplace_back(G4ExtrudedSolid::ZSection(sh->GetZ(i) * CM_2_MM,
                                                  {sh->GetXOffset(i), sh->GetYOffset(i)},
-                                                 sh->GetScale(i)));
+                                                 sh->GetScale(i));
         polygon.emplace_back(G4TwoVector(sh->GetX(i) * CM_2_MM,sh->GetY(i) * CM_2_MM));
       }
       return new G4ExtrudedSolid(sh->GetName(), polygon, z);

--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -139,7 +139,7 @@ namespace dd4hep {
         z.emplace_back(G4ExtrudedSolid::ZSection(sh->GetZ(i) * CM_2_MM,
                                                  {sh->GetXOffset(i), sh->GetYOffset(i)},
                                                  sh->GetScale(i));
-        polygon.emplace_back(G4TwoVector(sh->GetX(i) * CM_2_MM,sh->GetY(i) * CM_2_MM));
+        polygon.emplace_back(sh->GetX(i) * CM_2_MM,sh->GetY(i) * CM_2_MM);
       }
       return new G4ExtrudedSolid(sh->GetName(), polygon, z);
     }

--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -136,9 +136,7 @@ namespace dd4hep {
       z.reserve(nz);
       polygon.reserve(nz);
       for(size_t i=0; i<nz; ++i)   {
-        z.emplace_back(sh->GetZ(i) * CM_2_MM,
-                                                 {sh->GetXOffset(i), sh->GetYOffset(i)},
-                                                 sh->GetScale(i));
+        z.emplace_back(G4ExtrudedSolid::ZSection(sh->GetZ(i) * CM_2_MM, {sh->GetXOffset(i), sh->GetYOffset(i)}, sh->GetScale(i)));
         polygon.emplace_back(sh->GetX(i) * CM_2_MM,sh->GetY(i) * CM_2_MM);
       }
       return new G4ExtrudedSolid(sh->GetName(), polygon, z);

--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -1,0 +1,220 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+#include "DD4hep/Shapes.h"
+#include "DD4hep/Printout.h"
+#include "DD4hep/DD4hepUnits.h"
+
+#include "Geant4ShapeConverter.h"
+
+// ROOT includes
+#include "TClass.h"
+#include "TGeoMatrix.h"
+#include "TGeoBoolNode.h"
+#include "TGeoScaledShape.h"
+
+// Geant4 include files
+#include "G4Box.hh"
+#include "G4Trd.hh"
+#include "G4Tubs.hh"
+#include "G4Trap.hh"
+#include "G4Cons.hh"
+#include "G4Hype.hh"
+#include "G4Torus.hh"
+#include "G4Sphere.hh"
+#include "G4CutTubs.hh"
+#include "G4Polycone.hh"
+#include "G4Polyhedra.hh"
+#include "G4Paraboloid.hh"
+#include "G4Ellipsoid.hh"
+#include "G4GenericTrap.hh"
+#include "G4ExtrudedSolid.hh"
+#include "G4EllipticalTube.hh"
+
+// C/C++ include files
+
+using namespace std;
+using namespace dd4hep::detail;
+namespace units = dd4hep;
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    static const double CM_2_MM = (CLHEP::centimeter/dd4hep::centimeter);
+
+    /// Convert a specific TGeo shape into the geant4 equivalent
+    template <typename T> G4VSolid* convertShape(const TGeoShape* shape)    {
+      if ( shape )   {
+        dd4hep::except("convertShape","Unsupported shape: %s",shape->IsA()->GetName());
+      }
+      dd4hep::except("convertShape","Invalid shape conversion requested.");
+      return 0;
+    }
+
+    template <> G4VSolid* convertShape<TGeoShapeAssembly>(const TGeoShape* /* shape */)  {
+      return 0;
+    }
+
+    template <> G4VSolid* convertShape<TGeoBBox>(const TGeoShape* shape)  {
+      const TGeoBBox* sh = (const TGeoBBox*) shape;
+      return new G4Box(sh->GetName(), sh->GetDX() * CM_2_MM, sh->GetDY() * CM_2_MM, sh->GetDZ() * CM_2_MM);
+    }
+
+    template <> G4VSolid* convertShape<TGeoTube>(const TGeoShape* shape)  {
+      const TGeoTube* sh = (const TGeoTube*) shape;
+      return new G4Tubs(sh->GetName(), sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM, sh->GetDz() * CM_2_MM, 0, 2. * M_PI);
+    }
+
+    template <> G4VSolid* convertShape<TGeoTubeSeg>(const TGeoShape* shape)  {
+      const TGeoTubeSeg* sh = (const TGeoTubeSeg*) shape;
+      return new G4Tubs(sh->GetName(), sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM, sh->GetDz() * CM_2_MM,
+                        sh->GetPhi1() * DEGREE_2_RAD, (sh->GetPhi2()-sh->GetPhi1()) * DEGREE_2_RAD);
+    }
+
+    template <> G4VSolid* convertShape<TGeoCtub>(const TGeoShape* shape)  {
+      const TGeoCtub* sh = (const TGeoCtub*) shape;
+      const Double_t* ln = sh->GetNlow();
+      const Double_t* hn = sh->GetNhigh();
+      G4ThreeVector   lowNorm (ln[0], ln[1], ln[2]);
+      G4ThreeVector   highNorm(hn[0], hn[1], hn[2]);
+      return new G4CutTubs(sh->GetName(), sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM, sh->GetDz() * CM_2_MM,
+                           sh->GetPhi1() * DEGREE_2_RAD, (sh->GetPhi2()-sh->GetPhi1()) * DEGREE_2_RAD, lowNorm, highNorm);
+    }
+
+    template <> G4VSolid* convertShape<TGeoEltu>(const TGeoShape* shape)  {
+      const TGeoEltu* sh = (const TGeoEltu*) shape;
+      return new G4EllipticalTube(sh->GetName(),sh->GetA() * CM_2_MM, sh->GetB() * CM_2_MM, sh->GetDz() * CM_2_MM);
+    }
+
+    template <> G4VSolid* convertShape<TGeoTrd1>(const TGeoShape* shape)  {
+      const TGeoTrd1* sh = (const TGeoTrd1*) shape;
+      return new G4Trd(sh->GetName(), sh->GetDx1() * CM_2_MM, sh->GetDx2() * CM_2_MM, sh->GetDy() * CM_2_MM, sh->GetDy() * CM_2_MM,
+                       sh->GetDz() * CM_2_MM);
+    }
+
+    template <> G4VSolid* convertShape<TGeoTrd2>(const TGeoShape* shape)  {
+      const TGeoTrd2* sh = (const TGeoTrd2*) shape;
+      return new G4Trd(sh->GetName(), sh->GetDx1() * CM_2_MM, sh->GetDx2() * CM_2_MM, sh->GetDy1() * CM_2_MM, sh->GetDy2() * CM_2_MM,
+                       sh->GetDz() * CM_2_MM);
+    }
+
+    template <> G4VSolid* convertShape<TGeoHype>(const TGeoShape* shape)  {
+      const TGeoHype* sh = (const TGeoHype*) shape;
+      return new G4Hype(sh->GetName(), sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM,
+                        sh->GetStIn() * DEGREE_2_RAD, sh->GetStOut() * DEGREE_2_RAD,
+                        sh->GetDz() * CM_2_MM);
+    }
+
+    template <> G4VSolid* convertShape<TGeoArb8>(const TGeoShape* shape)  {
+      vector<G4TwoVector> vertices;
+      TGeoArb8* sh = (TGeoArb8*) shape;
+      Double_t* vtx_xy = sh->GetVertices();
+      for ( size_t i=0; i<8; ++i, vtx_xy +=2 )
+        vertices.emplace_back(G4TwoVector(vtx_xy[0] * CM_2_MM,vtx_xy[1] * CM_2_MM));
+      return new G4GenericTrap(sh->GetName(), sh->GetDz() * CM_2_MM, vertices);
+    }
+
+    template <> G4VSolid* convertShape<TGeoXtru>(const TGeoShape* shape)  {
+      const TGeoXtru* sh = (const TGeoXtru*) shape;
+      size_t nz = sh->GetNz();
+      vector<G4ExtrudedSolid::ZSection> z;
+      vector<G4TwoVector> polygon;
+      z.reserve(nz);
+      polygon.reserve(nz);
+      for(size_t i=0; i<nz; ++i)   {
+        z.emplace_back(G4ExtrudedSolid::ZSection(sh->GetZ(i) * CM_2_MM,
+                                                 {sh->GetXOffset(i), sh->GetYOffset(i)},
+                                                 sh->GetScale(i)));
+        polygon.emplace_back(G4TwoVector(sh->GetX(i) * CM_2_MM,sh->GetY(i) * CM_2_MM));
+      }
+      return new G4ExtrudedSolid(sh->GetName(), polygon, z);
+    }
+
+    template <> G4VSolid* convertShape<TGeoPgon>(const TGeoShape* shape)  {
+      const TGeoPgon* sh = (const TGeoPgon*) shape;
+      double phi_start = sh->GetPhi1() * DEGREE_2_RAD;
+      double phi_total = (sh->GetDphi() + sh->GetPhi1()) * DEGREE_2_RAD;
+      vector<double> rmin, rmax, z;
+      for (Int_t i = 0; i < sh->GetNz(); ++i) {
+        rmin.emplace_back(sh->GetRmin(i) * CM_2_MM);
+        rmax.emplace_back(sh->GetRmax(i) * CM_2_MM);
+        z.emplace_back(sh->GetZ(i) * CM_2_MM);
+      }
+      return new G4Polyhedra(sh->GetName(), phi_start, phi_total, sh->GetNedges(), sh->GetNz(), &z[0], &rmin[0], &rmax[0]);
+    }
+
+    template <> G4VSolid* convertShape<TGeoPcon>(const TGeoShape* shape)  {
+      const TGeoPcon* sh = (const TGeoPcon*) shape;
+      double phi_start = sh->GetPhi1() * DEGREE_2_RAD;
+      double phi_total = (sh->GetDphi() + sh->GetPhi1()) * DEGREE_2_RAD;
+      vector<double> rmin, rmax, z;
+      for (Int_t i = 0; i < sh->GetNz(); ++i) {
+        rmin.emplace_back(sh->GetRmin(i) * CM_2_MM);
+        rmax.emplace_back(sh->GetRmax(i) * CM_2_MM);
+        z.emplace_back(sh->GetZ(i) * CM_2_MM);
+      }
+      return new G4Polycone(sh->GetName(), phi_start, phi_total, sh->GetNz(), &z[0], &rmin[0], &rmax[0]);
+    }
+
+    template <> G4VSolid* convertShape<TGeoCone>(const TGeoShape* shape)  {
+      const TGeoCone* sh = (const TGeoCone*) shape;
+      return new G4Cons(sh->GetName(), sh->GetRmin1() * CM_2_MM, sh->GetRmax1() * CM_2_MM, sh->GetRmin2() * CM_2_MM,
+                        sh->GetRmax2() * CM_2_MM, sh->GetDz() * CM_2_MM, 0.0, 2.*M_PI);
+    }
+
+    template <> G4VSolid* convertShape<TGeoConeSeg>(const TGeoShape* shape)  {
+      const TGeoConeSeg* sh = (const TGeoConeSeg*) shape;
+      return new G4Cons(sh->GetName(), sh->GetRmin1() * CM_2_MM, sh->GetRmax1() * CM_2_MM,
+                        sh->GetRmin2() * CM_2_MM, sh->GetRmax2() * CM_2_MM,
+                        sh->GetDz() * CM_2_MM,
+                        sh->GetPhi1() * DEGREE_2_RAD, (sh->GetPhi2()-sh->GetPhi1()) * DEGREE_2_RAD);
+    }
+
+    template <> G4VSolid* convertShape<TGeoParaboloid>(const TGeoShape* shape)  {
+      const TGeoParaboloid* sh = (const TGeoParaboloid*) shape;
+      return new G4Paraboloid(sh->GetName(), sh->GetDz() * CM_2_MM, sh->GetRlo() * CM_2_MM, sh->GetRhi() * CM_2_MM);
+    }
+
+    template <> G4VSolid* convertShape<TGeoSphere>(const TGeoShape* shape)  {
+      const TGeoSphere* sh = (const TGeoSphere*) shape;
+      return new G4Sphere(sh->GetName(), sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM, sh->GetPhi1() * DEGREE_2_RAD,
+                          sh->GetPhi2() * DEGREE_2_RAD, sh->GetTheta1() * DEGREE_2_RAD, sh->GetTheta2() * DEGREE_2_RAD);
+    }
+
+    template <> G4VSolid* convertShape<TGeoTorus>(const TGeoShape* shape)  {
+      const TGeoTorus* sh = (const TGeoTorus*) shape;
+      return new G4Torus(sh->GetName(), sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM, sh->GetR() * CM_2_MM,
+                         sh->GetPhi1() * DEGREE_2_RAD, sh->GetDphi() * DEGREE_2_RAD);
+    }
+
+    template <> G4VSolid* convertShape<TGeoTrap>(const TGeoShape* shape)  {
+      const TGeoTrap* sh = (const TGeoTrap*) shape;
+      return new G4Trap(sh->GetName(), sh->GetDz() * CM_2_MM, sh->GetTheta() * DEGREE_2_RAD, sh->GetPhi() * DEGREE_2_RAD,
+                        sh->GetH1() * CM_2_MM, sh->GetBl1() * CM_2_MM, sh->GetTl1() * CM_2_MM, sh->GetAlpha1() * DEGREE_2_RAD,
+                        sh->GetH2() * CM_2_MM, sh->GetBl2() * CM_2_MM, sh->GetTl2() * CM_2_MM, sh->GetAlpha2() * DEGREE_2_RAD);
+    }
+
+    template <> G4VSolid* convertShape<G4GenericTrap>(const TGeoShape* shape)  {
+      vector<G4TwoVector> vertices;
+      TGeoTrap* sh = (TGeoTrap*) shape;
+      Double_t* vtx_xy = sh->GetVertices();
+      for ( size_t i=0; i<8; ++i, vtx_xy +=2 )
+        vertices.emplace_back(G4TwoVector(vtx_xy[0] * CM_2_MM,vtx_xy[1] * CM_2_MM));
+      return new G4GenericTrap(sh->GetName(), sh->GetDz() * CM_2_MM, vertices);
+    }
+  }    // End namespace sim
+}      // End namespace dd4hep

--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -213,7 +213,7 @@ namespace dd4hep {
       TGeoTrap* sh = (TGeoTrap*) shape;
       Double_t* vtx_xy = sh->GetVertices();
       for ( size_t i=0; i<8; ++i, vtx_xy +=2 )
-        vertices.emplace_back(G4TwoVector(vtx_xy[0] * CM_2_MM,vtx_xy[1] * CM_2_MM));
+        vertices.emplace_back(vtx_xy[0] * CM_2_MM, vtx_xy[1] * CM_2_MM);
       return new G4GenericTrap(sh->GetName(), sh->GetDz() * CM_2_MM, vertices);
     }
   }    // End namespace sim

--- a/DDG4/src/Geant4ShapeConverter.h
+++ b/DDG4/src/Geant4ShapeConverter.h
@@ -1,0 +1,35 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DD4HEP_DDG4_GEANT4SHAPECONVERTER_H
+#define DD4HEP_DDG4_GEANT4SHAPECONVERTER_H
+
+// Framework include files
+
+// C/C++ include files
+
+// Forward declarations
+class TGeoShape;
+class G4VSolid;
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    /// Convert a specific TGeo shape into the geant4 equivalent
+    template <typename T> G4VSolid* convertShape(const TGeoShape* shape);
+
+  }    // End namespace sim
+}      // End namespace dd4hep
+#endif // DD4HEP_DDG4_GEANT4SHAPECONVERTER_H


### PR DESCRIPTION
BEGINRELEASENOTES
 - Add function `bool isInstance(const Handle<TGeoShape>& solid)`
   - compares types of shapes and behaves like `dynamic_cast`, similar to python's `isinstance(obj,type)`
   - remove deprecated function `instanceOf` in favour of `isInstance`. Same behavior.
 - Add function `bool isA(const Handle<TGeoShape>& solid)`
   - compares types of shapes and requires exact match, no polymorphism allowed.
- Add Geant4 conversion for shape `TGeoCtub` -> `G4CutTube`

ENDRELEASENOTES