### PR TITLE
Try to make examples standalone per case

### DIFF
--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -556,7 +556,7 @@ function(dd4hep_add_dictionary dictionary )
   if ( NOT "${ARG_OUTPUT}" STREQUAL "" )
     set ( output_dir ${ARG_OUTPUT} )
   endif()
-
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory ${output_dir})
   SET(COMP_DEFS )
   file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${dictionary}_arguments
     CONTENT "${ROOT_rootcling_CMD} -cint -f ${dictionary}.cxx -s ${output_dir}/${dictionary} -inlineInputHeader -c -p ${ARG_OPTIONS} -std=c++${CMAKE_CXX_STANDARD}  \

--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -692,7 +692,7 @@ MACRO(DD4HEP_SETUP_BOOST_TARGETS)
   # stdc++fs needed in gcc8, no lib for gcc9.1, c++fs for llvm
   FOREACH(FS_LIB_NAME stdc++fs "" c++fs )
     dd4hep_debug("|++++> linking against ${FS_LIB_NAME}")
-    try_compile(HAVE_FILESYSTEM ${CMAKE_BINARY_DIR}/try ${CMAKE_CURRENT_LIST_DIR}/cmake/TryFileSystem.cpp
+    try_compile(HAVE_FILESYSTEM ${CMAKE_BINARY_DIR}/try ${DD4hep_DIR}/cmake/TryFileSystem.cpp
       CXX_STANDARD ${CMAKE_CXX_STANDARD}
       CXX_EXTENSIONS False
       OUTPUT_VARIABLE HAVE_FS_OUTPUT

--- a/cmake/DD4hepMacros.cmake
+++ b/cmake/DD4hepMacros.cmake
@@ -84,7 +84,6 @@ MACRO( DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES )
                 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                                 "${PROJECT_BINARY_DIR}/${arg}" @ONLY
                 )
-                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
                 INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION ./cmake )
             ENDIF()
         ENDIF()
@@ -94,7 +93,6 @@ MACRO( DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES )
     WRITE_BASIC_PACKAGE_VERSION_FILE( DD4hepConfigVersion.cmake
                                       VERSION ${DD4hep_VERSION}
                                       COMPATIBILITY AnyNewerVersion )
-    INSTALL( FILES "${PROJECT_BINARY_DIR}/DD4hepConfigVersion.cmake" DESTINATION . )
     INSTALL( FILES "${PROJECT_BINARY_DIR}/DD4hepConfigVersion.cmake" DESTINATION ./cmake )
 
 ENDMACRO( DD4HEP_GENERATE_PACKAGE_CONFIGURATION_FILES )

--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -9,11 +9,16 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================
-dd4hep_configure_output()
 
 set(AlignDet_INSTALL ${CMAKE_INSTALL_PREFIX}/examples/AlignDet)
 dd4hep_add_plugin(AlignDetExample SOURCES src/*.cpp

--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -9,16 +9,16 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================
-dd4hep_configure_output ()
-
-IF(NOT TARGET DD4hep::DDCore)
-  find_package(DD4hep)
-  find_package(ROOT REQUIRED COMPONENTS Geom)
-ENDIF()
 
 set(CLICSiDEx_INSTALL         ${CMAKE_INSTALL_PREFIX}/examples/CLICSiD)
 dd4hep_install_dir( scripts sim DESTINATION ${CLICSiDEx_INSTALL} )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,20 +28,12 @@ project( DD4hep_Examples )
 include(CTest)
 option(BUILD_TESTING "Enable and build tests" ON)
 
-option(CMAKE_MACOSX_RPATH "Build with rpath on macos" ON)
-#
+SET( ENV{DD4hepExamplesINSTALL} ${CMAKE_INSTALL_PREFIX} )
+
 IF(NOT TARGET DD4hep::DDCore)
   find_package ( DD4hep REQUIRED )
-  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
-  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
-  find_package ( ROOT REQUIRED COMPONENTS Geom GenVector )
-  dd4hep_set_compiler_flags()
 ENDIF()
-#
-#include(${ROOT_USE_FILE})
-#
-SET( ENV{DD4hepExamplesINSTALL} ${CMAKE_INSTALL_PREFIX} )
-#
+
 dd4hep_configure_output()
 
 add_subdirectory(CLICSiD)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,19 +36,14 @@ ENDIF()
 
 dd4hep_configure_output()
 
-add_subdirectory(CLICSiD)
-add_subdirectory(LHeD)
-add_subdirectory(AlignDet)
-add_subdirectory(ClientTests)
-add_subdirectory(Conditions)
-add_subdirectory(DDG4)
-add_subdirectory(DDDigi)
-add_subdirectory(Persistency)
-add_subdirectory(SimpleDetector)
-add_subdirectory(DDG4_MySensDet)
-add_subdirectory(DDCodex)
+#==========================================================================
 
-add_subdirectory(DDDB)
-add_subdirectory(DDCMS)
+SET(DD4HEP_BUILD_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDB DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency SimpleDetector"
+  CACHE STRING "List of DD4hep Examples to build")
+SEPARATE_ARGUMENTS(DD4HEP_BUILD_EXAMPLES)
+MESSAGE(STATUS "Will be building these examples: ${DD4HEP_BUILD_EXAMPLES}")
 
-add_subdirectory(OpticalSurfaces)
+FOREACH(DDExample IN LISTS DD4HEP_BUILD_EXAMPLES)
+  dd4hep_print("|> Building ${DDExample}")
+  add_subdirectory(${DDExample})
+ENDFOREACH()

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -9,12 +9,16 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================
-dd4hep_configure_output()
-
 if(TARGET XercesC::XercesC)
   SET(OPT_XERCESC XercesC::XercesC)
 endif()

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -9,11 +9,16 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================
-dd4hep_configure_output ()
 
 if(TARGET XercesC::XercesC)
   SET(OPT_XERCESC XercesC::XercesC)

--- a/examples/DDCMS/CMakeLists.txt
+++ b/examples/DDCMS/CMakeLists.txt
@@ -13,7 +13,13 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================

--- a/examples/DDCMS/data/dd4hep-config.xml
+++ b/examples/DDCMS/data/dd4hep-config.xml
@@ -106,7 +106,7 @@
   </display>
 
   <plugin name="DD4hep_XMLLoader">
-    <arg value="file:${DD4hepINSTALL}/examples/DDCMS/data/cms_tracker.xml"/>
+    <arg value="file:${DD4hepExamplesINSTALL}/examples/DDCMS/data/cms_tracker.xml"/>
   </plugin>
 
   <plugin name="DD4hep_PlacedVolumeProcessor">

--- a/examples/DDCMS/scripts/CMSTrackerSim.py
+++ b/examples/DDCMS/scripts/CMSTrackerSim.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 def run():
   kernel = DDG4.Kernel()
-  install_dir = os.environ['DD4hepINSTALL']
+  install_dir = os.environ['DD4hepExamplesINSTALL']
   kernel.setOutputLevel(str('Geant4Converter'), Output.DEBUG)
   kernel.setOutputLevel(str('Gun'), Output.INFO)
   kernel.detectorDescription().fromXML(str("file:" + install_dir + "/examples/DDCMS/data/dd4hep-config.xml"))

--- a/examples/DDCodex/CMakeLists.txt
+++ b/examples/DDCodex/CMakeLists.txt
@@ -9,7 +9,13 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================

--- a/examples/DDDB/CMakeLists.txt
+++ b/examples/DDDB/CMakeLists.txt
@@ -17,7 +17,13 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================

--- a/examples/DDDB/CMakeLists.txt
+++ b/examples/DDDB/CMakeLists.txt
@@ -35,10 +35,6 @@ else()
   return()
 endif()
 
-#------------------------------------------------------------------------------
-dd4hep_configure_output ()
-
-#
 #---DDDB library --------------------------------------------------------------
 FILE(GLOB DDDB_SOURCES src/*.cpp src/Detector/*.cpp)
 add_library(DDDB SHARED ${DDDB_SOURCES})

--- a/examples/DDDigi/CMakeLists.txt
+++ b/examples/DDDigi/CMakeLists.txt
@@ -9,7 +9,13 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================

--- a/examples/DDDigi/scripts/TestFramework.py
+++ b/examples/DDDigi/scripts/TestFramework.py
@@ -6,7 +6,7 @@ import DDDigi
 
 DDDigi.setPrintFormat(str('%-32s %5s %s'))
 kernel = DDDigi.Kernel()
-install_dir = os.environ['DD4hepINSTALL']
+install_dir = os.environ['DD4hepExamplesINSTALL']
 fname = "file:" + install_dir + "/examples/ClientTests/compact/MiniTel.xml"
 kernel.loadGeometry(str(fname))
 kernel.printProperties()

--- a/examples/DDG4/CMakeLists.txt
+++ b/examples/DDG4/CMakeLists.txt
@@ -9,11 +9,16 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================
-dd4hep_configure_output ()
 
 set(DDG4examples_INSTALL  ${CMAKE_INSTALL_PREFIX}/examples/DDG4)
 #
@@ -24,7 +29,6 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_dictionary(G__DDG4UserDict
   SOURCES ${DD4hep_DIR}/include/ROOT/Warnings.h src/Dictionary.h
   LINKDEF ${DD4hep_DIR}/include/ROOT/LinkDef.h
-  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/lib
   )
   #----  Example of a client library with user defined plugins  --------------------
   dd4hep_add_plugin( DDG4UserLib

--- a/examples/DDG4/CMakeLists.txt
+++ b/examples/DDG4/CMakeLists.txt
@@ -14,9 +14,9 @@ IF(NOT TARGET DD4hep::DDCore)
   find_package ( DD4hep REQUIRED )
   include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
   include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
-  dd4hep_configure_output()
 ENDIF()
 
+dd4hep_configure_output()
 dd4hep_set_compiler_flags()
 #==========================================================================
 
@@ -29,6 +29,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_dictionary(G__DDG4UserDict
   SOURCES ${DD4hep_DIR}/include/ROOT/Warnings.h src/Dictionary.h
   LINKDEF ${DD4hep_DIR}/include/ROOT/LinkDef.h
+  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/lib
   )
   #----  Example of a client library with user defined plugins  --------------------
   dd4hep_add_plugin( DDG4UserLib

--- a/examples/DDG4/CMakeLists.txt
+++ b/examples/DDG4/CMakeLists.txt
@@ -14,9 +14,9 @@ IF(NOT TARGET DD4hep::DDCore)
   find_package ( DD4hep REQUIRED )
   include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
   include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
 ENDIF()
 
-dd4hep_configure_output()
 dd4hep_set_compiler_flags()
 #==========================================================================
 
@@ -29,7 +29,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_dictionary(G__DDG4UserDict
   SOURCES ${DD4hep_DIR}/include/ROOT/Warnings.h src/Dictionary.h
   LINKDEF ${DD4hep_DIR}/include/ROOT/LinkDef.h
-  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/lib
+  OUTPUT ${LIBRARY_OUTPUT_PATH}
   )
   #----  Example of a client library with user defined plugins  --------------------
   dd4hep_add_plugin( DDG4UserLib

--- a/examples/DDG4_MySensDet/CMakeLists.txt
+++ b/examples/DDG4_MySensDet/CMakeLists.txt
@@ -14,9 +14,9 @@ IF(NOT TARGET DD4hep::DDCore)
   find_package ( DD4hep REQUIRED )
   include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
   include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
-  dd4hep_configure_output()
 ENDIF()
 
+dd4hep_configure_output()
 dd4hep_set_compiler_flags()
 #==========================================================================
 if(NOT TARGET Geant4::Interface)
@@ -38,6 +38,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_dictionary(G__DDG4_MySensDet
     SOURCES ${DD4hep_DIR}/include/ROOT/Warnings.h src/MyTrackerHit.h
     LINKDEF ${DD4hep_DIR}/include/ROOT/LinkDef.h
+    OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/lib
     )
 
   #----  Example of a client library with user defined plugins  --------------------

--- a/examples/DDG4_MySensDet/CMakeLists.txt
+++ b/examples/DDG4_MySensDet/CMakeLists.txt
@@ -9,7 +9,13 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================

--- a/examples/DDG4_MySensDet/CMakeLists.txt
+++ b/examples/DDG4_MySensDet/CMakeLists.txt
@@ -14,9 +14,9 @@ IF(NOT TARGET DD4hep::DDCore)
   find_package ( DD4hep REQUIRED )
   include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
   include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
 ENDIF()
 
-dd4hep_configure_output()
 dd4hep_set_compiler_flags()
 #==========================================================================
 if(NOT TARGET Geant4::Interface)
@@ -38,7 +38,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_dictionary(G__DDG4_MySensDet
     SOURCES ${DD4hep_DIR}/include/ROOT/Warnings.h src/MyTrackerHit.h
     LINKDEF ${DD4hep_DIR}/include/ROOT/LinkDef.h
-    OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/lib
+    OUTPUT  ${LIBRARY_OUTPUT_PATH}
     )
 
   #----  Example of a client library with user defined plugins  --------------------

--- a/examples/LHeD/CMakeLists.txt
+++ b/examples/LHeD/CMakeLists.txt
@@ -9,11 +9,16 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================
-dd4hep_configure_output ()
 set(LHeDEx_INSTALL         ${CMAKE_INSTALL_PREFIX}/examples/LHeD)
 dd4hep_install_dir( src compact scripts sim DESTINATION ${LHeDEx_INSTALL} )
 #-----------------------------------------------------------------------------------

--- a/examples/OpticalSurfaces/CMakeLists.txt
+++ b/examples/OpticalSurfaces/CMakeLists.txt
@@ -9,7 +9,13 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================

--- a/examples/Persistency/CMakeLists.txt
+++ b/examples/Persistency/CMakeLists.txt
@@ -9,7 +9,13 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,31 @@
+# DD4hep Examples
+
+The subfolders in this directory contain several examples on how to use DD4hep. There are two ways to build these examples:
+1. **Recommended way**: 
+  to build all examples in this folder:
+   ```
+   mkir build
+   cd build
+   cmake ..
+   make
+   make install
+   ctest --output-on-failure
+   ```
+    or to build a subset, use the variable `DD4HEP_BUILD_EXAMPLES` e.g.
+      ```
+   cmake -DDD4HEP_BUILD_EXAMPLES="OpticalSurfaces DDG4" ..
+   make
+   make install
+   ctest --output-on-failure
+   ```
+2. Not-recommended way:
+  It is also possible to build each subfolder separately, however in this case the tests are not enabled:
+     ```
+   cd OpticalSurfaces
+   mkir build
+   cd build
+   cmake ..
+   make
+   make install
+   ```
+

--- a/examples/Segmentation/CMakeLists.txt
+++ b/examples/Segmentation/CMakeLists.txt
@@ -14,9 +14,9 @@ IF(NOT TARGET DD4hep::DDCore)
   find_package ( DD4hep REQUIRED )
   include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
   include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
-  dd4hep_configure_output()
 ENDIF()
 
+dd4hep_configure_output()
 dd4hep_set_compiler_flags()
 #==========================================================================
 
@@ -50,17 +50,12 @@ ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 
-find_package( ROOT REQUIRED )
-set( ROOT_COMPONENT_LIBRARIES Geom Reflex)
-
-#-------------------------------------------------------------
-# add additional packages here
-
+find_package ( ROOT REQUIRED COMPONENTS Geom GenVector )
 
 #-------------------------------------------------------------
 
 include_directories( ${CMAKE_SOURCE_DIR}/include
-  ${dd4hep_INCLUDE_DIRS}
+  ${DD4hep_INCLUDE_DIRS}
   ${ROOT_INCLUDE_DIR}
   )
 
@@ -76,7 +71,7 @@ endif()
 
 add_executable(Segmentation SegmentationTest.cpp ${sources})
 
-target_link_libraries(Segmentation ${dd4hep_LIBRARIES} )
+target_link_libraries(Segmentation ${DD4hep_LIBRARIES} )
 
 #---Rootmap generation--------------------------------------------------------------
 #

--- a/examples/Segmentation/CMakeLists.txt
+++ b/examples/Segmentation/CMakeLists.txt
@@ -9,15 +9,20 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================
+
 #---------------------------
 set( PackageName Segmentation )
 #---------------------------
-
-project(${PackageName})
 
 # project version
 SET( ${PackageName}_VERSION_MAJOR 0 )
@@ -44,13 +49,8 @@ ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-find_package( DD4hep ) 
-
-set(CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}  ${dd4hep_ROOT}/cmake ) 
-include( dd4hep )
 
 find_package( ROOT REQUIRED )
-#find_package( ROOT REQUIRED COMPONENTS Geom Reflex)
 set( ROOT_COMPONENT_LIBRARIES Geom Reflex)
 
 #-------------------------------------------------------------
@@ -88,7 +88,7 @@ target_link_libraries(Segmentation ${dd4hep_LIBRARIES} )
 
 
 #---- configure run environment ---------------
-configure_file( ${dd4hep_ROOT}/cmake/thisdd4hep_package.sh.in  this${PackageName}.sh @ONLY)
+configure_file( ${DD4hep_ROOT}/cmake/thisdd4hep_package.sh.in  this${PackageName}.sh @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/this${PackageName}.sh
   DESTINATION bin

--- a/examples/Segmentation/CMakeLists.txt
+++ b/examples/Segmentation/CMakeLists.txt
@@ -70,3 +70,10 @@ dd4hep_configure_scripts(${PackageName} DEFAULT_SETUP WITH_TESTS)
 install(TARGETS ${PackageName} LIBRARY DESTINATION lib)
 
 #-------------------------------------------------------
+
+dd4hep_add_test_reg( Segmentation_Example_Test
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Segmentation.sh"
+  EXEC_ARGS  SegmentationTest
+  REGEX_PASS "Neighbours of system:1,barrel:0,module:5,layer:12,slice:0,x:10,y:-30:"
+  REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )

--- a/examples/Segmentation/CMakeLists.txt
+++ b/examples/Segmentation/CMakeLists.txt
@@ -14,9 +14,9 @@ IF(NOT TARGET DD4hep::DDCore)
   find_package ( DD4hep REQUIRED )
   include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
   include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
 ENDIF()
 
-dd4hep_configure_output()
 dd4hep_set_compiler_flags()
 #==========================================================================
 
@@ -54,47 +54,19 @@ find_package ( ROOT REQUIRED COMPONENTS Geom GenVector )
 
 #-------------------------------------------------------------
 
-include_directories( ${CMAKE_SOURCE_DIR}/include
-  ${DD4hep_INCLUDE_DIRS}
-  ${ROOT_INCLUDE_DIR}
-  )
 
-file(GLOB sources src/*.cpp )
-file(GLOB headers include/*.h)
-
-include(DD4hep_XML_setup)
-
-if(DD4HEP_USE_PYROOT)
-  ROOT_GENERATE_DICTIONARY(G__Segmentation ${headers} LINKDEF include/ROOT/LinkDef.h)
-  list(APPEND sources G__Segmentation.cxx)
-endif()
-
-add_executable(Segmentation SegmentationTest.cpp ${sources})
-
-target_link_libraries(Segmentation ${DD4hep_LIBRARIES} )
-
-#---Rootmap generation--------------------------------------------------------------
+set(Segmentationexamples_INSTALL  ${CMAKE_INSTALL_PREFIX}/examples/Segmentation)
 #
-#if(APPLE)
-#  dd4hep_generate_rootmap_apple(${PackageName} )
-#else()
-#  dd4hep_generate_rootmap(${PackageName} )
-#endif()
+add_executable(SegmentationTest SegmentationTest.cpp)
+target_link_libraries(SegmentationTest DD4hep::DDCore)
+install(TARGETS SegmentationTest LIBRARY DESTINATION bin)
 
 
 #---- configure run environment ---------------
-configure_file( ${DD4hep_ROOT}/cmake/thisdd4hep_package.sh.in  this${PackageName}.sh @ONLY)
-
-install(FILES ${CMAKE_BINARY_DIR}/this${PackageName}.sh
-  DESTINATION bin
-  )
-
+dd4hep_configure_scripts(${PackageName} DEFAULT_SETUP WITH_TESTS)
 
 #--- install target-------------------------------------
 
-install(TARGETS ${PackageName}
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  )
-# to do: add corresponding uninstall...
+install(TARGETS ${PackageName} LIBRARY DESTINATION lib)
+
 #-------------------------------------------------------

--- a/examples/Segmentation/SegmentationTest.cpp
+++ b/examples/Segmentation/SegmentationTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "DD4hep/Detector.h"
+#include "DDSegmentation/BitField64.h"
 
 #include "DDSegmentation/SegmentationFactory.h"
 #include "DDSegmentation/SegmentationParameter.h"
@@ -17,7 +18,7 @@ using namespace dd4hep;
 using namespace detail;
 using namespace DDSegmentation;
 
-int main(int argc, char** argv) {
+int main(int, char**) {
 
 	SegmentationFactory* f = SegmentationFactory::instance();
 
@@ -29,16 +30,16 @@ int main(int argc, char** argv) {
 		DDSegmentation::Segmentation* s = f->create(typeName);
 		cout << "\t" << typeName << ", " << s->type() << endl;
 		Parameters parameters = s->parameters();
-		Parameters::iterator it;
-		for (it = parameters.begin(); it != parameters.end(); ++it) {
-			Parameter p = *it;
+		Parameters::iterator it2;
+		for (it2 = parameters.begin(); it2 != parameters.end(); ++it2) {
+			Parameter p = *it2;
 			cout << "\t\t" << p->name() << " = " << p->value() << endl;
 		}
 		delete s;
 	}
 
 	DDSegmentation::Segmentation* s = f->create("CartesianGridXY", "system:8,barrel:3,module:4,layer:8,slice:5,x:32:-16,y:-16");
-	BitField64& d = *s->decoder();
+	BitField64 d = s->decoder();
 	d["system"] = 1;
 	d["barrel"] = 0;
 	d["module"] = 5;
@@ -56,4 +57,4 @@ int main(int argc, char** argv) {
 	}
 	delete s;
 	return 0;
-};
+}

--- a/examples/SimpleDetector/CMakeLists.txt
+++ b/examples/SimpleDetector/CMakeLists.txt
@@ -9,7 +9,13 @@
 #
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+
+IF(NOT TARGET DD4hep::DDCore)
+  find_package ( DD4hep REQUIRED )
+  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
+  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
+  dd4hep_configure_output()
+ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix bug that the c++ filesystem check is called from `${DD4hep_ROOT}`
- Install `DD4hepConfig.cmake` only in `__prefix__/cmake` to avoid path detection confusion
- Enable choosing examples in the `examples/CMakeLists.cmake` via cmake flag `-DDD4HEP_BUILD_EXAMPLES=OpticalSurfaces` (recommended method)
- Make each example folder to compile standalone (not recommended method)
- Update cmake of Segmentation example to more current state and fix resulting errors
  - include segmentation example as test
- Resolves #582 and resolves #583 
ENDRELEASENOTES