### PR TITLE
Fix for dumpbfield and magnets example

### DIFF
--- a/DDCore/src/FieldTypes.cpp
+++ b/DDCore/src/FieldTypes.cpp
@@ -109,7 +109,7 @@ void MultipoleField::fieldComponents(const double* pos, double* field) {
     double x2 = x*x;
     double y2 = y*y;
     switch(coefficents.size())  {
-    case 4:      // Ocupole momentum
+    case 4:      // Octupole momentum
       by += (1./6.) * ( coefficents[3] * (x2*x - 3.0*x*y2) + skews[3]*(y2*y - 3.0*x2*y) );
       bx += (1./6.) * ( coefficents[3] * (3.0*x2*y - y2*y) + skews[3]*(x2*x - 3.0*x*y2) );
       ATTR_FALLTHROUGH;

--- a/UtilityApps/src/dumpBfield.cpp
+++ b/UtilityApps/src/dumpBfield.cpp
@@ -42,20 +42,20 @@ static int invoke_dump_B_field(int argc, char** argv ){
   sstr << argv[2] << " " << argv[3] << " " << argv[4] << " " << argv[5] << " " << argv[6] << " " << argv[7] ;
   
   float xRange , yRange , zRange , dx , dy, dz ;
-  sstr >> xRange ;
-  sstr >> yRange ;
-  sstr >> zRange ;
-  sstr >> dx ;
-  sstr >> dy ;
-  sstr >> dz ;
-  
-  
-  
+  sstr >> xRange >> yRange >> zRange >> dx >> dy >> dz;
+
+  xRange *= dd4hep::cm;
+  yRange *= dd4hep::cm;
+  zRange *= dd4hep::cm;
+  dx *= dd4hep::cm;
+  dy *= dd4hep::cm;
+  dz *= dd4hep::cm;
+
   Detector& description = Detector::getInstance();
   description.fromCompact( inFile );
   
   printf("#######################################################################################################\n");
-  printf("       x[cm]             y[cm]           z[cm]           Bx[Tesla]        By[cm]          Bz[cm]       \n");
+  printf("      x[cm]            y[cm]            z[cm]          Bx[Tesla]        By[Tesla]        Bz[Tesla]     \n");
 
   for( float x = -xRange ; x <=xRange ; x += dx ){
     for( float y = -yRange ; y <=yRange ; y += dy ){
@@ -66,7 +66,7 @@ static int invoke_dump_B_field(int argc, char** argv ){
 	description.field().magneticField( posV  , bfieldV  ) ;
 
 	printf(" %+15.8e  %+15.8e  %+15.8e  %+15.8e  %+15.8e  %+15.8e  \n",
-         posV[0], posV[1],  posV[2],
+         posV[0]/dd4hep::cm, posV[1]/dd4hep::cm,  posV[2]/dd4hep::cm,
          bfieldV[0]/dd4hep::tesla , bfieldV[1]/dd4hep::tesla, bfieldV[2]/dd4hep::tesla ) ; 
 
       }

--- a/examples/ClientTests/compact/MagnetFields.xml
+++ b/examples/ClientTests/compact/MagnetFields.xml
@@ -51,7 +51,7 @@
     </field>
 
 
-    <field name="MagnetFields_GlobalMultipole" type="MultipoleMagnet" Z="50*cm">
+    <field name="MagnetFields_GlobalMultipole" type="MultipoleMagnet" Z="5*tesla">
       <position x="30*cm" y="20*cm" z="40*cm"/>
       <rotation x="1" y="0" z="0"/>
       <coefficient coefficient="1.0*tesla" skew="0.1*tesla"/>


### PR DESCRIPTION
Triggered by #589 

BEGINRELEASENOTES
- DumpBField: correct the column unit printout and prepare for eventual change of default length unit
- MagneticFields example: correct the unit for the Z parameter of the MultiPole to tesla

ENDRELEASENOTES