### PR TITLE
Fix AClick Tests (fixes #591)

### DIFF
--- a/DDG4/examples/initAClick.C
+++ b/DDG4/examples/initAClick.C
@@ -62,7 +62,7 @@ int initAClick(const char* command=0)  {
   std::string clhep   = make_str(gSystem->Getenv("CLHEP_ROOT_DIR"));
   std::string defs    = "";
   std::string libs    = " -L"+rootsys+"/lib";
-  std::string inc     = " -I"+dd4hep+"/examples/DDG4/examples -I"+dd4hep + " -I"+dd4hep+"/include";
+  std::string inc     = " -I"+dd4hep+"/examples/DDG4/examples -I"+dd4hep + " -I"+dd4hep+"/include ";
   std::string ext = "so";
   if ( !geant4.empty() )  {
     inc  += " -I"+geant4+"/include/Geant4";

--- a/DDG4/examples/initAClick.C
+++ b/DDG4/examples/initAClick.C
@@ -63,10 +63,12 @@ int initAClick(const char* command=0)  {
   std::string defs    = "";
   std::string libs    = " -L"+rootsys+"/lib";
   std::string inc     = " -I"+dd4hep+"/examples/DDG4/examples -I"+dd4hep + " -I"+dd4hep+"/include";
+  std::string ext = "so";
   if ( !geant4.empty() )  {
     inc  += " -I"+geant4+"/include/Geant4";
 #ifdef __APPLE__
     libs += (" -L"+geant4+"/lib");
+    ext = "dylib";
 #else
     libs += (" -L"+geant4+"/lib -L"+geant4+"/lib64");
 #endif
@@ -82,10 +84,10 @@ int initAClick(const char* command=0)  {
 #ifndef __APPLE__
   libs += " -lCore -lMathCore -pthread -lm -ldl -rdynamic";
 #endif
-  libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr.so";
-  libs += " " +dd4hep+"/lib/libDDCore.so";
-  libs += " " +dd4hep+"/lib/libDDG4.so";
-  gSystem->Load("libDD4hepGaudiPluginMgr.so");
+  libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr." + ext;
+  libs += " " +dd4hep+"/lib/libDDCore."+ ext;
+  libs += " " +dd4hep+"/lib/libDDG4."+ ext;
+  gSystem->Load(std::string("libDD4hepGaudiPluginMgr." + ext).c_str());
   gSystem->AddIncludePath(inc.c_str());
   gSystem->AddLinkedLibs(libs.c_str());
   std::cout << "+++ Includes:   " << gSystem->GetIncludePath() << std::endl;

--- a/DDG4/examples/initAClick.C
+++ b/DDG4/examples/initAClick.C
@@ -87,7 +87,6 @@ int initAClick(const char* command=0)  {
   libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr." + ext;
   libs += " " +dd4hep+"/lib/libDDCore."+ ext;
   libs += " " +dd4hep+"/lib/libDDG4."+ ext;
-  gSystem->Load(std::string("libDD4hepGaudiPluginMgr." + ext).c_str());
   gSystem->AddIncludePath(inc.c_str());
   gSystem->AddLinkedLibs(libs.c_str());
   std::cout << "+++ Includes:   " << gSystem->GetIncludePath() << std::endl;

--- a/DDG4/examples/initAClick.C
+++ b/DDG4/examples/initAClick.C
@@ -87,6 +87,9 @@ int initAClick(const char* command=0)  {
   libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr." + ext;
   libs += " " +dd4hep+"/lib/libDDCore."+ ext;
   libs += " " +dd4hep+"/lib/libDDG4."+ ext;
+#ifdef __APPLE__
+  gSystem->Load("libDD4hepGaudiPluginMgr");
+#endif
   gSystem->AddIncludePath(inc.c_str());
   gSystem->AddLinkedLibs(libs.c_str());
   std::cout << "+++ Includes:   " << gSystem->GetIncludePath() << std::endl;

--- a/DDG4/examples/initAClick.C
+++ b/DDG4/examples/initAClick.C
@@ -63,7 +63,6 @@ int initAClick(const char* command=0)  {
   std::string defs    = "";
   std::string libs    = " -L"+rootsys+"/lib";
   std::string inc     = " -I"+dd4hep+"/examples/DDG4/examples -I"+dd4hep + " -I"+dd4hep+"/include";
-  libs += " -L"+dd4hep+"/lib -lDD4hepGaudiPluginMgr -lDDCore -lDDG4";
   if ( !geant4.empty() )  {
     inc  += " -I"+geant4+"/include/Geant4";
 #ifdef __APPLE__
@@ -83,7 +82,10 @@ int initAClick(const char* command=0)  {
 #ifndef __APPLE__
   libs += " -lCore -lMathCore -pthread -lm -ldl -rdynamic";
 #endif
-  gSystem->Load("libDD4hepGaudiPluginMgr");
+  libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr.so";
+  libs += " " +dd4hep+"/lib/libDDCore.so";
+  libs += " " +dd4hep+"/lib/libDDG4.so";
+  gSystem->Load("libDD4hepGaudiPluginMgr.so");
   gSystem->AddIncludePath(inc.c_str());
   gSystem->AddLinkedLibs(libs.c_str());
   std::cout << "+++ Includes:   " << gSystem->GetIncludePath() << std::endl;

--- a/examples/LHeD/scripts/initAClick.C
+++ b/examples/LHeD/scripts/initAClick.C
@@ -63,10 +63,12 @@ int initAClick(const char* command=0)  {
   std::string defs    = "";
   std::string libs    = " -L"+rootsys+"/lib";
   std::string inc     = " -I"+dd4hep+"/examples/LHeD/scripts -I"+dd4hep + " -I"+dd4hep+"/include"+clhep+"/include -I"+geant4+"/include";
+  std::string ext = "so";
   if ( !geant4.empty() )  {
     inc  += " -I"+geant4+"/include/Geant4";
 #ifdef __APPLE__
     libs += (" -L"+geant4+"/lib");
+    ext = "dylib";
 #else
     libs += (" -L"+geant4+"/lib -L"+geant4+"/lib64");
 #endif
@@ -82,10 +84,10 @@ int initAClick(const char* command=0)  {
 #ifndef __APPLE__
   libs += " -lCore -lMathCore -pthread -lm -ldl -rdynamic";
 #endif
-  libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr.so";
-  libs += " " +dd4hep+"/lib/libDDCore.so";
-  libs += " " +dd4hep+"/lib/libDDG4.so";
-  gSystem->Load("libDD4hepGaudiPluginMgr");
+  libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr." + ext;
+  libs += " " +dd4hep+"/lib/libDDCore." + ext;
+  libs += " " +dd4hep+"/lib/libDDG4." + ext;
+  gSystem->Load(std::string("libDD4hepGaudiPluginMgr." + ext).c_str());
   gSystem->AddIncludePath(inc.c_str());
   gSystem->AddLinkedLibs(libs.c_str());
   std::cout << "+++ Includes:   " << gSystem->GetIncludePath() << std::endl;

--- a/examples/LHeD/scripts/initAClick.C
+++ b/examples/LHeD/scripts/initAClick.C
@@ -62,7 +62,13 @@ int initAClick(const char* command=0)  {
   std::string clhep   = make_str(gSystem->Getenv("CLHEP_ROOT_DIR"));
   std::string defs    = "";
   std::string libs    = " -L"+rootsys+"/lib";
-  std::string inc     = " -I"+dd4hep+"/examples/LHeD/scripts -I"+dd4hep + " -I"+dd4hep+"/include"+clhep+"/include -I"+geant4+"/include";
+  std::string inc     = "";
+  inc += " -I" + dd4hep + "/examples/LHeD/scripts ";
+  inc += " -I" + dd4hep;
+  inc += " -I" + dd4hep + "/include ";
+  inc += " -I" + clhep  + "/include ";
+  inc += " -I" + geant4 + "/include ";
+
   std::string ext = "so";
   if ( !geant4.empty() )  {
     inc  += " -I"+geant4+"/include/Geant4";

--- a/examples/LHeD/scripts/initAClick.C
+++ b/examples/LHeD/scripts/initAClick.C
@@ -63,7 +63,6 @@ int initAClick(const char* command=0)  {
   std::string defs    = "";
   std::string libs    = " -L"+rootsys+"/lib";
   std::string inc     = " -I"+dd4hep+"/examples/LHeD/scripts -I"+dd4hep + " -I"+dd4hep+"/include"+clhep+"/include -I"+geant4+"/include";
-  libs += " -L"+dd4hep+"/lib -lDD4hepGaudiPluginMgr -lDDCore -lDDG4";
   if ( !geant4.empty() )  {
     inc  += " -I"+geant4+"/include/Geant4";
 #ifdef __APPLE__
@@ -83,6 +82,9 @@ int initAClick(const char* command=0)  {
 #ifndef __APPLE__
   libs += " -lCore -lMathCore -pthread -lm -ldl -rdynamic";
 #endif
+  libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr.so";
+  libs += " " +dd4hep+"/lib/libDDCore.so";
+  libs += " " +dd4hep+"/lib/libDDG4.so";
   gSystem->Load("libDD4hepGaudiPluginMgr");
   gSystem->AddIncludePath(inc.c_str());
   gSystem->AddLinkedLibs(libs.c_str());

--- a/examples/LHeD/scripts/initAClick.C
+++ b/examples/LHeD/scripts/initAClick.C
@@ -93,6 +93,9 @@ int initAClick(const char* command=0)  {
   libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr." + ext;
   libs += " " +dd4hep+"/lib/libDDCore." + ext;
   libs += " " +dd4hep+"/lib/libDDG4." + ext;
+#ifdef __APPLE__
+  gSystem->Load("libDD4hepGaudiPluginMgr");
+#endif
   gSystem->AddIncludePath(inc.c_str());
   gSystem->AddLinkedLibs(libs.c_str());
   std::cout << "+++ Includes:   " << gSystem->GetIncludePath() << std::endl;

--- a/examples/LHeD/scripts/initAClick.C
+++ b/examples/LHeD/scripts/initAClick.C
@@ -93,7 +93,6 @@ int initAClick(const char* command=0)  {
   libs += " " +dd4hep+"/lib/libDD4hepGaudiPluginMgr." + ext;
   libs += " " +dd4hep+"/lib/libDDCore." + ext;
   libs += " " +dd4hep+"/lib/libDDG4." + ext;
-  gSystem->Load(std::string("libDD4hepGaudiPluginMgr." + ext).c_str());
   gSystem->AddIncludePath(inc.c_str());
   gSystem->AddLinkedLibs(libs.c_str());
   std::cout << "+++ Includes:   " << gSystem->GetIncludePath() << std::endl;


### PR DESCRIPTION
As far as I can tell rootcling (or something) does something weird with the library flags passed to it in the AClick scripts. Instead of taking the libraries from the "-L" location before it takes them from wherever it finds them first (or maybe that is correct behaviour that just doesn't work here), which means if the libraries exist already in the LCG CVMFS installation we use for some dependencies then things go wrong.

So now the DD4hep library locations are explicitly specified.

Solves #591 
Also running a pipeline on gitlab: https://gitlab.cern.ch/sailer/DD4hep/pipelines/1183456
Could be missing some other place where this is necessary