### PR TITLE
Disable default ROOT element table

### DIFF
--- a/DDCore/CMakeLists.txt
+++ b/DDCore/CMakeLists.txt
@@ -76,7 +76,7 @@ target_link_libraries(DDCore
   PUBLIC
   DD4hep::DDParsers
   ROOT::Core ROOT::Rint ROOT::Tree ROOT::Physics ROOT::Geom ROOT::GenVector
-  ${XML_LIBRARIES}
+  ${XML_LIBRARIES} ${CMAKE_DL_LIBS}
   )
 
 if(${CMAKE_VERSION} VERSION_GREATER 3.7.99)

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -174,13 +174,13 @@ DetectorImp::DetectorImp(const string& name)
   m_manager = new TGeoManager(name.c_str(), "Detector Geometry");
   {
     gGeoManager = m_manager;
-#if 0 //FIXME: eventually this should be set to 1 - needs fixes in examples ...
+#if 1 //FIXME: eventually this should be set to 1 - needs fixes in examples ...
     TGeoElementTable*	table = m_manager->GetElementTable();
     table->TGeoElementTable::~TGeoElementTable();
     new(table) TGeoElementTable();
     // This will initialize the table without filling:
-    table->AddElement("VACUUM","VACUUM", 0, 0, 0.0);
-    table->Print();
+    table->AddElement("VACUUM","VACUUM", 1, 1, 1e-15);
+    // table->Print();
 #endif
   }
   if ( 0 == gGeoIdentity )

--- a/DDCore/src/Plugins.cpp
+++ b/DDCore/src/Plugins.cpp
@@ -36,6 +36,10 @@ bool PluginService::setDebug(bool new_value)   {
   return old_value;
 }
 
+#if defined(__linux) && !defined(__APPLE__)
+#define DD4HEP_PARSERS_NO_ROOT
+#endif
+
 #include "DD4hep/Printout.h"
 #if !defined(DD4HEP_PARSERS_NO_ROOT)
 #include "TSystem.h"
@@ -94,9 +98,11 @@ namespace   {
   {
     void* handle = 0;
     const char* plugin_name = ::getenv("DD4HEP_PLUGINMGR");
-    if ( 0 == plugin_name )   {
-      plugin_name = "libDD4hepGaudiPluginMgr";
-    }
+#if defined(__linux) && !defined(__APPLE__)
+    if ( 0 == plugin_name ) plugin_name = "libDD4hepGaudiPluginMgr.so";
+#else
+    if ( 0 == plugin_name ) plugin_name = "libDD4hepGaudiPluginMgr";
+#endif
 #if defined(DD4HEP_PARSERS_NO_ROOT)
     handle = ::dlopen(plugin_name, RTLD_LAZY | RTLD_GLOBAL);
 #else

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,12 +38,12 @@ dd4hep_configure_output()
 
 #==========================================================================
 
-SET(DD4HEP_BUILD_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDB DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency SimpleDetector"
+SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDB DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency SimpleDetector"
   CACHE STRING "List of DD4hep Examples to build")
-SEPARATE_ARGUMENTS(DD4HEP_BUILD_EXAMPLES)
+SEPARATE_ARGUMENTS(DD4HEP_EXAMPLES)
 MESSAGE(STATUS "Will be building these examples: ${DD4HEP_BUILD_EXAMPLES}")
 
-FOREACH(DDExample IN LISTS DD4HEP_BUILD_EXAMPLES)
+FOREACH(DDExample IN LISTS DD4HEP_EXAMPLES)
   dd4hep_print("|> Building ${DDExample}")
   add_subdirectory(${DDExample})
 ENDFOREACH()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,7 +41,7 @@ dd4hep_configure_output()
 SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDB DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency SimpleDetector"
   CACHE STRING "List of DD4hep Examples to build")
 SEPARATE_ARGUMENTS(DD4HEP_EXAMPLES)
-MESSAGE(STATUS "Will be building these examples: ${DD4HEP_BUILD_EXAMPLES}")
+MESSAGE(STATUS "Will be building these examples: ${DD4HEP_EXAMPLES}")
 
 FOREACH(DDExample IN LISTS DD4HEP_EXAMPLES)
   dd4hep_print("|> Building ${DDExample}")

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -124,7 +124,7 @@ dd4hep_add_test_reg( ClientTests_DumpElements
   EXEC_ARGS  geoPluginRun
   -input file:${ClientTestsEx_INSTALL}/compact/MiniTel.xml
   -volmgr -destroy -plugin DD4hep_ElementTable -type xml
-  REGEX_PASS "formula=\"UUB\" name=\"UUB\""
+  REGEX_PASS "formula=\"Zr\" name=\"Zr\""
   REGEX_FAIL "Exception"
   REGEX_FAIL "FAILED"
   )

--- a/examples/ClientTests/compact/CheckShape.xml
+++ b/examples/ClientTests/compact/CheckShape.xml
@@ -12,32 +12,11 @@
   </info>
   <steer open="false" close="false"/>
 
-  <materials>
-    <element Z="7" formula="N" name="N" >
-      <atom type="A" unit="g/mol" value="14.0068" />
-    </element>
-    <element Z="8" formula="O" name="O" >
-      <atom type="A" unit="g/mol" value="15.9994" />
-    </element>
-    <element Z="18" formula="Ar" name="Ar" >
-      <atom type="A" unit="g/mol" value="39.9477" />
-    </element>
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/materials.xml"/>
+  </includes>
 
-    <material name="Air">
-      <D type="density" unit="g/cm3" value="0.0012"/>
-      <fraction n="0.754" ref="N"/>
-      <fraction n="0.234" ref="O"/>
-      <fraction n="0.012" ref="Ar"/>
-    </material>  
-    <!-- We model vakuum just as very thin air -->
-    <material name="Vacuum">  
-      <D type="density" unit="g/cm3" value="0.0000000001" />
-      <fraction n="0.754" ref="N"/>
-      <fraction n="0.234" ref="O"/>
-      <fraction n="0.012" ref="Ar"/>
-    </material>
-  </materials>
- 
   <define>
     <constant name="world_side" value="300*cm"/>
     <constant name="world_x" value="world_side"/>

--- a/examples/DDCMS/CMakeLists.txt
+++ b/examples/DDCMS/CMakeLists.txt
@@ -23,13 +23,25 @@ ENDIF()
 
 dd4hep_set_compiler_flags()
 #==========================================================================
+set (Geant4_builtin_clhep_FOUND ON)
+# Configure Geant4
+if(DD4HEP_USE_GEANT4)
+  find_package( Geant4 REQUIRED )
+  if(NOT Geant4_builtin_clhep_FOUND)
+    SET(DD4HEP_USE_CLHEP TRUE)
+  else()
+    include_directories(${Geant4_INCLUDE_DIRS})
+  endif()
+  dd4hep_print("|++> Setup Geant4 targets.")
+  DD4HEP_SETUP_GEANT4_TARGETS()
+endif()
 
 # CLHEP dependent stuff
 if(NOT TARGET CLHEP::CLHEP)
   # ensure we only look for CLHEP once
   find_package(CLHEP QUIET)
 endif()
-if (TARGET CLHEP::CLHEP)
+if (TARGET CLHEP::CLHEP OR Geant4_builtin_clhep_FOUND)
   dd4hep_print("|++> CLHEP PRESENT. Building DDCMS examples.")
 else()
   dd4hep_print("|++> CLHEP is not present. NOT building DDCMS examples.")

--- a/examples/DDCMS/CMakeLists.txt
+++ b/examples/DDCMS/CMakeLists.txt
@@ -45,8 +45,8 @@ else()
   set(CLHEP CLHEP::CLHEP)
 endif()
 #
-
 #
+#-------------------------------------------------------------------------------
 # we only create only library for DDCMS. The whole package is a single component
 # library. A priory there is no need to seperate the implementation from the
 # plugins....

--- a/examples/DDCMS/CMakeLists.txt
+++ b/examples/DDCMS/CMakeLists.txt
@@ -22,20 +22,17 @@ IF(NOT TARGET DD4hep::DDCore)
 ENDIF()
 
 dd4hep_set_compiler_flags()
+#
 #==========================================================================
-set (Geant4_builtin_clhep_FOUND ON)
-# Configure Geant4
+# Configure Geant4 to if we have a builtin CLHEP
 if(DD4HEP_USE_GEANT4)
   find_package( Geant4 REQUIRED )
-  if(NOT Geant4_builtin_clhep_FOUND)
-    SET(DD4HEP_USE_CLHEP TRUE)
-  else()
+  if(Geant4_builtin_clhep_FOUND)
     include_directories(${Geant4_INCLUDE_DIRS})
+    DD4HEP_SETUP_GEANT4_TARGETS()
   endif()
-  dd4hep_print("|++> Setup Geant4 targets.")
-  DD4HEP_SETUP_GEANT4_TARGETS()
 endif()
-
+#
 # CLHEP dependent stuff
 if(NOT TARGET CLHEP::CLHEP)
   # ensure we only look for CLHEP once

--- a/examples/DDCMS/data/cms_test_solids.xml
+++ b/examples/DDCMS/data/cms_test_solids.xml
@@ -3,13 +3,13 @@
   <debug>
     <debug_shapes/>
     <debug_includes/>
+    <debug_materials/>
+    <debug_namespaces/>
 <!-- 
     <debug_rotations/>
-    <debug_materials/>
 
     <debug_volumes/>
     <debug_constants/>
-    <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
     <debug_visattr/>

--- a/examples/DDCMS/data/materials.xml
+++ b/examples/DDCMS/data/materials.xml
@@ -1,77 +1,112 @@
 <?xml version="1.0"?>
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
  <MaterialSection label="materials.xml">
-  <ElementaryMaterial name="Aluminium" density="2.7*g/cm3" symbol=" " atomicWeight="26.98*g/mole" atomicNumber="13"/>
- <ElementaryMaterial name="TD_Aluminium" density="8.1*g/cm3" symbol=" " atomicWeight="26.98*g/mole" atomicNumber="13"/>
-  <ElementaryMaterial name="Antimony" density="6.679*g/cm3" symbol=" " atomicWeight="121.75*g/mole" atomicNumber="51"/>
-  <ElementaryMaterial name="Argon" density="1.639*mg/cm3" symbol=" " atomicWeight="39.948*g/mole" atomicNumber="18"/>
-  <ElementaryMaterial name="Arsenic" density="5.72*g/cm3" symbol=" " atomicWeight="74.922*g/mole" atomicNumber="33"/>
-  <ElementaryMaterial name="Barium" density="3.5*g/cm3" symbol=" " atomicWeight="137.33*g/mole" atomicNumber="56"/>
-  <ElementaryMaterial name="Beryllium" density="1.848*g/cm3" symbol=" " atomicWeight="9.0122*g/mole" atomicNumber="4"/>
-  <ElementaryMaterial name="Bismuth" density="9.37*g/cm3" symbol=" " atomicWeight="208.98*g/mole" atomicNumber="83"/>
-  <ElementaryMaterial name="Bor 10" density="2.34*g/cm3" symbol=" " atomicWeight="10*g/mole" atomicNumber="5"/>
-  <ElementaryMaterial name="Bor 11" density="2.34*g/cm3" symbol=" " atomicWeight="11*g/mole" atomicNumber="5"/>
-  <ElementaryMaterial name="Bromine" density="3.11*g/cm3" symbol=" " atomicWeight="79.904*g/mole" atomicNumber="35"/>
-  <ElementaryMaterial name="Cadmium" density="8.63*g/cm3" symbol=" " atomicWeight="112.41*g/mole" atomicNumber="48"/>
-  <ElementaryMaterial name="Calcium" density="1.55*g/cm3" symbol=" " atomicWeight="40.078*g/mole" atomicNumber="20"/>
-  <ElementaryMaterial name="Carbon" density="2.265*g/cm3" symbol=" " atomicWeight="12.011*g/mole" atomicNumber="6"/>
-  <ElementaryMaterial name="Cerium" density="6.637*g/cm3" symbol=" " atomicWeight="140.12*g/mole" atomicNumber="58"/>
-  <ElementaryMaterial name="Cesium" density="1.87*g/cm3" symbol=" " atomicWeight="132.9054*g/mole" atomicNumber="55"/>
-  <ElementaryMaterial name="Chlorine" density="1.56*g/cm3" symbol=" " atomicWeight="35.45*g/mole" atomicNumber="17"/>
-  <ElementaryMaterial name="Chromium" density="7.18*g/cm3" symbol=" " atomicWeight="51.996*g/mole" atomicNumber="24"/>
-  <ElementaryMaterial name="Cobalt" density="8.9*g/cm3" symbol=" " atomicWeight="58.933*g/mole" atomicNumber="27"/>
-  <ElementaryMaterial name="Copper" density="8.96*g/cm3" symbol=" " atomicWeight="63.546*g/mole" atomicNumber="29"/>
-  <ElementaryMaterial name="Deuterium" density="162*mg/cm3" symbol=" " atomicWeight="2.01*g/mole" atomicNumber="1"/>
-  <ElementaryMaterial name="Fluorine" density="1.108*g/cm3" symbol=" " atomicWeight="18.998*g/mole" atomicNumber="9"/>
-  <ElementaryMaterial name="Gallium" density="5.877*g/cm3" symbol=" " atomicWeight="69.723*g/mole" atomicNumber="31"/>
-  <ElementaryMaterial name="Germanium" density="5.323*g/cm3" symbol=" " atomicWeight="72.61*g/mole" atomicNumber="32"/>
-  <ElementaryMaterial name="Gold" density="18.85*g/cm3" symbol=" " atomicWeight="196.97*g/mole" atomicNumber="79"/>
-  <ElementaryMaterial name="Helium" density="125*mg/cm3" symbol=" " atomicWeight="4.0026*g/mole" atomicNumber="2"/>
-  <ElementaryMaterial name="Hydrogen" density="70.8*mg/cm3" symbol=" " atomicWeight="1.00794*g/mole" atomicNumber="1"/>
-  <ElementaryMaterial name="Indium" density="7.3*g/cm3" symbol=" " atomicWeight="114.82*g/mole" atomicNumber="49"/>
-  <ElementaryMaterial name="Iodine" density="7.3*g/cm3" symbol=" " atomicWeight="114.82*g/mole" atomicNumber="53"/>
-  <ElementaryMaterial name="Iron" density="7.87*g/cm3" symbol=" " atomicWeight="55.85*g/mole" atomicNumber="26"/>
-  <ElementaryMaterial name="Krypton" density="2.6*g/cm3" symbol=" " atomicWeight="83.8*g/mole" atomicNumber="36"/>
-  <ElementaryMaterial name="Lanthanum" density="6.127*g/cm3" symbol=" " atomicWeight="138.9055*g/mole" atomicNumber="57"/>
-  <ElementaryMaterial name="Lead" density="11.35*g/cm3" symbol=" " atomicWeight="207.19*g/mole" atomicNumber="82"/>
-  <ElementaryMaterial name="Lithium" density="534*mg/cm3" symbol=" " atomicWeight="6.941*g/mole" atomicNumber="3"/>
-   <ElementaryMaterial name="Lutecium" density="9.841*g/cm3" symbol=" " atomicWeight="174.96*g/mole" atomicNumber="71"/>
-  <ElementaryMaterial name="Magnesium" density="1.735*g/cm3" symbol=" " atomicWeight="24.305*g/mole" atomicNumber="12"/>
-  <ElementaryMaterial name="Manganese" density="7.43*g/cm3" symbol=" " atomicWeight="54.938*g/mole" atomicNumber="25"/>
-  <ElementaryMaterial name="Molybdenum" density="10.2*g/cm3" symbol=" " atomicWeight="95.94*g/mole" atomicNumber="42"/>
-  <ElementaryMaterial name="Neodymium" density="1e-22*mg/cm3" symbol=" " atomicWeight="144.24*g/mole" atomicNumber="60"/>
-  <ElementaryMaterial name="Neon" density="1.207*g/cm3" symbol=" " atomicWeight="20.18*g/mole" atomicNumber="10"/>
-  <ElementaryMaterial name="Nickel" density="8.876*g/cm3" symbol=" " atomicWeight="58.693*g/mole" atomicNumber="28"/>
-  <ElementaryMaterial name="Niobium" density="8.55*g/cm3" symbol=" " atomicWeight="92.906*g/mole" atomicNumber="41"/>
-  <ElementaryMaterial name="Nitrogen" density="808*mg/cm3" symbol=" " atomicWeight="14.007*g/mole" atomicNumber="7"/>
-  <ElementaryMaterial name="Oxygen" density="1.43*mg/cm3" symbol=" " atomicWeight="15.999*g/mole" atomicNumber="8"/>
-  <ElementaryMaterial name="Palladium" density="12*g/cm3" symbol=" " atomicWeight="106.42*g/mole" atomicNumber="46"/>
-  <ElementaryMaterial name="Phosphor" density="1.82*g/cm3" symbol=" " atomicWeight="30.974*g/mole" atomicNumber="15"/>
-  <ElementaryMaterial name="Potassium" density="860*mg/cm3" symbol=" " atomicWeight="39.098*g/mole" atomicNumber="19"/>
+  <ElementaryMaterial name="Vacuum"       density="1e-13*mg/cm3" symbol=" " atomicWeight="1*g/mole"        atomicNumber="1"/>
+  <ElementaryMaterial name="Deuterium"    density="162*mg/cm3"   symbol=" " atomicWeight="2.01*g/mole"     atomicNumber="1"/>
+  <ElementaryMaterial name="Hydrogen"     density="70.8*mg/cm3"  symbol=" " atomicWeight="1.00794*g/mole"  atomicNumber="1"/>
+  <ElementaryMaterial name="Helium"       density="125*mg/cm3"   symbol=" " atomicWeight="4.0026*g/mole"   atomicNumber="2"/>
+  <ElementaryMaterial name="Lithium"      density="534*mg/cm3"   symbol=" " atomicWeight="6.941*g/mole"    atomicNumber="3"/>
+  <ElementaryMaterial name="Beryllium"    density="1.848*g/cm3"  symbol=" " atomicWeight="9.0122*g/mole"   atomicNumber="4"/>
+  <ElementaryMaterial name="Bor 10"       density="2.34*g/cm3"   symbol=" " atomicWeight="10*g/mole"       atomicNumber="5"/>
+  <ElementaryMaterial name="Bor 11"       density="2.34*g/cm3"   symbol=" " atomicWeight="11*g/mole"       atomicNumber="5"/>
+  <ElementaryMaterial name="Carbon"       density="2.265*g/cm3"  symbol=" " atomicWeight="12.011*g/mole"   atomicNumber="6"/>
+  <ElementaryMaterial name="Nitrogen"     density="808*mg/cm3"   symbol=" " atomicWeight="14.007*g/mole"   atomicNumber="7"/>
+  <ElementaryMaterial name="Oxygen"       density="1.43*mg/cm3"  symbol=" " atomicWeight="15.999*g/mole"   atomicNumber="8"/>
+  <ElementaryMaterial name="Fluorine"     density="1.108*g/cm3"  symbol=" " atomicWeight="18.998*g/mole"   atomicNumber="9"/>
+  <ElementaryMaterial name="Neon"         density="1.207*g/cm3"  symbol=" " atomicWeight="20.18*g/mole"    atomicNumber="10"/>
+
+  <ElementaryMaterial name="Sodium"       density="969*mg/cm3"   symbol=" " atomicWeight="22.99*g/mole"    atomicNumber="11"/>
+  <ElementaryMaterial name="Magnesium"    density="1.735*g/cm3"  symbol=" " atomicWeight="24.305*g/mole"   atomicNumber="12"/>
+  <ElementaryMaterial name="Aluminium"    density="2.7*g/cm3"    symbol=" " atomicWeight="26.98*g/mole"    atomicNumber="13"/>
+  <ElementaryMaterial name="TD_Aluminium" density="8.1*g/cm3"    symbol=" " atomicWeight="26.98*g/mole"    atomicNumber="13"/>
+  <ElementaryMaterial name="Silicon"      density="2.33*g/cm3"   symbol=" " atomicWeight="28.09*g/mole"    atomicNumber="14"/>
+  <ElementaryMaterial name="Phosphor"     density="1.82*g/cm3"   symbol=" " atomicWeight="30.974*g/mole"   atomicNumber="15"/>
+  <ElementaryMaterial name="Sulfur"       density="2.07*g/cm3"   symbol=" " atomicWeight="32.066*g/mole"   atomicNumber="16"/>
+  <ElementaryMaterial name="Chlorine"     density="1.56*g/cm3"   symbol=" " atomicWeight="35.45*g/mole"    atomicNumber="17"/>
+  <ElementaryMaterial name="Argon"        density="1.639*mg/cm3" symbol=" " atomicWeight="39.948*g/mole"   atomicNumber="18"/>
+  <ElementaryMaterial name="Potassium"    density="860*mg/cm3"   symbol=" " atomicWeight="39.098*g/mole"   atomicNumber="19"/>
+  <ElementaryMaterial name="Calcium"      density="1.55*g/cm3"   symbol=" " atomicWeight="40.078*g/mole"   atomicNumber="20"/>
+ 
+  <ElementaryMaterial name="Scandium"     density="2.98*g/cm3"   symbol=" " atomicWeight="44.956*g/mole"   atomicNumber="21"/>
+  <ElementaryMaterial name="Titanium"     density="4.53*g/cm3"   symbol=" " atomicWeight="47.88*g/mole"    atomicNumber="22"/>
+  <ElementaryMaterial name="Vanadium"     density="6.1*g/cm3"    symbol=" " atomicWeight="50.941*g/mole"   atomicNumber="23"/>
+  <ElementaryMaterial name="Chromium"     density="7.18*g/cm3"   symbol=" " atomicWeight="51.996*g/mole"   atomicNumber="24"/>
+  <ElementaryMaterial name="Manganese"    density="7.43*g/cm3"   symbol=" " atomicWeight="54.938*g/mole"   atomicNumber="25"/>
+  <ElementaryMaterial name="Iron"         density="7.87*g/cm3"   symbol=" " atomicWeight="55.85*g/mole"    atomicNumber="26"/>
+  <ElementaryMaterial name="Cobalt"       density="8.9*g/cm3"    symbol=" " atomicWeight="58.933*g/mole"   atomicNumber="27"/>
+  <ElementaryMaterial name="Nickel"       density="8.876*g/cm3"  symbol=" " atomicWeight="58.693*g/mole"   atomicNumber="28"/>
+  <ElementaryMaterial name="Copper"       density="8.96*g/cm3"   symbol=" " atomicWeight="63.546*g/mole"   atomicNumber="29"/>
+  <ElementaryMaterial name="Zinc"         density="7.112*g/cm3"  symbol=" " atomicWeight="65.39*g/mole"    atomicNumber="30"/>
+
+  <ElementaryMaterial name="Gallium"      density="5.877*g/cm3"  symbol=" " atomicWeight="69.723*g/mole"   atomicNumber="31"/>
+  <ElementaryMaterial name="Germanium"    density="5.323*g/cm3"  symbol=" " atomicWeight="72.61*g/mole"    atomicNumber="32"/>
+  <ElementaryMaterial name="Arsenic"      density="5.72*g/cm3"   symbol=" " atomicWeight="74.922*g/mole"   atomicNumber="33"/>
+  <ElementaryMaterial name="Selenium"     density="4.78*g/cm3"   symbol=" " atomicWeight="78.96*g/mole"    atomicNumber="34"/>
+  <ElementaryMaterial name="Bromine"      density="3.11*g/cm3"   symbol=" " atomicWeight="79.904*g/mole"   atomicNumber="35"/>
+  <ElementaryMaterial name="Krypton"      density="2.6*g/cm3"    symbol=" " atomicWeight="83.8*g/mole"     atomicNumber="36"/>
+  <ElementaryMaterial name="Rubidium"     density="1.529*g/cm3"  symbol=" " atomicWeight="85.4678*g/mole"  atomicNumber="37"/>
+  <ElementaryMaterial name="Strontium"    density="2.54*g/cm3"   symbol=" " atomicWeight="87.62*g/mole"    atomicNumber="38"/>
+  <ElementaryMaterial name="Yttrium"      density="4.456*g/cm3"  symbol=" " atomicWeight="88.9059*g/mole"  atomicNumber="39"/>
+  <ElementaryMaterial name="Zirconium"    density="6.494*g/cm3"  symbol=" " atomicWeight="91.22*g/mole"    atomicNumber="40"/>
+
+  <ElementaryMaterial name="Niobium"      density="8.55*g/cm3"   symbol=" " atomicWeight="92.906*g/mole"   atomicNumber="41"/>
+  <ElementaryMaterial name="Molybdenum"   density="10.2*g/cm3"   symbol=" " atomicWeight="95.94*g/mole"    atomicNumber="42"/>
+  <ElementaryMaterial name="Technetium"   density="11.48*g/cm3"  symbol=" " atomicWeight="98*g/mole"       atomicNumber="43"/>
+  <ElementaryMaterial name="Ruthenium"    density="12.39*g/cm3"  symbol=" " atomicWeight="101.07*g/mole"   atomicNumber="44"/>
+  <ElementaryMaterial name="Rhodium"      density="12.39*g/cm3"  symbol=" " atomicWeight="102.9055*g/mole" atomicNumber="45"/>
+  <ElementaryMaterial name="Palladium"    density="12*g/cm3"     symbol=" " atomicWeight="106.42*g/mole"   atomicNumber="46"/>
+  <ElementaryMaterial name="Silver"       density="10.48*g/cm3"  symbol=" " atomicWeight="107.87*g/mole"   atomicNumber="47"/>
+  <ElementaryMaterial name="Cadmium"      density="8.63*g/cm3"   symbol=" " atomicWeight="112.41*g/mole"   atomicNumber="48"/>
+  <ElementaryMaterial name="Indium"       density="7.3*g/cm3"    symbol=" " atomicWeight="114.82*g/mole"   atomicNumber="49"/>
+  <ElementaryMaterial name="Tin"          density="7.31*g/cm3"   symbol=" " atomicWeight="118.69*g/mole"   atomicNumber="50"/>
+
+  <ElementaryMaterial name="Antimony"     density="6.679*g/cm3"  symbol=" " atomicWeight="121.75*g/mole"   atomicNumber="51"/>
+  <ElementaryMaterial name="Tellurium"    density="6.23*g/cm3"   symbol=" " atomicWeight="127.6*g/mole"    atomicNumber="52"/>
+  <ElementaryMaterial name="Iodine"       density="7.3*g/cm3"    symbol=" " atomicWeight="114.82*g/mole"   atomicNumber="53"/>
+  <ElementaryMaterial name="Xenon"        density="3.057*g/cm3"  symbol=" " atomicWeight="131.29*g/mole"   atomicNumber="54"/>
+  <ElementaryMaterial name="Cesium"       density="1.87*g/cm3"   symbol=" " atomicWeight="132.9054*g/mole" atomicNumber="55"/>
+  <ElementaryMaterial name="Barium"       density="3.5*g/cm3"    symbol=" " atomicWeight="137.33*g/mole"   atomicNumber="56"/>
+  <ElementaryMaterial name="Lanthanum"    density="6.127*g/cm3"  symbol=" " atomicWeight="138.9055*g/mole" atomicNumber="57"/>
+  <ElementaryMaterial name="Cerium"       density="6.637*g/cm3"  symbol=" " atomicWeight="140.12*g/mole"   atomicNumber="58"/>
   <ElementaryMaterial name="Praseodymium" density="1e-22*mg/cm3" symbol=" " atomicWeight="140.9077*g/mole" atomicNumber="59"/>
-  <ElementaryMaterial name="Rhodium" density="12.39*g/cm3" symbol=" " atomicWeight="102.9055*g/mole" atomicNumber="45"/>
-  <ElementaryMaterial name="Rubidium" density="1.529*g/cm3" symbol=" " atomicWeight="85.4678*g/mole" atomicNumber="37"/>
-  <ElementaryMaterial name="Ruthenium" density="12.39*g/cm3" symbol=" " atomicWeight="101.07*g/mole" atomicNumber="44"/>
-  <ElementaryMaterial name="Scandium" density="2.98*g/cm3" symbol=" " atomicWeight="44.956*g/mole" atomicNumber="21"/>
-  <ElementaryMaterial name="Selenium" density="4.78*g/cm3" symbol=" " atomicWeight="78.96*g/mole" atomicNumber="34"/>
-  <ElementaryMaterial name="Silicon" density="2.33*g/cm3" symbol=" " atomicWeight="28.09*g/mole" atomicNumber="14"/>
-  <ElementaryMaterial name="Silver" density="10.48*g/cm3" symbol=" " atomicWeight="107.87*g/mole" atomicNumber="47"/>
-  <ElementaryMaterial name="Sodium" density="969*mg/cm3" symbol=" " atomicWeight="22.99*g/mole" atomicNumber="11"/>
-  <ElementaryMaterial name="Strontium" density="2.54*g/cm3" symbol=" " atomicWeight="87.62*g/mole" atomicNumber="38"/>
-  <ElementaryMaterial name="Sulfur" density="2.07*g/cm3" symbol=" " atomicWeight="32.066*g/mole" atomicNumber="16"/>
-  <ElementaryMaterial name="Tantalum" density="16.65*g/cm3" symbol=" " atomicWeight="180.9479*g/mole" atomicNumber="73"/>
-  <ElementaryMaterial name="Technetium" density="11.48*g/cm3" symbol=" " atomicWeight="98*g/mole" atomicNumber="43"/>
-  <ElementaryMaterial name="Tellurium" density="6.23*g/cm3" symbol=" " atomicWeight="127.6*g/mole" atomicNumber="52"/>
-  <ElementaryMaterial name="Tin" density="7.31*g/cm3" symbol=" " atomicWeight="118.69*g/mole" atomicNumber="50"/>
-  <ElementaryMaterial name="Titanium" density="4.53*g/cm3" symbol=" " atomicWeight="47.88*g/mole" atomicNumber="22"/>
-  <ElementaryMaterial name="Tungsten" density="19.3*g/cm3" symbol=" " atomicWeight="183.85*g/mole" atomicNumber="74"/>
-  <ElementaryMaterial name="Uranium" density="18.95*g/cm3" symbol=" " atomicWeight="238.03*g/mole" atomicNumber="92"/>
-  <ElementaryMaterial name="Vacuum" density="1e-13*mg/cm3" symbol=" " atomicWeight="1*g/mole" atomicNumber="1"/>
-  <ElementaryMaterial name="Vanadium" density="6.1*g/cm3" symbol=" " atomicWeight="50.941*g/mole" atomicNumber="23"/>
-  <ElementaryMaterial name="Xenon" density="3.057*g/cm3" symbol=" " atomicWeight="131.29*g/mole" atomicNumber="54"/>
-  <ElementaryMaterial name="Yttrium" density="4.456*g/cm3" symbol=" " atomicWeight="88.9059*g/mole" atomicNumber="39"/>
-  <ElementaryMaterial name="Zinc" density="7.112*g/cm3" symbol=" " atomicWeight="65.39*g/mole" atomicNumber="30"/>
-  <ElementaryMaterial name="Zirconium" density="6.494*g/cm3" symbol=" " atomicWeight="91.22*g/mole" atomicNumber="40"/>
+  <ElementaryMaterial name="Neodymium"    density="1e-22*mg/cm3" symbol=" " atomicWeight="144.24*g/mole"   atomicNumber="60"/>
+
+  <ElementaryMaterial name="Promethium"   density="7.22*g/cm3"   symbol=" " atomicWeight="144.913*g/mole"  atomicNumber="61"/>
+  <ElementaryMaterial name="Samarium"     density="7.46*g/cm3"   symbol=" " atomicWeight="150.366*g/mole"  atomicNumber="62"/>
+  <ElementaryMaterial name="Europium"     density="5.243*g/cm3"  symbol=" " atomicWeight="151.964*g/mole"  atomicNumber="63"/>
+  <ElementaryMaterial name="Gadolinium"   density="7.9004*g/cm3" symbol=" " atomicWeight="157.252*g/mole"  atomicNumber="64"/>
+  <ElementaryMaterial name="Terbium"      density="8.229*g/cm3"  symbol=" " atomicWeight="158.925*g/mole"  atomicNumber="65"/>
+  <ElementaryMaterial name="Dysprosium"   density="8.55*g/cm3"   symbol=" " atomicWeight="162.497*g/mole"  atomicNumber="66"/>
+  <ElementaryMaterial name="Holmium"      density="8.795*g/cm3"  symbol=" " atomicWeight="164.93*g/mole"   atomicNumber="67"/>
+  <ElementaryMaterial name="Erbium"       density="9.066*g/cm3"  symbol=" " atomicWeight="167.256*g/mole"  atomicNumber="68"/>
+  <ElementaryMaterial name="Thulium"      density="9.321*g/cm3"  symbol=" " atomicWeight="168.934*g/mole"  atomicNumber="69"/>
+  <ElementaryMaterial name="Ytterbium"    density="6.73*g/cm3"   symbol=" " atomicWeight="173.038*g/mole"  atomicNumber="70"/>
+
+  <ElementaryMaterial name="Lutecium"     density="9.841*g/cm3"  symbol=" " atomicWeight="174.96*g/mole"   atomicNumber="71"/>
+  <ElementaryMaterial name="Hafnium"      density="13.31*g/cm3"  symbol=" " atomicWeight="178.485*g/mole"  atomicNumber="72"/>
+  <ElementaryMaterial name="Tantalum"     density="16.65*g/cm3"  symbol=" " atomicWeight="180.9479*g/mole" atomicNumber="73"/>
+  <ElementaryMaterial name="Tungsten"     density="19.3*g/cm3"   symbol=" " atomicWeight="183.85*g/mole"   atomicNumber="74"/>
+  <ElementaryMaterial name="Rhenium"      density="21.02*g/cm3"  symbol=" " atomicWeight="186.207*g/mole"  atomicNumber="75"/>
+  <ElementaryMaterial name="Osmium"       density="22.57*g/cm3"  symbol=" " atomicWeight="190.225*g/mole"  atomicNumber="76"/>
+  <ElementaryMaterial name="Platinum"     density="21.45*g/cm3"  symbol=" " atomicWeight="195.078*g/mole"  atomicNumber="78"/>
+  <ElementaryMaterial name="Gold"         density="18.85*g/cm3"  symbol=" " atomicWeight="196.97*g/mole"   atomicNumber="79"/>
+  <ElementaryMaterial name="Mercury"      density="13.546*g/cm3" symbol=" " atomicWeight="200.599*g/mole"  atomicNumber="80"/>
+
+  <ElementaryMaterial name="Thallium"     density="11.72*g/cm3"  symbol=" " atomicWeight="204.383*g/mole"  atomicNumber="81"/>
+  <ElementaryMaterial name="Lead"         density="11.35*g/cm3"  symbol=" " atomicWeight="207.19*g/mole"   atomicNumber="82"/>
+  <ElementaryMaterial name="Bismuth"      density="9.37*g/cm3"   symbol=" " atomicWeight="208.98*g/mole"   atomicNumber="83"/>
+  <ElementaryMaterial name="Polonium"     density="9.32*g/cm3"   symbol=" " atomicWeight="208.982*g/mole"  atomicNumber="84"/>
+  <ElementaryMaterial name="Astatine"     density="9.32*g/cm3"   symbol=" " atomicWeight="209.987*g/mole"  atomicNumber="85"/>
+  <ElementaryMaterial name="Radon"        density="0.00900662*g/cm3" symbol=" " atomicWeight="222.018*g/mole" atomicNumber="86"/>
+  <ElementaryMaterial name="Francium"     density="1*g/cm3"      symbol=" " atomicWeight="223.02*g/mole"   atomicNumber="87"/>
+  <ElementaryMaterial name="Radium"       density="5*g/cm3"      symbol=" " atomicWeight="226.025*g/mole"  atomicNumber="88"/>
+  <ElementaryMaterial name="Actinium"     density="10.07*g/cm3"  symbol=" " atomicWeight="227.028*g/mole"  atomicNumber="89"/>
+  <ElementaryMaterial name="Thorium"      density="11.72*g/cm3"  symbol=" " atomicWeight="232.038*g/mole"  atomicNumber="90"/>
+
+  <ElementaryMaterial name="Protactinium" density="15.37*g/cm3"  symbol=" " atomicWeight="231.036*g/mole"  atomicNumber="91"/>
+  <ElementaryMaterial name="Uranium"      density="18.95*g/cm3 " symbol=" " atomicWeight="238.03*g/mole"   atomicNumber="92"/>
+
+
   <CompositeMaterial name="FPix_Thermflow" density="0.7625*g/cm3" symbol=" " method="mixture by weight">
    <MaterialFraction fraction="0.3787448">
     <rMaterial name="materials:Silicon"/>

--- a/examples/DDCMS/src/plugins/DDCMSDetElementCreator.cpp
+++ b/examples/DDCMS/src/plugins/DDCMSDetElementCreator.cpp
@@ -103,7 +103,7 @@ DDCMSDetElementCreator::DDCMSDetElementCreator(Detector& desc)
   : description(desc)
 {
   DetectorHelper helper(description);
-  silicon = helper.element("SI");
+  silicon = helper.element("materials:Silicon");
   if ( !silicon.isValid() )   {
     except("DDCMSDetElementCreator",
            "++ Failed to extract SILICON from the element table.");

--- a/examples/DDCMS/src/plugins/DDDefinitions2Objects.cpp
+++ b/examples/DDCMS/src/plugins/DDDefinitions2Objects.cpp
@@ -489,7 +489,7 @@ template <> void Converter<compositematerial>::operator()(xml_h element) const  
   TGeoMaterial* mat = mgr.GetMaterial(nam.c_str());
   if ( 0 == mat )   {
     const char*  matname = nam.c_str();
-    double       density = xmat.density();
+    double       density = xmat.density() / (dd4hep::g/dd4hep::cm3);
     xml_coll_t   composites(xmat,_CMU(MaterialFraction));
     TGeoMixture* mix = new TGeoMixture(nam.c_str(), composites.size(), density);
 

--- a/examples/DDDB/CMakeLists.txt
+++ b/examples/DDDB/CMakeLists.txt
@@ -51,26 +51,30 @@ target_include_directories(DDDB
 #---DDDB plugin library -------------------------------------------------------
 dd4hep_add_plugin(DDDBPlugins SOURCES src/plugins/*.cpp USES DDDB)
 install(TARGETS DDDB DDDBPlugins LIBRARY DESTINATION lib)
+set(DDDB_BIN  ${CMAKE_INSTALL_PREFIX}/bin)
+set(DDDB_DATA ${CMAKE_INSTALL_PREFIX}/examples/DDDB)
 
 #---Package installation procedure(s) -----------------------------------------
 install ( PROGRAMS scripts/run_dddb.sh DESTINATION bin)
 install ( PROGRAMS scripts/display_dddb.sh DESTINATION bin)
 install ( PROGRAMS scripts/extract_dddb.sh DESTINATION bin)
-install ( FILES    data/DDDB.tar.gz DESTINATION examples/DDDB)
+install ( FILES    data/DDDB.tar.gz    DESTINATION examples/DDDB)
+install ( FILES    data/materials.xml  DESTINATION examples/DDDB)
 #---Testing--------------------------------------------------------------------
 dd4hep_configure_scripts ( DDDB DEFAULT_SETUP WITH_TESTS )
 #
 #---Testing: Extract DDDB data from zip archive -------------------------------
 dd4hep_add_test_reg( DDDB_extract_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/extract_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/extract_dddb.sh
   REGEX_PASS "DDDB Database successfully installed."
   )
 #
 #---Testing: Load the geometry from archive -----------------------------------
 dd4hep_add_test_reg( DDDB_load_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config DD4hep_ConditionsManagerInstaller
   DEPENDS    DDDB_extract_LONGTEST
   REGEX_PASS "\\+ Converted    12852 placements"
@@ -79,8 +83,9 @@ dd4hep_add_test_reg( DDDB_load_LONGTEST
 #
 #---Testing: Load the geometry + conditions from archive ----------------------
 dd4hep_add_test_reg( DDDB_conditions_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   DEPENDS    DDDB_extract_LONGTEST
   REGEX_PASS "\\+ Converted     9353 conditions" 
@@ -89,8 +94,9 @@ dd4hep_add_test_reg( DDDB_conditions_LONGTEST
 #
 #---Testing: Load the geometry + conditions dump as view from DetElement ------
 dd4hep_add_test_reg( DDDB_conditions_dump_simple_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   -exec      DDDB_ConditionsSummary
   DEPENDS    DDDB_extract_LONGTEST
@@ -100,8 +106,9 @@ dd4hep_add_test_reg( DDDB_conditions_dump_simple_LONGTEST
 #
 #---Testing: Load the geometry + dump detector elemets ------------------------
 dd4hep_add_test_reg( DDDB_det_elements_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller  -end-plugin
   -plugin    DDDB_DetectorDump -print DEBUG   -end-plugin
   DEPENDS    DDDB_extract_LONGTEST
@@ -111,8 +118,9 @@ dd4hep_add_test_reg( DDDB_det_elements_LONGTEST
 #
 #---Testing: Load the geometry + dump volumes ---------------------------------
 dd4hep_add_test_reg( DDDB_det_volumes_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   -plugin    DDDB_DetectorVolumeDump -print DEBUG
   DEPENDS    DDDB_extract_LONGTEST
@@ -122,8 +130,9 @@ dd4hep_add_test_reg( DDDB_det_volumes_LONGTEST
 #
 #---Testing: Load the geometry + dump condition keys --------------------------
 dd4hep_add_test_reg( DDDB_det_conditions_keys_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   -plugin    DDDB_DetectorConditionKeysDump -print DEBUG
   DEPENDS    DDDB_extract_LONGTEST
@@ -133,8 +142,9 @@ dd4hep_add_test_reg( DDDB_det_conditions_keys_LONGTEST
 #
 #---Testing: Load the geometry + dump condition keys --------------------------
 dd4hep_add_test_reg( DDDB_det_catalog_data_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   -plugin    DDDB_DetectorConditionDump -print DEBUG
   DEPENDS    DDDB_extract_LONGTEST
@@ -144,8 +154,9 @@ dd4hep_add_test_reg( DDDB_det_catalog_data_LONGTEST
 #
 #---Testing: Load the geometry + dump condition keys --------------------------
 dd4hep_add_test_reg( DDDB_det_catalog_align_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   -plugin    DDDB_DetectorAlignmentDump -print DEBUG
   DEPENDS    DDDB_extract_LONGTEST
@@ -155,8 +166,9 @@ dd4hep_add_test_reg( DDDB_det_catalog_align_LONGTEST
 #
 #---Testing: Load the geometry + conditions dump as view from DetElement ------
 dd4hep_add_test_reg( DDDB_detelement_conditions_dump_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   -plugin    DDDB_DetElementConditionDump -print DEBUG
   DEPENDS    DDDB_extract_LONGTEST
@@ -165,8 +177,9 @@ dd4hep_add_test_reg( DDDB_detelement_conditions_dump_LONGTEST
 #
 #---Testing: Load the geometry + conditions + conditions derives
 dd4hep_add_test_reg( DDDB_derived_conditions_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   -plugin    DDDB_DerivedCondTest -print DEBUG
   DEPENDS    DDDB_extract_LONGTEST
@@ -176,8 +189,9 @@ dd4hep_add_test_reg( DDDB_derived_conditions_LONGTEST
 #
 #---Testing: Load the geometry + conditions + run basic derived alignments test
 dd4hep_add_test_reg( DDDB_alignment_derived_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   -plugin    DDDB_DerivedAlignmentsTest -print DEBUG -turns 1 -access 3
   DEPENDS    DDDB_extract_LONGTEST
@@ -187,8 +201,9 @@ dd4hep_add_test_reg( DDDB_alignment_derived_LONGTEST
 #
 #---Testing: Load the geometry + conditions + access derived alignments from DetElement structures
 dd4hep_add_test_reg( DDDB_alignment_access_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config    DD4hep_ConditionsManagerInstaller
   -plugin    DDDB_AlignmentsAccessTest -print DEBUG
   DEPENDS    DDDB_extract_LONGTEST
@@ -198,9 +213,10 @@ dd4hep_add_test_reg( DDDB_alignment_access_LONGTEST
 #
 #---Testing: Load the geometry + conditions + create DeVelo detector elements
 dd4hep_add_test_reg( DDDB_DeVelo_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
   -iov_start 31-12-2000-00:00:00 -iov_end 31-12-2019-00:00:00
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config DD4hep_ConditionsManagerInstaller
   -plugin DDDB_DeVeloTest -print DEBUG
   DEPENDS    DDDB_extract_LONGTEST
@@ -210,9 +226,10 @@ dd4hep_add_test_reg( DDDB_DeVelo_LONGTEST
 #
 #---Testing: As above, but access conditions using Gaudi-like service
 dd4hep_add_test_reg( DDDB_DeVelo_Gaudi_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/run_dddb.sh
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/run_dddb.sh
   -iov_start 31-12-2000-00:00:00 -iov_end 31-12-2019-00:00:00
+  -config DD4hep_XMLLoader -arg ${DDDB_DATA}/materials.xml 
   -config DD4hep_ConditionsManagerInstaller
   -plugin DDDB_DeVeloServiceTest -print DEBUG
   DEPENDS    DDDB_extract_LONGTEST
@@ -222,8 +239,8 @@ dd4hep_add_test_reg( DDDB_DeVelo_Gaudi_LONGTEST
 #
 #---Testing: Extract DDDB data from zip archive -------------------------------
 dd4hep_add_test_reg( DDDB_clean_LONGTEST
-  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDB.sh"
-  EXEC_ARGS  ${CMAKE_INSTALL_PREFIX}/bin/extract_dddb.sh -clean
+  COMMAND    "${DDDB_BIN}/run_test_DDDB.sh"
+  EXEC_ARGS  ${DDDB_BIN}/extract_dddb.sh -clean
   DEPENDS    DDDB_extract_LONGTEST
   DDDB_alignment_access_LONGTEST
   DDDB_alignment_derived_LONGTEST

--- a/examples/DDDB/data/materials.xml
+++ b/examples/DDDB/data/materials.xml
@@ -1,0 +1,22 @@
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+  <info name="lhcb_full"
+        title="LHCb detector geometry"
+        author="Markus Frank"
+        url="http://lhcb.cern.ch"
+        status="development"
+        version="1.0">
+    <comment>The conversion of a detector to DD4hep</comment>        
+  </info>
+
+  <geometry open="false" close="false">
+  </geometry>
+  <debug>
+    <type name="materials" value="0"/>
+  </debug>
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/materials.xml"/>
+  </includes>
+</lccdd>

--- a/examples/OpticalSurfaces/compact/OpNovice.xml
+++ b/examples/OpticalSurfaces/compact/OpNovice.xml
@@ -292,20 +292,11 @@
     </ignore>
   </properties>
 
-  <materials>
-    <element Z="1" formula="H" name="H" >
-      <atom type="A" unit="g/mol" value="1.00794" />
-    </element>
-    <element Z="8" formula="O" name="O" >
-      <atom type="A" unit="g/mol" value="15.9994" />
-    </element>
-    <element Z="7" formula="N" name="N" >
-      <atom type="A" unit="g/mol" value="14.0068" />
-    </element>
-    <element Z="18" formula="Ar" name="Ar" >
-      <atom type="A" unit="g/mol" value="39.9477" />
-    </element>
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+  </includes>
 
+  <materials>
     <material name="Air">
       <D type="density" unit="g/cm3" value="0.0012"/>
       <fraction n="0.754" ref="N"/>

--- a/examples/OpticalSurfaces/compact/ReadMaterialProperties.xml
+++ b/examples/OpticalSurfaces/compact/ReadMaterialProperties.xml
@@ -193,20 +193,10 @@
     </ignore>
   </properties>
 
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+  </includes>
   <materials>
-    <element Z="1" formula="H" name="H" >
-      <atom type="A" unit="g/mol" value="1.00794" />
-    </element>
-    <element Z="8" formula="O" name="O" >
-      <atom type="A" unit="g/mol" value="15.9994" />
-    </element>
-    <element Z="7" formula="N" name="N" >
-      <atom type="A" unit="g/mol" value="14.0068" />
-    </element>
-    <element Z="18" formula="Ar" name="Ar" >
-      <atom type="A" unit="g/mol" value="39.9477" />
-    </element>
-
     <material name="Air">
       <D type="density" unit="g/cm3" value="0.0012"/>
       <fraction n="0.754" ref="N"/>


### PR DESCRIPTION

BEGINRELEASENOTES
- As agreed last meeting the default ROOT element table is disabled. All materials must now be entered explicitly.
- Fix some examples, which relied on the default ROOT elements being present
- Fix issue  https://github.com/AIDASoft/DD4hep/issues/595 for DDCMS:
  -- The density was not re-normalized to the units TGeo was expecting. Same for atomic weights.
  -- Fill missing elements to DDCMS/data/materials.xml (Values to be cross-checked by CMS)
ENDRELEASENOTES