### PR TITLE
Allow to set ambient temperature and pressure for all materials

### DIFF
--- a/DDCore/include/DD4hep/Detector.h
+++ b/DDCore/include/DD4hep/Detector.h
@@ -54,6 +54,25 @@ namespace dd4hep {
     class UriReader;
   }
 
+  /// Helper class to access default temperature and pressure
+  class STD_Conditions   {
+  public:
+    enum  Conventions {
+      STP           = 1<<0, // Standard temperature and pressure (273.15 Kelvin, 1 ATM)
+      NTP           = 1<<1, // Normal   temperature and pressure (293.15 Kelvin, 1 ATM)
+      USER          = 1<<2, // Explicitly set before materials are defined (recommended)
+      USER_SET      = 1<<3,
+      USER_NOTIFIED = 1<<4
+    };
+  public:
+    double pressure;
+    double temperature;
+    long   convention;
+    bool is_NTP()  const           {  return (convention&NTP)  != 0; }
+    bool is_STP()  const           {  return (convention&STP)  != 0; }
+    bool is_user_defined()  const  {  return (convention&USER) != 0; }
+  };
+  
   /// The main interface to the dd4hep detector description package
   /**
    *  Note: The usage of the factory method:
@@ -128,6 +147,14 @@ namespace dd4hep {
     /// Access the optical surface manager
     virtual OpticalSurfaceManager surfaceManager()  const = 0;
 
+    /// Access default conditions (temperature and pressure
+    virtual const STD_Conditions& stdConditions()  const = 0;
+    /// Set the STD temperature and pressure
+    virtual void setStdConditions(double temp, double pressure) = 0;
+    /// Set the STD conditions according to defined types (STP or NTP)
+    virtual void setStdConditions(const std::string& type) = 0;
+    
+    
     /// Accessor to the map of header entries
     virtual Header header() const = 0;
     /// Accessor to the header entry

--- a/DDCore/include/DD4hep/DetectorImp.h
+++ b/DDCore/include/DD4hep/DetectorImp.h
@@ -61,6 +61,9 @@ namespace dd4hep {
     /// Cached map with detector types:
     typedef std::map<std::string, std::vector<DetElement> > DetectorTypeMap;
 
+    /// Standard conditions
+    mutable STD_Conditions m_std_conditions;
+    
     /// Inventory of detector types
     DetectorTypeMap   m_detectorTypes;
 
@@ -207,6 +210,14 @@ namespace dd4hep {
     virtual OverlayedField field() const  override {
       return m_field;
     }
+
+    /// Access default conditions (temperature and pressure
+    virtual const STD_Conditions& stdConditions()  const  override;
+    /// Set the STD temperature and pressure
+    virtual void setStdConditions(double temp, double pressure) override;
+    /// Set the STD conditions according to defined types (STP or NTP)
+    virtual void setStdConditions(const std::string& type)  override;
+
     /// Accessor to the header entry
     virtual Header header() const  override {
       return m_header;

--- a/DDCore/include/XML/UnicodeValues.h
+++ b/DDCore/include/XML/UnicodeValues.h
@@ -454,6 +454,7 @@ UNICODE (starttheta);
 UNICODE (state);
 UNICODE (stave);
 UNICODE (staves);
+UNICODE (std_conditions);
 UNICODE (step);
 UNICODE (steps);
 UNICODE (step_x);

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -26,6 +26,7 @@
 #include "DD4hep/detail/VolumeManagerInterna.h"
 #include "DD4hep/detail/OpticalSurfaceManagerInterna.h"
 #include "DD4hep/DetectorImp.h"
+#include "DD4hep/DD4hepUnits.h"
 
 // C/C++ include files
 #include <iostream>
@@ -188,7 +189,10 @@ DetectorImp::DetectorImp(const string& name)
     gGeoIdentity = new TGeoIdentity();
   }
   m_surfaceManager = new detail::OpticalSurfaceManagerObject(*this);
-
+  m_std_conditions.convention  = STD_Conditions::NTP;
+  m_std_conditions.pressure    = NTP_Pressure;
+  m_std_conditions.temperature = NTP_Temperature;  
+  
   VisAttr attr("invisible");
   attr.setColor(0.5, 0.5, 0.5);
   attr.setAlpha(1);
@@ -314,6 +318,48 @@ Volume DetectorImp::pickMotherVolume(const DetElement& de) const {
   }
   except("DD4hep","Detector: Attempt access mother volume of invalid detector [Invalid-handle]");
   return 0;
+}
+
+/// Access default conditions (temperature and pressure
+const STD_Conditions& DetectorImp::stdConditions()   const   {
+  if ( (m_std_conditions.convention&STD_Conditions::USER_SET) == 0 &&
+       (m_std_conditions.convention&STD_Conditions::USER_NOTIFIED) == 0 )
+  {
+    printout(WARNING,"DD4hep","++ STD conditions NOT defined by client. NTP defaults taken.");
+    m_std_conditions.convention |= STD_Conditions::USER_NOTIFIED;
+  }
+  return m_std_conditions;
+}
+/// Set the STD temperature and pressure
+void DetectorImp::setStdConditions(double temp, double pressure)  {
+  m_std_conditions.temperature = temp;
+  m_std_conditions.pressure = pressure;
+  m_std_conditions.convention = STD_Conditions::USER_SET;
+  if      ( std::abs(temp-NTP_Temperature) < 1e-10 && std::abs(pressure-NTP_Pressure) < 1e-10 )
+    m_std_conditions.convention |= STD_Conditions::NTP;
+  else if ( std::abs(temp-STP_Temperature) < 1e-10 && std::abs(pressure-STP_Pressure) < 1e-10 )
+    m_std_conditions.convention |= STD_Conditions::STP;
+  else
+    m_std_conditions.convention |= STD_Conditions::USER;
+}
+
+/// Set the STD conditions according to defined types (STP or NTP)
+void DetectorImp::setStdConditions(const std::string& type)   {
+  if ( type == "STP" )   {
+    m_std_conditions.temperature = STP_Temperature;
+    m_std_conditions.pressure    = STP_Pressure;
+    m_std_conditions.convention  = STD_Conditions::STP|STD_Conditions::USER_SET;
+  }
+  else if ( type == "NTP" )   {
+    m_std_conditions.temperature = NTP_Temperature;
+    m_std_conditions.pressure    = NTP_Pressure;
+    m_std_conditions.convention  = STD_Conditions::NTP|STD_Conditions::USER_SET;
+  }
+  else   {
+    except("DD4hep",
+           "++ Attempt to set standard conditions to "
+           "unknown conventions (Only STP and NTP allowed).");
+  }
 }
 
 /// Retrieve a subdetector element by it's name from the detector description

--- a/DDG4/include/DDG4/Geant4UIManager.h
+++ b/DDG4/include/DDG4/Geant4UIManager.h
@@ -79,6 +79,8 @@ namespace dd4hep {
       Geant4UIManager(Geant4Context* context, const std::string& name);
       /// Default destructor
       virtual ~Geant4UIManager();
+      /// Install command control messenger to write GDML file from command prompt.
+      void installCommandMessenger();
       /// Start visualization
       G4VisManager* startVis();
       /// Start UI
@@ -87,7 +89,9 @@ namespace dd4hep {
       void start();
       /// Stop and release resources
       void stop();
-      /// Run UI
+      /// Force exiting this process without calling atexit handlers
+      void forceExit();
+     /// Run UI
       virtual void operator()(void* param);
     };
 

--- a/DDG4/include/DDG4/Geant4UIMessenger.h
+++ b/DDG4/include/DDG4/Geant4UIMessenger.h
@@ -38,17 +38,17 @@ namespace dd4hep {
       typedef std::map<G4UIcommand*, Callback> Actions;
     protected:
       /// The UI directory of this component
-      G4UIdirectory* m_directory;
+      G4UIdirectory*   m_directory;
       /// Reference to the property manager corresponding to the component
       PropertyManager* m_properties;
       /// Component name
-      std::string m_name;
+      std::string      m_name;
       /// Path in the UI hierarchy of this component
-      std::string m_path;
+      std::string      m_path;
       /// Property update command map
-      Commands m_propertyCmd;
+      Commands         m_propertyCmd;
       /// Action map
-      Actions m_actionCmd;
+      Actions          m_actionCmd;
 
     public:
       /// Initializing constructor
@@ -56,12 +56,18 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4UIMessenger();
       /// Add a new callback structure
-      void addCall(const std::string& name, const std::string& description, const Callback& cb);
-      /// Add any callback (without parameters to the messenger
+      void addCall(const std::string& name, const std::string& description, const Callback& cb, size_t npar=0);
+      /// Add any callback without parameters to the messenger
       template <typename Q, typename R, typename T>
       void addCall(const std::string& name, const std::string& description, Q* p, R (T::*f)()) {
         CallbackSequence::checkTypes(typeid(Q), typeid(T), dynamic_cast<T*>(p));
-        addCall(name, description, Callback(p).make(f));
+        addCall(name, description, Callback(p).make(f), 0);
+      }
+      /// Add any callback with ONE parameter to the messenger
+      template <typename Q, typename R, typename T, typename A1>
+      void addCall(const std::string& name, const std::string& description, Q* p, R (T::*f)(A1)) {
+        CallbackSequence::checkTypes(typeid(Q), typeid(T), dynamic_cast<T*>(p));
+        addCall(name, description, Callback(p).make(f), 1);
       }
       /// Export all properties to the Geant4 UI
       void exportProperties(PropertyManager& mgr);

--- a/DDG4/src/Geant4UIManager.cpp
+++ b/DDG4/src/Geant4UIManager.cpp
@@ -14,6 +14,7 @@
 // Framework include files
 #include "DDG4/Geant4UIManager.h"
 #include "DDG4/Geant4Kernel.h"
+#include "DDG4/Geant4UIMessenger.h"
 #include "DD4hep/Primitives.h"
 #include "DD4hep/Printout.h"
 
@@ -24,6 +25,8 @@
 #include "G4VisExecutive.hh"
 #include "G4UIExecutive.hh"
 #include "G4RunManager.hh"
+
+#include <cstdlib>
 
 using namespace dd4hep::sim;
 using namespace std;
@@ -47,10 +50,22 @@ Geant4UIManager::Geant4UIManager(Geant4Context* ctxt, const std::string& nam)
   declareProperty("HaveVIS",        m_haveVis=false);
   declareProperty("HaveUI",         m_haveUI=true);
   declareProperty("Prompt",         m_prompt);
+  enableUI();
 }
 
 /// Default destructor
 Geant4UIManager::~Geant4UIManager()   {
+}
+
+/// Install command control messenger to write GDML file from command prompt.
+void Geant4UIManager::installCommandMessenger()   {
+  m_control->addCall("exit", "Force exiting this process",
+                     Callback(this).make(&Geant4UIManager::forceExit),0);
+}
+
+/// Force exiting this process without calling atexit handlers
+void Geant4UIManager::forceExit()   {
+  std::_Exit(0);
 }
 
 /// Start visualization

--- a/DDParsers/include/Evaluator/DD4hepUnits.h
+++ b/DDParsers/include/Evaluator/DD4hepUnits.h
@@ -204,9 +204,9 @@ namespace dd4hep {
     //
     // Pressure [E][L^-3]
     //
-#define pascal hep_pascal                          // a trick to avoid warnings
+#define pascal hep_pascal                               // a trick to avoid warnings
     static constexpr double hep_pascal = newton / m2;   // pascal = 6.24150 e+3 * MeV/mm3
-    static constexpr double bar = 100000 * pascal;   // bar    = 6.24150 e+8 * MeV/mm3
+    static constexpr double bar = 100000 * pascal;      // bar    = 6.24150 e+8 * MeV/mm3
     static constexpr double atmosphere = 101325 * pascal;   // atm    = 6.32420 e+8 * MeV/mm3
 
     //
@@ -408,12 +408,16 @@ namespace dd4hep {
     static constexpr double k_Boltzmann = 8.617343e-11 * MeV / kelvin;
 
     //
-    //
-    //
+    // IUPAC standard temperature and pressure (STP)
+    // STP uses 273.15 K (0 °C, 32 °F) and (since 1982) 1 bar (100 kPa) and not 1 atm!
     static constexpr double STP_Temperature = 273.15 * kelvin;
-    static constexpr double STP_Pressure = 1. * atmosphere;
-    static constexpr double kGasThreshold = 10. * mg / cm3;
-
+    static constexpr double STP_Pressure    = 1. * bar;
+    //
+    // NTP uses the NIST convention: 20 °C (293.15 K, 68 °F), 1 atm (14.696 psi, 101.325 kPa)
+    static constexpr double NTP_Temperature = 293.15 * kelvin;
+    static constexpr double NTP_Pressure    = 1. * atmosphere;
+    //
+    static constexpr double kGasThreshold   = 10. * mg / cm3;
     //
     //
     //

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -208,6 +208,14 @@ dd4hep_add_test_reg( ClientTests_Check_VolumeDivisionTest
   -plugin DD4hep_VolumeDump
   REGEX_PASS "Checked 8 physical volume placements")
 #
+#  Test Setting temperature and pressure to material
+dd4hep_add_test_reg( ClientTests_Check_Temp_Pressure_Air
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+  EXEC_ARGS  geoPluginRun
+  -destroy -input file:${ClientTestsEx_INSTALL}/compact/Check_Air.xml
+  -plugin DD4hep_MaterialTable -name Vacuum
+  REGEX_PASS "Temp=111 \\[Kelvin\\] Pressure=6.2415e-07 \\[pascal\\] state=Undefined"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
 #
 # only if root version > 6.19: MaterialTester
 #
@@ -295,6 +303,15 @@ endforeach()
 #      EXEC_ARGS  test_with_root.sh ${script}
 #
 if (DD4HEP_USE_GEANT4)
+  #
+  #  Test Setting temperature and pressure to material
+  dd4hep_add_test_reg( ClientTests_sim_Check_Temp_Pressure_Air
+    COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+    EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/Check_Air.py
+    -geometry  ${ClientTestsEx_INSTALL}/compact/Check_Air.xml
+    REQUIRES   DDG4 Geant4
+    REGEX_PASS "Imean:  85.538 eV   temperature: 333.33 K  pressure:   2.22 atm"
+    REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
   #
   # Geant4 test if production cuts are processed
   dd4hep_add_test_reg( ClientTests_sim_MiniTel_prod_cuts

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -308,7 +308,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_test_reg( ClientTests_sim_Check_Temp_Pressure_Air
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/Check_Air.py
-    -geometry  ${ClientTestsEx_INSTALL}/compact/Check_Air.xml
+    -geometry  ${ClientTestsEx_INSTALL}/compact/Check_Air.xml batch
     REQUIRES   DDG4 Geant4
     REGEX_PASS "Imean:  85.538 eV   temperature: 333.33 K  pressure:   2.22 atm"
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )

--- a/examples/ClientTests/compact/Check_Air.xml
+++ b/examples/ClientTests/compact/Check_Air.xml
@@ -1,0 +1,66 @@
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+  
+  <info name=   "ShapeCheck"
+	title=  "Checking individual shapes in D4hep by comparing the mesh vertices"
+	author= "Markus Frank"
+	url=    "http://www.cern.ch/lhcb"
+	status= "development"
+	version="1.0">
+    <comment>Shape tester</comment>        
+  </info>
+  <steer open="false" close="false"/>
+
+  <debug>
+    <type name="materials" value="1"/>
+  </debug>
+
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+  </includes>
+
+  <define>
+    <constant name="world_side" value="300*cm"/>
+    <constant name="world_x" value="world_side"/>
+    <constant name="world_y" value="world_side"/>
+    <constant name="world_z" value="world_side"/>
+  </define>
+
+  <std_conditions type="STP">
+      <T unit="kelvin" value="333.33"/>
+      <P unit="atmosphere" value="2.22"/>
+  </std_conditions>
+
+  <display>
+    <vis name="Box_vis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
+  </display>
+
+  <materials>
+    <material name="Air">
+      <D type="density" unit="g/cm3" value="0.001214"/>
+      <fraction n="0.7494" ref="N"/>
+      <fraction n="0.2369" ref="O"/>
+      <fraction n="0.0129" ref="Ar"/>
+      <fraction n="0.0008" ref="H"/>
+    </material>
+  
+    <!-- We model vakuum just as very thin air -->
+    <material name="Vacuum">  
+      <D type="density" unit="g/cm3" value="0.0000000001" />
+      <T unit="kelvin" value="111.11"/>
+      <P unit="pascal" value="1e-10"/>
+      <composite n="1" ref="Air"/>
+    </material>
+  </materials>
+
+  <detectors>
+    <detector id="3" name="B1" type="DD4hep_BoxSegment" vis="Box_vis">
+      <comment>Vertical box</comment>
+      <material name="Vacuum"/>
+      <box      x="10"  y="20"   z="30"/>
+      <position x="-10" y="30"   z="10"/>
+      <rotation x="0"   y="0"    z="0"/>
+    </detector>
+  </detectors>
+</lccdd>

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -54,11 +54,12 @@ def run():
   kernel.physicsList().enableUI()
   DDG4.setPrintLevel(DDG4.OutputLevel.DEBUG)
   #
-  #      '/ddg4/ConstructGeometry/writeGDML   test.gdml',
   ui.Commands = [
-      ,'/ddg4/ConstructGeometry/printVolume /world_volume_1/Shape_Test_0/Shape_Test_vol_0_0'
-      ,'exit'
-      ]
+    '/ddg4/ConstructGeometry/printVolume /world_volume_1'
+    ,'/ddg4/ConstructGeometry/printMaterial Air'
+    ,'/ddg4/ConstructGeometry/printMaterial Vacuum'
+    ,'/ddg4/UI/exit'
+    ]
   kernel.NumEvents = 0
   kernel.configure()
   kernel.initialize()

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -61,7 +61,7 @@ def run():
       '/ddg4/ConstructGeometry/printMaterial Air',
       '/ddg4/ConstructGeometry/printMaterial Vacuum',
       '/ddg4/UI/exit'
-    ]
+      ]
   kernel.NumEvents = 0
   kernel.configure()
   kernel.initialize()

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -69,5 +69,6 @@ def run():
   kernel.terminate()
 
 
+# Main entry point:
 if __name__ == "__main__":
   run()

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -24,8 +24,8 @@ def run():
   geo = None
   vis = False
   batch = False
-  for i in xrange(len(sys.argv)):
-    c = sys.argv[i].upper()
+  for i in sys.argv:
+    c = i.upper()
     if c.find('BATCH') < 2 and c.find('BATCH') >= 0:
       batch = True
     if c[:4] == '-GEO':

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -42,8 +42,8 @@ def run():
   # Configure UI
   geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')
   if batch:
-    ui = geant4.setupCshUI(ui=None, vis=None)
-    kernel.UI = 'UI'
+    ui = geant4.setupCshUI(typ=None, ui=None, vis=None)
+    kernel.UI = ui.name
   else:
     ui = geant4.setupCshUI(vis=vis)
   kernel.loadGeometry(geo)

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -57,16 +57,17 @@ def run():
   DDG4.setPrintLevel(DDG4.OutputLevel.DEBUG)
   #
   ui.Commands = [
-    '/ddg4/ConstructGeometry/printVolume /world_volume_1'
-    ,'/ddg4/ConstructGeometry/printMaterial Air'
-    ,'/ddg4/ConstructGeometry/printMaterial Vacuum'
-    ,'/ddg4/UI/exit'
+    '/ddg4/ConstructGeometry/printVolume /world_volume_1',
+    '/ddg4/ConstructGeometry/printMaterial Air',
+    '/ddg4/ConstructGeometry/printMaterial Vacuum',
+    '/ddg4/UI/exit'
     ]
   kernel.NumEvents = 0
   kernel.configure()
   kernel.initialize()
   kernel.run()
   kernel.terminate()
+
 
 if __name__ == "__main__":
   run()

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -21,15 +21,17 @@ def help():
 
 
 def run():
+  cnt = 0
   geo = None
   vis = False
   batch = False
   for i in sys.argv:
+    cnt = cnt + 1
     c = i.upper()
     if c.find('BATCH') < 2 and c.find('BATCH') >= 0:
       batch = True
     if c[:4] == '-GEO':
-      geo = sys.argv[i + 1]
+      geo = sys.argv[cnt]
     if c[:4] == '-VIS':
       vis = True
 

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -42,8 +42,8 @@ def run():
   # Configure UI
   geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')
   if batch:
-    kernel.UI = ''
-    ui = geant4.setupCshUI(ui=None, vis=vis)
+    ui = geant4.setupCshUI(ui=None, vis=None)
+    kernel.UI = 'UI'
   else:
     ui = geant4.setupCshUI(vis=vis)
   kernel.loadGeometry(geo)

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -30,9 +30,9 @@ def run():
     c = i.upper()
     if c.find('BATCH') < 2 and c.find('BATCH') >= 0:
       batch = True
-    if c[:4] == '-GEO':
+    elif c[:4] == '-GEO':
       geo = sys.argv[cnt]
-    if c[:4] == '-VIS':
+    elif c[:4] == '-VIS':
       vis = True
 
   if not geo:
@@ -57,10 +57,10 @@ def run():
   DDG4.setPrintLevel(DDG4.OutputLevel.DEBUG)
   #
   ui.Commands = [
-    '/ddg4/ConstructGeometry/printVolume /world_volume_1',
-    '/ddg4/ConstructGeometry/printMaterial Air',
-    '/ddg4/ConstructGeometry/printMaterial Vacuum',
-    '/ddg4/UI/exit'
+      '/ddg4/ConstructGeometry/printVolume /world_volume_1',
+      '/ddg4/ConstructGeometry/printMaterial Air',
+      '/ddg4/ConstructGeometry/printMaterial Vacuum',
+      '/ddg4/UI/exit'
     ]
   kernel.NumEvents = 0
   kernel.configure()

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -43,7 +43,7 @@ def run():
   geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')
   if batch:
     ui = geant4.setupCshUI(typ=None, ui=None, vis=None)
-    kernel.UI = ui.name
+    kernel.UI = 'UI'
   else:
     ui = geant4.setupCshUI(vis=vis)
   kernel.loadGeometry(geo)

--- a/examples/ClientTests/scripts/Check_shape.py
+++ b/examples/ClientTests/scripts/Check_shape.py
@@ -56,14 +56,15 @@ def run():
   #
   #      '/ddg4/ConstructGeometry/writeGDML   test.gdml',
   ui.Commands = [
-      ,'/ddg4/ConstructGeometry/printVolume /world_volume_1/Shape_Test_0/Shape_Test_vol_0_0'
-      ,'exit'
+      '/ddg4/ConstructGeometry/printVolume /world_volume_1/Shape_Test_0/Shape_Test_vol_0_0',
+      'exit'
       ]
   kernel.NumEvents = 0
   kernel.configure()
   kernel.initialize()
   kernel.run()
   kernel.terminate()
+
 
 if __name__ == "__main__":
   run()

--- a/examples/ClientTests/scripts/Check_shape.py
+++ b/examples/ClientTests/scripts/Check_shape.py
@@ -28,9 +28,9 @@ def run():
     c = sys.argv[i].upper()
     if c.find('BATCH') < 2 and c.find('BATCH') >= 0:
       batch = True
-    if c[:4] == '-GEO':
+    elif c[:4] == '-GEO':
       geo = sys.argv[i + 1]
-    if c[:4] == '-VIS':
+    elif c[:4] == '-VIS':
       vis = True
 
   if not geo:
@@ -42,8 +42,8 @@ def run():
   # Configure UI
   geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')
   if batch:
-    kernel.UI = ''
-    ui = geant4.setupCshUI(ui=None, vis=vis)
+    ui = geant4.setupCshUI(ui=None, vis=None)
+    kernel.UI = 'UI'
   else:
     ui = geant4.setupCshUI(vis=vis)
   kernel.loadGeometry(geo)
@@ -57,7 +57,7 @@ def run():
   #      '/ddg4/ConstructGeometry/writeGDML   test.gdml',
   ui.Commands = [
       '/ddg4/ConstructGeometry/printVolume /world_volume_1/Shape_Test_0/Shape_Test_vol_0_0',
-      'exit'
+      '/ddg4/UI/exit'
       ]
   kernel.NumEvents = 0
   kernel.configure()


### PR DESCRIPTION

BEGINRELEASENOTES
- Allow to set ambient temperature and pressure for all materials. 
  Predefined settings: STP, NTP
- Examples: With examples/ClientTests/compact/Check_Air.xml
  apply global temperature and pressure for all materials and especially for one single material.
  Verification for Geant4: examples/ClientTests/scripts/Check_Air.py
- DDG4: allow Geant4 messengers to pass parameter string.
ENDRELEASENOTES