### PR TITLE
Fix for issue https://github.com/AIDASoft/DD4hep/issues/605

### DIFF
--- a/DDCore/include/DD4hep/DetElement.h
+++ b/DDCore/include/DD4hep/DetElement.h
@@ -197,20 +197,21 @@ namespace dd4hep {
     typedef std::map<std::string, DetElement> Children;
 
     enum CopyParameters {
-      COPY_NONE      = 0,
-      COPY_PLACEMENT = 1 << 0,
-      COPY_PARENT    = 1 << 1,
-      COPY_ALIGNMENT = 1 << 2,
+      COPY_NONE           = 0,
+      COPY_PLACEMENT      = 1 << 0,
+      COPY_PARENT         = 1 << 1,
+      COPY_ALIGNMENT      = 1 << 2,
+      PROPAGATE_PARENT_ID = 1 << 3,
       LAST
     };
 
     enum UpdateParam {
-      CONDITIONS_CHANGED = 1<<0,
-      PLACEMENT_CHANGED  = 1<<1,
-      SOMETHING_CHANGED  = 1<<2,
-      PLACEMENT_ELEMENT  = 1<<20,
-      PLACEMENT_HIGHEST  = 1<<21,
-      PLACEMENT_DETECTOR = 1<<22,
+      CONDITIONS_CHANGED  = 1<<0,
+      PLACEMENT_CHANGED   = 1<<1,
+      SOMETHING_CHANGED   = 1<<2,
+      PLACEMENT_ELEMENT   = 1<<20,
+      PLACEMENT_HIGHEST   = 1<<21,
+      PLACEMENT_DETECTOR  = 1<<22,
       PLACEMENT_NONE
     };
 

--- a/DDCore/src/DetectorInterna.cpp
+++ b/DDCore/src/DetectorInterna.cpp
@@ -118,7 +118,8 @@ DetElementObject* DetElementObject::clone(int new_id, int flg) const {
   obj->children.clear();
   for (const auto& i : children )  {
     const DetElementObject& d = i.second._data();
-    DetElement c = d.clone(obj->id, DetElement::COPY_PLACEMENT);
+    int child_id = flg&DetElement::PROPAGATE_PARENT_ID ? obj->id : d.id;
+    DetElement c = d.clone(child_id, DetElement::COPY_PLACEMENT);
     c->SetName(d.GetName());
     c->SetTitle(d.GetTitle());
     bool r = obj->children.emplace(c.name(), c).second;


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix issue https://github.com/AIDASoft/DD4hep/issues/605
- There was an apparent bug when cloning DetElement trees. Not only for the top element, which should receive a new ID, this top ID was propagated to all children. This is clearly wrong.
The correct solution is: 
-- Top element gets a new ID
-- Children keep their ID
- To preserve the old functionality the flag DetElement::PROPAGATE_PARENT_ID must be set in the clone statement.
ENDRELEASENOTES