### PR TITLE
Remove DTD links from lcdd xml files. Add STD conditions checks

### DIFF
--- a/DDAlign/src/plugins/GlobalAlignmentParser.cpp
+++ b/DDAlign/src/plugins/GlobalAlignmentParser.cpp
@@ -58,6 +58,8 @@ using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::align;
 
+static long setup_Alignment(Detector& description, const xml_h& e);
+
 /** Convert to enable/disable debugging.
  *
  *  @author  M.Frank
@@ -196,6 +198,8 @@ template <> void Converter<include_file>::operator()(xml_h element) const {
   string tag = node.tag();
   if ( tag == "alignment" )
     Converter<alignment>(description,param,optional)(node);
+  else if ( tag == "global_alignment" )
+    setup_Alignment(description, node);
   else if ( tag == "detelement" )
     Converter<detelement>(description,param,optional)(node);
   else if ( tag == "subdetectors" || tag == "detelements" )

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -480,8 +480,8 @@ template <> void Converter<Material>::operator()(xml_h e) const {
     mat->SetTemperature(temp_val);
     mat->SetPressure(pressure_val);
     printout(s_debug.materials ? ALWAYS : DEBUG, "Compact",
-             "++ Converting material %-16s  Density: %9.7g  Temperature:%9.7g Pressure:%9.7g.",
-             matname, dens_val, temp_val, pressure_val);
+             "++ Converting material %-16s  Density: %9.7g  Temperature:%9.7g [K] Pressure:%9.7g [hPa].",
+             matname, dens_val, temp_val/dd4hep::kelvin, pressure_val/dd4hep::pascal/100.0);
 
     mix->SetRadLen(0e0);
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,12,0)

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -512,8 +512,8 @@ static long root_materials(Detector& description, int argc, char** argv) {
       ::printf("         Aeff=%7.3f Zeff=%7.4f rho=%8.3f [g/mole] radlen=%8.3g [cm] intlen=%8.3g [cm] index=%3d\n",
                mat->GetA(), mat->GetZ(), mat->GetDensity(),
                mat->GetRadLen(), mat->GetIntLen(), mat->GetIndex());
-      ::printf("         Temp=%.3g [Kelvin] Pressure=%.5g [pascal] state=%s\n",
-               mat->GetTemperature(), mat->GetPressure(), st);
+      ::printf("         Temp=%.3g [Kelvin] Pressure=%.5g [hPa] state=%s\n",
+               mat->GetTemperature(), mat->GetPressure()/dd4hep::pascal/100.0, st);
       return elt_h(0);
     }
     virtual void print(elt_h, TGeoElement* elt, double frac)   {

--- a/examples/AlignDet/compact/AlephTPC.xml
+++ b/examples/AlignDet/compact/AlephTPC.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
   
   <info name="Alignment_aleph_tpc"
 	title="Alignment test detector with ALPEH TPC like sectors"

--- a/examples/AlignDet/compact/Telescope.xml
+++ b/examples/AlignDet/compact/Telescope.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="TelescopeSensor"
     title="Simple emulation of the EU Telescope"

--- a/examples/AlignDet/compact/compact.xml
+++ b/examples/AlignDet/compact/compact.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
   
   <info name="alignment_boxes"
 	title="Alignment test with 2 simple boxes"

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -214,7 +214,25 @@ dd4hep_add_test_reg( ClientTests_Check_Temp_Pressure_Air
   EXEC_ARGS  geoPluginRun
   -destroy -input file:${ClientTestsEx_INSTALL}/compact/Check_Air.xml
   -plugin DD4hep_MaterialTable -name Vacuum
-  REGEX_PASS "Temp=111 \\[Kelvin\\] Pressure=6.2415e-07 \\[pascal\\] state=Undefined"
+  REGEX_PASS "Temp=111 \\[Kelvin\\] Pressure=1e-12 \\[hPa\\] state=Undefined"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
+#
+#  Test Setting temperature and pressure to material
+dd4hep_add_test_reg( ClientTests_Check_Temp_Pressure_Air_NTP
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+  EXEC_ARGS  geoPluginRun
+  -destroy -input file:${ClientTestsEx_INSTALL}/compact/Check_Air_NTP.xml
+  -plugin DD4hep_MaterialTable -name Vacuum
+  REGEX_PASS "Temp=293 \\[Kelvin\\] Pressure=1013.2 \\[hPa\\] state=Undefined"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
+#
+#  Test Setting temperature and pressure to material
+dd4hep_add_test_reg( ClientTests_Check_Temp_Pressure_Air_STP
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+  EXEC_ARGS  geoPluginRun
+  -destroy -input file:${ClientTestsEx_INSTALL}/compact/Check_Air_STP.xml
+  -plugin DD4hep_MaterialTable -name Vacuum
+  REGEX_PASS "Temp=273 \\[Kelvin\\] Pressure=1000 \\[hPa\\] state=Undefined"
   REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
 #
 # only if root version > 6.19: MaterialTester

--- a/examples/ClientTests/compact/Assemblies.xml
+++ b/examples/ClientTests/compact/Assemblies.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 <!-- #==========================================================================
      #  AIDA Detector description implementation 
      #==========================================================================

--- a/examples/ClientTests/compact/Bitfield_SidesTest.xml
+++ b/examples/ClientTests/compact/Bitfield_SidesTest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
 <!-- #==========================================================================
      #  AIDA Detector description implementation 

--- a/examples/ClientTests/compact/Bitfield_SidesTest2.xml
+++ b/examples/ClientTests/compact/Bitfield_SidesTest2.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
 <!-- #==========================================================================
      #  AIDA Detector description implementation 

--- a/examples/ClientTests/compact/BoxTrafos.xml
+++ b/examples/ClientTests/compact/BoxTrafos.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
   
 <!-- #==========================================================================
      #  AIDA Detector description implementation 

--- a/examples/ClientTests/compact/CaloEndcapReflection.xml
+++ b/examples/ClientTests/compact/CaloEndcapReflection.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="clic_sid_cdr"
         title="CLIC Silicon Detector CDR"

--- a/examples/ClientTests/compact/CheckShape.xml
+++ b/examples/ClientTests/compact/CheckShape.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
   
   <info name=   "ShapeCheck"
 	title=  "Checking individual shapes in D4hep by comparing the mesh vertices"
@@ -10,7 +8,7 @@
 	version="1.0">
     <comment>Shape tester</comment>        
   </info>
-  <steer open="false" close="false"/>
+  <geometry open="false" close="false"/>
 
   <includes>
     <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>

--- a/examples/ClientTests/compact/Check_Air_NTP.xml
+++ b/examples/ClientTests/compact/Check_Air_NTP.xml
@@ -24,10 +24,7 @@
     <constant name="world_z" value="world_side"/>
   </define>
 
-  <std_conditions type="STP">
-      <T unit="kelvin" value="333.33"/>
-      <P unit="atmosphere" value="2.22"/>
-  </std_conditions>
+  <std_conditions type="NTP"/>
 
   <display>
     <vis name="Box_vis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
@@ -45,8 +42,6 @@
     <!-- We model vakuum just as very thin air -->
     <material name="Vacuum">  
       <D type="density" unit="g/cm3" value="0.0000000001" />
-      <T unit="kelvin" value="111.11"/>
-      <P unit="pascal" value="1e-10"/>
       <composite n="1" ref="Air"/>
     </material>
   </materials>

--- a/examples/ClientTests/compact/Check_Air_STP.xml
+++ b/examples/ClientTests/compact/Check_Air_STP.xml
@@ -24,10 +24,7 @@
     <constant name="world_z" value="world_side"/>
   </define>
 
-  <std_conditions type="STP">
-      <T unit="kelvin" value="333.33"/>
-      <P unit="atmosphere" value="2.22"/>
-  </std_conditions>
+  <std_conditions type="STP"/>
 
   <display>
     <vis name="Box_vis" alpha="1.0" r="1" g="0" b="0" showDaughters="true" visible="true"/>
@@ -45,8 +42,6 @@
     <!-- We model vakuum just as very thin air -->
     <material name="Vacuum">  
       <D type="density" unit="g/cm3" value="0.0000000001" />
-      <T unit="kelvin" value="111.11"/>
-      <P unit="pascal" value="1e-10"/>
       <composite n="1" ref="Air"/>
     </material>
   </materials>

--- a/examples/ClientTests/compact/Check_Handles.xml
+++ b/examples/ClientTests/compact/Check_Handles.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
 <!-- #==========================================================================
      #  AIDA Detector description implementation 

--- a/examples/ClientTests/compact/DuplicateSysID.xml
+++ b/examples/ClientTests/compact/DuplicateSysID.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
   
   <info name="alignment_boxes"
 	title="Alignment test with 2 simple boxes"

--- a/examples/ClientTests/compact/FCC_HcalBarrel.xml
+++ b/examples/ClientTests/compact/FCC_HcalBarrel.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-    xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
     <includes>
         <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>

--- a/examples/ClientTests/compact/InhibitConstants.xml
+++ b/examples/ClientTests/compact/InhibitConstants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <define>
     <constant name="Detector_InhibitConstants" value="1"/>;

--- a/examples/ClientTests/compact/IronCylinder.xml
+++ b/examples/ClientTests/compact/IronCylinder.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <includes>
     <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>

--- a/examples/ClientTests/compact/LheD_tracker.xml
+++ b/examples/ClientTests/compact/LheD_tracker.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="LHeD_cdr"
         title="LHe Detector - based on CLIC Silicon Detector CDR"

--- a/examples/ClientTests/compact/MagnetFields.xml
+++ b/examples/ClientTests/compact/MagnetFields.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="clic_sid_cdr"
         title="CLIC Silicon Detector CDR"

--- a/examples/ClientTests/compact/MaterialTester.xml
+++ b/examples/ClientTests/compact/MaterialTester.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <define>
     <constant name="world_size" value="30*m"/>

--- a/examples/ClientTests/compact/MiniTel.xml
+++ b/examples/ClientTests/compact/MiniTel.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="Sensor"
 	title="Sensor for New experiment"

--- a/examples/ClientTests/compact/MiniTel_json.xml
+++ b/examples/ClientTests/compact/MiniTel_json.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="Sensor"
 	title="Sensor for New experiment"

--- a/examples/ClientTests/compact/MultiCollections.xml
+++ b/examples/ClientTests/compact/MultiCollections.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="Nested_Detectors_test"
         title="Test for nested detector descriptions"

--- a/examples/ClientTests/compact/MultiSegmentCollections.xml
+++ b/examples/ClientTests/compact/MultiSegmentCollections.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="Nested_Detectors_test"
         title="Test for nested detector descriptions"

--- a/examples/ClientTests/compact/MultiSegmentations.xml
+++ b/examples/ClientTests/compact/MultiSegmentations.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="Nested_Detectors_test"
         title="Test for nested detector descriptions"

--- a/examples/ClientTests/compact/NamespaceConstants.xml
+++ b/examples/ClientTests/compact/NamespaceConstants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-       xmlns:xs="http://www.w3.org/2001/XMLSchema"
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <define>
     <constant name="world_side"             value="2*m"/>

--- a/examples/ClientTests/compact/NestedDetectors.xml
+++ b/examples/ClientTests/compact/NestedDetectors.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="Nested_Detectors_test"
         title="Test for nested detector descriptions"

--- a/examples/ClientTests/compact/NestedSimple.xml
+++ b/examples/ClientTests/compact/NestedSimple.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="Nested_Detectors_test"
         title="Test for nested detector descriptions"

--- a/examples/ClientTests/compact/SectorBarrelCalorimeter.xml
+++ b/examples/ClientTests/compact/SectorBarrelCalorimeter.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="clic_sid_cdr"
         title="CLIC Silicon Detector CDR"

--- a/examples/ClientTests/compact/SiBarrelMultiSensitiveDetector.xml
+++ b/examples/ClientTests/compact/SiBarrelMultiSensitiveDetector.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="Nested_Detectors_test"
         title="Test for nested detector descriptions"

--- a/examples/ClientTests/compact/SiBarrelMultiSensitiveLongVolID.xml
+++ b/examples/ClientTests/compact/SiBarrelMultiSensitiveLongVolID.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="Nested_Detectors_test"
         title="Test for nested detector descriptions"

--- a/examples/ClientTests/compact/SiliconBlock.xml
+++ b/examples/ClientTests/compact/SiliconBlock.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
  
   <info name="SiliconBlock"
 	title="Test with 2 simple silicon boxes"

--- a/examples/ClientTests/compact/TrackingRegion.xml
+++ b/examples/ClientTests/compact/TrackingRegion.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
  
   <info name="SiliconBlock"
 	title="Test with 2 simple silicon boxes"

--- a/examples/ClientTests/compact/WorldVolume.xml
+++ b/examples/ClientTests/compact/WorldVolume.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
  
   <info name="SiliconBlock"
 	title="Test with 2 simple silicon boxes"

--- a/examples/Conditions/src/ConditionExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionExampleObjects.cpp
@@ -51,8 +51,8 @@ Condition ConditionUpdate1::operator()(const ConditionKey& key, ConditionUpdateC
 void ConditionUpdate1::resolve(Condition target, ConditionUpdateContext& context)  {
   vector<int>& data  = target.get<vector<int> >();
   Condition    cond0 = context.condition(context.key(0));
-  data.push_back(cond0.get<int>());
-  data.push_back(cond0.get<int>()*2);
+  data.emplace_back(cond0.get<int>());
+  data.emplace_back(cond0.get<int>()*2);
 }
 
 /// Interface to client Callback in order to update the condition

--- a/examples/OpticalSurfaces/compact/OpNovice.xml
+++ b/examples/OpticalSurfaces/compact/OpNovice.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="TestMaterialProperties"
     title="Test reading of TGeo's Material Properties"

--- a/examples/OpticalSurfaces/compact/OpNovice_gdml.xml
+++ b/examples/OpticalSurfaces/compact/OpNovice_gdml.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
-       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="gdml_import_test"
         title="GDML import test"

--- a/examples/OpticalSurfaces/compact/ReadGDMLMatrices.xml
+++ b/examples/OpticalSurfaces/compact/ReadGDMLMatrices.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="TestGDMLMatrices"
     title="Test reading of TGeo's GDML matrices"

--- a/examples/OpticalSurfaces/compact/ReadMaterialProperties.xml
+++ b/examples/OpticalSurfaces/compact/ReadMaterialProperties.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="TestMaterialProperties"
     title="Test reading of TGeo's Material Properties"

--- a/examples/OpticalSurfaces/compact/ReadOpticalSurfaces.xml
+++ b/examples/OpticalSurfaces/compact/ReadOpticalSurfaces.xml
@@ -1,6 +1,4 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+<lccdd>
 
   <info name="TestOpticalSurfaces"
     title="Test reading of TGeo's Optical Surfaces"


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove DTD links from lcdd xml files in examples. SInce we do not use DTD checking these are useless.
- Add 2 examples to check the usage of NTP and STP temperature/pressure conditions
ENDRELEASENOTES