### PR TITLE
Improvements: Plugin service, dd4hep_add_dictionary

### DIFF
--- a/GaudiPluginService/CMakeLists.txt
+++ b/GaudiPluginService/CMakeLists.txt
@@ -26,7 +26,7 @@ target_compile_options(DD4hepGaudiPluginMgr PRIVATE -Wno-shadow
   -Wno-return-type-c-linkage
   )
 
-target_link_libraries(DD4hepGaudiPluginMgr PUBLIC ${FS_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(DD4hepGaudiPluginMgr PUBLIC Boost::boost ${FS_LIBRARIES} ${CMAKE_DL_LIBS})
 SET_TARGET_PROPERTIES(DD4hepGaudiPluginMgr PROPERTIES VERSION ${DD4hep_VERSION} SOVERSION ${DD4hep_SOVERSION})
 
 add_executable(listcomponents src/listcomponents.cpp )

--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -557,16 +557,17 @@ function(dd4hep_add_dictionary dictionary )
     set ( output_dir ${ARG_OUTPUT} )
   endif()
   EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory ${output_dir})
-  SET(COMP_DEFS )
-  file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${dictionary}_arguments
-    CONTENT "${ROOT_rootcling_CMD} -f ${dictionary}.cxx -s ${output_dir}/${dictionary} -inlineInputHeader ${ARG_OPTIONS}  \
-   $<$<BOOL:${comp_defs}>:-D$<JOIN:${comp_defs}, -D>> \
-   $<$<BOOL:${inc_dirs}>:-I$<JOIN:${inc_dirs}, -I>> \
-   $<JOIN:${headers}, >  $<JOIN:${linkdefs}, >"
-    )
+
   add_custom_command(OUTPUT ${dictionary}.cxx ${output_dir}/${dictionary}_rdict.pcm
-    COMMAND bash ${dictionary}_arguments
-    DEPENDS ${headers} ${linkdefs}
+    COMMAND ${ROOT_rootcling_CMD}
+    ARGS -f ${dictionary}.cxx -s ${output_dir}/${dictionary} -inlineInputHeader
+    ${ARG_OPTIONS} -std=c++${CMAKE_CXX_STANDARD}
+   "$<$<BOOL:$<JOIN:${comp_defs},>>:-D$<JOIN:${comp_defs},;-D>>"
+   "$<$<BOOL:$<JOIN:${inc_dirs},>>:-I$<JOIN:${inc_dirs},;-I>>"
+   "$<JOIN:${headers},;>" "$<JOIN:${linkdefs},;>"
+
+   DEPENDS ${headers} ${linkdefs}
+   COMMAND_EXPAND_LISTS
     )
   add_custom_target(${dictionary}
     DEPENDS ${dictionary}.cxx ${output_dir}/${dictionary}_rdict.pcm


### PR DESCRIPTION
BEGINRELEASENOTES
- Cmake: dd4hep_add_dictionary: directly use command, no longer created bash script to be called. See details of call with `make VERBOSE=1`
- PluginServiceV2: use `boost::split` instead of walking of char arrays, fix bug when two colons are in the environment variable. Fixes #600 
ENDRELEASENOTES