### PR TITLE
Fixed handling of test dependencies

### DIFF
--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -449,7 +449,7 @@ function ( dd4hep_add_test_reg test_name )
     endif()
     # Set test dependencies if present
     foreach ( _dep ${ARG_DEPENDS} )
-      set_tests_properties( t_${test_name} PROPERTIES DEPENDS t_${_dep} )
+      set_property( TEST t_${test_name} APPEND PROPERTY DEPENDS t_${_dep} )
     endforeach()
   endif()
 endfunction()

--- a/examples/DDDB/CMakeLists.txt
+++ b/examples/DDDB/CMakeLists.txt
@@ -237,7 +237,6 @@ dd4hep_add_test_reg( DDDB_clean_LONGTEST
   DDDB_load_LONGTEST
   DDDB_DeVelo_Gaudi_LONGTEST
   DDDB_DeVelo_LONGTEST
-  DDDB_extract_LONGTEST
   REGEX_PASS "DDDB Database successfully removed"
   )
 


### PR DESCRIPTION
There was a bug in the dd4hep_add_test_reg function which was only taking into account the last dependency of a test when several were present.
On the way, dropped a double dependency in DDDB_clean_LONGTEST

BEGINRELEASENOTES
- Fixed bug in the `dd4hep_add_test_reg` function which was only taking into account the last dependency of a test when several were present.
ENDRELEASENOTES