### PR TITLE
Check before importing libglapi

### DIFF
--- a/DDDigi/python/DDDigi.py
+++ b/DDDigi/python/DDDigi.py
@@ -21,10 +21,11 @@ def loadDDDigi():
 
   # Try to load libglapi to avoid issues with TLS Static
   # Turn off all errors from ROOT about the library missing
-  orgLevel = ROOT.gErrorIgnoreLevel
-  ROOT.gErrorIgnoreLevel = 6000
-  gSystem.Load("libglapi")
-  ROOT.gErrorIgnoreLevel = orgLevel
+  if('libglapi' not in gSystem.GetLibraries()):
+    orgLevel = ROOT.gErrorIgnoreLevel
+    ROOT.gErrorIgnoreLevel = 6000
+    gSystem.Load("libglapi")
+    ROOT.gErrorIgnoreLevel = orgLevel
 
   import platform
   import os

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -22,10 +22,11 @@ def loadDDG4():
 
   # Try to load libglapi to avoid issues with TLS Static
   # Turn off all errors from ROOT about the library missing
-  orgLevel = ROOT.gErrorIgnoreLevel
-  ROOT.gErrorIgnoreLevel = 6000
-  gSystem.Load("libglapi")
-  ROOT.gErrorIgnoreLevel = orgLevel
+  if('libglapi' not in gSystem.GetLibraries()):
+    orgLevel = ROOT.gErrorIgnoreLevel
+    ROOT.gErrorIgnoreLevel = 6000
+    gSystem.Load("libglapi")
+    ROOT.gErrorIgnoreLevel = orgLevel
 
   import platform
   import os

--- a/DDTest/python/test_import.py
+++ b/DDTest/python/test_import.py
@@ -10,10 +10,10 @@ import pytest
 parametrize = pytest.mark.parametrize
 
 moduleNames = [
-    'DDDigi',
-    'DDG4',
     'dd4hep',
+    'DDG4',
     'DDRec',
+    'DDDigi',
     ]
 
 # List here the modules that are allowed to Fail.


### PR DESCRIPTION
Resolves #623 
BEGINRELEASENOTES
- Check in python modules that load `libglapi` is only called if the library is not already loaded.

ENDRELEASENOTES