### PR TITLE
Adapt to ROOT 6.22 python library ROOTTPython

### DIFF
--- a/DDCore/CMakeLists.txt
+++ b/DDCore/CMakeLists.txt
@@ -104,15 +104,15 @@ ELSE()
 ENDIF()
     
 #---------------------------  Specialized PYTHON plugin ----------------------------
-IF(TARGET ROOT::PyROOT)
+IF(TARGET ${DD4HEP_ROOT_PYTHON})
   dd4hep_add_plugin(DDPythonPlugins
     SOURCES src/python/*.cpp
-    USES DDCore ROOT::Core ROOT::PyROOT
+    USES DDCore ROOT::Core ${DD4HEP_ROOT_PYTHON}
     )
   set_target_properties(DDPythonPlugins PROPERTIES VERSION ${DD4hep_VERSION} SOVERSION ${DD4hep_SOVERSION})
   LIST(APPEND OPTIONAL_TARGETS DDPythonPlugins)
 ELSE()
-  dd4hep_print("ROOT does not include PyRoot, not building DDCore DDPython Plugins")
+  dd4hep_print("ROOT does not include Python support, not building DDCore DDPython Plugins")
 ENDIF()
 
 # install python files

--- a/DDG4/CMakeLists.txt
+++ b/DDG4/CMakeLists.txt
@@ -49,8 +49,7 @@ dd4hep_add_plugin(DDG4Plugins
   )
 #---------------------------  Plugin library for the simulation framework  ---------
 
-
-if(TARGET Python::Python AND TARGET ROOT::PyROOT)
+if(TARGET Python::Python AND TARGET ${DD4HEP_ROOT_PYTHON})
   dd4hep_print("|++> Python found, creating DDG4Python Dictionary")
   dd4hep_add_dictionary(G__DDG4Python
     SOURCES src/python/DDG4Python.C
@@ -64,7 +63,7 @@ if(TARGET Python::Python AND TARGET ROOT::PyROOT)
   dd4hep_print("|++> ROOT Has Python, creating DDPython library and plugins")
   add_library(DDPython G__DDPython.cxx tpython/DDPython.cpp)
   add_library(DD4hep::DDPython ALIAS DDPython)
-  target_link_libraries(DDPython DD4hep::DDG4 ROOT::Core Python::Python ROOT::PyROOT)
+  target_link_libraries(DDPython DD4hep::DDG4 ROOT::Core Python::Python ${DD4HEP_ROOT_PYTHON})
   IF(${CMAKE_CXX_STANDARD} GREATER 16)
     # python header not cxx17 compatible, gives error in clang
     target_compile_options(DDPython PUBLIC -Wno-register)
@@ -76,7 +75,7 @@ if(TARGET Python::Python AND TARGET ROOT::PyROOT)
     )
   #---Helper to overcome deficiency of the python executable concerning multi-threading
   add_executable(pyddg4 pyddg4.cpp)
-  target_link_libraries(pyddg4 PUBLIC DD4hep::DDPython ROOT::Core ROOT::PyROOT)
+  target_link_libraries(pyddg4 PUBLIC DD4hep::DDPython ROOT::Core ${DD4HEP_ROOT_PYTHON})
 
   # install these libraries
   set_target_properties(DDPython DDG4Python PROPERTIES VERSION ${DD4hep_VERSION} SOVERSION ${DD4hep_SOVERSION})
@@ -84,7 +83,7 @@ if(TARGET Python::Python AND TARGET ROOT::PyROOT)
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin)
 else()
-  dd4hep_print("|+++++> Python or PyROOT not found, not creating DDG4 Python Dictionaries")
+  dd4hep_print("|+++++> Python or PyRoot/ROOTTPython not found, not creating DDG4 Python Dictionaries")
 endif()
 
 #---------------------------  Plugin library for the simulation framework  ---------

--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -654,6 +654,13 @@ macro(DD4HEP_SETUP_ROOT_TARGETS)
     ENDIF()
   ENDIF()
 
+  # root python changes target name in 6.22
+  IF(TARGET ROOT::PyROOT)
+    SET(DD4HEP_ROOT_PYTHON ROOT::PyROOT)
+  ELSEIF(TARGET ROOT::ROOTTPython)
+    # New "pyroot" in 6.22
+    SET(DD4HEP_ROOT_PYTHON ROOT::ROOTTPython)
+  ENDIF()
   #ROOT CXX Flags are a string with quotes, not a list, so we need to convert to a list...
   string(REPLACE " " ";" DD4HEP_ROOT_CXX_FLAGS ${ROOT_CXX_FLAGS})
 


### PR DESCRIPTION
Fixes another part of #625 

BEGINRELEASENOTES
- CMake:  Adapt to ROOT 6.22 python library ROOTTPython

ENDRELEASENOTES

This PR is at the moment for testing against dev3.
While this PR here include s #631, #631 should just be merged by itself.