### PR TITLE
EDM4hep output Plugin for DDSim (python changes)

### DIFF
--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -714,11 +714,7 @@ class Geant4:
     return evt_lcio
 
   def setupEDM4hepOutput(self, name, output):
-    """
-       Configure EDM4hep root output for the simulated events
-
-       \author  F.Gaede
-    """
+    """Configure EDM4hep root output for the simulated events."""
     evt_edm4hep = EventAction(self.kernel(), 'Geant4Output2EDM4hep/' + name, True)
     evt_edm4hep.Control = True
     evt_edm4hep.Output = output

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -713,6 +713,19 @@ class Geant4:
     self.kernel().eventAction().add(evt_lcio)
     return evt_lcio
 
+  def setupEDM4hepOutput(self, name, output):
+    """
+       Configure EDM4hep root output for the simulated events
+
+       \author  F.Gaede
+    """
+    evt_edm4hep = EventAction(self.kernel(), 'Geant4Output2EDM4hep/' + name, True)
+    evt_edm4hep.Control = True
+    evt_edm4hep.Output = output
+    evt_edm4hep.enableUI()
+    self.kernel().eventAction().add(evt_edm4hep)
+    return evt_edm4hep
+
   def buildInputStage(self, generator_input_modules, output_level=None, have_mctruth=True):
     """
     Generic build of the input stage with multiple input modules.

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -155,7 +155,8 @@ class DD4hepSimulation(object):
                         help="InputFiles for simulation %s files are supported" % ", ".join(POSSIBLEINPUTFILES))
 
     parser.add_argument("--outputFile", "-O", action="store", default=self.outputFile,
-                        help="Outputfile from the simulation,only lcio output is supported")
+                        help="Outputfile from the simulation: .slcio, edm4hep.root and .root"
+                        " output files are supported")
 
     parser.add_argument("-v", "--printLevel", action="store", default=self.printLevel, dest="printLevel",
                         choices=(1, 2, 3, 4, 5, 6, 7, 'VERBOSE', 'DEBUG',
@@ -346,6 +347,12 @@ class DD4hepSimulation(object):
       lcOut.EventParametersString, lcOut.EventParametersInt, lcOut.EventParametersFloat = eventPars
       lcOut.RunNumberOffset = self.meta.runNumberOffset if self.meta.runNumberOffset > 0 else 0
       lcOut.EventNumberOffset = self.meta.eventNumberOffset if self.meta.eventNumberOffset > 0 else 0
+    elif self.outputFile.endswith("edm4hep.root"):
+      e4Out = simple.setupEDM4hepOutput('EDM4hepOutput', self.outputFile)
+      eventPars = self.meta.parseEventParameters()
+      e4Out.EventParametersString, e4Out.EventParametersInt, e4Out.EventParametersFloat = eventPars
+      e4Out.RunNumberOffset = self.meta.runNumberOffset if self.meta.runNumberOffset > 0 else 0
+      e4Out.EventNumberOffset = self.meta.eventNumberOffset if self.meta.eventNumberOffset > 0 else 0
     elif self.outputFile.endswith(".root"):
       simple.setupROOTOutput('RootOutput', self.outputFile)
 


### PR DESCRIPTION
This PR supersedes #619, and includes the changes to the python code to allow calling the `Geant4Output2EDM4hep` plugin in ddsim  This option won't work without the plugin, which has moved to https://github.com/HSF/EDM4hep/pull/43/files.

BEGINRELEASENOTES
- DDSim: add option to use edm4hep output

ENDRELEASENOTES