### PR TITLE
DDSim: bring back the visible printout of dumpSteeringFile

### DIFF
--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -294,20 +294,37 @@ def _get(self, name):
   raise KeyError(msg)
 
 
-def _set(self, name, value):
-  a = Interface.toAction(self)
-  if isinstance(value, list):
-    value = [str(x) for x in value]
-  if isinstance(value, dict):
+def _deUnicode(value):
+  """Turn any unicode literal into str, needed when passing to c++.
+
+  Recursively transverses dicts, lists, sets, tuples
+
+  :return: always a str
+  """
+  if isinstance(value, (bool, float, six.integer_types)):
+    value = value
+  elif isinstance(value, six.string_types):
+    value = str(value)
+  elif isinstance(value, (list, set, tuple)):
+    value = [_deUnicode(x) for x in value]
+  elif isinstance(value, dict):
     tempDict = {}
     for key, val in value.items():
-      if isinstance(val, six.string_types):
-        val = str(val)
-      tempDict[str(key)] = val
+      key = _deUnicode(key)
+      val = _deUnicode(val)
+      tempDict[key] = val
     value = tempDict
-  if Interface.setProperty(a, str(name), str(value)):
+  return str(value)
+
+
+def _set(self, name, value):
+  """This function is called when properties are passed to the c++ objects."""
+  a = Interface.toAction(self)
+  name = _deUnicode(name)
+  value = _deUnicode(value)
+  if Interface.setProperty(a, name, value):
     return
-  msg = 'Geant4Action::SetProperty [Unhandled]: Cannot set ' + a.name() + '.' + name + ' = ' + str(value)
+  msg = 'Geant4Action::SetProperty [Unhandled]: Cannot set ' + a.name() + '.' + name + ' = ' + value
   raise KeyError(msg)
 
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -6,7 +6,7 @@ Based on M. Frank and F. Gaede runSim.py
    @version 0.1
 
 """
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, unicode_literals, division, print_function
 __RCSID__ = "$Id$"
 import sys
 import os
@@ -628,7 +628,8 @@ SIM = DD4hepSimulation()
         else:
           steeringFileBase += "SIM.%s = %s" % (parName, str(parameter))
         steeringFileBase += "\n"
-    logger.info("%s", steeringFileBase)
+    for line in steeringFileBase.splitlines():
+      print(line)
 
   def _consistencyChecks(self):
     """Check if the requested setup makes sense, or if there is something preventing it from working correctly

--- a/DDG4/python/DDSim/Helper/ConfigHelper.py
+++ b/DDG4/python/DDSim/Helper/ConfigHelper.py
@@ -53,10 +53,10 @@ class ConfigHelper(object):
     return self.printOptions()
 
   def printOptions(self):
-    """print all paramters"""
+    """print all parameters"""
     options = []
     for opt, val in six.iteritems(self.getOptions()):
-      options.append("\n\t'%s': '%s'" % (opt, val[0]))
+      options.append("\n\t'%s': '%s'" % (opt, val['default']))
     return "".join(options)
 
   def setOption(self, name, val):

--- a/DDG4/python/DDSim/bin/ddsim.py
+++ b/DDG4/python/DDSim/bin/ddsim.py
@@ -14,11 +14,11 @@ from DDSim.DD4hepSimulation import DD4hepSimulation
 
 
 if __name__ == "__main__":
-  RUNNER = DD4hepSimulation()
-  RUNNER.parseOptions()
-
   logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
   logger = logging.getLogger('DDSim')
+
+  RUNNER = DD4hepSimulation()
+  RUNNER.parseOptions()
 
   try:
     RUNNER.run()

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -64,7 +64,7 @@ if (DD4HEP_USE_GEANT4)
 
   ADD_TEST( t_test_ddsim "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
     ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml --runType=batch -G -N=2 --outputFile=testSid.root
-    --part.userParticleHandler=)
+    --gun.position "0.0 0.0 0.0" --gun.direction "1.0 0.0 1.0" --gun.energy 100*GeV --part.userParticleHandler=)
   SET_TESTS_PROPERTIES( t_test_ddsim PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
 endif()

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -64,7 +64,7 @@ if (DD4HEP_USE_GEANT4)
 
   ADD_TEST( t_test_ddsim "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
     ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml --runType=batch -G -N=2 --outputFile=testSid.root
-    --gun.position "0.0 0.0 0.0" --gun.direction "1.0 0.0 1.0" --gun.energy 100*GeV --part.userParticleHandler=)
+    --gun.position \"0.0 0.0 1.0*cm\" --gun.direction \"1.0 0.0 1.0\" --gun.energy 100*GeV --part.userParticleHandler=)
   SET_TESTS_PROPERTIES( t_test_ddsim PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
 endif()

--- a/cmake/run_test.sh
+++ b/cmake/run_test.sh
@@ -24,4 +24,4 @@ done
 echo " #### LD_LIBRARY_PATH = :  ${LD_LIBRARY_PATH}"
 
 echo "---running test :  '" ${command} ${theargs} "'"
-${command} ${theargs}
+eval ${command} ${theargs}


### PR DESCRIPTION
BEGINRELEASENOTES
- DDSim: make the output of `ddsim --dumpSteeringFile` visible again
- DDSim: fix exception in ConfigHelper.printOptions, called by `--dumpParameters` option
- DDSim: fix parsing of vector command line parameters, gun.position, gun.direction etc.
- DDSim: better testing of command line parameters

ENDRELEASENOTES

When moving to logger, the logger was only configured after the parsing or parameters, but actually just `print`ing the steering file is better, because then we don't get the logging header, which would invalidate the steering file."
Resolves #643 