### PR TITLE
Add um unit of length to system of units

### DIFF
--- a/DDParsers/src/Evaluator/setSystemOfUnits.cpp
+++ b/DDParsers/src/Evaluator/setSystemOfUnits.cpp
@@ -262,6 +262,7 @@ namespace dd4hep  {
       setVariable("micrometer", micro_ * m);
       setVariable("micron",     micro_ * m);
       setVariable("mum",        micro_ * m);
+      setVariable("um",         micro_ * m);
       setVariable("nanometer",  nano_  * m);
       setVariable("nm",         nano_  * m);
 


### PR DESCRIPTION
Given that there is `um` unit in the python interface 
https://github.com/AIDASoft/DD4hep/blob/9970ab5bc40e58b889c2618222b3a92c205e6dcf/DDCore/python/dd4hep_base.py#L266
the XML parser should understand that `um` is a valid unit.
