### PR TITLE
[CMake]: add DD4HEP_HIGH_MEM_POOL_DEPTH option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ ENDIF()
 ###############################
 # Define DD4hep build options #
 ###############################
+# NINJA ONLY
+# Limit number of parallel DDParser builds to number equal to 2 gigs per core
+cmake_host_system_information(RESULT HOST_RAM_MB QUERY TOTAL_PHYSICAL_MEMORY)
+math(EXPR DD4HEP_HIGH_MEM_POOL_DEPTH "${HOST_RAM_MB} / 2000" OUTPUT_FORMAT DECIMAL)
 
 option(DD4HEP_USE_XERCESC "Enable 'Detector Builders' based on XercesC"   OFF)
 option(DD4HEP_USE_GEANT4  "Enable the simulation part based on Geant4"    OFF)
@@ -81,7 +85,10 @@ OPTION(DD4HEP_BUILD_EXAMPLES "Build all the examples" OFF)
 OPTION(DD4HEP_DEBUG_CMAKE "Print debugging information for DD4hep CMAKE" OFF)
 
 SET(DD4HEP_USE_EXISTING_DD4HEP "" CACHE STRING "Build some parts of DD4hep against an existing installation")
+SET(DD4HEP_HIGH_MEM_POOL_DEPTH "${DD4HEP_HIGH_MEM_POOL_DEPTH}" CACHE STRING "Number of build slots for high memory compile units (DDParsers), Ninja only")
 
+# create the job pool
+set_property(GLOBAL PROPERTY JOB_POOLS HIGH_MEM_POOL=${DD4HEP_HIGH_MEM_POOL_DEPTH})
 #####################
 # Configure version #
 #####################

--- a/DDParsers/CMakeLists.txt
+++ b/DDParsers/CMakeLists.txt
@@ -12,6 +12,10 @@
 
 dd4hep_print("|++> Will build DDParsers")
 
+
+# set the default job pool to use, is unset below, although this only applies for this directory
+SET(CMAKE_JOB_POOL_COMPILE HIGH_MEM_POOL)
+
 file(GLOB DDParsers_SOURCES src/Parsers/*.cpp src/Evaluator/*.cpp)
 file(GLOB DDParsers_SPIRIT_SOURCES src/Spirit/*.cpp)
 
@@ -33,3 +37,5 @@ install(DIRECTORY include/Parsers include/Evaluator DESTINATION include)
 install(TARGETS DDParsers ${OPTIONAL_TARGETS} EXPORT DD4hep
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
+# Unset job pool
+SET(CMAKE_JOB_POOL_COMPILE)


### PR DESCRIPTION
BEGINRELEASENOTES
- CMake: add `DD4HEP_HIGH_MEM_POOL_DEPTH` option. Allow setting of parallel builds of DDParser objects with the ninja generator. Defaults to "memory / 2000 cores (rounded down)"

ENDRELEASENOTES