### PR TITLE
Support for conditions with non-default ctor

### DIFF
--- a/DDCore/include/DD4hep/AlignmentData.h
+++ b/DDCore/include/DD4hep/AlignmentData.h
@@ -196,5 +196,6 @@ namespace dd4hep {
     {  return detectorToLocal(Position(det[0],det[1],det[2]));                        }
   };
 }         /* End namespace dd4hep               */
+std::ostream& operator << (std::ostream& s, const dd4hep::Delta& data);
 std::ostream& operator << (std::ostream& s, const dd4hep::AlignmentData& data);
 #endif    /* DD4HEP_ALIGMENTS_ALIGNMENTDATA_H   */

--- a/DDCore/include/DD4hep/Conditions.h
+++ b/DDCore/include/DD4hep/Conditions.h
@@ -212,7 +212,7 @@ namespace dd4hep {
      *  Note: The type definition is possible exactly once.
      *  Any further rebindings MUST match the identical type.
      */
-    template <typename T, typename... Args> T& construct(Args&&... args);
+    template <typename T, typename... Args> T& construct(Args... args);
     /** Bind the data of the conditions object to a given format.
      *
      *  Note: The type definition is possible exactly once.
@@ -240,7 +240,7 @@ namespace dd4hep {
     : Handle<Condition::Object>(e) {}
 
   /// Construct conditions object and bind the data
-  template <typename T, typename... Args> T& Condition::construct(Args&&... args)   {
+  template <typename T, typename... Args> T& Condition::construct(Args... args)   {
     return data().construct<T,Args...>(args...);
   }
   /// Bind the data of the conditions object to a given format.

--- a/DDCore/include/DD4hep/DD4hepRootPersistency.h
+++ b/DDCore/include/DD4hep/DD4hepRootPersistency.h
@@ -16,6 +16,7 @@
 // Framework include files
 #include "DD4hep/DetectorData.h"
 
+
 /// Helper class to support ROOT persistency of Detector objects
 /**
  *  \author  M.Frank
@@ -34,9 +35,10 @@ public:
   std::map<dd4hep::DetElement,dd4hep::AlignmentCondition> nominals;
 
   /// Default constructor
-  DD4hepRootPersistency() : TNamed() {}
+  DD4hepRootPersistency();
+
   /// Default destructor
-  virtual ~DD4hepRootPersistency() {}
+  virtual ~DD4hepRootPersistency();
 
   /// Save an existing detector description in memory to a ROOT file
   static int save(dd4hep::Detector& description, const char* fname, const char* instance = "Geometry");
@@ -87,6 +89,7 @@ public:
   /// ROOT implementation macro
   ClassDef(DD4hepRootPersistency,1);
 };
+
 
 /// Helper class to check various ingredients of the Detector object after loaded from ROOT
 /**

--- a/DDCore/include/DD4hep/Grammar.h
+++ b/DDCore/include/DD4hep/Grammar.h
@@ -214,6 +214,8 @@ namespace dd4hep {
   class GrammarRegistry {
     /// Default constructor
     GrammarRegistry() = default;
+    /// PropertyGrammar overload: Serialize a property to a string
+    template <typename T> static std::string str(const BasicGrammar&, const void*)  { return ""; }
   public:
     /// Registry instance singleton
     static const GrammarRegistry& instance();
@@ -230,6 +232,7 @@ namespace dd4hep {
       BasicGrammar::specialization_t spec;
       spec.bind = detail::constructObject<T>;
       spec.copy = detail::copyObject<T>;
+      spec.str  = GrammarRegistry::str<T>;
       return pre_note_specs<T>(spec);
     }
     template <typename T> static const GrammarRegistry& pre_note()   {

--- a/DDCore/include/DD4hep/OpaqueData.h
+++ b/DDCore/include/DD4hep/OpaqueData.h
@@ -122,6 +122,8 @@ namespace dd4hep {
     void* bind(const BasicGrammar* grammar);
     /// Bind data value in place
     void* bind(void* ptr, size_t len, const BasicGrammar* grammar);
+    /// Bind external data value to the pointer
+    void bindExtern(void* ptr, const BasicGrammar* grammar);
     /// Construct conditions object and bind the data
     template <typename T, typename... Args> T& construct(Args... args);
     /// Bind data value
@@ -132,6 +134,8 @@ namespace dd4hep {
     template <typename T> T& bind(const std::string& value);
     /// Bind data value
     template <typename T> T& bind(void* ptr, size_t len, const std::string& value);
+    /// Bind external data value to the pointer
+    template <typename T> void bindExtern(T* ptr);
   };
 
   /// Generic getter. Specify the exact type, not a polymorph type
@@ -183,5 +187,10 @@ namespace dd4hep {
     }
     return ret;
   }
+  /// Bind external data value to the pointer
+  template <typename T> void OpaqueDataBlock::bindExtern(T* ptr)    {
+    bindExtern(ptr, &BasicGrammar::instance<T>());
+  }
+
 }      /* End namespace dd4hep */
 #endif /* DD4HEP_OPAQUEDATA_H  */

--- a/DDCore/include/DD4hep/OpaqueData.h
+++ b/DDCore/include/DD4hep/OpaqueData.h
@@ -123,7 +123,7 @@ namespace dd4hep {
     /// Bind data value in place
     void* bind(void* ptr, size_t len, const BasicGrammar* grammar);
     /// Construct conditions object and bind the data
-    template <typename T, typename... Args> T& construct(Args&&... args);
+    template <typename T, typename... Args> T& construct(Args... args);
     /// Bind data value
     template <typename T> T& bind();
     /// Bind data value
@@ -147,7 +147,7 @@ namespace dd4hep {
   }
 
   /// Construct conditions object and bind the data
-  template <typename T, typename... Args> T& OpaqueDataBlock::construct(Args&&... args)   {
+  template <typename T, typename... Args> T& OpaqueDataBlock::construct(Args... args)   {
     this->bind(&BasicGrammar::instance<T>());
     return *(new(this->pointer) T(std::forward<Args>(args)...));
   }

--- a/DDCore/include/DD4hep/detail/Grammar_parsed.h
+++ b/DDCore/include/DD4hep/detail/Grammar_parsed.h
@@ -224,8 +224,15 @@ namespace dd4hep {
 
   /// Standarsd constructor
   template <typename TYPE> const BasicGrammar& BasicGrammar::instance()  {
-    static Grammar<TYPE> s_gr;
-    return s_gr;
+    static Grammar<TYPE> *s_gr = 0;
+    if ( 0 != s_gr )  {
+      return *s_gr;
+    }
+    static Grammar<TYPE> gr;
+    if ( 0 == gr.specialization.bind ) gr.specialization.bind = detail::constructObject<TYPE>;
+    if ( 0 == gr.specialization.copy ) gr.specialization.copy = detail::copyObject<TYPE>;
+    s_gr = &gr;
+    return *s_gr;
   }
 }      // End namespace dd4hep
 

--- a/DDCore/include/DD4hep/detail/Grammar_parsed.h
+++ b/DDCore/include/DD4hep/detail/Grammar_parsed.h
@@ -237,9 +237,11 @@ namespace dd4hep {
     static Grammar<TYPE> gr;
     if ( 0 == gr.specialization.bind       ) gr.specialization.bind       = detail::constructObject<TYPE>;
     if ( 0 == gr.specialization.copy       ) gr.specialization.copy       = detail::copyObject<TYPE>;
-    if ( 0 == gr.specialization.fromString ) gr.specialization.fromString = detail::grammar_fromString<TYPE>;
-    if ( 0 == gr.specialization.eval       ) gr.specialization.eval       = detail::grammar_eval<TYPE>;
-    if ( 0 == gr.specialization.str        ) gr.specialization.str        = detail::grammar_str<TYPE>;
+    if ( 0 == gr.specialization.fromString )  {
+      gr.specialization.fromString = detail::grammar_fromString<TYPE>;
+      gr.specialization.eval       = detail::grammar_eval<TYPE>;
+      gr.specialization.str        = detail::grammar_str<TYPE>;
+    }
     s_gr = &gr;
     return *s_gr;
   }

--- a/DDCore/include/DD4hep/detail/Grammar_unparsed.h
+++ b/DDCore/include/DD4hep/detail/Grammar_unparsed.h
@@ -45,7 +45,7 @@ namespace dd4hep {
 
   /// Standarsd constructor
   template <typename TYPE> const BasicGrammar& BasicGrammar::instance()  {
-    static Grammar<TYPE> s_gr();
+    static Grammar<TYPE> s_gr;
     return s_gr;
   }
 }

--- a/DDCore/include/DD4hep/detail/Grammar_unparsed.h
+++ b/DDCore/include/DD4hep/detail/Grammar_unparsed.h
@@ -23,7 +23,6 @@
 
 // Framework include files
 #include "DD4hep/Grammar.h"
-#include "DD4hep/Printout.h"
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/include/DD4hep/detail/Grammar_unparsed.h
+++ b/DDCore/include/DD4hep/detail/Grammar_unparsed.h
@@ -27,21 +27,6 @@
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
 
-  /// PropertyGrammar overload: Retrieve value from string
-  template <typename TYPE> bool Grammar<TYPE>::fromString(void* /*ptr*/, const std::string& /*val*/) const {
-    return true;
-  }
-  
-  /// Serialize a property to a string
-  template <typename TYPE> std::string Grammar<TYPE>::str(const void* /*ptr*/) const {
-    return "";
-  }
-  
-  /// Evaluate string value if possible before calling boost::spirit
-  template <typename TYPE> int Grammar<TYPE>::evaluate(void*, const std::string&) const {
-    return 0;
-  }
-
   /// Standarsd constructor
   template <typename TYPE> const BasicGrammar& BasicGrammar::instance()  {
     static Grammar<TYPE> s_gr;

--- a/DDCore/include/DD4hep/detail/Grammar_unparsed.h
+++ b/DDCore/include/DD4hep/detail/Grammar_unparsed.h
@@ -23,24 +23,29 @@
 
 // Framework include files
 #include "DD4hep/Grammar.h"
+#include "DD4hep/Printout.h"
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
+
   /// PropertyGrammar overload: Retrieve value from string
   template <typename TYPE> bool Grammar<TYPE>::fromString(void* /*ptr*/, const std::string& /*val*/) const {
     return true;
   }
-   /// Serialize a property to a string
+  
+  /// Serialize a property to a string
   template <typename TYPE> std::string Grammar<TYPE>::str(const void* /*ptr*/) const {
     return "";
   }
+  
   /// Evaluate string value if possible before calling boost::spirit
   template <typename TYPE> int Grammar<TYPE>::evaluate(void*, const std::string&) const {
     return 0;
   }
+
   /// Standarsd constructor
   template <typename TYPE> const BasicGrammar& BasicGrammar::instance()  {
-    static Grammar<TYPE> s_gr;
+    static Grammar<TYPE> s_gr();
     return s_gr;
   }
 }

--- a/DDCore/include/Parsers/Primitives.h
+++ b/DDCore/include/Parsers/Primitives.h
@@ -311,6 +311,10 @@ namespace dd4hep {
       const T* src = (const T*)source;
       ::new(target) T(*src);
     }
+    /// Helper to copy objects.
+    template <typename T> inline void constructObject(void* target)  {
+      ::new(target) T();
+    }
     /// Helper to destruct objects. Note: The memory is NOT released!
     template <typename T> inline void destructObject(T* ptr) {
       ptr->~T();

--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -111,22 +111,26 @@ std_list = std.list
 std_map = std.map
 std_pair = std.pair
 # ---------------------------------------------------------------------------
-core = dd4hep
-cond = dd4hep.cond
-tools = dd4hep.tools
-align = dd4hep.align
+core   = dd4hep
+cond   = dd4hep.cond
+tools  = dd4hep.tools
+align  = dd4hep.align
 detail = dd4hep.detail
-units = imp.new_module('units')
+units  = imp.new_module('units')
 # ---------------------------------------------------------------------------
 import_namespace_item('tools', 'Evaluator')
 # ---------------------------------------------------------------------------
 import_namespace_item('core', 'NamedObject')
 import_namespace_item('core', 'run_interpreter')
-
+#
+import_namespace_item('detail', 'interp')
+import_namespace_item('detail', 'eval')
+#def run_interpreter(name):   detail.interp.run(name)
+#def evaluator():     return eval.instance()
+#def g4Evaluator():   return eval.g4instance()
 
 def import_detail():
   import_namespace_item('detail', 'DD4hepUI')
-
 
 def import_geometry():
   import_namespace_item('core', 'setPrintLevel')
@@ -197,7 +201,6 @@ def import_geometry():
   import_namespace_item('core', 'SubtractionSolid')
   import_namespace_item('core', 'UnionSolid')
   import_namespace_item('core', 'IntersectionSolid')
-
 
 def import_tgeo():
   import_root('TGeoManager')

--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -125,10 +125,11 @@ import_namespace_item('core', 'run_interpreter')
 #
 import_namespace_item('detail', 'interp')
 import_namespace_item('detail', 'eval')
-#
-#def run_interpreter(name):   detail.interp.run(name)
-#def evaluator():     return eval.instance()
-#def g4Evaluator():   return eval.g4instance()
+# ---------------------------------------------------------------------------
+# def run_interpreter(name):   detail.interp.run(name)
+# def evaluator():     return eval.instance()
+# def g4Evaluator():   return eval.g4instance()
+# ---------------------------------------------------------------------------
 
 
 def import_detail():

--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -111,12 +111,12 @@ std_list = std.list
 std_map = std.map
 std_pair = std.pair
 # ---------------------------------------------------------------------------
-core   = dd4hep
-cond   = dd4hep.cond
-tools  = dd4hep.tools
-align  = dd4hep.align
+core = dd4hep
+cond = dd4hep.cond
+tools = dd4hep.tools
+align = dd4hep.align
 detail = dd4hep.detail
-units  = imp.new_module('units')
+units = imp.new_module('units')
 # ---------------------------------------------------------------------------
 import_namespace_item('tools', 'Evaluator')
 # ---------------------------------------------------------------------------
@@ -125,12 +125,15 @@ import_namespace_item('core', 'run_interpreter')
 #
 import_namespace_item('detail', 'interp')
 import_namespace_item('detail', 'eval')
+#
 #def run_interpreter(name):   detail.interp.run(name)
 #def evaluator():     return eval.instance()
 #def g4Evaluator():   return eval.g4instance()
 
+
 def import_detail():
   import_namespace_item('detail', 'DD4hepUI')
+
 
 def import_geometry():
   import_namespace_item('core', 'setPrintLevel')
@@ -201,6 +204,7 @@ def import_geometry():
   import_namespace_item('core', 'SubtractionSolid')
   import_namespace_item('core', 'UnionSolid')
   import_namespace_item('core', 'IntersectionSolid')
+
 
 def import_tgeo():
   import_root('TGeoManager')

--- a/DDCore/src/AlignmentData.cpp
+++ b/DDCore/src/AlignmentData.cpp
@@ -230,7 +230,6 @@ Alignment AlignmentData::nominal() const   {
 }
 
 #include "DD4hep/detail/Grammar_unparsed.h"
-// Ensure the grammars are registered and instantiated
-static auto s_registry = GrammarRegistry::pre_note<Delta>()
-              .pre_note<AlignmentData>()
-              .pre_note<std::map<DetElement, Delta> >();
+static auto s_registry = GrammarRegistry::pre_note<Delta>(1)
+              .pre_note<AlignmentData>(1)
+              .pre_note<std::map<DetElement, Delta> >(1);

--- a/DDCore/src/AlignmentsCalculator.cpp
+++ b/DDCore/src/AlignmentsCalculator.cpp
@@ -324,5 +324,4 @@ size_t AlignmentsCalculator::extract_deltas(DetElement start,
 }
 
 #include "DD4hep/detail/Grammar_unparsed.h"
-// Ensure the grammars are registered and instantiated
-static auto s_registry = GrammarRegistry::pre_note<AlignmentsCalculator::OrderedDeltas>();
+static auto s_registry = GrammarRegistry::pre_note<AlignmentsCalculator::OrderedDeltas>(1);

--- a/DDCore/src/AlignmentsInterna.cpp
+++ b/DDCore/src/AlignmentsInterna.cpp
@@ -68,6 +68,4 @@ void AlignmentObject::clear()   {
 }
 
 #include "DD4hep/detail/Grammar_unparsed.h"
-namespace dd4hep {
-  //template const BasicGrammar& BasicGrammar::instance<AlignmentObject>();
-}
+static auto s_registry = GrammarRegistry::pre_note<AlignmentObject>();

--- a/DDCore/src/ComponentProperties.cpp
+++ b/DDCore/src/ComponentProperties.cpp
@@ -245,6 +245,6 @@ namespace dd4hep {
   }
   // Ensure the grammars are registered
   template class Grammar<Property>;
-  static auto s_registry = GrammarRegistry::pre_note<Property>();
+  static auto s_registry = GrammarRegistry::pre_note<Property>(1);
 }
 

--- a/DDCore/src/ComponentProperties.cpp
+++ b/DDCore/src/ComponentProperties.cpp
@@ -240,9 +240,11 @@ namespace dd4hep {
       return os << result.str();
     }
   }
+#if 0
   template<> int Grammar<Property>::evaluate(void* _p, const std::string& _v) const {
     return eval_obj ((Property*)_p,_v);
   }
+#endif
   // Ensure the grammars are registered
   template class Grammar<Property>;
   static auto s_registry = GrammarRegistry::pre_note<Property>(1);

--- a/DDCore/src/ConditionsData.cpp
+++ b/DDCore/src/ConditionsData.cpp
@@ -77,5 +77,4 @@ AbstractMap& AbstractMap::operator=(const AbstractMap& c)  {
 }
 
 #include "DD4hep/detail/Grammar_unparsed.h"
-// Ensure the grammars are registered and instantiated
-static auto s_registry = dd4hep::GrammarRegistry::pre_note<AbstractMap>();
+static auto s_registry = dd4hep::GrammarRegistry::pre_note<AbstractMap>(1);

--- a/DDCore/src/DD4hepRootPersistency.cpp
+++ b/DDCore/src/DD4hepRootPersistency.cpp
@@ -27,6 +27,14 @@ ClassImp(DD4hepRootPersistency)
 using namespace dd4hep;
 using namespace std;
 
+/// Default constructor
+DD4hepRootPersistency::DD4hepRootPersistency() : TNamed() {
+}
+
+/// Default destructor
+DD4hepRootPersistency::~DD4hepRootPersistency() {
+}
+
 int DD4hepRootPersistency::save(Detector& description, const char* fname, const char* instance)   {
   TFile* f = TFile::Open(fname,"RECREATE");
   if ( f && !f->IsZombie()) {

--- a/DDCore/src/DetectorData.cpp
+++ b/DDCore/src/DetectorData.cpp
@@ -114,8 +114,12 @@ namespace {
       //printout(INFO,"OpaqueData","   Data type:%s  [%016llX]",gr.name.c_str(),key);
       void* ptr = block->ptr();
       if ( !ptr )  { // Some blocks are already bound. Skip those.
+	if ( !gr.specialization.bind )   {
+	  except("stream_opaque_datablock","Object cannot be handled by ROOT persistency. "
+		 "Grammar %s does not allow for ROOT persistency.",gr.type_name().c_str());
+	}
         ptr = block->bind(&gr);
-        gr.bind(ptr);
+        gr.specialization.bind(ptr);
       }
       /// Now perform the I/O action
       if ( gr.type() == typeid(std::string) )

--- a/DDCore/src/Grammar.cpp
+++ b/DDCore/src/Grammar.cpp
@@ -147,8 +147,33 @@ void dd4hep::BasicGrammar::invalidConversion(const std::type_info& from, const s
                              "' to '" + to_name + "' is not implemented.");
 }
 
+/// Serialize an opaque value to a string
+std::string dd4hep::BasicGrammar::str(const void* ptr) const    {
+  if ( specialization.str )
+    return specialization.str(*this,ptr);
+  except("Grammar","Cannot serialize object with incomplete grammar: %s",type_name().c_str());
+  return "";
+}
+
+/// Set value from serialized string. On successful data conversion TRUE is returned.
+bool dd4hep::BasicGrammar::fromString(void* ptr, const std::string& value) const    {
+  if ( specialization.fromString )
+    return specialization.fromString(*this,ptr, value);
+  except("Grammar","Cannot deserialize object with incomplete grammar: %s",type_name().c_str());
+  return false;
+}
+
+/// Evaluate string value if possible before calling boost::spirit
+int dd4hep::BasicGrammar::evaluate(void* ptr, const std::string& value) const    {
+  if ( specialization.eval )
+    return specialization.eval(*this,ptr, value);
+  except("Grammar","Cannot evaluate object with incomplete grammar: %s",type_name().c_str());
+  return 0;
+}
+
 /// Registry instance singleton
 const dd4hep::GrammarRegistry& dd4hep::GrammarRegistry::instance()   {
   static GrammarRegistry s_reg;
   return s_reg;
 }
+

--- a/DDCore/src/OpaqueData.cpp
+++ b/DDCore/src/OpaqueData.cpp
@@ -143,6 +143,18 @@ void* OpaqueDataBlock::bind(const BasicGrammar* g)   {
   return 0;
 }
 
+/// Bind external data value to the pointer
+void OpaqueDataBlock::bindExtern(void* ptr, const BasicGrammar* gr)    {
+  if ( grammar != 0 && type != EXTERN_DATA )  {
+    // We cannot ingore secondary requests for data bindings.
+    // This leads to memory leaks in the caller!
+    except("OpaqueData","You may not bind opaque data multiple times!");
+  }
+  pointer = ptr;
+  grammar = gr;
+  type    = EXTERN_DATA;
+}
+
 /// Set data value
 void* OpaqueDataBlock::bind(void* ptr, size_t size, const BasicGrammar* g)   {
   if ( (type&EXTERN_DATA) == EXTERN_DATA )  {

--- a/DDCore/src/RootDictionary.h
+++ b/DDCore/src/RootDictionary.h
@@ -41,9 +41,10 @@
 // C/C++ include files
 #include <vector>
 #include <map>
-#include <string>
+ #include <string>
 
 #include "TRint.h"
+
 namespace dd4hep {
   namespace cond {}
   namespace align {}
@@ -53,8 +54,35 @@ namespace dd4hep {
     TRint app(name.c_str(), &a.first, a.second);
     app.Run();
   }
+
   tools::Evaluator& evaluator();
   tools::Evaluator& g4Evaluator();
+
+  namespace detail {
+    /// Helper to invoke the ROOT interpreter
+    struct interp  {
+    public:
+      interp() = default;
+      virtual ~interp() = default;
+      static void run(const std::string& name)  {
+	pair<int, char**> a(0,0);
+	TRint app(name.c_str(), &a.first, a.second);
+	app.Run();
+      }
+    };
+    //// Helper to access the evaluator instances
+    struct eval  {
+    public:
+      eval() = default;
+      virtual ~eval() = default;
+      static dd4hep::tools::Evaluator& instance()     {
+	return dd4hep::evaluator();
+      }
+      static dd4hep::tools::Evaluator& g4instance()   {
+	return dd4hep::g4Evaluator();
+      }
+    };
+  }
 }
 
 namespace dd4hep   {   namespace Parsers   {
@@ -94,6 +122,9 @@ template class map< string, dd4hep::Handle<dd4hep::NamedObject> >;
 template class pair<dd4hep::Callback,unsigned long>;
 #endif
 
+#pragma link C++ class DD4hepRootPersistency+;
+#pragma link C++ class DD4hepRootCheck+;
+
 #pragma link C++ class pair<unsigned int,string>+;
 //#pragma link C++ class dd4hep::Callback+;
 #pragma link C++ class pair<dd4hep::Callback,unsigned long>+;
@@ -129,8 +160,6 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::DetectorData::ObjectHandleMap+;
 #pragma link C++ class dd4hep::Detector::PropertyValues+;
 #pragma link C++ class dd4hep::Detector::Properties+;
-#pragma link C++ class DD4hepRootPersistency+;
-#pragma link C++ class DD4hepRootCheck+;
 #pragma link C++ class pair<dd4hep::IDDescriptor,dd4hep::DDSegmentation::Segmentation*>+;
 #pragma link C++ class map<dd4hep::Readout,pair<dd4hep::IDDescriptor,dd4hep::DDSegmentation::Segmentation*> >+;
 
@@ -299,6 +328,9 @@ template class dd4hep::Handle<TNamed>;
 #endif
 
 #pragma link C++ class dd4hep::Detector+;
+
+#pragma link C++ class dd4hep::detail::interp;
+#pragma link C++ class dd4hep::detail::eval;
 
 #pragma link C++ function dd4hep::run_interpreter(const string& name);
 #pragma link C++ function dd4hep::_toDictionary(const string&, const string&);

--- a/DDG4/include/DDG4/Python/DDPython.h
+++ b/DDG4/include/DDG4/Python/DDPython.h
@@ -68,7 +68,7 @@ namespace dd4hep  {
     /// Release python object
     static void assignObject(PyObject*& obj, PyObject* new_obj);
 
-    /// Start the interpreter in normal mode without hacks like 'pythopn.exe' does.
+    /// Start the interpreter in normal mode without hacks like 'python.exe' does.
     static int run_interpreter(int argc, char** argv);
 
     /// Copy constructor 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,8 +41,7 @@ dd4hep_configure_output()
 
 #==========================================================================
 
-###SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDB DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency DDCAD SimpleDetector"
-SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCodex DDDB DDDigi DDG4 DDG4_MySensDet DDmightyt LHeD OpticalSurfaces Persistency DDCAD SimpleDetector"
+SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDB DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency DDCAD SimpleDetector"
   CACHE STRING "List of DD4hep Examples to build")
 SEPARATE_ARGUMENTS(DD4HEP_EXAMPLES)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,7 +41,8 @@ dd4hep_configure_output()
 
 #==========================================================================
 
-SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDB DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency DDCAD SimpleDetector"
+###SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDB DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency DDCAD SimpleDetector"
+SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCodex DDDB DDDigi DDG4 DDG4_MySensDet DDmightyt LHeD OpticalSurfaces Persistency DDCAD SimpleDetector"
   CACHE STRING "List of DD4hep Examples to build")
 SEPARATE_ARGUMENTS(DD4HEP_EXAMPLES)
 

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -63,7 +63,7 @@ dd4hep_add_test_reg( Conditions_Telescope_populate
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_populate
       -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 5
-  REGEX_PASS "Accessed a total of 800 conditions \\(S:   500,L:     0,C:   300,M:0\\)"
+  REGEX_PASS "Accessed a total of 900 conditions \\(S:   500,L:     0,C:   400,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -72,7 +72,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress 
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 10 -runs 20
-  REGEX_PASS "\\+  Accessed a total of 3200 conditions \\(S:  2660,L:     0,C:   540,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 3600 conditions \\(S:  2880,L:     0,C:   720,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -81,7 +81,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress2
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress2 
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 10
-  REGEX_PASS "\\+  Accessed a total of 1600 conditions \\(S:  1000,L:     0,C:   600,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 1800 conditions \\(S:  1000,L:     0,C:   800,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -90,7 +90,7 @@ dd4hep_add_test_reg( Conditions_Telescope_MT_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_MT 
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 30 -runs 10 -threads 1
-  REGEX_PASS "\\+  Accessed a total of 286400 conditions \\(S:268400,L:     0,C: 18000,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 322200 conditions \\(S:298200,L:     0,C: 24000,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -111,7 +111,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_iov
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore iovpool
   DEPENDS Conditions_Telescope_root_save
-  REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 5400 conditions \\(S:  4800,L:     0,C:   600,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -122,7 +122,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_usr
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore userpool
   DEPENDS Conditions_Telescope_root_save
-  REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 5400 conditions \\(S:  4800,L:     0,C:   600,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -133,7 +133,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_pool
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore condpool
   DEPENDS Conditions_Telescope_root_save
-  REGEX_PASS "\\+  Accessed a total of 4800 conditions \\(S:  4800,L:     0,C:     0,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 5400 conditions \\(S:  4800,L:     0,C:   600,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -142,7 +142,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress 
     -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 10 -runs 100
-  REGEX_PASS "\\+  Accessed a total of 28085600 conditions \\(S:27032390,L:     0,C:1053210,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 31596300 conditions \\(S:30192020,L:     0,C:1404280,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -151,7 +151,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress2_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress2 
     -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 20
-  REGEX_PASS "\\+  Accessed a total of 5617120 conditions \\(S:3510700,L:     0,C:2106420,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 6319260 conditions \\(S:3510700,L:     0,C:2808560,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -160,7 +160,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_MT_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_MT 
     -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 3 -runs 2 -threads 1
-  REGEX_PASS "\\+  Accessed a total of 9549104 conditions \\(S:8917178,L:     0,C:631926,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 10742742 conditions \\(S:9900174,L:     0,C:842568,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -181,7 +181,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_iov_LONGTEST
     -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 3 -restore iovpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
-  REGEX_PASS "\\+  Accessed a total of 842568 conditions \\(S:842568,L:     0,C:     0,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 947889 conditions \\(S:842568,L:     0,C:105321,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -192,7 +192,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_usr_LONGTEST
     -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 3 -restore userpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
-  REGEX_PASS "\\+  Accessed a total of 842568 conditions \\(S:842568,L:     0,C:     0,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 947889 conditions \\(S:842568,L:     0,C:105321,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -203,6 +203,6 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_cond_LONGTEST
     -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 3 -restore condpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
-  REGEX_PASS "\\+  Accessed a total of 842568 conditions \\(S:842568,L:     0,C:     0,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 947889 conditions \\(S:842568,L:     0,C:105321,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )

--- a/examples/Conditions/src/ConditionExampleObjects.h
+++ b/examples/Conditions/src/ConditionExampleObjects.h
@@ -59,7 +59,55 @@ namespace dd4hep {
       /// Default destructor
       virtual ~OutputLevel() = default;
     };
+
+    /// Specialized condition only offering non-default ctor
+    /**
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_CONDITIONS
+     */
+    class NonDefaultCtorCond  {
+    private:
+      /// Inhibit default constructor
+      NonDefaultCtorCond() = delete;
+      /// Inhibit move constructor
+      NonDefaultCtorCond(NonDefaultCtorCond&& copy) = delete;
+      /// Inhibit copy constructor
+      NonDefaultCtorCond(const NonDefaultCtorCond& copy) = delete;
+      /// Inhibit move assignment
+      NonDefaultCtorCond& operator=(NonDefaultCtorCond&& copy) = delete;
+      /// Inhibit copy assignment
+      NonDefaultCtorCond& operator=(const NonDefaultCtorCond& copy) = delete;
+    public:
+      int a, b, c, d;
+      /// Initializing constructor only
+      NonDefaultCtorCond(int aa, int bb, int cc);
+      /// Default descructor
+      virtual ~NonDefaultCtorCond();
+      /// Set data member
+      void set(int val);
+    };
     
+    /// Specialized conditions update callback 
+    /**
+     *  Used by clients to update a condition.
+     *
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_CONDITIONS
+     */
+    class ConditionNonDefaultCtorUpdate1 : public ConditionUpdateCall, public OutputLevel  {
+    public:
+      /// Initializing constructor
+      ConditionNonDefaultCtorUpdate1(PrintLevel p) : OutputLevel(p) {    }
+      /// Default destructor
+      virtual ~ConditionNonDefaultCtorUpdate1() = default;
+      /// Interface to client Callback in order to update the condition
+      virtual Condition operator()(const ConditionKey& key, ConditionUpdateContext& context) override  final;
+      /// Interface to client Callback in order to update the condition
+      virtual void resolve(Condition condition, ConditionUpdateContext& context) override  final;
+    };
+
     /// Specialized conditions update callback 
     /**
      *  Used by clients to update a condition.
@@ -148,9 +196,11 @@ namespace dd4hep {
       /// Content object to be filled
       ConditionsContent&   content;
       /// Three different update call types
-      std::shared_ptr<ConditionUpdateCall> call1, call2, call3;
+      std::shared_ptr<ConditionUpdateCall> scall1, call1, call2, call3;
+      /// Flag for special setup for ROOT persistency
+      bool persist_conditions;
       /// Constructor
-      ConditionsDependencyCreator(ConditionsContent& c, PrintLevel p);
+      ConditionsDependencyCreator(ConditionsContent& c, PrintLevel p, bool persist=false);
       /// Destructor
       virtual ~ConditionsDependencyCreator();
       /// Callback to process a single detector element
@@ -177,9 +227,14 @@ namespace dd4hep {
       virtual ~ConditionsCreator() = default;
       /// Callback to process a single detector element
       virtual int operator()(DetElement de, int level)  const final;
-      template<typename T> Condition make_condition(DetElement de,
-                                                    const std::string& name,
-                                                    T val)  const;
+      template<typename T>
+      Condition make_condition(DetElement de,
+			       const std::string& name,
+			       const T& val)  const;
+      template<typename T, typename... Args>
+      Condition make_condition_args(DetElement de,
+				    const std::string& name,
+				    Args... args)  const;
     };
 
     /// Example how to access the conditions constants from a detector element

--- a/examples/Conditions/src/ConditionExample_save.cpp
+++ b/examples/Conditions/src/ConditionExample_save.cpp
@@ -86,7 +86,8 @@ static int condition_example (Detector& description, int argc, char** argv)  {
   shared_ptr<ConditionsContent> content(new ConditionsContent());
   shared_ptr<ConditionsSlice>   slice(new ConditionsSlice(manager,content));
   Scanner(ConditionsKeys(*content,INFO),description.world());
-  Scanner(ConditionsDependencyCreator(*content,DEBUG),description.world());
+  // Setup for persistency
+  Scanner(ConditionsDependencyCreator(*content,DEBUG,true),description.world());
 
   /******************** Save the conditions store *********************/
   // Have 10 run-slices [11,20] .... [91,100]

--- a/examples/Conditions/src/NonDefaultCtorCond.cpp
+++ b/examples/Conditions/src/NonDefaultCtorCond.cpp
@@ -1,0 +1,32 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+#include "ConditionExampleObjects.h"
+
+using namespace dd4hep::ConditionExamples;
+
+NonDefaultCtorCond::NonDefaultCtorCond(int aa, int bb, int cc)
+  : a(aa), b(bb), c(cc), d(0)
+{
+}
+
+NonDefaultCtorCond::~NonDefaultCtorCond()   {
+}
+
+void NonDefaultCtorCond::set(int val)  {
+  d = val;
+}
+
+#include "DD4hep/detail/Grammar_unparsed.h"
+static auto s_registry = dd4hep::GrammarRegistry::pre_note<NonDefaultCtorCond>();


### PR DESCRIPTION
BEGINRELEASENOTES
 - Allow condition objects, which do not provide a default constructor. If such objects should be managed, these cannot be saved with ROOT - these objects may only live in memory. ROOT requires a default constructor.

ENDRELEASENOTES