### PR TITLE
fix compilation of DigiKernel.cpp w/ TBB

### DIFF
--- a/DDDigi/src/DigiKernel.cpp
+++ b/DDDigi/src/DigiKernel.cpp
@@ -273,7 +273,7 @@ void DigiKernel::submit(const DigiAction::Actors<DigiEventAction>& actions, Digi
   if ( parallel )   {
     tbb::task_group que;
     for ( auto* i : actions )
-      que.run(Wrapper(context, *i));
+      que.run(Wrapper(context, i));
     que.wait();
     goto print_stamp;
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- fix compilation of `DigiKernel.cpp` with TBB

ENDRELEASENOTES
Resolves #668 