### PR TITLE
Dictionaries: use unique include guards

### DIFF
--- a/DDCore/include/DD4hep/BitFieldCoder.h
+++ b/DDCore/include/DD4hep/BitFieldCoder.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_BITFIELDCODER_H
-#define DD4HEP_DDCORE_BITFIELDCODER_H
+#ifndef DD4HEP_DDCORE_BITFIELD64_H
+#define DD4HEP_DDCORE_BITFIELD64_H
 
 // Framework include files
 #include "DDSegmentation/BitFieldCoder.h"
@@ -27,4 +27,4 @@ namespace dd4hep {
 
   }       /* End namespace detail           */
 }         /* End namespace dd4hep             */
-#endif    /* DD4HEP_DDCORE_BITFIELDCODER_H     */
+#endif    /* DD4HEP_DDCORE_BITFIELD64_H     */

--- a/DDCore/include/DD4hep/BitFieldCoder.h
+++ b/DDCore/include/DD4hep/BitFieldCoder.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_BITFIELD64_H
-#define DD4HEP_DDCORE_BITFIELD64_H
+#ifndef DD4HEP_DDCORE_BITFIELDCODER_H
+#define DD4HEP_DDCORE_BITFIELDCODER_H
 
 // Framework include files
 #include "DDSegmentation/BitFieldCoder.h"
@@ -27,4 +27,4 @@ namespace dd4hep {
 
   }       /* End namespace detail           */
 }         /* End namespace dd4hep             */
-#endif    /* DD4HEP_DDCORE_BITFIELD64_H     */
+#endif    /* DD4HEP_DDCORE_BITFIELDCODER_H     */

--- a/DDCore/src/GeoDictionary.h
+++ b/DDCore/src/GeoDictionary.h
@@ -13,8 +13,8 @@
 //  M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_ROOTDICTIONARY_H
-#define DD4HEP_DDCORE_ROOTDICTIONARY_H
+#ifndef DD4HEP_DDCORE_GEODICTIONARY_H
+#define DD4HEP_DDCORE_GEODICTIONARY_H
 
 // Framework include files
 #include "DD4hep/Volumes.h"
@@ -138,4 +138,4 @@ template vector<pair<string, int> >::iterator;
 #pragma link C++ class dd4hep::TwistedTubeObject+;
 
 #endif  // __CINT__
-#endif  /* DD4HEP_DDCORE_ROOTDICTIONARY_H  */
+#endif  /* DD4HEP_DDCORE_GEODICTIONARY_H  */

--- a/DDCore/src/SegmentationDictionary.h
+++ b/DDCore/src/SegmentationDictionary.h
@@ -13,8 +13,8 @@
 //  M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_ROOTDICTIONARY_H
-#define DD4HEP_DDCORE_ROOTDICTIONARY_H
+#ifndef DD4HEP_DDCORE_SEGMENTATIONDICTIONARY_H
+#define DD4HEP_DDCORE_SEGMENTATIONDICTIONARY_H
 
 // Framework include files
 #define __HAVE_DDSEGMENTATION__
@@ -96,4 +96,4 @@ typedef dd4hep::DDSegmentation::CellID CellID;
 #endif  // __CINT__
 #endif  // __HAVE_DDSEGMENTATION__
 
-#endif  /* DD4HEP_DDCORE_ROOTDICTIONARY_H  */
+#endif  /* DD4HEP_DDCORE_SEGMENTATIONDICTIONARY_H  */

--- a/DDG4/include/DDG4/Geant4SensDetAction.inl
+++ b/DDG4/include/DDG4/Geant4SensDetAction.inl
@@ -12,9 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#ifndef DD4HEP_DDG4_GEANT4SENSDETACTION_H
 #include "DDG4/Geant4SensDetAction.h"
-#endif
 #include "DD4hep/detail/ObjectsInterna.h"
 #include "DD4hep/InstanceCount.h"
 


### PR DESCRIPTION
As advised by https://sft.its.cern.ch/jira/browse/ROOT-10669

BEGINRELEASENOTES

- Use unique include guards

ENDRELEASENOTES

Partially addresses #671