### PR TITLE
Fix guard and consequences and casting to string

### DIFF
--- a/DDCore/include/DD4hep/BitFieldCoder.h
+++ b/DDCore/include/DD4hep/BitFieldCoder.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_BITFIELD64_H
-#define DD4HEP_DDCORE_BITFIELD64_H
+#ifndef DD4HEP_DDCORE_BITFIELDCODER_H
+#define DD4HEP_DDCORE_BITFIELDCODER_H
 
 // Framework include files
 #include "DDSegmentation/BitFieldCoder.h"
@@ -27,4 +27,4 @@ namespace dd4hep {
 
   }       /* End namespace detail           */
 }         /* End namespace dd4hep             */
-#endif    /* DD4HEP_DDCORE_BITFIELD64_H     */
+#endif    /* DD4HEP_DDCORE_BITFIELDCODER_H     */

--- a/DDCore/include/DDSegmentation/BitField64.h
+++ b/DDCore/include/DDSegmentation/BitField64.h
@@ -19,7 +19,7 @@
 #include <map>
 #include <sstream>
 
-#include "BitFieldCoder.h"
+#include "DDSegmentation/BitFieldCoder.h"
 
 namespace dd4hep {
   

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -599,16 +599,16 @@ class Geant4:
         params = {}
         if isinstance(coll, tuple) or isinstance(coll, list):
           if len(coll) > 2:
-            coll_nam = coll[0]
+            coll_nam = str(coll[0])
             sensitive_type = coll[1]
-            params = coll[2]
+            params = str(coll[2])
           elif len(coll) > 1:
-            coll_nam = coll[0]
+            coll_nam = str(coll[0])
             sensitive_type = coll[1]
           else:
-            coll_nam = coll[0]
+            coll_nam = str(coll[0])
         else:
-          coll_nam = coll
+          coll_nam = str(coll)
         act = SensitiveAction(self.kernel(), sensitive_type + '/' + coll_nam + 'Handler', name)
         act.CollectionName = coll_nam
         for parameter, value in six.iteritems(params):

--- a/UtilityApps/src/test_surfaces.cpp
+++ b/UtilityApps/src/test_surfaces.cpp
@@ -19,7 +19,6 @@
 #include "DD4hep/DDTest.h"
 
 #include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/BitField64.h"
 
 #include "lcio.h"
 #include "IO/LCReader.h"
@@ -35,7 +34,6 @@ using namespace std ;
 using namespace dd4hep ;
 using namespace dd4hep::detail;
 using namespace dd4hep::rec ;
-using namespace lcio;
 
 
 static DDTest test( "surfaces" ) ; 
@@ -91,10 +89,10 @@ int main_wrapper(int argc, char** argv ){
 
   std::string lcioFileName = argv[2] ;
 
-  LCReader* rdr = LCFactory::getInstance()->createLCReader() ;
+  IO::LCReader* rdr = IOIMPL::LCFactory::getInstance()->createLCReader() ;
   rdr->open( lcioFileName ) ;
 
-  LCEvent* evt = 0 ;
+  EVENT::LCEvent* evt = 0 ;
 
 
   while( ( evt = rdr->readNextEvent() ) != 0 ){
@@ -103,7 +101,7 @@ int main_wrapper(int argc, char** argv ){
 
     for(unsigned icol=0, ncol = colNames.size() ; icol < ncol ; ++icol ){
 
-      LCCollection* col =  evt->getCollection( colNames[ icol ] ) ;
+      EVENT::LCCollection* col =  evt->getCollection( colNames[ icol ] ) ;
 
       std::string typeName = col->getTypeName() ;
 
@@ -114,13 +112,13 @@ int main_wrapper(int argc, char** argv ){
 
       std::string cellIDEcoding = col->getParameters().getStringVal("CellIDEncoding") ;
       
-      BitField64 idDecoder( cellIDEcoding ) ;
+      lcio::BitField64 idDecoder( cellIDEcoding ) ;
 
       int nHit = col->getNumberOfElements() ;
       
       for(int i=0 ; i< nHit ; ++i){
 	
-        SimTrackerHit* sHit = (SimTrackerHit*) col->getElementAt(i) ;
+        EVENT::SimTrackerHit* sHit = (EVENT::SimTrackerHit*) col->getElementAt(i) ;
 	
         dd4hep::long64 id = sHit->getCellID0() ;
 	


### PR DESCRIPTION
`DDCore/include/DD4hep/BitField64.h` has an include
```cpp
#include "DDSegmentation/BitField64.h"
```
which has an include
```cpp
#include "BitFieldCoder.h"
```
which probably should be the one from `DDSegmentation`?

Because of the re-usage of the include guard (and of course `using namespace`) an ambiguity in `BitField64` was shadowed. 

BEGINRELEASENOTES
- Use unique include guard in `BitFieldCoder.h`
  - fix ambiguity in test between `BitField64` in LCIO and DD4hep
- Cast to string `coll_nam` in `DDG4.py` before using further, otherwise string concatenation does not work

ENDRELEASENOTES
Resolves #671 