### PR TITLE
Iov improvements

### DIFF
--- a/DDCond/src/ConditionsManager.cpp
+++ b/DDCond/src/ConditionsManager.cpp
@@ -98,7 +98,7 @@ const vector<const IOVType*> ConditionsManagerObject::iovTypesUsed() const   {
   vector<const IOVType*> result;
   const auto& types = this->iovTypes();
   for ( const auto& i : types )  {
-    if ( int(i.type) != IOVType::UNKNOWN_IOV ) result.emplace_back(&i);
+    if ( i.type != IOVType::UNKNOWN_IOV ) result.emplace_back(&i);
   }
   return result;
 }
@@ -210,7 +210,7 @@ const vector<const IOVType*> ConditionsManager::iovTypesUsed() const  {
   const auto& types = obj->iovTypes();
   result.reserve(types.size());
   for(const auto& i : types )
-    if ( int(i.type) != IOVType::UNKNOWN_IOV ) result.emplace_back(&i);
+    if ( i.type != IOVType::UNKNOWN_IOV ) result.emplace_back(&i);
   return result;
 }
 

--- a/DDCore/include/DD4hep/IOV.h
+++ b/DDCore/include/DD4hep/IOV.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <limits>
 #include <algorithm>
+#include <utility>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/include/DD4hep/IOV.h
+++ b/DDCore/include/DD4hep/IOV.h
@@ -34,8 +34,8 @@ namespace dd4hep {
    */
   class IOVType   {
   public:
-    enum _IOVTypes { UNKNOWN_IOV = ~0x0 };
-    /// integer identifier ised internally
+    static constexpr unsigned int UNKNOWN_IOV = ~0x0;
+    /// integer identifier used internally
     unsigned int type = UNKNOWN_IOV;
     /// String name
     std::string  name;
@@ -72,11 +72,9 @@ namespace dd4hep {
     using Key_second_type = long;
     using Key = std::pair<Key_first_type,Key_second_type>;
 
-    enum {
-      INVALID_KEY = 0,
-      MIN_KEY = std::numeric_limits<long>::min(),
-      MAX_KEY = std::numeric_limits<long>::max()
-    };
+    static constexpr Key_first_type INVALID_KEY = 0;
+    static constexpr Key_first_type MIN_KEY = std::numeric_limits<long>::min();
+    static constexpr Key_first_type MAX_KEY = std::numeric_limits<long>::max();
     
     /// Reference to IOV type
     const IOVType* iovType = 0;

--- a/DDCore/include/DD4hep/IOV.h
+++ b/DDCore/include/DD4hep/IOV.h
@@ -68,9 +68,9 @@ namespace dd4hep {
     explicit IOV() = delete;
   public:
     /// Key definition
-    typedef long Key_first_type;
-    typedef long Key_second_type;
-    typedef std::pair<Key_first_type,Key_second_type> Key;
+    using Key_first_type = long;
+    using Key_second_type = long;
+    using Key = std::pair<Key_first_type,Key_second_type>;
 
     enum {
       INVALID_KEY = 0,

--- a/DDCore/include/DD4hep/IOV.h
+++ b/DDCore/include/DD4hep/IOV.h
@@ -69,14 +69,13 @@ namespace dd4hep {
     explicit IOV() = delete;
   public:
     /// Key definition
-    using Key_first_type = long;
-    using Key_second_type = long;
-    using Key = std::pair<Key_first_type,Key_second_type>;
+    using Key_value_type = long;
+    using Key = std::pair<Key_value_type, Key_value_type>;
 
-    static constexpr Key_first_type INVALID_KEY = 0;
-    static constexpr Key_first_type MIN_KEY = std::numeric_limits<long>::min();
-    static constexpr Key_first_type MAX_KEY = std::numeric_limits<long>::max();
-    
+    static constexpr Key_value_type INVALID_KEY = 0;
+    static constexpr Key_value_type MIN_KEY = std::numeric_limits<Key_value_type>::min();
+    static constexpr Key_value_type MAX_KEY = std::numeric_limits<Key_value_type>::max();
+
     /// Reference to IOV type
     const IOVType* iovType = 0;
     /// IOV key (if second==first, discrete, otherwise range)
@@ -91,7 +90,7 @@ namespace dd4hep {
     /// Specialized copy constructor for range IOVs
     explicit IOV(const IOVType* typ, const Key& key);
     /// Specialized copy constructor for discrete IOVs
-    explicit IOV(const IOVType* typ, Key_first_type iov_value);
+    explicit IOV(const IOVType* typ, Key_value_type iov_value);
     /// Copy constructor
     IOV(const IOV& copy) = default;
     /// Move constructor
@@ -117,9 +116,9 @@ namespace dd4hep {
     /// Set discrete IOV value
     void set(const Key& value);
     /// Set discrete IOV value
-    void set(Key_first_type value);
+    void set(Key_value_type value);
     /// Set range IOV value
-    void set(Key_first_type val_1, Key_second_type val_2);
+    void set(Key_value_type val_1, Key_value_type val_2);
     /// Set keys to unphysical values (LONG_MAX, LONG_MIN)
     IOV& reset();
     /// Invert the key values (first=second and second=first)

--- a/DDCore/include/DD4hep/IOV.h
+++ b/DDCore/include/DD4hep/IOV.h
@@ -18,6 +18,7 @@
 #include <limits>
 #include <algorithm>
 #include <utility>
+#include <cstdint>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -69,7 +70,7 @@ namespace dd4hep {
     explicit IOV() = delete;
   public:
     /// Key definition
-    using Key_value_type = long;
+    using Key_value_type = std::int64_t;
     using Key = std::pair<Key_value_type, Key_value_type>;
 
     static constexpr Key_value_type INVALID_KEY = 0;

--- a/DDCore/src/IOV.cpp
+++ b/DDCore/src/IOV.cpp
@@ -47,7 +47,7 @@ IOV::IOV(const IOVType* t) : iovType(t)  {
 }
 
 /// Specialized copy constructor for discrete IOVs
-IOV::IOV(const IOVType* t, Key_first_type iov_value)
+IOV::IOV(const IOVType* t, Key_value_type iov_value)
   : iovType(t), keyData(iov_value,iov_value)
 {
   if ( t ) type = t->type;

--- a/examples/DDDB/include/Detector/IDetService.h
+++ b/examples/DDDB/include/Detector/IDetService.h
@@ -43,7 +43,7 @@ namespace gaudi   {
     typedef dd4hep::cond::ConditionsCleanup           Cleanup;
     typedef dd4hep::DetElement                        DetElement;
     typedef dd4hep::Condition                         Condition;
-    typedef dd4hep::IOV::Key_first_type               EventStamp;
+    typedef dd4hep::IOV::Key_value_type               EventStamp;
     typedef dd4hep::IOVType                           IOVType;
     typedef std::shared_ptr<dd4hep::cond::ConditionsContent> Content;
     typedef std::shared_ptr<dd4hep::cond::ConditionsSlice>   Slice;


### PR DESCRIPTION
Trying to use `dd4hep::IOV` we found a things that could be improved:
- use modern C++ instead of legacy C
- `IOV::Key` was allowing for different types for the two bounds of the interval, but the feature was not used and could lead to weird situations
- the value type in the `IOV::Key` was `long`, but that's not portable across architectures, so I changed it to `std::int64_t` 

BEGINRELEASENOTES

- Modernization and clean up of `dd4hep::IOV` (`using` instead of `typedef`, `constexpr` instead of `enum`)
- Make `dd4hep::IOV::Key` uniform wrt first and second type
- Use `std::int64_t`instead of `long` for `dd4hep::IOV::Key` elements

ENDRELEASENOTES