### PR TITLE
IOV: declare static constexpr members, as required by c++14

### DIFF
--- a/DDCore/src/IOV.cpp
+++ b/DDCore/src/IOV.cpp
@@ -24,6 +24,11 @@
 using namespace std;
 using namespace dd4hep;
 
+#if __cplusplus == 201402
+const IOV::Key_value_type IOV::MIN_KEY;
+const IOV::Key_value_type IOV::MAX_KEY;
+#endif
+
 #if 0
 /// Assignment operator
 IOVType& IOVType::operator=(const IOVType& copy)  {


### PR DESCRIPTION
Fixes #683 

Also test: https://gitlab.cern.ch/sailer/DD4hep/pipelines/1767487