### PR TITLE
fix headers guard style

### DIFF
--- a/DDAlign/include/DDAlign/AlignmentTags.h
+++ b/DDAlign/include/DDAlign/AlignmentTags.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_ALIGNMENT_ALIGNMENT_TAGS_H
-#define DD4HEP_ALIGNMENT_ALIGNMENT_TAGS_H
+#ifndef DDALIGN_ALIGNMENTTAGS_H
+#define DDALIGN_ALIGNMENTTAGS_H
 
 // Framework include files
 #include "XML/XMLElements.h"
@@ -49,4 +49,4 @@ namespace dd4hep {
 
 #define _ALU(a) ::dd4hep::DDAlign::Unicode_##a
 
-#endif /* DD4HEP_ALIGNMENT_ALIGNMENT_TAGS_H  */
+#endif // DDALIGN_ALIGNMENTTAGS_H

--- a/DDAlign/include/DDAlign/AlignmentsCalib.h
+++ b/DDAlign/include/DDAlign/AlignmentsCalib.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDALIGN_ALIGNMENTCALIB_H
-#define DD4HEP_DDALIGN_ALIGNMENTCALIB_H
+#ifndef DDALIGN_ALIGNMENTSCALIB_H
+#define DDALIGN_ALIGNMENTSCALIB_H
 
 // Framework includes
 #include "DD4hep/DetElement.h"
@@ -126,4 +126,4 @@ namespace dd4hep {
     };    
   }       /* End namespace align              */
 }         /* End namespace dd4hep                  */
-#endif    /* DD4HEP_DDALIGN_ALIGNMENTCALIB_H       */
+#endif // DDALIGN_ALIGNMENTSCALIB_H

--- a/DDAlign/include/DDAlign/GlobalAlignmentCache.h
+++ b/DDAlign/include/DDAlign/GlobalAlignmentCache.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_ALIGNMENT_GLOBALALIGNMENTCACHE_H
-#define DD4HEP_ALIGNMENT_GLOBALALIGNMENTCACHE_H
+#ifndef DDALIGN_GLOBALALIGNMENTCACHE_H
+#define DDALIGN_GLOBALALIGNMENTCACHE_H
 
 // Framework include files
 #include "DD4hep/ExtensionEntry.h"
@@ -104,4 +104,4 @@ namespace dd4hep {
 
   } /* End namespace align                            */
 } /* End namespace dd4hep                                  */
-#endif    /* DD4HEP_ALIGNMENT_GLOBALALIGNMENTCACHE_H       */
+#endif // DDALIGN_GLOBALALIGNMENTCACHE_H

--- a/DDAlign/include/DDAlign/GlobalAlignmentOperators.h
+++ b/DDAlign/include/DDAlign/GlobalAlignmentOperators.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_ALIGNMENT_GLOBALALIGNMENTOPERATORS_H
-#define DD4HEP_ALIGNMENT_GLOBALALIGNMENTOPERATORS_H
+#ifndef DDALIGN_GLOBALALIGNMENTOPERATORS_H
+#define DDALIGN_GLOBALALIGNMENTOPERATORS_H
 
 // Framework include files
 #include "DD4hep/Alignments.h"
@@ -106,4 +106,4 @@ namespace dd4hep {
     template <> void GlobalAlignmentActor<DDAlign_standard_operations::node_align>::operator() (Nodes::value_type& n)  const;
   }       /* End namespace align                    */
 }         /* End namespace dd4hep                        */
-#endif    /* DD4HEP_ALIGNMENT_GLOBALALIGNMENTOPERATORS_H */
+#endif // DDALIGN_GLOBALALIGNMENTOPERATORS_H

--- a/DDAlign/include/DDAlign/GlobalAlignmentStack.h
+++ b/DDAlign/include/DDAlign/GlobalAlignmentStack.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_ALIGNMENT_GLOBALALIGNMENTSTACK_H
-#define DD4HEP_ALIGNMENT_GLOBALALIGNMENTSTACK_H
+#ifndef DDALIGN_GLOBALALIGNMENTSTACK_H
+#define DDALIGN_GLOBALALIGNMENTSTACK_H
 
 // Framework include files
 #include "DD4hep/Alignments.h"
@@ -149,4 +149,4 @@ namespace dd4hep {
 
   }       /* End namespace detail                        */
 }         /* End namespace dd4hep                          */
-#endif    /* DD4HEP_ALIGNMENT_GLOBALALIGNMENTSTACK_H       */
+#endif // DDALIGN_GLOBALALIGNMENTSTACK_H

--- a/DDAlign/include/DDAlign/GlobalAlignmentWriter.h
+++ b/DDAlign/include/DDAlign/GlobalAlignmentWriter.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDALIGN_GLOBALALIGNMENTWRITER_H
-#define DD4HEP_DDALIGN_GLOBALALIGNMENTWRITER_H
+#ifndef DDALIGN_GLOBALALIGNMENTWRITER_H
+#define DDALIGN_GLOBALALIGNMENTWRITER_H
 
 // Framework include files
 #include "XML/XMLElements.h"
@@ -60,5 +60,5 @@ namespace dd4hep {
     };
   }    // End namespace xml
 }      // End namespace dd4hep
-#endif // DD4HEP_DDALIGN_GLOBALALIGNMENTWRITER_H
+#endif // DDALIGN_GLOBALALIGNMENTWRITER_H
 

--- a/DDAlign/include/DDAlign/GlobalDetectorAlignment.h
+++ b/DDAlign/include/DDAlign/GlobalDetectorAlignment.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_GLOBALDETECTORALIGNMENT_H
-#define DD4HEP_DDCORE_GLOBALDETECTORALIGNMENT_H
+#ifndef DDALIGN_GLOBALDETECTORALIGNMENT_H
+#define DDALIGN_GLOBALDETECTORALIGNMENT_H
 
 // Framework include files
 #include "DD4hep/DetElement.h"
@@ -77,4 +77,4 @@ namespace dd4hep {
 
   } /* End namespace align                           */
 } /* End namespace dd4hep                                 */
-#endif    /* DD4HEP_DDCORE_GLOBALDETECTORALIGNMENT_H    */
+#endif // DDALIGN_GLOBALDETECTORALIGNMENT_H

--- a/DDCAD/include/DDCAD/ASSIMPReader.h
+++ b/DDCAD/include/DDCAD/ASSIMPReader.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCAD_ASSIMPREADER_H
-#define DD4HEP_DDCAD_ASSIMPREADER_H
+#ifndef DDCAD_ASSIMPREADER_H
+#define DDCAD_ASSIMPREADER_H
 
 /// Framework include files
 #include <DDCAD/InputReader.h>
@@ -36,4 +36,4 @@ namespace dd4hep {
     
   }        /* End namespace cad                      */
 }          /* End namespace dd4hep                   */
-#endif // DD4HEP_DDCAD_ASSIMPREADER_H
+#endif // DDCAD_ASSIMPREADER_H

--- a/DDCAD/include/DDCAD/InputReader.h
+++ b/DDCAD/include/DDCAD/InputReader.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCAD_INPUTREADER_H
-#define DD4HEP_DDCAD_INPUTREADER_H
+#ifndef DDCAD_INPUTREADER_H
+#define DDCAD_INPUTREADER_H
 
 // Framework include files
 #include <DD4hep/config.h>
@@ -42,4 +42,4 @@ namespace dd4hep {
     
   }        /* End namespace cad                      */
 }          /* End namespace dd4hep                   */
-#endif // DD4HEP_DDCAD_INPUTREADER_H
+#endif // DDCAD_INPUTREADER_H

--- a/DDCAD/src/CADDictionary.h
+++ b/DDCAD/src/CADDictionary.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCAD_CADDICTIONARY_H
-#define DD4HEP_DDCAD_CADDICTIONARY_H
+#ifndef DDCAD_SRC_CADDICTIONARY_H
+#define DDCAD_SRC_CADDICTIONARY_H
 
 // Framework include files
 #include "DDCAD/InputReader.h"
@@ -38,4 +38,4 @@ using namespace dd4hep::cad;
 
 #endif
 
-#endif // DD4HEP_DDCAD_CADDICTIONARY_H
+#endif // DDCAD_SRC_CADDICTIONARY_H

--- a/DDCond/include/DDCond/ConditionsCleanup.h
+++ b/DDCond/include/DDCond/ConditionsCleanup.h
@@ -70,4 +70,4 @@ namespace dd4hep {
   } /* End namespace cond                   */
 } /* End namespace dd4hep                   */
 
-#endif     /* DDCOND_CONDITIONSCLEANUP_H    */
+#endif // DDCOND_CONDITIONSCLEANUP_H

--- a/DDCond/include/DDCond/ConditionsContent.h
+++ b/DDCond/include/DDCond/ConditionsContent.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCOND_CONDITIONSCONTENT_H
-#define DD4HEP_DDCOND_CONDITIONSCONTENT_H
+#ifndef DDCOND_CONDITIONSCONTENT_H
+#define DDCOND_CONDITIONSCONTENT_H
 
 // Framework include files
 #include "DD4hep/Memory.h"
@@ -164,4 +164,4 @@ namespace dd4hep {
 
   }        /* End namespace cond               */
 }          /* End namespace dd4hep                   */
-#endif     /* DD4HEP_DDCOND_CONDITIONSCONTENT_H      */
+#endif // DDCOND_CONDITIONSCONTENT_H

--- a/DDCond/include/DDCond/ConditionsDataLoader.h
+++ b/DDCond/include/DDCond/ConditionsDataLoader.h
@@ -102,4 +102,4 @@ namespace dd4hep {
     };
   }        /* End namespace cond         */
 }          /* End namespace dd4hep             */
-#endif     /* DDCOND_CONDITIONSDATALOADER_H    */
+#endif // DDCOND_CONDITIONSDATALOADER_H

--- a/DDCond/include/DDCond/ConditionsDependencyHandler.h
+++ b/DDCond/include/DDCond/ConditionsDependencyHandler.h
@@ -162,4 +162,4 @@ namespace dd4hep {
   }        /* End namespace cond                */
 }          /* End namespace dd4hep                    */
 
-#endif     /* DDCOND_CONDITIONSDEPENDENCYHANDLER_H    */
+#endif // DDCOND_CONDITIONSDEPENDENCYHANDLER_H

--- a/DDCond/include/DDCond/ConditionsEntry.h
+++ b/DDCond/include/DDCond/ConditionsEntry.h
@@ -59,4 +59,4 @@ namespace dd4hep {
   } /* End namespace cond             */
 } /* End namespace dd4hep                   */
 
-#endif     /* DDCOND_CONDITIONSENTRY_H    */
+#endif // DDCOND_CONDITIONSENTRY_H

--- a/DDCond/include/DDCond/ConditionsIOVPool.h
+++ b/DDCond/include/DDCond/ConditionsIOVPool.h
@@ -83,4 +83,4 @@ namespace dd4hep {
   } /* End namespace cond             */
 } /* End namespace dd4hep                   */
 
-#endif     /*  DDCOND_CONDITIONSIOVPOOL_H   */
+#endif // DDCOND_CONDITIONSIOVPOOL_H

--- a/DDCond/include/DDCond/ConditionsManager.h
+++ b/DDCond/include/DDCond/ConditionsManager.h
@@ -216,4 +216,4 @@ namespace dd4hep {
     }
   }       /* End namespace cond        */
 }         /* End namespace dd4hep            */
-#endif    /* DDCOND_CONDITIONSMANAGER_H      */
+#endif // DDCOND_CONDITIONSMANAGER_H

--- a/DDCond/include/DDCond/ConditionsManagerObject.h
+++ b/DDCond/include/DDCond/ConditionsManagerObject.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DDCOND_CONDITIONS_CONDITIONSMANAGEROBJECT_H
-#define DDCOND_CONDITIONS_CONDITIONSMANAGEROBJECT_H
+#ifndef DDCOND_CONDITIONSMANAGEROBJECT_H
+#define DDCOND_CONDITIONSMANAGEROBJECT_H
 
 // Framework include files
 #include "DD4hep/Conditions.h"
@@ -198,4 +198,4 @@ namespace dd4hep {
     };
   }    /* End namespace detail                       */
 }      /* End namespace dd4hep                         */
-#endif /* DDCOND_CONDITIONS_CONDITIONSMANAGEROBJECT_H  */
+#endif // DDCOND_CONDITIONSMANAGEROBJECT_H

--- a/DDCond/include/DDCond/ConditionsOperators.h
+++ b/DDCond/include/DDCond/ConditionsOperators.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_CONDITIONS_CONDITIONSOPERATORS_H
-#define DD4HEP_CONDITIONS_CONDITIONSOPERATORS_H
+#ifndef DDCOND_CONDITIONSOPERATORS_H
+#define DDCOND_CONDITIONSOPERATORS_H
 
 // Framework include files
 #include "DDCond/ConditionsManager.h"
@@ -42,4 +42,4 @@ namespace dd4hep {
   } /* End namespace cond             */
 } /* End namespace dd4hep                   */
 
-#endif /* DD4HEP_CONDITIONS_CONDITIONSOPERATORS_H  */
+#endif // DDCOND_CONDITIONSOPERATORS_H

--- a/DDCond/include/DDCond/ConditionsPool.h
+++ b/DDCond/include/DDCond/ConditionsPool.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DDCOND_CONDITIONS_CONDITIONSPOOL_H
-#define DDCOND_CONDITIONS_CONDITIONSPOOL_H
+#ifndef DDCOND_CONDITIONSPOOL_H
+#define DDCOND_CONDITIONSPOOL_H
 
 // Framework include files
 #include "DD4hep/NamedObject.h"
@@ -250,4 +250,4 @@ namespace dd4hep {
     };
   }        /* End namespace cond                     */
 }          /* End namespace dd4hep                   */
-#endif     /* DDCOND_CONDITIONS_CONDITIONSPOOL_H     */
+#endif // DDCOND_CONDITIONSPOOL_H

--- a/DDCond/include/DDCond/ConditionsRepository.h
+++ b/DDCond/include/DDCond/ConditionsRepository.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_CONDITIONS_CONDITIONSREPOSITORY_H
-#define DD4HEP_CONDITIONS_CONDITIONSREPOSITORY_H
+#ifndef DDCOND_CONDITIONSREPOSITORY_H
+#define DDCOND_CONDITIONSREPOSITORY_H
 
 // Framework include files
 #include "DDCond/ConditionsManager.h"
@@ -69,4 +69,4 @@ namespace dd4hep {
   } /* End namespace cond             */
 } /* End namespace dd4hep                   */
 
-#endif /* DD4HEP_CONDITIONS_CONDITIONSREPOSITORY_H  */
+#endif // DDCOND_CONDITIONSREPOSITORY_H

--- a/DDCond/include/DDCond/ConditionsRootPersistency.h
+++ b/DDCond/include/DDCond/ConditionsRootPersistency.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_CONDITIONS_CONDITIONSROOTPERSISTENCY_H
-#define DD4HEP_CONDITIONS_CONDITIONSROOTPERSISTENCY_H
+#ifndef DDCOND_CONDITIONSROOTPERSISTENCY_H
+#define DDCOND_CONDITIONSROOTPERSISTENCY_H
 
 // Framework/ROOT include files
 #include "DDCond/ConditionsPool.h"
@@ -139,4 +139,4 @@ namespace dd4hep {
     
   }        /* End namespace cond                            */
 }          /* End namespace dd4hep                          */
-#endif     /* DD4HEP_CONDITIONS_CONDITIONSROOTPERSISTENCY_H */
+#endif // DDCOND_CONDITIONSROOTPERSISTENCY_H

--- a/DDCond/include/DDCond/ConditionsSelectors.h
+++ b/DDCond/include/DDCond/ConditionsSelectors.h
@@ -286,4 +286,4 @@ namespace dd4hep {
     }        /* End namespace Operators            */
   }          /* End namespace cond           */
 }            /* End namespace dd4hep               */
-#endif       /* DDCOND_CONDITIONSSELECTORS_H       */
+#endif // DDCOND_CONDITIONSSELECTORS_H

--- a/DDCond/include/DDCond/ConditionsSlice.h
+++ b/DDCond/include/DDCond/ConditionsSlice.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCOND_CONDITIONSSLICE_H
-#define DD4HEP_DDCOND_CONDITIONSSLICE_H
+#ifndef DDCOND_CONDITIONSSLICE_H
+#define DDCOND_CONDITIONSSLICE_H
 
 // Framework include files
 #include "DD4hep/Conditions.h"
@@ -201,4 +201,4 @@ namespace dd4hep {
 
   }        /* End namespace cond               */
 }          /* End namespace dd4hep                   */
-#endif     /* DD4HEP_DDCOND_CONDITIONSSLICE_H        */
+#endif // DDCOND_CONDITIONSSLICE_H

--- a/DDCond/include/DDCond/ConditionsTags.h
+++ b/DDCond/include/DDCond/ConditionsTags.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_CONDITIONS_CONDITIONSTAGS_H
-#define DD4HEP_CONDITIONS_CONDITIONSTAGS_H
+#ifndef DDCOND_CONDITIONSTAGS_H
+#define DDCOND_CONDITIONSTAGS_H
 
 // Framework include files
 #include "XML/XMLElements.h"
@@ -61,4 +61,4 @@ namespace dd4hep {
 #include "XML/XMLTags.h"
 #define _UC(x) ::dd4hep::xml::cond::Unicode_##x
 
-#endif /* DD4HEP_CONDITIONS_CONDITIONSTAGS_H  */
+#endif // DDCOND_CONDITIONSTAGS_H

--- a/DDCond/include/DDCond/ConditionsTextRepository.h
+++ b/DDCond/include/DDCond/ConditionsTextRepository.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_CONDITIONS_CONDITIONSTEXTREPOSITORY_H
-#define DD4HEP_CONDITIONS_CONDITIONSTEXTREPOSITORY_H
+#ifndef DDCOND_CONDITIONSTEXTREPOSITORY_H
+#define DDCOND_CONDITIONSTEXTREPOSITORY_H
 
 // Framework include files
 #include "DDCond/ConditionsManager.h"
@@ -72,4 +72,4 @@ namespace dd4hep {
   } /* End namespace detail               */
 } /* End namespace dd4hep                   */
 
-#endif /* DD4HEP_CONDITIONS_CONDITIONSTEXTREPOSITORY_H  */
+#endif // DDCOND_CONDITIONSTEXTREPOSITORY_H

--- a/DDCond/include/DDCond/ConditionsTreePersistency.h
+++ b/DDCond/include/DDCond/ConditionsTreePersistency.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_CONDITIONS_CONDITIONSTREEPERSISTENCY_H
-#define DD4HEP_CONDITIONS_CONDITIONSTREEPERSISTENCY_H
+#ifndef DDCOND_CONDITIONSTREEPERSISTENCY_H
+#define DDCOND_CONDITIONSTREEPERSISTENCY_H
 
 // Framework/ROOT include files
 #include "DDCond/ConditionsPool.h"
@@ -210,5 +210,5 @@ namespace dd4hep {
     
   }        /* End namespace cond                            */
 }          /* End namespace dd4hep                          */
-#endif     /* DD4HEP_CONDITIONS_CONDITIONSTREEPERSISTENCY_H */
+#endif // DDCOND_CONDITIONSTREEPERSISTENCY_H
 

--- a/DDCond/include/DDCond/Type1/Manager_Type1.h
+++ b/DDCond/include/DDCond/Type1/Manager_Type1.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DDCOND_CONDITIONSMANAGEROBJECT_TYPE1_H
-#define DDCOND_CONDITIONSMANAGEROBJECT_TYPE1_H
+#ifndef DDCOND_TYPE1_MANAGER_TYPE1_H
+#define DDCOND_TYPE1_MANAGER_TYPE1_H
 
 // Framework include files%
 #include "DD4hep/Mutex.h"
@@ -194,4 +194,4 @@ namespace dd4hep {
     };
   }        /* End namespace cond               */
 }          /* End namespace dd4hep                   */
-#endif     /* DDCOND_CONDITIONSMANAGEROBJECT_TYPE1_H */
+#endif // DDCOND_TYPE1_MANAGER_TYPE1_H

--- a/DDCond/src/ConditionsDictionary.h
+++ b/DDCond/src/ConditionsDictionary.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_CONDITIONS_CONDITIONSDICTIONARY_H
-#define DD4HEP_CONDITIONS_CONDITIONSDICTIONARY_H
+#ifndef DDCOND_SRC_CONDITIONSDICTIONARY_H
+#define DDCOND_SRC_CONDITIONSDICTIONARY_H
 
 // Framework include files
 #include "DDCond/ConditionsPool.h"
@@ -73,4 +73,4 @@ template class std::list< std::pair< std::pair< std::string, std::pair< std::pai
 
 #endif
 
-#endif /* DD4HEP_CONDITIONS_CONDITIONSDICTIONARY_H  */
+#endif // DDCOND_SRC_CONDITIONSDICTIONARY_H

--- a/DDCore/include/DD4hep/AlignmentData.h
+++ b/DDCore/include/DD4hep/AlignmentData.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_ALIGMENTS_ALIGNMENTDATA_H
-#define DD4HEP_ALIGMENTS_ALIGNMENTDATA_H
+#ifndef DD4HEP_ALIGNMENTDATA_H
+#define DD4HEP_ALIGNMENTDATA_H
 
 // Framework include files
 #include "DD4hep/NamedObject.h"
@@ -198,4 +198,4 @@ namespace dd4hep {
 }         /* End namespace dd4hep               */
 std::ostream& operator << (std::ostream& s, const dd4hep::Delta& data);
 std::ostream& operator << (std::ostream& s, const dd4hep::AlignmentData& data);
-#endif    /* DD4HEP_ALIGMENTS_ALIGNMENTDATA_H   */
+#endif // DD4HEP_ALIGNMENTDATA_H

--- a/DDCore/include/DD4hep/AlignmentTools.h
+++ b/DDCore/include/DD4hep/AlignmentTools.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_ALIGMENTS_ALIGNMENTTOOLS_H
-#define DD4HEP_ALIGMENTS_ALIGNMENTTOOLS_H
+#ifndef DD4HEP_ALIGNMENTTOOLS_H
+#define DD4HEP_ALIGNMENTTOOLS_H
 
 // Framework include files
 #include "DD4hep/Alignments.h"
@@ -53,4 +53,4 @@ namespace dd4hep {
 
   } /* End namespace Aligments               */
 } /* End namespace dd4hep                    */
-#endif    /* DD4HEP_ALIGMENTS_ALIGNMENTTOOLS_H   */
+#endif // DD4HEP_ALIGNMENTTOOLS_H

--- a/DDCore/include/DD4hep/Alignments.h
+++ b/DDCore/include/DD4hep/Alignments.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_ALIGMENTS_ALIGNMENTS_H
-#define DD4HEP_ALIGMENTS_ALIGNMENTS_H
+#ifndef DD4HEP_ALIGNMENTS_H
+#define DD4HEP_ALIGNMENTS_H
 
 // Framework include files
 #include "DD4hep/IOV.h"
@@ -197,4 +197,4 @@ namespace dd4hep {
     {  return detectorToLocal({det[0],det[1],det[2]});                              }
   };
 }         /* End namespace dd4hep                    */
-#endif    /* DD4HEP_ALIGMENTS_ALIGNMENTS_H           */
+#endif // DD4HEP_ALIGNMENTS_H

--- a/DDCore/include/DD4hep/AlignmentsCalculator.h
+++ b/DDCore/include/DD4hep/AlignmentsCalculator.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_ALIGNMENTCALCULATOR_H
-#define DD4HEP_DDCORE_ALIGNMENTCALCULATOR_H
+#ifndef DD4HEP_ALIGNMENTSCALCULATOR_H
+#define DD4HEP_ALIGNMENTSCALCULATOR_H
 
 // Framework include files
 #include "DD4hep/Alignments.h"
@@ -193,4 +193,4 @@ namespace dd4hep {
 
   }       /* End namespace align                  */
 }         /* End namespace dd4hep                      */
-#endif    /* DD4HEP_DDCORE_ALIGNMENTCALCULATOR_H      */
+#endif // DD4HEP_ALIGNMENTSCALCULATOR_H

--- a/DDCore/include/DD4hep/AlignmentsNominalMap.h
+++ b/DDCore/include/DD4hep/AlignmentsNominalMap.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_ALIGNMENTSNOMINALMAP_H
-#define DD4HEP_DDCORE_ALIGNMENTSNOMINALMAP_H
+#ifndef DD4HEP_ALIGNMENTSNOMINALMAP_H
+#define DD4HEP_ALIGNMENTSNOMINALMAP_H
 
 // Framework include files
 #include "DD4hep/ConditionsMap.h"
@@ -89,4 +89,4 @@ namespace dd4hep {
                       const Condition::Processor& processor) const  override;
   };
 }         /* End namespace dd4hep                        */
-#endif    /* DD4HEP_DDCORE_ALIGNMENTSNOMINALMAP_H        */
+#endif // DD4HEP_ALIGNMENTSNOMINALMAP_H

--- a/DDCore/include/DD4hep/AlignmentsPrinter.h
+++ b/DDCore/include/DD4hep/AlignmentsPrinter.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_ALIGNMENTSPRINTER_H
-#define DD4HEP_DDCORE_ALIGNMENTSPRINTER_H
+#ifndef DD4HEP_ALIGNMENTSPRINTER_H
+#define DD4HEP_ALIGNMENTSPRINTER_H
 
 // Framework includes
 #include "DD4hep/Printout.h"
@@ -108,4 +108,4 @@ namespace dd4hep {
 
   }    /* End namespace align           */
 }      /* End namespace dd4hep               */
-#endif /* DD4HEP_DDCORE_ALIGNMENTSPRINTER_H  */
+#endif // DD4HEP_ALIGNMENTSPRINTER_H

--- a/DDCore/include/DD4hep/AlignmentsProcessor.h
+++ b/DDCore/include/DD4hep/AlignmentsProcessor.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_ALIGNMENTSPROCESSOR_H
-#define DD4HEP_DDCORE_ALIGNMENTSPROCESSOR_H
+#ifndef DD4HEP_ALIGNMENTSPROCESSOR_H
+#define DD4HEP_ALIGNMENTSPROCESSOR_H
 
 // Framework includes
 #include "DD4hep/ConditionsMap.h"
@@ -195,4 +195,4 @@ namespace dd4hep {
 
   }    /* End namespace align  */
 }      /* End namespace dd4hep      */
-#endif /* DD4HEP_DDCORE_ALIGNMENTSPROCESSOR_H  */
+#endif // DD4HEP_ALIGNMENTSPROCESSOR_H

--- a/DDCore/include/DD4hep/BitField64.h
+++ b/DDCore/include/DD4hep/BitField64.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_BITFIELD64_H
-#define DD4HEP_DDCORE_BITFIELD64_H
+#ifndef DD4HEP_BITFIELD64_H
+#define DD4HEP_BITFIELD64_H
 
 // Framework include files
 #include "DDSegmentation/BitField64.h"
@@ -27,4 +27,4 @@ namespace dd4hep {
 
   }       /* End namespace detail           */
 }         /* End namespace dd4hep             */
-#endif    /* DD4HEP_DDCORE_BITFIELD64_H     */
+#endif // DD4HEP_BITFIELD64_H

--- a/DDCore/include/DD4hep/BitFieldCoder.h
+++ b/DDCore/include/DD4hep/BitFieldCoder.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_BITFIELDCODER_H
-#define DD4HEP_DDCORE_BITFIELDCODER_H
+#ifndef DD4HEP_BITFIELDCODER_H
+#define DD4HEP_BITFIELDCODER_H
 
 // Framework include files
 #include "DDSegmentation/BitFieldCoder.h"
@@ -27,4 +27,4 @@ namespace dd4hep {
 
   }       /* End namespace detail           */
 }         /* End namespace dd4hep             */
-#endif    /* DD4HEP_DDCORE_BITFIELDCODER_H     */
+#endif // DD4HEP_BITFIELDCODER_H

--- a/DDCore/include/DD4hep/BuildType.h
+++ b/DDCore/include/DD4hep/BuildType.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_BUILDTYPES_H 
-#define DD4HEP_BUILDTYPES_H 1
+#ifndef DD4HEP_BUILDTYPE_H
+#define DD4HEP_BUILDTYPE_H 1
 
 // C/C++ include files
 #include <string>
@@ -47,4 +47,4 @@ namespace dd4hep {
   bool buildMatch(const std::string& value, DetectorBuildType match);
 
 } /* End namespace dd4hep             */
-#endif  // DD4HEP_BUILDTYPES_H
+#endif // DD4HEP_BUILDTYPE_H

--- a/DDCore/include/DD4hep/Callback.h
+++ b/DDCore/include/DD4hep/Callback.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CALLBACK_H
-#define DD4HEP_DDCORE_CALLBACK_H
+#ifndef DD4HEP_CALLBACK_H
+#define DD4HEP_CALLBACK_H
 
 // C/C++ include files
 #include <algorithm>
@@ -493,4 +493,4 @@ namespace dd4hep {
   }
 
 }       // End namespace dd4hep
-#endif  // DD4HEP_DDCORE_CALLBACK_H
+#endif // DD4HEP_CALLBACK_H

--- a/DDCore/include/DD4hep/CartesianGridXY.h
+++ b/DDCore/include/DD4hep/CartesianGridXY.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CARTESIANGRIDXY_H 
-#define DD4HEP_DDCORE_CARTESIANGRIDXY_H 1
+#ifndef DD4HEP_CARTESIANGRIDXY_H
+#define DD4HEP_CARTESIANGRIDXY_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -104,4 +104,4 @@ namespace dd4hep {
   };
 
 } /* End namespace dd4hep                */
-#endif // DD4HEP_DDCORE_CARTESIANGRIDXY_H
+#endif // DD4HEP_CARTESIANGRIDXY_H

--- a/DDCore/include/DD4hep/CartesianGridXYZ.h
+++ b/DDCore/include/DD4hep/CartesianGridXYZ.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CARTESIANGRIDXYZ_H 
-#define DD4HEP_DDCORE_CARTESIANGRIDXYZ_H 1
+#ifndef DD4HEP_CARTESIANGRIDXYZ_H
+#define DD4HEP_CARTESIANGRIDXYZ_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -113,4 +113,4 @@ namespace dd4hep {
     std::vector<double> cellDimensions(const CellID& cellID) const;
   };
 }       /* End namespace dd4hep                */
-#endif  /* DD4HEP_DDCORE_CARTESIANGRIDXYZ_H    */
+#endif // DD4HEP_CARTESIANGRIDXYZ_H

--- a/DDCore/include/DD4hep/CartesianGridXZ.h
+++ b/DDCore/include/DD4hep/CartesianGridXZ.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CARTESIANGRIDXZ_H 
-#define DD4HEP_DDCORE_CARTESIANGRIDXZ_H 1
+#ifndef DD4HEP_CARTESIANGRIDXZ_H
+#define DD4HEP_CARTESIANGRIDXZ_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -103,4 +103,4 @@ namespace dd4hep {
     std::vector<double> cellDimensions(const CellID& cellID) const;
   };
 }       /* End namespace dd4hep                */
-#endif  /* DD4HEP_DDCORE_CARTESIANGRIDXZ_H     */
+#endif // DD4HEP_CARTESIANGRIDXZ_H

--- a/DDCore/include/DD4hep/CartesianGridYZ.h
+++ b/DDCore/include/DD4hep/CartesianGridYZ.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CARTESIANGRIDYZ_H 
-#define DD4HEP_DDCORE_CARTESIANGRIDYZ_H 1
+#ifndef DD4HEP_CARTESIANGRIDYZ_H
+#define DD4HEP_CARTESIANGRIDYZ_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -104,4 +104,4 @@ namespace dd4hep {
     std::vector<double> cellDimensions(const CellID& cellID) const;
   };
 }       /* End namespace dd4hep                */
-#endif  /* DD4HEP_DDCORE_CARTESIANGRIDYZ_H     */
+#endif // DD4HEP_CARTESIANGRIDYZ_H

--- a/DDCore/include/DD4hep/CartesianStripX.h
+++ b/DDCore/include/DD4hep/CartesianStripX.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CARTESIANSTRIPX_H
-#define DD4HEP_DDCORE_CARTESIANSTRIPX_H 1
+#ifndef DD4HEP_CARTESIANSTRIPX_H
+#define DD4HEP_CARTESIANSTRIPX_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -92,4 +92,4 @@ class CartesianStripX : public CartesianStripXHandle {
     std::vector<double> cellDimensions(const CellID& cellID) const;
 };
 } /* End namespace dd4hep                */
-#endif  // DD4HEP_DDCORE_CARTESIANSTRIPX_H
+#endif // DD4HEP_CARTESIANSTRIPX_H

--- a/DDCore/include/DD4hep/CartesianStripY.h
+++ b/DDCore/include/DD4hep/CartesianStripY.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CARTESIANSTRIPY_H
-#define DD4HEP_DDCORE_CARTESIANSTRIPY_H 1
+#ifndef DD4HEP_CARTESIANSTRIPY_H
+#define DD4HEP_CARTESIANSTRIPY_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -92,4 +92,4 @@ class CartesianStripY : public CartesianStripYHandle {
     std::vector<double> cellDimensions(const CellID& cellID) const;
 };
 } /* End namespace dd4hep                */
-#endif  // DD4HEP_DDCORE_CARTESIANSTRIPY_H
+#endif // DD4HEP_CARTESIANSTRIPY_H

--- a/DDCore/include/DD4hep/CartesianStripZ.h
+++ b/DDCore/include/DD4hep/CartesianStripZ.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CARTESIANSTRIPZ_H
-#define DD4HEP_DDCORE_CARTESIANSTRIPZ_H 1
+#ifndef DD4HEP_CARTESIANSTRIPZ_H
+#define DD4HEP_CARTESIANSTRIPZ_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -92,4 +92,4 @@ class CartesianStripZ : public CartesianStripZHandle {
     std::vector<double> cellDimensions(const CellID& cellID) const;
 };
 } /* End namespace dd4hep                */
-#endif  // DD4HEP_DDCORE_CARTESIANSTRIPZ_H
+#endif // DD4HEP_CARTESIANSTRIPZ_H

--- a/DDCore/include/DD4hep/ComponentProperties.h
+++ b/DDCore/include/DD4hep/ComponentProperties.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_COMPONENTPROPERTIES_H
-#define DD4HEP_DDG4_COMPONENTPROPERTIES_H
+#ifndef DD4HEP_COMPONENTPROPERTIES_H
+#define DD4HEP_COMPONENTPROPERTIES_H
 
 // Framework include files
 #include "DD4hep/Grammar.h"
@@ -343,4 +343,4 @@ namespace dd4hep {
   }
 
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_COMPONENTPROPERTIES_H
+#endif // DD4HEP_COMPONENTPROPERTIES_H

--- a/DDCore/include/DD4hep/ConditionDerived.h
+++ b/DDCore/include/DD4hep/ConditionDerived.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CONDITIONDERIVED_H
-#define DD4HEP_DDCORE_CONDITIONDERIVED_H
+#ifndef DD4HEP_CONDITIONDERIVED_H
+#define DD4HEP_CONDITIONDERIVED_H
 
 // Framework include files
 #include "DD4hep/Memory.h"
@@ -434,4 +434,4 @@ namespace dd4hep {
 
   }       /* End namespace cond               */
 }         /* End namespace dd4hep                   */
-#endif    /* DD4HEP_DDCORE_CONDITIONDERIVED_H     */
+#endif // DD4HEP_CONDITIONDERIVED_H

--- a/DDCore/include/DD4hep/ConditionTypes.h
+++ b/DDCore/include/DD4hep/ConditionTypes.h
@@ -1,3 +1,6 @@
+#ifndef DD4HEP_CONDITIONTYPES_H
+#define DD4HEP_CONDITIONTYPES_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -13,3 +16,5 @@
 
 #define DD4HEP_INSTANTIATE_GRAMMAR_TYPE(x)  \
 namespace dd4hep {template<> const BasicGrammar& BasicGrammar::instance<x>()  { static Grammar<x> s; return s;}}
+
+#endif

--- a/DDCore/include/DD4hep/Conditions.h
+++ b/DDCore/include/DD4hep/Conditions.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CONDITIONS_H
-#define DD4HEP_DDCORE_CONDITIONS_H
+#ifndef DD4HEP_CONDITIONS_H
+#define DD4HEP_CONDITIONS_H
 
 // Framework include files
 #include "DD4hep/IOV.h"
@@ -480,4 +480,4 @@ namespace dd4hep {
   typedef std::vector<Condition>          RangeConditions;
   
 }          /* End namespace dd4hep                   */
-#endif     /* DD4HEP_DDCORE_CONDITIONS_H             */
+#endif // DD4HEP_CONDITIONS_H

--- a/DDCore/include/DD4hep/ConditionsData.h
+++ b/DDCore/include/DD4hep/ConditionsData.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CONDITIONSDATA_H
-#define DD4HEP_DDCORE_CONDITIONSDATA_H
+#ifndef DD4HEP_CONDITIONSDATA_H
+#define DD4HEP_CONDITIONSDATA_H
 
 // Framework include files
 #include "DD4hep/Objects.h"
@@ -125,4 +125,4 @@ namespace dd4hep {
 
   } /* End namespace cond             */
 } /* End namespace dd4hep                   */
-#endif    /* DD4HEP_DDCORE_CONDITIONSDATA_H    */
+#endif // DD4HEP_CONDITIONSDATA_H

--- a/DDCore/include/DD4hep/ConditionsDebug.h
+++ b/DDCore/include/DD4hep/ConditionsDebug.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DDCORE_CONDITIONSDEBUG_H
-#define DDCORE_CONDITIONSDEBUG_H
+#ifndef DD4HEP_CONDITIONSDEBUG_H
+#define DD4HEP_CONDITIONSDEBUG_H
 
 // Framework include files
 #include "DD4hep/Conditions.h"
@@ -27,4 +27,4 @@ namespace dd4hep {
     
   } /* End namespace cond                 */
 } /* End namespace dd4hep                 */
-#endif     /* DDCORE_CONDITIONSDEBUG_H    */
+#endif // DD4HEP_CONDITIONSDEBUG_H

--- a/DDCore/include/DD4hep/ConditionsListener.h
+++ b/DDCore/include/DD4hep/ConditionsListener.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CONDITIONSLISTENER_H
-#define DD4HEP_DDCORE_CONDITIONSLISTENER_H
+#ifndef DD4HEP_CONDITIONSLISTENER_H
+#define DD4HEP_CONDITIONSLISTENER_H
 
 // Framework include files
 #include "DD4hep/Conditions.h"
@@ -60,4 +60,4 @@ namespace dd4hep {
   } /* End namespace detail               */
 } /* End namespace dd4hep                   */
 
-#endif /* DD4HEP_DDCORE_CONDITIONSLISTENER_H  */
+#endif // DD4HEP_CONDITIONSLISTENER_H

--- a/DDCore/include/DD4hep/ConditionsMap.h
+++ b/DDCore/include/DD4hep/ConditionsMap.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CONDITIONSMAP_H
-#define DD4HEP_DDCORE_CONDITIONSMAP_H
+#ifndef DD4HEP_CONDITIONSMAP_H
+#define DD4HEP_CONDITIONSMAP_H
 
 // Framework include files
 #include "DD4hep/Conditions.h"
@@ -161,4 +161,4 @@ namespace dd4hep {
   typedef ConditionsMapping<std::unordered_map<Condition::key_type,Condition> > ConditionsHashMap;
     
 }         /* End namespace dd4hep                   */
-#endif    /* DD4HEP_DDCORE_CONDITIONSMAP_H        */
+#endif // DD4HEP_CONDITIONSMAP_H

--- a/DDCore/include/DD4hep/ConditionsPrinter.h
+++ b/DDCore/include/DD4hep/ConditionsPrinter.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CONDITIONSPRINTER_H
-#define DD4HEP_DDCORE_CONDITIONSPRINTER_H
+#ifndef DD4HEP_CONDITIONSPRINTER_H
+#define DD4HEP_CONDITIONSPRINTER_H
 
 // Framework includes
 #include "DD4hep/Printout.h"
@@ -87,4 +87,4 @@ namespace dd4hep {
     
   }    /* End namespace cond           */
 }      /* End namespace dd4hep               */
-#endif /* DD4HEP_DDCORE_CONDITIONSPRINTER_H  */
+#endif // DD4HEP_CONDITIONSPRINTER_H

--- a/DDCore/include/DD4hep/ConditionsProcessor.h
+++ b/DDCore/include/DD4hep/ConditionsProcessor.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CONDITIONSPROCESSOR_H
-#define DD4HEP_DDCORE_CONDITIONSPROCESSOR_H
+#ifndef DD4HEP_CONDITIONSPROCESSOR_H
+#define DD4HEP_CONDITIONSPROCESSOR_H
 
 // Framework include files
 #include "DD4hep/DetElement.h"
@@ -153,4 +153,4 @@ namespace dd4hep {
 
   }       /* End namespace cond               */
 }         /* End namespace dd4hep                   */
-#endif    /* DD4HEP_DDCORE_CONDITIONSPROCESSOR_H  */
+#endif // DD4HEP_CONDITIONSPROCESSOR_H

--- a/DDCore/include/DD4hep/DD4hepRootPersistency.h
+++ b/DDCore/include/DD4hep/DD4hepRootPersistency.h
@@ -141,4 +141,4 @@ public:
   size_t checkAll()   const;
 };
 
-#endif    /* DD4HEP_DD4HEPROOTPERSISTENCY_H         */
+#endif // DD4HEP_DD4HEPROOTPERSISTENCY_H

--- a/DDCore/include/DD4hep/DD4hepUI.h
+++ b/DDCore/include/DD4hep/DD4hepUI.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_DD4HEPUI_H
-#define DD4HEP_DDCORE_DD4HEPUI_H
+#ifndef DD4HEP_DD4HEPUI_H
+#define DD4HEP_DD4HEPUI_H
 
 // Framework includes
 #include "DD4hep/Detector.h"
@@ -99,4 +99,4 @@ namespace dd4hep {
     
   }  
 } /* End namespace dd4hep        */
-#endif // DD4HEP_DDCORE_DD4HEPUI_H
+#endif // DD4HEP_DD4HEPUI_H

--- a/DDCore/include/DD4hep/DD4hepUnits.h
+++ b/DDCore/include/DD4hep/DD4hepUnits.h
@@ -1,1 +1,6 @@
+#ifndef DD4HEP_DD4HEPUNITS_H
+#define DD4HEP_DD4HEPUNITS_H
+
 #include "Evaluator/DD4hepUnits.h"
+
+#endif

--- a/DDCore/include/DD4hep/DDTest.h
+++ b/DDCore/include/DD4hep/DDTest.h
@@ -1,3 +1,6 @@
+#ifndef DD4HEP_DDTEST_H
+#define DD4HEP_DDTEST_H
+
 #include <iostream>
 #include <sstream>
 #include <stdlib.h>
@@ -174,3 +177,5 @@ namespace dd4hep{
 
 
 } // end namespace
+
+#endif

--- a/DDCore/include/DD4hep/DetElement.h
+++ b/DDCore/include/DD4hep/DetElement.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DETECTOR_H
-#define DD4HEP_DETECTOR_H
+#ifndef DD4HEP_DETELEMENT_H
+#define DD4HEP_DETELEMENT_H
 
 // Framework include files
 #include "DD4hep/Handle.h"
@@ -451,4 +451,4 @@ namespace dd4hep {
 
 #include "DD4hep/AlignmentData.h"
 
-#endif    /* DD4HEP_DETECTOR_H      */
+#endif // DD4HEP_DETELEMENT_H

--- a/DDCore/include/DD4hep/DetFactoryHelper.h
+++ b/DDCore/include/DD4hep/DetFactoryHelper.h
@@ -10,11 +10,11 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DETECTOR_DETFACTORYHELPER_H
-#define DD4HEP_DETECTOR_DETFACTORYHELPER_H
+#ifndef DD4HEP_DETFACTORYHELPER_H
+#define DD4HEP_DETFACTORYHELPER_H
 
 /** Obsolete header. Better use XML/Helper.h instead !  */
 
 #include "XML/Helper.h"
 
-#endif // dd4hep_DETECTOR_DETFACTORYHELPER_H
+#endif // DD4HEP_DETFACTORYHELPER_H

--- a/DDCore/include/DD4hep/DetType.h
+++ b/DDCore/include/DD4hep/DetType.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DetType_H
-#define DD4HEP_DetType_H
+#ifndef DD4HEP_DETTYPE_H
+#define DD4HEP_DETTYPE_H
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -122,4 +122,4 @@ namespace dd4hep {
   
 } /* End namespace dd4hep        */
 
-#endif    /* DD4HEP_DETECTOR_H      */
+#endif // DD4HEP_DETTYPE_H

--- a/DDCore/include/DD4hep/Detector.h
+++ b/DDCore/include/DD4hep/Detector.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DETECTOR_DETECTOR_H
-#define DD4HEP_DETECTOR_DETECTOR_H
+#ifndef DD4HEP_DETECTOR_H
+#define DD4HEP_DETECTOR_H
 
 #include "DD4hep/Version.h"
 
@@ -402,4 +402,4 @@ namespace dd4hep {
   }
 #endif
 }         /* End namespace dd4hep           */
-#endif    /* DD4HEP_DETECTOR_DETECTOR_H     */
+#endif // DD4HEP_DETECTOR_H

--- a/DDCore/include/DD4hep/DetectorData.h
+++ b/DDCore/include/DD4hep/DetectorData.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDCORE_DETECTORDATA_H
-#define DD4HEP_DDCORE_DETECTORDATA_H
+#ifndef DD4HEP_DETECTORDATA_H
+#define DD4HEP_DETECTORDATA_H
 
 // Framework includes
 #include "DD4hep/Printout.h"
@@ -205,4 +205,4 @@ namespace dd4hep {
   };
 
 }         /* End namespace dd4hep         */
-#endif    /* DD4HEP_DDCORE_DETECTORDATA_H */
+#endif // DD4HEP_DETECTORDATA_H

--- a/DDCore/include/DD4hep/DetectorHelper.h
+++ b/DDCore/include/DD4hep/DetectorHelper.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDCORE_DETECTORHELPER_H
-#define DD4HEP_DDCORE_DETECTORHELPER_H
+#ifndef DD4HEP_DETECTORHELPER_H
+#define DD4HEP_DETECTORHELPER_H
 
 #include "DD4hep/Detector.h"
 
@@ -58,4 +58,4 @@ namespace dd4hep {
   };
 
 }       /* End namespace dd4hep               */
-#endif  /* DD4HEP_DDCORE_DETECTORHELPER_H     */
+#endif // DD4HEP_DETECTORHELPER_H

--- a/DDCore/include/DD4hep/DetectorImp.h
+++ b/DDCore/include/DD4hep/DetectorImp.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DetectorGEOIMP_H
-#define DD4HEP_DetectorGEOIMP_H
+#ifndef DD4HEP_DETECTORIMP_H
+#define DD4HEP_DETECTORIMP_H
 
 //==========================================================================
 //
@@ -432,4 +432,4 @@ namespace dd4hep {
 #if defined(__CINT__) || defined(__MAKECINT__) || defined(__CLING__) || defined(__ROOTCLING__)
 #pragma link C++ class dd4hep::DetectorImp+;
 #endif
-#endif    /* dd4hep_DetectorGEOIMP_H    */
+#endif // DD4HEP_DETECTORIMP_H

--- a/DDCore/include/DD4hep/DetectorLoad.h
+++ b/DDCore/include/DD4hep/DetectorLoad.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_DETECTORLOAD_H
-#define DD4HEP_DDCORE_DETECTORLOAD_H
+#ifndef DD4HEP_DETECTORLOAD_H
+#define DD4HEP_DETECTORLOAD_H
 
 // Framework includes
 #include "DD4hep/Detector.h"
@@ -92,4 +92,4 @@ namespace dd4hep {
   };
 
 }         /* End namespace dd4hep         */
-#endif    /* DD4HEP_DDCORE_DETECTORLOAD_H */
+#endif // DD4HEP_DETECTORLOAD_H

--- a/DDCore/include/DD4hep/DetectorProcessor.h
+++ b/DDCore/include/DD4hep/DetectorProcessor.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_DETECTORPROCESSOR_H
-#define DD4HEP_DDCORE_DETECTORPROCESSOR_H
+#ifndef DD4HEP_DETECTORPROCESSOR_H
+#define DD4HEP_DETECTORPROCESSOR_H
 
 // Framework includes
 #include "DD4hep/DetElement.h"
@@ -204,4 +204,4 @@ namespace dd4hep {
     }
   };
 }      /* End namespace dd4hep               */
-#endif /* DD4HEP_DDCORE_DETECTORPROCESSOR_H  */
+#endif // DD4HEP_DETECTORPROCESSOR_H

--- a/DDCore/include/DD4hep/DetectorSelector.h
+++ b/DDCore/include/DD4hep/DetectorSelector.h
@@ -79,4 +79,4 @@ namespace dd4hep {
   };
 
 } /* End namespace dd4hep        */
-#endif    /* DD4HEP_DETECTORSELECTOR_H      */
+#endif // DD4HEP_DETECTORSELECTOR_H

--- a/DDCore/include/DD4hep/DetectorTools.h
+++ b/DDCore/include/DD4hep/DetectorTools.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_DETECTORTOOLS_H
-#define DD4HEP_DDCORE_DETECTORTOOLS_H
+#ifndef DD4HEP_DETECTORTOOLS_H
+#define DD4HEP_DETECTORTOOLS_H
 
 // Framework include files
 #include "DD4hep/DetElement.h"
@@ -84,4 +84,4 @@ namespace dd4hep {
     }
   }
 }         /* End namespace dd4hep                   */
-#endif    /* DD4HEP_DDCORE_DETECTORTOOLS_H    */
+#endif // DD4HEP_DETECTORTOOLS_H

--- a/DDCore/include/DD4hep/Exceptions.h
+++ b/DDCore/include/DD4hep/Exceptions.h
@@ -12,13 +12,13 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_EXCEPTIONS_H
-#define DD4HEP_DDCORE_EXCEPTIONS_H
+#ifndef DD4HEP_EXCEPTIONS_H
+#define DD4HEP_EXCEPTIONS_H
 
 // Forward declaring header for package configuration
 
 #include "DD4hep/config.h"
 #include "Parsers/Exceptions.h"
 
-#endif // DD4HEP_DDCORE_EXCEPTIONS_H
+#endif // DD4HEP_EXCEPTIONS_H
 

--- a/DDCore/include/DD4hep/ExtensionEntry.h
+++ b/DDCore/include/DD4hep/ExtensionEntry.h
@@ -18,8 +18,8 @@
 // sufficient for all practical purposes.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_EXTENSIONENTRY_H
-#define DD4HEP_DDCORE_EXTENSIONENTRY_H
+#ifndef DD4HEP_EXTENSIONENTRY_H
+#define DD4HEP_EXTENSIONENTRY_H
 
 #include "DD4hep/Primitives.h"
 
@@ -195,4 +195,4 @@ namespace dd4hep {
     };
   }     // End namespace detail
 }       // End namespace dd4hep
-#endif  /* DD4HEP_DDCORE_EXTENSIONENTRY_H */
+#endif // DD4HEP_EXTENSIONENTRY_H

--- a/DDCore/include/DD4hep/FieldTypes.h
+++ b/DDCore/include/DD4hep/FieldTypes.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_FIELDTYPES_H
-#define DD4HEP_DDCORE_FIELDTYPES_H
+#ifndef DD4HEP_FIELDTYPES_H
+#define DD4HEP_FIELDTYPES_H
 
 // Framework include files
 #include "DD4hep/Fields.h"
@@ -163,4 +163,4 @@ namespace dd4hep {
   };
 
 }         /* End namespace dd4hep             */
-#endif    /* DD4HEP_DDCORE_FIELDTYPES_H     */
+#endif // DD4HEP_FIELDTYPES_H

--- a/DDCore/include/DD4hep/Fields.h
+++ b/DDCore/include/DD4hep/Fields.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_FIELDS_H
-#define DD4HEP_DDCORE_FIELDS_H
+#ifndef DD4HEP_FIELDS_H
+#define DD4HEP_FIELDS_H
 
 // Framework include files
 #include "DD4hep/NamedObject.h"
@@ -262,4 +262,4 @@ namespace dd4hep {
     Properties& properties() const;
   };
 }         /* End namespace dd4hep             */
-#endif    /* DD4HEP_DDCORE_FIELDS_H         */
+#endif // DD4HEP_FIELDS_H

--- a/DDCore/include/DD4hep/Filter.h
+++ b/DDCore/include/DD4hep/Filter.h
@@ -10,8 +10,8 @@
 // Author     : Ianna Osborne
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_FILTER_H
-#define DD4HEP_DDCORE_FILTER_H
+#ifndef DD4HEP_FILTER_H
+#define DD4HEP_FILTER_H
 
 // -*- C++ -*-
 //

--- a/DDCore/include/DD4hep/GlobalAlignment.h
+++ b/DDCore/include/DD4hep/GlobalAlignment.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_GLOBALALIGNMENT_H
-#define DD4HEP_DDCORE_GLOBALALIGNMENT_H
+#ifndef DD4HEP_GLOBALALIGNMENT_H
+#define DD4HEP_GLOBALALIGNMENT_H
 
 // Framework include files
 #include "DD4hep/Objects.h"
@@ -84,5 +84,5 @@ namespace dd4hep {
 
   }       /* End namespace align                */
 }         /* End namespace dd4hep                    */
-#endif    /* DD4HEP_DDCORE_GLOBALALIGNMENT_H      */
+#endif // DD4HEP_GLOBALALIGNMENT_H
       

--- a/DDCore/include/DD4hep/Grammar.h
+++ b/DDCore/include/DD4hep/Grammar.h
@@ -18,8 +18,8 @@
 // sufficient for all practical purposes.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_DETAIL_GRAMMAR_H
-#define DD4HEP_DDCORE_DETAIL_GRAMMAR_H
+#ifndef DD4HEP_GRAMMAR_H
+#define DD4HEP_GRAMMAR_H
 
 // Framework include files
 #include "DD4hep/config.h"
@@ -252,4 +252,4 @@ namespace dd4hep {
     }
   };
 }
-#endif  /* DD4HEP_DDCORE_DETAIL_GRAMMAR_H */
+#endif // DD4HEP_GRAMMAR_H

--- a/DDCore/include/DD4hep/GridPhiEta.h
+++ b/DDCore/include/DD4hep/GridPhiEta.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_GRIDPHIETA_H
-#define DD4HEP_DDCORE_GRIDPHIETA_H 1
+#ifndef DD4HEP_GRIDPHIETA_H
+#define DD4HEP_GRIDPHIETA_H 1
 
 // Framework includes
 #include "DDSegmentation/GridPhiEta.h"
@@ -115,4 +115,4 @@ namespace dd4hep {
     }
   };
 }       /* End namespace dd4hep                */
-#endif  // DD4HEP_DDCORE_POLARGRIDRPHI_H
+#endif // DD4HEP_GRIDPHIETA_H

--- a/DDCore/include/DD4hep/GridRPhiEta.h
+++ b/DDCore/include/DD4hep/GridRPhiEta.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_GRIDRPHIETA_H
-#define DD4HEP_DDCORE_GRIDRPHIETA_H 1
+#ifndef DD4HEP_GRIDRPHIETA_H
+#define DD4HEP_GRIDRPHIETA_H 1
 
 // Framework includes
 #include "DD4hep/Segmentations.h"
@@ -133,4 +133,4 @@ namespace dd4hep {
     }
   };
 } /* End namespace dd4hep                */
-#endif  // DD4HEP_DDCORE_GRIDRPHIETA_H
+#endif // DD4HEP_GRIDRPHIETA_H

--- a/DDCore/include/DD4hep/Handle.h
+++ b/DDCore/include/DD4hep/Handle.h
@@ -442,5 +442,5 @@ namespace dd4hep {
   // Forward declarations
   class Detector;
 }         /* End namespace dd4hep    */
-#endif    /* DD4HEP_HANDLE_H         */
+#endif // DD4HEP_HANDLE_H
 

--- a/DDCore/include/DD4hep/IDDescriptor.h
+++ b/DDCore/include/DD4hep/IDDescriptor.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_IDDESCRIPTOR_H
-#define DD4HEP_DDCORE_IDDESCRIPTOR_H
+#ifndef DD4HEP_IDDESCRIPTOR_H
+#define DD4HEP_IDDESCRIPTOR_H
 
 // Framework include files
 #include "DD4hep/Handle.h"
@@ -82,4 +82,4 @@ namespace dd4hep {
     void rebuild(const std::string& description);
   };
 }         /* End namespace dd4hep          */
-#endif    /* DD4HEP_DDCORE_IDDESCRIPTOR_H  */
+#endif // DD4HEP_IDDESCRIPTOR_H

--- a/DDCore/include/DD4hep/IOV.h
+++ b/DDCore/include/DD4hep/IOV.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_IOV_H
-#define DD4HEP_DDCORE_IOV_H
+#ifndef DD4HEP_IOV_H
+#define DD4HEP_IOV_H
 
 // C/C++ include files
 #include <string>
@@ -186,4 +186,4 @@ namespace dd4hep {
   }
 
 } /* End namespace dd4hep                   */
-#endif    /* DD4HEP_DDCORE_IOV_H        */
+#endif // DD4HEP_IOV_H

--- a/DDCore/include/DD4hep/InstanceCount.h
+++ b/DDCore/include/DD4hep/InstanceCount.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_INSTANCECOUNT_H
-#define DD4HEP_DDCORE_INSTANCECOUNT_H
+#ifndef DD4HEP_INSTANCECOUNT_H
+#define DD4HEP_INSTANCECOUNT_H
 
 // Framework include files
 #include <typeinfo>
@@ -147,4 +147,4 @@ namespace dd4hep {
   };
 
 } /* End namespace dd4hep             */
-#endif    /* DD4HEP_DDCORE_INSTANCECOUNT_H     */
+#endif // DD4HEP_INSTANCECOUNT_H

--- a/DDCore/include/DD4hep/MatrixHelpers.h
+++ b/DDCore/include/DD4hep/MatrixHelpers.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_IMP_MATRIXHELPERS_H
-#define DD4HEP_IMP_MATRIXHELPERS_H
+#ifndef DD4HEP_MATRIXHELPERS_H
+#define DD4HEP_MATRIXHELPERS_H
 
 // Framework include files
 #include "DD4hep/Objects.h"
@@ -119,4 +119,4 @@ namespace dd4hep {
   }
 }       /* End namespace dd4hep            */
 
-#endif  /* DD4HEP_IMP_MATRIXHELPERS_H      */
+#endif // DD4HEP_MATRIXHELPERS_H

--- a/DDCore/include/DD4hep/MultiSegmentation.h
+++ b/DDCore/include/DD4hep/MultiSegmentation.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_MULTISEGMENTATION_H 
-#define DD4HEP_DDCORE_MULTISEGMENTATION_H 1
+#ifndef DD4HEP_MULTISEGMENTATION_H
+#define DD4HEP_MULTISEGMENTATION_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -92,4 +92,4 @@ namespace dd4hep {
     std::vector<double> cellDimensions(const CellID& cellID) const;
   };
 } /* End namespace dd4hep                */
-#endif // DD4HEP_DDCORE_MULTISEGMENTATION_H
+#endif // DD4HEP_MULTISEGMENTATION_H

--- a/DDCore/include/DD4hep/Mutex.h
+++ b/DDCore/include/DD4hep/Mutex.h
@@ -20,7 +20,7 @@
 #endif
 
 /// Namespace for the AIDA detector description toolkit
-namespace dd4hep  {
+namespace dd4hep {
 #if __cplusplus >= 201103L
   typedef std::recursive_mutex            dd4hep_mutex_t;
   typedef std::lock_guard<dd4hep_mutex_t> dd4hep_lock_t;

--- a/DDCore/include/DD4hep/NamedObject.h
+++ b/DDCore/include/DD4hep/NamedObject.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_NAMEDOBJECT_H
-#define DD4HEP_DDCORE_NAMEDOBJECT_H
+#ifndef DD4HEP_NAMEDOBJECT_H
+#define DD4HEP_NAMEDOBJECT_H
 
 // C/C++ include files
 #include <string>
@@ -69,4 +69,4 @@ namespace dd4hep {
   };
 
 }         /* End namespace dd4hep          */
-#endif    /* DD4HEP_DDCORE_NAMEDOBJECT_H   */
+#endif // DD4HEP_NAMEDOBJECT_H

--- a/DDCore/include/DD4hep/NoSegmentation.h
+++ b/DDCore/include/DD4hep/NoSegmentation.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_NoSegmentation_H 
-#define DD4HEP_DDCORE_NoSegmentation_H 1
+#ifndef DD4HEP_NOSEGMENTATION_H
+#define DD4HEP_NOSEGMENTATION_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -51,4 +51,4 @@ namespace dd4hep {
     CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const;
   };
 }       /* End namespace dd4hep                */
-#endif  // DD4HEP_DDCORE_NoSegmentation_H
+#endif // DD4HEP_NOSEGMENTATION_H

--- a/DDCore/include/DD4hep/ObjectExtensions.h
+++ b/DDCore/include/DD4hep/ObjectExtensions.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_OBJECTEXTENSIONS_H
-#define DD4HEP_DDCORE_OBJECTEXTENSIONS_H
+#ifndef DD4HEP_OBJECTEXTENSIONS_H
+#define DD4HEP_OBJECTEXTENSIONS_H
 
 // Framework include files
 #include "DD4hep/ExtensionEntry.h"
@@ -63,4 +63,4 @@ namespace dd4hep {
   };
 
 } /* End namespace dd4hep        */
-#endif    /* DD4HEP_DDCORE_OBJECTEXTENSIONS_H */
+#endif // DD4HEP_OBJECTEXTENSIONS_H

--- a/DDCore/include/DD4hep/Objects.h
+++ b/DDCore/include/DD4hep/Objects.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_OBJECTS_H
-#define DD4HEP_DDCORE_OBJECTS_H
+#ifndef DD4HEP_OBJECTS_H
+#define DD4HEP_OBJECTS_H
 
 // Framework include files
 #include "DD4hep/Handle.h"
@@ -530,4 +530,4 @@ namespace ROOT {
     bool operator<(const PxPyPzEVector& a, const PxPyPzEVector& b);
   }
 }
-#endif    /* DD4HEP_DDCORE_OBJECTS_H        */
+#endif // DD4HEP_OBJECTS_H

--- a/DDCore/include/DD4hep/OpaqueData.h
+++ b/DDCore/include/DD4hep/OpaqueData.h
@@ -193,4 +193,4 @@ namespace dd4hep {
   }
 
 }      /* End namespace dd4hep */
-#endif /* DD4HEP_OPAQUEDATA_H  */
+#endif // DD4HEP_OPAQUEDATA_H

--- a/DDCore/include/DD4hep/Operators.h
+++ b/DDCore/include/DD4hep/Operators.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DD4HEP_OPERATORS_H
-#define DD4HEP_DD4HEP_OPERATORS_H
+#ifndef DD4HEP_OPERATORS_H
+#define DD4HEP_OPERATORS_H
 
 // C/C++ include files
 #include <string>
@@ -64,4 +64,4 @@ namespace dd4hep {
   template <typename T> ByNameAttr<T> byNameAttr(const T& o) { return ByNameAttr<T>(o.name);  }
 
 }      // End namespace dd4hep
-#endif // DD4HEP_DD4HEP_OPERATORS_H
+#endif // DD4HEP_OPERATORS_H

--- a/DDCore/include/DD4hep/OpticalSurfaceManager.h
+++ b/DDCore/include/DD4hep/OpticalSurfaceManager.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_OPTICALSURFACEMANAGER_H
-#define DD4HEP_DDCORE_OPTICALSURFACEMANAGER_H
+#ifndef DD4HEP_OPTICALSURFACEMANAGER_H
+#define DD4HEP_OPTICALSURFACEMANAGER_H
 
 // Framework include files
 #include "DD4hep/OpticalSurfaces.h"
@@ -83,4 +83,4 @@ namespace dd4hep {
 #endif
   };
 }         /* End namespace dd4hep                  */
-#endif    /* DD4HEP_DDCORE_OPTICALSURFACEMANAGER_H */
+#endif // DD4HEP_OPTICALSURFACEMANAGER_H

--- a/DDCore/include/DD4hep/OpticalSurfaces.h
+++ b/DDCore/include/DD4hep/OpticalSurfaces.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_OPTICALSURFACES_H
-#define DD4HEP_DDCORE_OPTICALSURFACES_H
+#ifndef DD4HEP_OPTICALSURFACES_H
+#define DD4HEP_OPTICALSURFACES_H
 
 // Framework include files
 #include "DD4hep/Volumes.h"
@@ -196,4 +196,4 @@ namespace dd4hep {
 
 }         /* End namespace dd4hep              */
 #endif    /* ROOT_VERSION                      */
-#endif    /* DD4HEP_DDCORE_OPTICALSURFACES_H   */
+#endif // DD4HEP_OPTICALSURFACES_H

--- a/DDCore/include/DD4hep/Path.h
+++ b/DDCore/include/DD4hep/Path.h
@@ -12,8 +12,8 @@
 //  \version 1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_PATH_H
-#define DD4HEP_DDCORE_PATH_H
+#ifndef DD4HEP_PATH_H
+#define DD4HEP_PATH_H
 
 // Framework include files
 
@@ -114,4 +114,4 @@ namespace dd4hep {
     };
   };
 }         /* End namespace dd4hep           */
-#endif    /* DD4HEP_DDCORE_PATH_H           */
+#endif // DD4HEP_PATH_H

--- a/DDCore/include/DD4hep/Plugins.h
+++ b/DDCore/include/DD4hep/Plugins.h
@@ -210,4 +210,4 @@ namespace dd4hep {
     template <typename P> inline R Factory<P,R(A0,A1,A2,A3,A4)>::call(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
   
 #endif    /* __CINT__          */
-#endif    /* DD4HEP_PLUGINS_H  */
+#endif // DD4HEP_PLUGINS_H

--- a/DDCore/include/DD4hep/PolarGridRPhi.h
+++ b/DDCore/include/DD4hep/PolarGridRPhi.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_POLARGRIDRPHI_H 
-#define DD4HEP_DDCORE_POLARGRIDRPHI_H 1
+#ifndef DD4HEP_POLARGRIDRPHI_H
+#define DD4HEP_POLARGRIDRPHI_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -101,4 +101,4 @@ namespace dd4hep {
     std::vector<double> cellDimensions(const CellID& cellID) const;
   };
 }       /* End namespace dd4hep                */
-#endif  // DD4HEP_DDCORE_POLARGRIDRPHI_H
+#endif // DD4HEP_POLARGRIDRPHI_H

--- a/DDCore/include/DD4hep/PolarGridRPhi2.h
+++ b/DDCore/include/DD4hep/PolarGridRPhi2.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_POLARGRIDRPHI2_H 
-#define DD4HEP_DDCORE_POLARGRIDRPHI2_H 1
+#ifndef DD4HEP_POLARGRIDRPHI2_H
+#define DD4HEP_POLARGRIDRPHI2_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -118,4 +118,4 @@ namespace dd4hep {
     std::vector<double> cellDimensions(const CellID& cellID) const;
   };
 }      /* End namespace dd4hep                */
-#endif // DD4HEP_DDCORE_POLARGRIDRPHI2_H
+#endif // DD4HEP_POLARGRIDRPHI2_H

--- a/DDCore/include/DD4hep/Primitives.h
+++ b/DDCore/include/DD4hep/Primitives.h
@@ -12,12 +12,12 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_PRIMITIVES_H
-#define DD4HEP_DDCORE_PRIMITIVES_H
+#ifndef DD4HEP_PRIMITIVES_H
+#define DD4HEP_PRIMITIVES_H
 
 // Forward declaring header for package configuration
 
 #include "DD4hep/config.h"
 #include "Parsers/Primitives.h"
 
-#endif // DD4HEP_DDCORE_PRIMITIVES_H
+#endif // DD4HEP_PRIMITIVES_H

--- a/DDCore/include/DD4hep/Printout.h
+++ b/DDCore/include/DD4hep/Printout.h
@@ -12,12 +12,12 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_PRINTOUT_H
-#define DD4HEP_DDCORE_PRINTOUT_H
+#ifndef DD4HEP_PRINTOUT_H
+#define DD4HEP_PRINTOUT_H
 
 // Forward declaring header for package configuration
 
 #include "DD4hep/config.h"
 #include "Parsers/Printout.h"
 
-#endif // DD4HEP_DDCORE_PRINTOUT_H
+#endif // DD4HEP_PRINTOUT_H

--- a/DDCore/include/DD4hep/PropertyTable.h
+++ b/DDCore/include/DD4hep/PropertyTable.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_PROPERTYTABLE_H
-#define DD4HEP_DDCORE_PROPERTYTABLE_H
+#ifndef DD4HEP_PROPERTYTABLE_H
+#define DD4HEP_PROPERTYTABLE_H
 
 #include "RVersion.h"
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
@@ -61,4 +61,4 @@ namespace dd4hep {
 
 }         /* End namespace dd4hep              */
 #endif    /* ROOT_VERSION                      */
-#endif    /* DD4HEP_DDCORE_PROPERTYTABLE_H     */
+#endif // DD4HEP_PROPERTYTABLE_H

--- a/DDCore/include/DD4hep/Readout.h
+++ b/DDCore/include/DD4hep/Readout.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_READOUT_H
-#define DD4HEP_DDCORE_READOUT_H
+#ifndef DD4HEP_READOUT_H
+#define DD4HEP_READOUT_H
 
 // Framework include files
 #include "DD4hep/Handle.h"
@@ -88,4 +88,4 @@ namespace dd4hep {
     Segmentation segmentation() const;
   };
 }         /* End namespace dd4hep         */
-#endif    /* DD4HEP_DDCORE_READOUT_H      */
+#endif // DD4HEP_READOUT_H

--- a/DDCore/include/DD4hep/Segmentations.h
+++ b/DDCore/include/DD4hep/Segmentations.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_SEGMENTATIONS_H
-#define DD4HEP_DDCORE_SEGMENTATIONS_H
+#ifndef DD4HEP_SEGMENTATIONS_H
+#define DD4HEP_SEGMENTATIONS_H
 
 // Framework include files
 #include "DD4hep/Handle.h"
@@ -98,4 +98,4 @@ namespace dd4hep {
     DDSegmentation::Segmentation* segmentation() const;
   };
 } /* End namespace dd4hep                */
-#endif    /* DD4HEP_DDCORE_SEGMENTATIONS_H     */
+#endif // DD4HEP_SEGMENTATIONS_H

--- a/DDCore/include/DD4hep/ShapeTags.h
+++ b/DDCore/include/DD4hep/ShapeTags.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_SHAPETAGS_H
-#define DD4HEP_DDCORE_SHAPETAGS_H
+#ifndef DD4HEP_SHAPETAGS_H
+#define DD4HEP_SHAPETAGS_H
 
 #define SHAPELESS_TAG           "Assembly"
 #define BOX_TAG                 "Box"
@@ -42,5 +42,5 @@
 #define INTERSECTION_TAG        "Intersection"
 
 
-#endif // DD4HEP_DDCORE_SHAPETAGS_H
+#endif // DD4HEP_SHAPETAGS_H
 

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDCORE_SOLIDS_H
-#define DD4HEP_DDCORE_SOLIDS_H
+#ifndef DD4HEP_SHAPES_H
+#define DD4HEP_SHAPES_H
 
 // Framework include files
 #include "DD4hep/Handle.h"
@@ -1941,4 +1941,4 @@ namespace dd4hep {
   };
 
 }         /* End namespace dd4hep             */
-#endif    /* DD4HEP_DDCORE_SOLIDS_H         */
+#endif // DD4HEP_SHAPES_H

--- a/DDCore/include/DD4hep/SpecParRegistry.h
+++ b/DDCore/include/DD4hep/SpecParRegistry.h
@@ -10,8 +10,8 @@
 // Author     : Ianna Osborne
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_SPECPAR_REGISTRY_H
-#define DD4HEP_DDCORE_SPECPAR_REGISTRY_H
+#ifndef DD4HEP_SPECPARREGISTRY_H
+#define DD4HEP_SPECPARREGISTRY_H
 
 #include <string>
 #include <string_view>

--- a/DDCore/include/DD4hep/SurfaceInstaller.h
+++ b/DDCore/include/DD4hep/SurfaceInstaller.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDREC_SURFACEINSTALLER_H
-#define DD4HEP_DDREC_SURFACEINSTALLER_H 1
+#ifndef DD4HEP_SURFACEINSTALLER_H
+#define DD4HEP_SURFACEINSTALLER_H 1
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -215,4 +215,4 @@ typedef Installer<SURFACEINSTALLER_DATA> InstallerClass;
 DECLARE_SURFACE_INSTALLER(DD4HEP_USE_SURFACEINSTALL_HELPER,InstallerClass)
 
 #endif /* defined(DD4HEP_USE_SURFACEINSTALL_HELPER) */
-#endif /* DD4HEP_DDREC_SURFACEINSTALLER_H           */
+#endif // DD4HEP_SURFACEINSTALLER_H

--- a/DDCore/include/DD4hep/TGeoUnits.h
+++ b/DDCore/include/DD4hep/TGeoUnits.h
@@ -17,4 +17,4 @@ namesapce tgeo{
 
 #endif
 
-#endif /*DD4HEP_TGEOUNITS_H */
+#endif // DD4HEP_TGEOUNITS_H

--- a/DDCore/include/DD4hep/VolumeManager.h
+++ b/DDCore/include/DD4hep/VolumeManager.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDCORE_VOLUMEMANAGER_H
-#define DD4HEP_DDCORE_VOLUMEMANAGER_H
+#ifndef DD4HEP_VOLUMEMANAGER_H
+#define DD4HEP_VOLUMEMANAGER_H
 
 // Framework include files
 #include "DD4hep/Volumes.h"
@@ -196,4 +196,4 @@ namespace dd4hep {
   /// Enable printouts for debugging
   std::ostream& operator<<(std::ostream& os, const VolumeManager& m);
 }         /* End namespace dd4hep                */
-#endif    /* DD4HEP_DDCORE_READOUT_H           */
+#endif // DD4HEP_VOLUMEMANAGER_H

--- a/DDCore/include/DD4hep/VolumeProcessor.h
+++ b/DDCore/include/DD4hep/VolumeProcessor.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_VOLUMEPROCESSOR_H
-#define DD4HEP_DDCORE_VOLUMEPROCESSOR_H
+#ifndef DD4HEP_VOLUMEPROCESSOR_H
+#define DD4HEP_VOLUMEPROCESSOR_H
 
 // Framework includes
 #include "DD4hep/DetElement.h"
@@ -179,4 +179,4 @@ namespace dd4hep {
     }
   };
 }      /* End namespace dd4hep               */
-#endif /* DD4HEP_DDCORE_VOLUMEPROCESSOR_H    */
+#endif // DD4HEP_VOLUMEPROCESSOR_H

--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_VOLUMES_H
-#define DD4HEP_DDCORE_VOLUMES_H
+#ifndef DD4HEP_VOLUMES_H
+#define DD4HEP_VOLUMES_H
 
 // Framework include files
 #include "DD4hep/Handle.h"
@@ -509,4 +509,4 @@ namespace dd4hep {
   /// Output mesh vertices to string
   std::string toStringMesh(PlacedVolume solid, int precision=2);
 }         /* End namespace dd4hep          */
-#endif    /* DD4HEP_DDCORE_VOLUMES_H       */
+#endif // DD4HEP_VOLUMES_H

--- a/DDCore/include/DD4hep/WaferGridXY.h
+++ b/DDCore/include/DD4hep/WaferGridXY.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_WAFERGRIDZY_H 
-#define DD4HEP_DDCORE_WAFERGRIDZY_H 1
+#ifndef DD4HEP_WAFERGRIDXY_H
+#define DD4HEP_WAFERGRIDXY_H 1
 
 // Framework include files
 #include "DD4hep/Segmentations.h"
@@ -97,4 +97,4 @@ namespace dd4hep {
     std::vector<double> cellDimensions(const CellID& cellID) const;
   };
 }       /* End namespace dd4hep                */
-#endif  // DD4HEP_DDCORE_WAFERGRIDZY_H
+#endif // DD4HEP_WAFERGRIDXY_H

--- a/DDCore/include/DD4hep/World.h
+++ b/DDCore/include/DD4hep/World.h
@@ -48,4 +48,4 @@ namespace dd4hep {
 #endif
   };
 } /* End namespace dd4hep            */
-#endif    /* DD4HEP_WORLD_H          */
+#endif // DD4HEP_WORLD_H

--- a/DDCore/include/DD4hep/config.h
+++ b/DDCore/include/DD4hep/config.h
@@ -51,4 +51,4 @@ namespace dd4hep {
     }     /* End namespace matrix    */
   }       /* End namespace detail    */
 }         /* End namespace dd4hep    */
-#endif    /* DD4HEP_CONFIG_H         */
+#endif // DD4HEP_CONFIG_H

--- a/DDCore/include/DD4hep/detail/AlignmentsInterna.h
+++ b/DDCore/include/DD4hep/detail/AlignmentsInterna.h
@@ -18,8 +18,8 @@
 // sufficient for all practical purposes.
 //
 //==========================================================================
-#ifndef DD4HEP_ALIGNMENTS_ALIGNMENTSINTERNA_H
-#define DD4HEP_ALIGNMENTS_ALIGNMENTSINTERNA_H
+#ifndef DD4HEP_DETAIL_ALIGNMENTSINTERNA_H
+#define DD4HEP_DETAIL_ALIGNMENTSINTERNA_H
 
 // Framework include files
 #include "DD4hep/IOV.h"
@@ -76,4 +76,4 @@ namespace dd4hep {
     };
   }       /* End namespace detail                     */
 }         /* End namespace dd4hep                      */
-#endif    /* DD4HEP_ALIGNMENTS_ALIGNMENTSINTERNA_H     */
+#endif // DD4HEP_DETAIL_ALIGNMENTSINTERNA_H

--- a/DDCore/include/DD4hep/detail/ConditionsInterna.h
+++ b/DDCore/include/DD4hep/detail/ConditionsInterna.h
@@ -18,8 +18,8 @@
 // sufficient for all practical purposes.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_CONDITIONINTERNA_H
-#define DD4HEP_DDCORE_CONDITIONINTERNA_H
+#ifndef DD4HEP_DETAIL_CONDITIONSINTERNA_H
+#define DD4HEP_DETAIL_CONDITIONSINTERNA_H
 
 // Framework include files
 #include "DD4hep/DetElement.h"
@@ -118,4 +118,4 @@ namespace dd4hep {
 
   }       /* End namespace detail                   */
 }         /* End namespace dd4hep                   */
-#endif    /* DD4HEP_DDCORE_CONDITIONINTERNA_H       */
+#endif // DD4HEP_DETAIL_CONDITIONSINTERNA_H

--- a/DDCore/include/DD4hep/detail/ContainerHelpers.h
+++ b/DDCore/include/DD4hep/detail/ContainerHelpers.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DD4HEP_CONTAINERHELPERS_H
-#define DD4HEP_DD4HEP_CONTAINERHELPERS_H
+#ifndef DD4HEP_DETAIL_CONTAINERHELPERS_H
+#define DD4HEP_DETAIL_CONTAINERHELPERS_H
 
 // Framework include files
 #include "DD4hep/Primitives.h"
@@ -109,4 +109,4 @@ namespace dd4hep {
     c.emplace(de.path(),d);
   }
 }      // End namespace dd4hep
-#endif // DD4HEP_DD4HEP_CONTAINERHELPERS_H
+#endif // DD4HEP_DETAIL_CONTAINERHELPERS_H

--- a/DDCore/include/DD4hep/detail/DetectorInterna.h
+++ b/DDCore/include/DD4hep/detail/DetectorInterna.h
@@ -18,8 +18,8 @@
 // sufficient for all practical purposes.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_DETECTORINTERNA_H
-#define DD4HEP_DDCORE_DETECTORINTERNA_H
+#ifndef DD4HEP_DETAIL_DETECTORINTERNA_H
+#define DD4HEP_DETAIL_DETECTORINTERNA_H
 
 // Framework include files
 #include "DD4hep/Callback.h"
@@ -212,4 +212,4 @@ namespace dd4hep {
   }
 
 }         /* End namespace dd4hep                   */
-#endif    /* DD4HEP_DDCORE_DETECTORINTERNA_H      */
+#endif // DD4HEP_DETAIL_DETECTORINTERNA_H

--- a/DDCore/include/DD4hep/detail/Grammar_parsed.h
+++ b/DDCore/include/DD4hep/detail/Grammar_parsed.h
@@ -18,8 +18,8 @@
 // sufficient for all practical purposes.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_DETAIL_GRAMMAR_PARSED_H
-#define DD4HEP_DDCORE_DETAIL_GRAMMAR_PARSED_H
+#ifndef DD4HEP_DETAIL_GRAMMAR_PARSED_H
+#define DD4HEP_DETAIL_GRAMMAR_PARSED_H
 
 /// Framework include files
 #include "DD4hep/Grammar.h"
@@ -311,4 +311,4 @@ namespace dd4hep {
 #define DD4HEP_DEFINE_PARSER_GRAMMAR_CONT_VL(x,eval_func) DD4HEP_DEFINE_PARSER_GRAMMAR_CONT_VL_SERIAL(__LINE__,x,eval_func)
 #define DD4HEP_DEFINE_PARSER_GRAMMAR_DUMMY(x,func)        DD4HEP_DEFINE_PARSER_GRAMMAR_DUMMY_SERIAL(__LINE__,x,func)
 
-#endif  /* DD4HEP_DDCORE_DETAIL_GRAMMAR_PARSED_H */
+#endif // DD4HEP_DETAIL_GRAMMAR_PARSED_H

--- a/DDCore/include/DD4hep/detail/Grammar_unparsed.h
+++ b/DDCore/include/DD4hep/detail/Grammar_unparsed.h
@@ -18,8 +18,8 @@
 // sufficient for all practical purposes.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_DETAIL_GRAMMAR_UNPARSED_H
-#define DD4HEP_DDCORE_DETAIL_GRAMMAR_UNPARSED_H
+#ifndef DD4HEP_DETAIL_GRAMMAR_UNPARSED_H
+#define DD4HEP_DETAIL_GRAMMAR_UNPARSED_H
 
 // Framework include files
 #include "DD4hep/Grammar.h"
@@ -33,4 +33,4 @@ namespace dd4hep {
     return s_gr;
   }
 }
-#endif  /* DD4HEP_DDCORE_DETAIL_GRAMMAR_UNPARSED_H */
+#endif // DD4HEP_DETAIL_GRAMMAR_UNPARSED_H

--- a/DDCore/include/DD4hep/detail/ObjectsInterna.h
+++ b/DDCore/include/DD4hep/detail/ObjectsInterna.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_OBJECTSINTERNA_H
-#define DD4HEP_DDCORE_OBJECTSINTERNA_H
+#ifndef DD4HEP_DETAIL_OBJECTSINTERNA_H
+#define DD4HEP_DETAIL_OBJECTSINTERNA_H
 
 // Framework include files
 #include "DD4hep/Volumes.h"
@@ -232,4 +232,4 @@ namespace dd4hep {
 #endif
   };
 }      /* End namespace dd4hep            */
-#endif /* DD4HEP_DDCORE_OBJECTSINTERNA_H  */
+#endif // DD4HEP_DETAIL_OBJECTSINTERNA_H

--- a/DDCore/include/DD4hep/detail/OpticalSurfaceManagerInterna.h
+++ b/DDCore/include/DD4hep/detail/OpticalSurfaceManagerInterna.h
@@ -18,8 +18,8 @@
 // sufficient for all practical purposes.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_OPTICALSURFACEMANAGERINTERNA_H
-#define DD4HEP_DDCORE_OPTICALSURFACEMANAGERINTERNA_H
+#ifndef DD4HEP_DETAIL_OPTICALSURFACEMANAGERINTERNA_H
+#define DD4HEP_DETAIL_OPTICALSURFACEMANAGERINTERNA_H
 
 /// Framework include files
 #include "DD4hep/Detector.h"
@@ -71,4 +71,4 @@ namespace dd4hep {
 
   }       /* End namespace detail                          */
 }         /* End namespace dd4hep                          */
-#endif    /* DD4HEP_DDCORE_OPTICALSURFACEMANAGERINTERNA_H  */
+#endif // DD4HEP_DETAIL_OPTICALSURFACEMANAGERINTERNA_H

--- a/DDCore/include/DD4hep/detail/SegmentationsInterna.h
+++ b/DDCore/include/DD4hep/detail/SegmentationsInterna.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_SEGMENTATIONSINTERNA_H
-#define DD4HEP_DDCORE_SEGMENTATIONSINTERNA_H
+#ifndef DD4HEP_DETAIL_SEGMENTATIONSINTERNA_H
+#define DD4HEP_DETAIL_SEGMENTATIONSINTERNA_H
 
 // Framework include files
 #include "DD4hep/Handle.h"
@@ -122,4 +122,4 @@ namespace dd4hep {
   template <typename IMP> inline SegmentationWrapper<IMP>::~SegmentationWrapper()  {
   }
 }         /* End namespace dd4hep                       */
-#endif    /* DD4HEP_DDCORE_SEGMENTATIONSINTERNA_H     */
+#endif // DD4HEP_DETAIL_SEGMENTATIONSINTERNA_H

--- a/DDCore/include/DD4hep/detail/ShapesInterna.h
+++ b/DDCore/include/DD4hep/detail/ShapesInterna.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_SHAPESINTERNA_H
-#define DD4HEP_DDCORE_SHAPESINTERNA_H
+#ifndef DD4HEP_DETAIL_SHAPESINTERNA_H
+#define DD4HEP_DETAIL_SHAPESINTERNA_H
 
 // Framework include files
 #include "DD4hep/Shapes.h"
@@ -73,4 +73,4 @@ namespace dd4hep {
     ClassDefOverride(TwistedTubeObject,0);
   };
 }      /* End namespace dd4hep           */
-#endif /* DD4HEP_DDCORE_SHAPESINTERNA_H  */
+#endif // DD4HEP_DETAIL_SHAPESINTERNA_H

--- a/DDCore/include/DD4hep/detail/VolumeManagerInterna.h
+++ b/DDCore/include/DD4hep/detail/VolumeManagerInterna.h
@@ -18,8 +18,8 @@
 // sufficient for all practical purposes.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_VOLUMEMANAGERINTERNA_H
-#define DD4HEP_DDCORE_VOLUMEMANAGERINTERNA_H
+#ifndef DD4HEP_DETAIL_VOLUMEMANAGERINTERNA_H
+#define DD4HEP_DETAIL_VOLUMEMANAGERINTERNA_H
 
 // Framework include files
 #include "DD4hep/Volumes.h"
@@ -105,4 +105,4 @@ namespace dd4hep {
 
   }       /* End namespace detail                  */
 }         /* End namespace dd4hep                  */
-#endif    /* DD4HEP_DDCORE_VOLUMEMANAGERINTERNA_H  */
+#endif // DD4HEP_DETAIL_VOLUMEMANAGERINTERNA_H

--- a/DDCore/include/DDSegmentation/BitField64.h
+++ b/DDCore/include/DDSegmentation/BitField64.h
@@ -9,8 +9,8 @@
 //
 //==========================================================================
 
-#ifndef DDSegmentation_BitField64_H
-#define DDSegmentation_BitField64_H 1
+#ifndef DDSEGMENTATION_BITFIELD64_H
+#define DDSEGMENTATION_BITFIELD64_H 1
 
 #include <iostream>
 

--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -9,8 +9,8 @@
 //
 //==========================================================================
 
-#ifndef DDSegmentation_BitFieldCoder_H
-#define DDSegmentation_BitFieldCoder_H 1
+#ifndef DDSEGMENTATION_BITFIELDCODER_H
+#define DDSEGMENTATION_BITFIELDCODER_H 1
 
 
 #include <string>

--- a/DDCore/include/DDSegmentation/CartesianGrid.h
+++ b/DDCore/include/DDSegmentation/CartesianGrid.h
@@ -16,8 +16,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef DDSegmentation_CARTESIANGRID_H_
-#define DDSegmentation_CARTESIANGRID_H_
+#ifndef DDSEGMENTATION_CARTESIANGRID_H
+#define DDSEGMENTATION_CARTESIANGRID_H
 
 #include "DDSegmentation/Segmentation.h"
 
@@ -38,4 +38,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_CARTESIANGRID_H_ */
+#endif // DDSEGMENTATION_CARTESIANGRID_H

--- a/DDCore/include/DDSegmentation/CartesianGridXY.h
+++ b/DDCore/include/DDSegmentation/CartesianGridXY.h
@@ -19,8 +19,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef DDSegmentation_CARTESIANGRIDXY_H_
-#define DDSegmentation_CARTESIANGRIDXY_H_
+#ifndef DDSEGMENTATION_CARTESIANGRIDXY_H
+#define DDSEGMENTATION_CARTESIANGRIDXY_H
 
 #include "DDSegmentation/CartesianGrid.h"
 
@@ -117,4 +117,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_CARTESIANGRIDXY_H_ */
+#endif // DDSEGMENTATION_CARTESIANGRIDXY_H

--- a/DDCore/include/DDSegmentation/CartesianGridXYZ.h
+++ b/DDCore/include/DDSegmentation/CartesianGridXYZ.h
@@ -16,8 +16,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef DDSegmentation_CARTESIANGRIDXYZ_H_
-#define DDSegmentation_CARTESIANGRIDXYZ_H_
+#ifndef DDSEGMENTATION_CARTESIANGRIDXYZ_H
+#define DDSEGMENTATION_CARTESIANGRIDXYZ_H
 
 #include "DDSegmentation/CartesianGridXY.h"
 
@@ -85,4 +85,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_CARTESIANGRIDXYZ_H_ */
+#endif // DDSEGMENTATION_CARTESIANGRIDXYZ_H

--- a/DDCore/include/DDSegmentation/CartesianGridXZ.h
+++ b/DDCore/include/DDSegmentation/CartesianGridXZ.h
@@ -16,8 +16,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef DDSegmentation_CARTESIANGRIDXZ_H_
-#define DDSegmentation_CARTESIANGRIDXZ_H_
+#ifndef DDSEGMENTATION_CARTESIANGRIDXZ_H
+#define DDSEGMENTATION_CARTESIANGRIDXZ_H
 
 #include "DDSegmentation/CartesianGrid.h"
 
@@ -114,4 +114,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_CARTESIANGRIDXZ_H_ */
+#endif // DDSEGMENTATION_CARTESIANGRIDXZ_H

--- a/DDCore/include/DDSegmentation/CartesianGridYZ.h
+++ b/DDCore/include/DDSegmentation/CartesianGridYZ.h
@@ -8,8 +8,8 @@
 // For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 //
 //==========================================================================
-#ifndef DDSegmentation_CARTESIANGRIDYZ_H_
-#define DDSegmentation_CARTESIANGRIDYZ_H_
+#ifndef DDSEGMENTATION_CARTESIANGRIDYZ_H
+#define DDSEGMENTATION_CARTESIANGRIDYZ_H
 
 #include "DDSegmentation/CartesianGrid.h"
 
@@ -115,4 +115,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_CARTESIANGRIDXY_H_ */
+#endif // DDSEGMENTATION_CARTESIANGRIDYZ_H

--- a/DDCore/include/DDSegmentation/CartesianStrip.h
+++ b/DDCore/include/DDSegmentation/CartesianStrip.h
@@ -17,8 +17,8 @@
  *              David Blyth, ANL
  */
 
-#ifndef DDSegmentation_CARTESIANSTRIP_H_
-#define DDSegmentation_CARTESIANSTRIP_H_
+#ifndef DDSEGMENTATION_CARTESIANSTRIP_H
+#define DDSEGMENTATION_CARTESIANSTRIP_H
 
 #include "DDSegmentation/Segmentation.h"
 
@@ -39,4 +39,4 @@ namespace dd4hep {
     };
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif  // DDSegmentation_CARTESIANSTRIP_H_
+#endif // DDSEGMENTATION_CARTESIANSTRIP_H

--- a/DDCore/include/DDSegmentation/CartesianStripX.h
+++ b/DDCore/include/DDSegmentation/CartesianStripX.h
@@ -17,8 +17,8 @@
  *              David Blyth, ANL
  */
 
-#ifndef DDSegmentation_CARTESIANSTRIPX_H_
-#define DDSegmentation_CARTESIANSTRIPX_H_
+#ifndef DDSEGMENTATION_CARTESIANSTRIPX_H
+#define DDSEGMENTATION_CARTESIANSTRIPX_H
 
 #include "DDSegmentation/CartesianStrip.h"
 
@@ -72,4 +72,4 @@ class CartesianStripX : public DDSegmentation::CartesianStrip {
 };
 }  // namespace DDSegmentation
 } /* namespace dd4hep */
-#endif  // DDSegmentation_CARTESIANSTRIPX_H_
+#endif // DDSEGMENTATION_CARTESIANSTRIPX_H

--- a/DDCore/include/DDSegmentation/CartesianStripY.h
+++ b/DDCore/include/DDSegmentation/CartesianStripY.h
@@ -17,8 +17,8 @@
  *              David Blyth, ANL
  */
 
-#ifndef DDSegmentation_CARTESIANSTRIPY_H_
-#define DDSegmentation_CARTESIANSTRIPY_H_
+#ifndef DDSEGMENTATION_CARTESIANSTRIPY_H
+#define DDSEGMENTATION_CARTESIANSTRIPY_H
 
 #include "DDSegmentation/CartesianStrip.h"
 
@@ -72,4 +72,4 @@ namespace dd4hep {
     };
   }  // namespace DDSegmentation
 } /* namespace dd4hep */
-#endif  // DDSegmentation_CARTESIANSTRIPY_H_
+#endif // DDSEGMENTATION_CARTESIANSTRIPY_H

--- a/DDCore/include/DDSegmentation/CartesianStripZ.h
+++ b/DDCore/include/DDSegmentation/CartesianStripZ.h
@@ -17,8 +17,8 @@
  *              David Blyth, ANL
  */
 
-#ifndef DDSegmentation_CARTESIANSTRIPZ_H_
-#define DDSegmentation_CARTESIANSTRIPZ_H_
+#ifndef DDSEGMENTATION_CARTESIANSTRIPZ_H
+#define DDSEGMENTATION_CARTESIANSTRIPZ_H
 
 #include "DDSegmentation/CartesianStrip.h"
 
@@ -72,4 +72,4 @@ namespace dd4hep {
     };
   }  // namespace DDSegmentation
 } /* namespace dd4hep */
-#endif  // DDSegmentation_CARTESIANSTRIPZ_H_
+#endif // DDSEGMENTATION_CARTESIANSTRIPZ_H

--- a/DDCore/include/DDSegmentation/CylindricalSegmentation.h
+++ b/DDCore/include/DDSegmentation/CylindricalSegmentation.h
@@ -16,8 +16,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef DDSegmentation_CYLINDRICALSEGMENTATION_H_
-#define DDSegmentation_CYLINDRICALSEGMENTATION_H_
+#ifndef DDSEGMENTATION_CYLINDRICALSEGMENTATION_H
+#define DDSEGMENTATION_CYLINDRICALSEGMENTATION_H
 
 #include "DDSegmentation/Segmentation.h"
 
@@ -42,4 +42,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_CYLINDRICALSEGMENTATION_H_ */
+#endif // DDSEGMENTATION_CYLINDRICALSEGMENTATION_H

--- a/DDCore/include/DDSegmentation/GridPhiEta.h
+++ b/DDCore/include/DDSegmentation/GridPhiEta.h
@@ -9,8 +9,8 @@
 //
 //==========================================================================
 
-#ifndef DETSEGMENTATION_GRIDPHIETA_H
-#define DETSEGMENTATION_GRIDPHIETA_H
+#ifndef DDSEGMENTATION_GRIDPHIETA_H
+#define DDSEGMENTATION_GRIDPHIETA_H
 
 #include "DDSegmentation/Segmentation.h"
 
@@ -157,4 +157,4 @@ namespace dd4hep {
     };
   }
 }
-#endif /* DETSEGMENTATION_GRIDPHIETA_H */
+#endif // DDSEGMENTATION_GRIDPHIETA_H

--- a/DDCore/include/DDSegmentation/GridRPhiEta.h
+++ b/DDCore/include/DDSegmentation/GridRPhiEta.h
@@ -9,8 +9,8 @@
 //
 //==========================================================================
 
-#ifndef DETSEGMENTATION_GRIDRPHIETA_H
-#define DETSEGMENTATION_GRIDRPHIETA_H
+#ifndef DDSEGMENTATION_GRIDRPHIETA_H
+#define DDSEGMENTATION_GRIDRPHIETA_H
 
 // Framework includes
 #include "DDSegmentation/GridPhiEta.h"
@@ -105,4 +105,4 @@ namespace dd4hep {
     };
   }
 }
-#endif /* DETSEGMENTATION_GRIDRPHIETA_H */
+#endif // DDSEGMENTATION_GRIDRPHIETA_H

--- a/DDCore/include/DDSegmentation/MegatileLayerGridXY.h
+++ b/DDCore/include/DDSegmentation/MegatileLayerGridXY.h
@@ -16,8 +16,8 @@
  *      Author: S. Lu, DESY
  */
 
-#ifndef DDSegmentation_MEGATILELAYERGRIDXY_H_
-#define DDSegmentation_MEGATILELAYERGRIDXY_H_
+#ifndef DDSEGMENTATION_MEGATILELAYERGRIDXY_H
+#define DDSEGMENTATION_MEGATILELAYERGRIDXY_H
 
 #include "DDSegmentation/CartesianGrid.h"
 
@@ -170,4 +170,4 @@ namespace dd4hep {
 
   }    /* namespace DDSegmentation              */
 }      /* namespace dd4hep                      */
-#endif /* DDSegmentation_MEGATILELAYERGRIDXY_H_ */
+#endif // DDSEGMENTATION_MEGATILELAYERGRIDXY_H

--- a/DDCore/include/DDSegmentation/MultiSegmentation.h
+++ b/DDCore/include/DDSegmentation/MultiSegmentation.h
@@ -11,8 +11,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DDSegmentation_MULITSEGMENTATION_H_
-#define DDSegmentation_MULITSEGMENTATION_H_
+#ifndef DDSEGMENTATION_MULTISEGMENTATION_H
+#define DDSEGMENTATION_MULTISEGMENTATION_H
 
 #include "DDSegmentation/Segmentation.h"
 
@@ -96,4 +96,4 @@ namespace dd4hep {
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
 
-#endif /* DDSegmentation_MULITSEGMENTATION_H_ */
+#endif // DDSEGMENTATION_MULTISEGMENTATION_H

--- a/DDCore/include/DDSegmentation/NoSegmentation.h
+++ b/DDCore/include/DDSegmentation/NoSegmentation.h
@@ -16,8 +16,8 @@
  *      Author: Whitney Armstrong, ANL
  */
 
-#ifndef DDSegmentation_NoSegmentation_H_
-#define DDSegmentation_NoSegmentation_H_
+#ifndef DDSEGMENTATION_NOSEGMENTATION_H
+#define DDSEGMENTATION_NOSEGMENTATION_H
 
 #include "DDSegmentation/Segmentation.h"
 
@@ -41,4 +41,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_NoSegmentation */
+#endif // DDSEGMENTATION_NOSEGMENTATION_H

--- a/DDCore/include/DDSegmentation/PolarGrid.h
+++ b/DDCore/include/DDSegmentation/PolarGrid.h
@@ -16,8 +16,8 @@
  *      Author: Marko Petric
  */
 
-#ifndef DDSegmentation_POLARGRID_H_
-#define DDSegmentation_POLARGRID_H_
+#ifndef DDSEGMENTATION_POLARGRID_H
+#define DDSEGMENTATION_POLARGRID_H
 
 #include "DDSegmentation/Segmentation.h"
 
@@ -38,4 +38,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_POLARGRID_H_ */
+#endif // DDSEGMENTATION_POLARGRID_H

--- a/DDCore/include/DDSegmentation/PolarGridRPhi.h
+++ b/DDCore/include/DDSegmentation/PolarGridRPhi.h
@@ -16,8 +16,8 @@
  *      Author: Marko Petric
  */
 
-#ifndef DDSegmentation_POLARGRIDRPHI_H_
-#define DDSegmentation_POLARGRIDRPHI_H_
+#ifndef DDSEGMENTATION_POLARGRIDRPHI_H
+#define DDSEGMENTATION_POLARGRIDRPHI_H
 
 #include "DDSegmentation/PolarGrid.h"
 #include <math.h>
@@ -115,4 +115,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_POLARGRIDRPHI_H_ */
+#endif // DDSEGMENTATION_POLARGRIDRPHI_H

--- a/DDCore/include/DDSegmentation/PolarGridRPhi2.h
+++ b/DDCore/include/DDSegmentation/PolarGridRPhi2.h
@@ -16,8 +16,8 @@
  *      Author: Marko Petric
  */
 
-#ifndef DDSegmentation_PolarGridRPhi2_H_
-#define DDSegmentation_PolarGridRPhi2_H_
+#ifndef DDSEGMENTATION_POLARGRIDRPHI2_H
+#define DDSEGMENTATION_POLARGRIDRPHI2_H
 
 #include "DDSegmentation/PolarGrid.h"
 #include <cmath>
@@ -157,4 +157,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_PolarGridRPhi2_H_ */
+#endif // DDSEGMENTATION_POLARGRIDRPHI2_H

--- a/DDCore/include/DDSegmentation/ProjectiveCylinder.h
+++ b/DDCore/include/DDSegmentation/ProjectiveCylinder.h
@@ -16,8 +16,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef PROJECTIVECYLINDER_H_
-#define PROJECTIVECYLINDER_H_
+#ifndef DDSEGMENTATION_PROJECTIVECYLINDER_H
+#define DDSEGMENTATION_PROJECTIVECYLINDER_H
 
 #include "CylindricalSegmentation.h"
 
@@ -109,4 +109,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* PROJECTIVECYLINDER_H_ */
+#endif // DDSEGMENTATION_PROJECTIVECYLINDER_H

--- a/DDCore/include/DDSegmentation/Segmentation.h
+++ b/DDCore/include/DDSegmentation/Segmentation.h
@@ -16,8 +16,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef DDSegmentation_SEGMENTATION_H_
-#define DDSegmentation_SEGMENTATION_H_
+#ifndef DDSEGMENTATION_SEGMENTATION_H
+#define DDSEGMENTATION_SEGMENTATION_H
 
 #include "DDSegmentation/BitFieldCoder.h"
 #include "DDSegmentation/SegmentationFactory.h"
@@ -183,4 +183,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_SEGMENTATION_H_ */
+#endif // DDSEGMENTATION_SEGMENTATION_H

--- a/DDCore/include/DDSegmentation/SegmentationFactory.h
+++ b/DDCore/include/DDSegmentation/SegmentationFactory.h
@@ -18,8 +18,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef DDSegmentation_SEGMENTATIONFACTORY_H_
-#define DDSegmentation_SEGMENTATIONFACTORY_H_
+#ifndef DDSEGMENTATION_SEGMENTATIONFACTORY_H
+#define DDSEGMENTATION_SEGMENTATIONFACTORY_H
 
 #include "DDSegmentation/Segmentation.h"
 
@@ -85,4 +85,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_SEGMENTATIONFACTORY_H_ */
+#endif // DDSEGMENTATION_SEGMENTATIONFACTORY_H

--- a/DDCore/include/DDSegmentation/SegmentationParameter.h
+++ b/DDCore/include/DDSegmentation/SegmentationParameter.h
@@ -18,8 +18,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef DDSegmentation_SEGMENTATIONPARAMETER_H_
-#define DDSegmentation_SEGMENTATIONPARAMETER_H_
+#ifndef DDSEGMENTATION_SEGMENTATIONPARAMETER_H
+#define DDSEGMENTATION_SEGMENTATIONPARAMETER_H
 
 #include <sstream>
 #include <string>
@@ -311,4 +311,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_SEGMENTATIONPARAMETER_H_ */
+#endif // DDSEGMENTATION_SEGMENTATIONPARAMETER_H

--- a/DDCore/include/DDSegmentation/SegmentationUtil.h
+++ b/DDCore/include/DDSegmentation/SegmentationUtil.h
@@ -5,8 +5,8 @@
  *      Author: Christian Grefe, CERN
  */
 
-#ifndef DDSegmentation_SEGMENTATIONUTIL_H_
-#define DDSegmentation_SEGMENTATIONUTIL_H_
+#ifndef DDSEGMENTATION_SEGMENTATIONUTIL_H
+#define DDSEGMENTATION_SEGMENTATIONUTIL_H
 
 #include <cmath>
 #include <vector>
@@ -117,4 +117,4 @@ inline Vector3D positionFromREtaPhi(double ar, double aeta, double aphi) {
 } /* namespace DDSegmentation */
 } /* namespace dd4hep */
 
-#endif /* DDSegmentation_SEGMENTATIONUTIL_H_ */
+#endif // DDSEGMENTATION_SEGMENTATIONUTIL_H

--- a/DDCore/include/DDSegmentation/TiledLayerGridXY.h
+++ b/DDCore/include/DDSegmentation/TiledLayerGridXY.h
@@ -16,8 +16,8 @@
  *      Author: Shaojun Lu, DESY
  */
 
-#ifndef DDSegmentation_TILEDLAYERGRIDXY_H_
-#define DDSegmentation_TILEDLAYERGRIDXY_H_
+#ifndef DDSEGMENTATION_TILEDLAYERGRIDXY_H
+#define DDSEGMENTATION_TILEDLAYERGRIDXY_H
 
 #include "DDSegmentation/CartesianGrid.h"
 
@@ -170,4 +170,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_TILEDLAYERGRIDXY_H_ */
+#endif // DDSEGMENTATION_TILEDLAYERGRIDXY_H

--- a/DDCore/include/DDSegmentation/TiledLayerSegmentation.h
+++ b/DDCore/include/DDSegmentation/TiledLayerSegmentation.h
@@ -16,8 +16,8 @@
  *      Author: cgrefe
  */
 
-#ifndef DDSegmentation_TILEDLAYERSEGMENTATION_H_
-#define DDSegmentation_TILEDLAYERSEGMENTATION_H_
+#ifndef DDSEGMENTATION_TILEDLAYERSEGMENTATION_H
+#define DDSEGMENTATION_TILEDLAYERSEGMENTATION_H
 
 #include "DDSegmentation/Segmentation.h"
 
@@ -127,4 +127,4 @@ namespace dd4hep {
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
 
-#endif /* TILEDLAYERSEGMENTATION_H_ */
+#endif // DDSEGMENTATION_TILEDLAYERSEGMENTATION_H

--- a/DDCore/include/DDSegmentation/WaferGridXY.h
+++ b/DDCore/include/DDSegmentation/WaferGridXY.h
@@ -16,8 +16,8 @@
  *      Author: S. Lu, DESY
  */
 
-#ifndef DDSegmentation_WAFERGRIDXY_H_
-#define DDSegmentation_WAFERGRIDXY_H_
+#ifndef DDSEGMENTATION_WAFERGRIDXY_H
+#define DDSEGMENTATION_WAFERGRIDXY_H
 
 #include "DDSegmentation/CartesianGrid.h"
 
@@ -143,4 +143,4 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-#endif /* DDSegmentation_WAFERGRIDXY_H_ */
+#endif // DDSEGMENTATION_WAFERGRIDXY_H

--- a/DDCore/include/JSON/ChildValue.h
+++ b/DDCore/include/JSON/ChildValue.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_JSON_CHILDVALUE_H
-#define DD4HEP_JSON_CHILDVALUE_H
+#ifndef JSON_CHILDVALUE_H
+#define JSON_CHILDVALUE_H
 
 // Framework include files
 #include "JSON/Dimension.h"
@@ -21,4 +21,4 @@
 #undef  DD4HEP_DIMENSION_NS
 
 
-#endif    /* DD4HEP_JSON_CHILDVALUE_H   */
+#endif // JSON_CHILDVALUE_H

--- a/DDCore/include/JSON/Conversions.h
+++ b/DDCore/include/JSON/Conversions.h
@@ -10,11 +10,11 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_JSON_CONVERSIONS_H
-#define DD4HEP_JSON_CONVERSIONS_H
+#ifndef JSON_CONVERSIONS_H
+#define JSON_CONVERSIONS_H
 
 #define DD4HEP_CONVERSION_NS json
 #include "Parsers/detail/Conversions.h"
 #undef  DD4HEP_CONVERSION_NS
 
-#endif /* DD4HEP_JSON_CONVERSIONS_H  */
+#endif // JSON_CONVERSIONS_H

--- a/DDCore/include/JSON/Detector.h
+++ b/DDCore/include/JSON/Detector.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_JSON_DETECTOR_H
-#define DD4HEP_JSON_DETECTOR_H
+#ifndef JSON_DETECTOR_H
+#define JSON_DETECTOR_H
 
 // Framework include files
 #include "JSON/Dimension.h"
@@ -21,4 +21,4 @@
 #include "Parsers/detail/Detector.h"
 #undef DD4HEP_DIMENSION_NS
 
-#endif    /* DD4HEP_JSON_DETECTOR_H   */
+#endif // JSON_DETECTOR_H

--- a/DDCore/include/JSON/Dimension.h
+++ b/DDCore/include/JSON/Dimension.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_JSON_DIMENSION_H
-#define DD4HEP_JSON_DIMENSION_H
+#ifndef JSON_DIMENSION_H
+#define JSON_DIMENSION_H
 
 // Framework include files
 #include "JSON/Elements.h"
@@ -21,4 +21,4 @@
 #include "Parsers/detail/Dimension.h"
 #undef DD4HEP_DIMENSION_NS
 
-#endif    /* DD4HEP_JSON_DIMENSION_H   */
+#endif // JSON_DIMENSION_H

--- a/DDCore/include/JSON/DocumentHandler.h
+++ b/DDCore/include/JSON/DocumentHandler.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_JSON_DOCUMENTHANDLER_H
-#define DD4HEP_DDCORE_JSON_DOCUMENTHANDLER_H
+#ifndef JSON_DOCUMENTHANDLER_H
+#define JSON_DOCUMENTHANDLER_H
 
 /// Framework include files
 #include "JSON/Elements.h"
@@ -44,4 +44,4 @@ namespace dd4hep {
 
   }       /* End namespace json                    */
 }         /* End namespace dd4hep                  */
-#endif    /* DD4HEP_DDCORE_JSON_DOCUMENTHANDLER_H  */
+#endif // JSON_DOCUMENTHANDLER_H

--- a/DDCore/include/JSON/Elements.h
+++ b/DDCore/include/JSON/Elements.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DDCORE_DD4HEP_JSON_ELEMENTS_H
-#define DDCORE_DD4HEP_JSON_ELEMENTS_H
+#ifndef JSON_ELEMENTS_H
+#define JSON_ELEMENTS_H
 
 // C/C++ include files
 #include <cmath>
@@ -431,4 +431,4 @@ namespace dd4hep {
 
   }       /* End namespace json              */
 }         /* End namespace dd4hep            */
-#endif    /* DDCORE_DD4HEP_JSON_ELEMENTS_H   */
+#endif // JSON_ELEMENTS_H

--- a/DDCore/include/JSON/Evaluator.h
+++ b/DDCore/include/JSON/Evaluator.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_JSON_EVALUATOR_H
-#define DD4HEP_DDCORE_JSON_EVALUATOR_H
+#ifndef JSON_EVALUATOR_H
+#define JSON_EVALUATOR_H
 
 // Forwarding printout functionality to dd4hep
 /** Note: This is necessary to use the JSON functionality as a standalone 
@@ -21,4 +21,4 @@
  */
 #include "Evaluator/Evaluator.h"
 
-#endif   /* DD4HEP_DDCORE_JSON_EVALUATOR_H  */
+#endif // JSON_EVALUATOR_H

--- a/DDCore/include/JSON/Helper.h
+++ b/DDCore/include/JSON/Helper.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_JSON_HELPER_H
-#define DD4HEP_JSON_HELPER_H
+#ifndef JSON_HELPER_H
+#define JSON_HELPER_H
 
 // Framework include files
 #include "JSON/Detector.h"
@@ -52,4 +52,4 @@ namespace dd4hep {
   }
 }
 
-#endif // DD4HEP_JSON_HELPER_H
+#endif // JSON_HELPER_H

--- a/DDCore/include/JSON/Printout.h
+++ b/DDCore/include/JSON/Printout.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_JSON_PRINTOUT_H
-#define DD4HEP_JSON_PRINTOUT_H
+#ifndef JSON_PRINTOUT_H
+#define JSON_PRINTOUT_H
 
 // Forwarding printout functionality to dd4hep
 /** Note: This is necessary to use the JSON functionality as a standalone 
@@ -21,4 +21,4 @@
  */
 #include "Parsers/Printout.h"
 
-#endif   /* DD4HEP_JSON_PRINTOUT_H  */
+#endif // JSON_PRINTOUT_H

--- a/DDCore/include/JSON/Tags.h
+++ b/DDCore/include/JSON/Tags.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_JSON_TAGS_H
-#define DD4HEP_JSON_TAGS_H
+#ifndef JSON_TAGS_H
+#define JSON_TAGS_H
 
 #define DECLARE_UNICODE_TAG(x)  
 
@@ -23,4 +23,4 @@
 #define _U(a) #a
 #define _Unicode(a) #a
 
-#endif // DD4HEP_JSON_TAGS_H
+#endif // JSON_TAGS_H

--- a/DDCore/include/JSON/config.h
+++ b/DDCore/include/JSON/config.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_JSON_CONFIG_H
-#define DD4HEP_DDCORE_JSON_CONFIG_H
+#ifndef JSON_CONFIG_H
+#define JSON_CONFIG_H
 
 #include "Parsers/config.h"
 
@@ -33,4 +33,4 @@ namespace dd4hep {
 
   }       /* End namespace json              */
 }         /* End namespace dd4hep            */
-#endif    /* DD4HEP_DDCORE_JSON_CONFIG_H  */
+#endif // JSON_CONFIG_H

--- a/DDCore/include/Parsers/Exceptions.h
+++ b/DDCore/include/Parsers/Exceptions.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_PARSERS_EXCEPTIONS_H
-#define DD4HEP_PARSERS_EXCEPTIONS_H
+#ifndef PARSERS_EXCEPTIONS_H
+#define PARSERS_EXCEPTIONS_H
 
 // Framework include files
 #include "Parsers/config.h"
@@ -52,4 +52,4 @@ namespace dd4hep {
 
 }      // End namespace dd4hep
 
-#endif  /* DD4HEP_PARSERS_EXCEPTIONS_H */
+#endif // PARSERS_EXCEPTIONS_H

--- a/DDCore/include/Parsers/Primitives.h
+++ b/DDCore/include/Parsers/Primitives.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_PARSERS_PRIMITIVES_H
-#define DD4HEP_PARSERS_PRIMITIVES_H
+#ifndef PARSERS_PRIMITIVES_H
+#define PARSERS_PRIMITIVES_H
 
 // Framework include files
 #include "Parsers/config.h"
@@ -678,4 +678,4 @@ namespace dd4hep {
 
   }    // End namespace detail
 }      // End namespace dd4hep
-#endif // DD4HEP_PARSERS_PRIMITIVES_H
+#endif // PARSERS_PRIMITIVES_H

--- a/DDCore/include/Parsers/Printout.h
+++ b/DDCore/include/Parsers/Printout.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_PARSERS_PRINTOUT_H
-#define DD4HEP_PARSERS_PRINTOUT_H
+#ifndef PARSERS_PRINTOUT_H
+#define PARSERS_PRINTOUT_H
 
 // Framework include files
 #include "Parsers/config.h"
@@ -323,4 +323,4 @@ namespace dd4hep {
   }
 
 }         /* End namespace dd4hep              */
-#endif    /* DD4HEP_PARSERS_PRINTOUT_H         */
+#endif // PARSERS_PRINTOUT_H

--- a/DDCore/include/Parsers/detail/ChildValue.h
+++ b/DDCore/include/Parsers/detail/ChildValue.h
@@ -1,3 +1,6 @@
+#ifndef PARSERS_DETAIL_CHILDVALUE_H
+#define PARSERS_DETAIL_CHILDVALUE_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -375,3 +378,5 @@ namespace dd4hep {
 
   }       /* End namespace DD4HEP_DIMENSION_NS       */
 }         /* End namespace dd4hep                    */
+
+#endif

--- a/DDCore/include/Parsers/detail/Conversions.h
+++ b/DDCore/include/Parsers/detail/Conversions.h
@@ -1,3 +1,6 @@
+#ifndef PARSERS_DETAIL_CONVERSIONS_H
+#define PARSERS_DETAIL_CONVERSIONS_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -72,3 +75,5 @@ namespace dd4hep {
     template <typename TYPE> TYPE* _option() const {    return (TYPE*) optional;  }
   };
 } /* End namespace dd4hep           */
+
+#endif

--- a/DDCore/include/Parsers/detail/Detector.h
+++ b/DDCore/include/Parsers/detail/Detector.h
@@ -1,3 +1,6 @@
+#ifndef PARSERS_DETAIL_DETECTOR_H
+#define PARSERS_DETAIL_DETECTOR_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -103,3 +106,5 @@ namespace dd4hep {
 
   }       /* End namespace DD4HEP_DIMENSION_NS       */
 }         /* End namespace dd4hep                    */
+
+#endif

--- a/DDCore/include/Parsers/detail/Dimension.h
+++ b/DDCore/include/Parsers/detail/Dimension.h
@@ -1,3 +1,6 @@
+#ifndef PARSERS_DETAIL_DIMENSION_H
+#define PARSERS_DETAIL_DIMENSION_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -729,3 +732,5 @@ namespace dd4hep {
 
   }       /* End namespace DD4HEP_DIMENSION_NS        */
 }         /* End namespace dd4hep                     */
+
+#endif

--- a/DDCore/include/ROOT/LinkDef.h
+++ b/DDCore/include/ROOT/LinkDef.h
@@ -1,3 +1,6 @@
+#ifndef ROOT_LINKDEF_H
+#define ROOT_LINKDEF_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -37,5 +40,7 @@
 #pragma clang diagnostic ignored "-Wdeprecated"
 #pragma clang diagnostic ignored "-Wunused"
 #pragma clang diagnostic ignored "-Woverlength-strings"
+
+#endif
 
 #endif

--- a/DDCore/include/ROOT/Warnings.h
+++ b/DDCore/include/ROOT/Warnings.h
@@ -1,3 +1,6 @@
+#ifndef ROOT_WARNINGS_H
+#define ROOT_WARNINGS_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -36,3 +39,5 @@
 #define  DD4HEP_DICTIONARY_CODE 1
 #endif
 
+
+#endif

--- a/DDCore/include/XML/Conversions.h
+++ b/DDCore/include/XML/Conversions.h
@@ -10,11 +10,11 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_COMPACT_CONVERSION_H
-#define DD4HEP_COMPACT_CONVERSION_H
+#ifndef XML_CONVERSIONS_H
+#define XML_CONVERSIONS_H
 
 #define DD4HEP_CONVERSION_NS xml
 #include "Parsers/detail/Conversions.h"
 #undef  DD4HEP_CONVERSION_NS
 
-#endif    /* DD4HEP_COMPACT_CONVERSION_H    */
+#endif // XML_CONVERSIONS_H

--- a/DDCore/include/XML/DocumentHandler.h
+++ b/DDCore/include/XML/DocumentHandler.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_XML_DOCUMENTHANDLER_H
-#define DD4HEP_XML_DOCUMENTHANDLER_H
+#ifndef XML_DOCUMENTHANDLER_H
+#define XML_DOCUMENTHANDLER_H
 
 // Framework include files
 #include "XML/XMLElements.h"
@@ -79,4 +79,4 @@ namespace dd4hep {
     };
   }
 } /* End namespace dd4hep            */
-#endif    /* DD4HEP_XML_DOCUMENTHANDLER_H    */
+#endif // XML_DOCUMENTHANDLER_H

--- a/DDCore/include/XML/Evaluator.h
+++ b/DDCore/include/XML/Evaluator.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_JSON_EVALUATOR_H
-#define DD4HEP_DDCORE_JSON_EVALUATOR_H
+#ifndef XML_EVALUATOR_H
+#define XML_EVALUATOR_H
 
 // Forwarding printout functionality to dd4hep
 /** Note: This is necessary to use the JSON functionality as a standalone 
@@ -21,4 +21,4 @@
  */
 #include "Evaluator/Evaluator.h"
 
-#endif   /* DD4HEP_DDCORE_JSON_EVALUATOR_H  */
+#endif // XML_EVALUATOR_H

--- a/DDCore/include/XML/Helper.h
+++ b/DDCore/include/XML/Helper.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_XML_HELPER_H
-#define DD4HEP_XML_HELPER_H
+#ifndef XML_HELPER_H
+#define XML_HELPER_H
 
 // Framework include files
 #include "XML/XML.h"
@@ -47,4 +47,4 @@ namespace dd4hep {
   }
 }
 
-#endif // DD4HEP_XML_HELPER_H
+#endif // XML_HELPER_H

--- a/DDCore/include/XML/Layering.h
+++ b/DDCore/include/XML/Layering.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDCORE_LAYERING_H
-#define DD4HEP_DDCORE_LAYERING_H
+#ifndef XML_LAYERING_H
+#define XML_LAYERING_H
 
 // Framework include files
 #include "XML/XMLElements.h"
@@ -160,4 +160,4 @@ namespace dd4hep {
     }
   }
 }         /* End namespace dd4hep          */
-#endif    /* DD4HEP_DDCORE_LAYERING_H      */
+#endif // XML_LAYERING_H

--- a/DDCore/include/XML/Printout.h
+++ b/DDCore/include/XML/Printout.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_XML_PRINTOUT_H
-#define DD4HEP_XML_PRINTOUT_H
+#ifndef XML_PRINTOUT_H
+#define XML_PRINTOUT_H
 
 // Forwarding printout functionality to dd4hep
 /** Note: This is necessary to use the JSON functionality as a standalone 
@@ -21,4 +21,4 @@
  */
 #include "Parsers/Printout.h"
 
-#endif   /* DD4HEP_XML_PRINTOUT_H  */
+#endif // XML_PRINTOUT_H

--- a/DDCore/include/XML/UnicodeValues.h
+++ b/DDCore/include/XML/UnicodeValues.h
@@ -1,3 +1,6 @@
+#ifndef XML_UNICODEVALUES_H
+#define XML_UNICODEVALUES_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -610,3 +613,5 @@ UNICODE (zpos);
 UNICODE (zmax);
 UNICODE (zplane);
 UNICODE (zstart);
+
+#endif

--- a/DDCore/include/XML/UriReader.h
+++ b/DDCore/include/XML/UriReader.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_XML_URIREADER_H
-#define DD4HEP_XML_URIREADER_H
+#ifndef XML_URIREADER_H
+#define XML_URIREADER_H
 
 // C/C++ include files
 #include <string>
@@ -112,4 +112,4 @@ namespace dd4hep {
 
   }       /* End namespace xml               */
 }         /* End namespace dd4hep            */
-#endif    /* DD4HEP_XML_URIREADER_H          */
+#endif // XML_URIREADER_H

--- a/DDCore/include/XML/Utilities.h
+++ b/DDCore/include/XML/Utilities.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_XML_XMLUTILITIES_H
-#define DD4HEP_XML_XMLUTILITIES_H
+#ifndef XML_UTILITIES_H
+#define XML_UTILITIES_H
 
 // Framework include files
 #include "XML/Conversions.h"
@@ -86,4 +86,4 @@ namespace dd4hep {
     void setDetectorTypeFlag( dd4hep::xml::Handle_t e, dd4hep::DetElement sdet ) ; 
   }       /* End namespace xml              */
 }         /* End namespace dd4hep           */
-#endif    /* dd4hep_XML_XMLUTILITIES_H */
+#endif // XML_UTILITIES_H

--- a/DDCore/include/XML/VolumeBuilder.h
+++ b/DDCore/include/XML/VolumeBuilder.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_XML_VOLUMEBUILDER_H
-#define DD4HEP_XML_VOLUMEBUILDER_H
+#ifndef XML_VOLUMEBUILDER_H
+#define XML_VOLUMEBUILDER_H
 
 // Framework include files
 #include "XML/XMLElements.h"
@@ -216,4 +216,4 @@ namespace dd4hep {
     }     /* End namespace tools            */    
   }       /* End namespace xml              */
 }         /* End namespace dd4hep           */
-#endif    /* dd4hep_XML_VOLUMEBUILDER_H     */
+#endif // XML_VOLUMEBUILDER_H

--- a/DDCore/include/XML/XML.h
+++ b/DDCore/include/XML/XML.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDCORE_XML_XML_H
-#define DD4HEP_DDCORE_XML_XML_H
+#ifndef XML_XML_H
+#define XML_XML_H
 
 #include "XML/XMLTags.h"
 #include "XML/XMLDimension.h"
@@ -36,4 +36,4 @@ typedef dd4hep::xml::Document        xml_doc_t;
 typedef dd4hep::xml::DocumentHolder  xml_doc_holder_t;
 typedef dd4hep::xml::DocumentHandler xml_handler_t;
 
-#endif // DD4HEP_DDCORE_XML_XML_H
+#endif // XML_XML_H

--- a/DDCore/include/XML/XMLChildValue.h
+++ b/DDCore/include/XML/XMLChildValue.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_XML_XMLCHILDVALUE_H
-#define DD4HEP_XML_XMLCHILDVALUE_H
+#ifndef XML_XMLCHILDVALUE_H
+#define XML_XMLCHILDVALUE_H
 
 // Framework include files
 #include "XML/XMLTags.h"
@@ -21,4 +21,4 @@
 #include "Parsers/detail/ChildValue.h"
 #undef  DD4HEP_DIMENSION_NS
 
-#endif    /* DD4HEP_XML_XMLCHILDVALUE_H   */
+#endif // XML_XMLCHILDVALUE_H

--- a/DDCore/include/XML/XMLDetector.h
+++ b/DDCore/include/XML/XMLDetector.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_XMLDETECTOR_H
-#define DD4HEP_XMLDETECTOR_H
+#ifndef XML_XMLDETECTOR_H
+#define XML_XMLDETECTOR_H
 
 // Framework include files
 #include "XML/XMLDimension.h"
@@ -20,4 +20,4 @@
 #include "Parsers/detail/Detector.h"
 #undef  DD4HEP_DIMENSION_NS
 
-#endif    /* DD4HEP_XMLDETECTOR_H    */
+#endif // XML_XMLDETECTOR_H

--- a/DDCore/include/XML/XMLDimension.h
+++ b/DDCore/include/XML/XMLDimension.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_XML_XMLDIMENSION_H
-#define DD4HEP_XML_XMLDIMENSION_H
+#ifndef XML_XMLDIMENSION_H
+#define XML_XMLDIMENSION_H
 
 // Framework include files
 #include "XML/XMLElements.h"
@@ -21,4 +21,4 @@
 #include "Parsers/detail/Dimension.h"
 #undef  DD4HEP_DIMENSION_NS
 
-#endif    /* DD4HEP_XML_XMLDIMENSION_H   */
+#endif // XML_XMLDIMENSION_H

--- a/DDCore/include/XML/XMLElements.h
+++ b/DDCore/include/XML/XMLElements.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_XMLELEMENTS_H
-#define DD4HEP_XMLELEMENTS_H
+#ifndef XML_XMLELEMENTS_H
+#define XML_XMLELEMENTS_H
 
 // C/C++ include files
 #include <cmath>
@@ -976,4 +976,4 @@ namespace dd4hep {
 
   }
 } /* End namespace dd4hep   */
-#endif    /* DD4HEP_XMLELEMENTS_H   */
+#endif // XML_XMLELEMENTS_H

--- a/DDCore/include/XML/XMLParsers.h
+++ b/DDCore/include/XML/XMLParsers.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DDCORE_XML_XMLPARSERS_H
-#define DDCORE_XML_XMLPARSERS_H
+#ifndef XML_XMLPARSERS_H
+#define XML_XMLPARSERS_H
 
 // Framework include files
 #include "DD4hep/AlignmentData.h"
@@ -126,4 +126,4 @@ namespace dd4hep {
     
   }    /*   End namespace xml            */
 }      /*   End namespace dd4hep         */
-#endif /*   End DDCORE_XML_XMLPARSERS_H  */
+#endif // XML_XMLPARSERS_H

--- a/DDCore/include/XML/XMLTags.h
+++ b/DDCore/include/XML/XMLTags.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_XML_TAGS_H
-#define DD4HEP_XML_TAGS_H
+#ifndef XML_XMLTAGS_H
+#define XML_XMLTAGS_H
 
 #define DECLARE_UNICODE_TAG(x)  namespace dd4hep { namespace xml { extern const Tag_t Unicode_##x (#x); }}
 
@@ -36,4 +36,4 @@ namespace dd4hep {
 #define _U(a)              ::dd4hep::xml::Unicode_##a
 #define _Unicode(a)        ::dd4hep::xml::Strng_t(#a)
 
-#endif // DD4HEP_XML_TAGS_H
+#endif // XML_XMLTAGS_H

--- a/DDCore/include/XML/config.h
+++ b/DDCore/include/XML/config.h
@@ -14,8 +14,8 @@
 // Setup XML parsing for the use of Apache Xerces-C and TiXml
 //
 //==========================================================================
-#ifndef DD4HEP_XML_CONFIG_H
-#define DD4HEP_XML_CONFIG_H
+#ifndef XML_CONFIG_H
+#define XML_CONFIG_H
 
 #include "Parsers/config.h"
 
@@ -63,4 +63,4 @@ namespace dd4hep {
 #else   // Xerces-C
 #define XML_IMPLEMENTATION_TYPE " Apache Xerces-C DOM Parser"
 #endif  // __TIXML__
-#endif  // DD4HEP_XML_CONFIG_H
+#endif // XML_CONFIG_H

--- a/DDCore/include/XML/tinystr.h
+++ b/DDCore/include/XML/tinystr.h
@@ -1,3 +1,6 @@
+#ifndef XML_TINYSTR_H
+#define XML_TINYSTR_H
+
 /*
   www.sourceforge.net/projects/tinyxml
   Original file by Yves Berquin.
@@ -64,8 +67,7 @@
   The buffer allocation is made by a simplistic power of 2 like mechanism : if we increase
   a string and there's no more room, we allocate a buffer twice as big as we need.
 */
-class TiXmlString
-{
+class TiXmlString{
 public :
   // The size type used
   typedef size_t size_type;
@@ -317,3 +319,5 @@ public :
 
 #endif  // TIXML_STRING_INCLUDED
 #endif  // TIXML_USE_STL
+
+#endif

--- a/DDCore/include/XML/tinyxml.h
+++ b/DDCore/include/XML/tinyxml.h
@@ -1,3 +1,6 @@
+#ifndef XML_TINYXML_H
+#define XML_TINYXML_H
+
 /*
   www.sourceforge.net/projects/tinyxml
   Original code (2.0 and earlier )copyright (c) 2000-2006 Lee Thomason (www.grinninglizard.com)
@@ -2021,3 +2024,5 @@ private:
 
 #endif
 
+
+#endif

--- a/DDCore/src/GeoDictionary.h
+++ b/DDCore/src/GeoDictionary.h
@@ -13,8 +13,8 @@
 //  M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_GEODICTIONARY_H
-#define DD4HEP_DDCORE_GEODICTIONARY_H
+#ifndef DDCORE_SRC_GEODICTIONARY_H
+#define DDCORE_SRC_GEODICTIONARY_H
 
 // Framework include files
 #include "DD4hep/Volumes.h"
@@ -138,4 +138,4 @@ template vector<pair<string, int> >::iterator;
 #pragma link C++ class dd4hep::TwistedTubeObject+;
 
 #endif  // __CINT__
-#endif  /* DD4HEP_DDCORE_GEODICTIONARY_H  */
+#endif // DDCORE_SRC_GEODICTIONARY_H

--- a/DDCore/src/GeometryTreeDump.h
+++ b/DDCore/src/GeometryTreeDump.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDCORE_CORETREEDUMP_H
-#define DD4HEP_DDCORE_CORETREEDUMP_H
+#ifndef DDCORE_SRC_GEOMETRYTREEDUMP_H
+#define DDCORE_SRC_GEOMETRYTREEDUMP_H
 
 #include "DD4hep/Detector.h"
 #include "DD4hep/GeoHandler.h"
@@ -62,4 +62,4 @@ namespace dd4hep {
     };
   }    // End namespace detail
 }      // End namespace dd4hep
-#endif /* DD4HEP_DDCORE_GEOMETRYTREEDUMP_H  */
+#endif // DDCORE_SRC_GEOMETRYTREEDUMP_H

--- a/DDCore/src/PropertyDictionary.h
+++ b/DDCore/src/PropertyDictionary.h
@@ -13,8 +13,8 @@
 // M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_PROPERTYDICTIONARY_H
-#define DD4HEP_DDCORE_PROPERTYDICTIONARY_H
+#ifndef DDCORE_SRC_PROPERTYDICTIONARY_H
+#define DDCORE_SRC_PROPERTYDICTIONARY_H
 
 // Framework include files
 #include "DD4hep/ComponentProperties.h"
@@ -153,4 +153,4 @@ template class std::map<std::string, dd4hep::Property>;
 #pragma link C++ class dd4hep::PropertyGrammar-;
 
 #endif  // __CINT__
-#endif  /* DD4HEP_DDCORE_PROPERTYDICTIONARY_H  */
+#endif // DDCORE_SRC_PROPERTYDICTIONARY_H

--- a/DDCore/src/RootDictionary.h
+++ b/DDCore/src/RootDictionary.h
@@ -13,8 +13,8 @@
 //  M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_ROOTDICTIONARY_H
-#define DD4HEP_DDCORE_ROOTDICTIONARY_H
+#ifndef DDCORE_SRC_ROOTDICTIONARY_H
+#define DDCORE_SRC_ROOTDICTIONARY_H
 
 // Framework include files
 #include "Evaluator/Evaluator.h"
@@ -344,4 +344,4 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::cond::AbstractMap::Params+;
 
 #endif  // __CINT__
-#endif  /* DD4HEP_DDCORE_ROOTDICTIONARY_H  */
+#endif // DDCORE_SRC_ROOTDICTIONARY_H

--- a/DDCore/src/SegmentationDictionary.h
+++ b/DDCore/src/SegmentationDictionary.h
@@ -13,8 +13,8 @@
 //  M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_SEGMENTATIONDICTIONARY_H
-#define DD4HEP_DDCORE_SEGMENTATIONDICTIONARY_H
+#ifndef DDCORE_SRC_SEGMENTATIONDICTIONARY_H
+#define DDCORE_SRC_SEGMENTATIONDICTIONARY_H
 
 // Framework include files
 #define __HAVE_DDSEGMENTATION__
@@ -96,4 +96,4 @@ typedef dd4hep::DDSegmentation::CellID CellID;
 #endif  // __CINT__
 #endif  // __HAVE_DDSEGMENTATION__
 
-#endif  /* DD4HEP_DDCORE_SEGMENTATIONDICTIONARY_H  */
+#endif // DDCORE_SRC_SEGMENTATIONDICTIONARY_H

--- a/DDCore/src/XML/tinyxml_inl.h
+++ b/DDCore/src/XML/tinyxml_inl.h
@@ -1,3 +1,6 @@
+#ifndef DDCORE_SRC_XML_TINYXML_INL_H
+#define DDCORE_SRC_XML_TINYXML_INL_H
+
 /*
   www.sourceforge.net/projects/tinyxml
   Original code (2.0 and earlier )copyright (c) 2000-2006 Lee Thomason (www.grinninglizard.com)
@@ -1904,3 +1907,5 @@ bool TiXmlPrinter::Visit( const TiXmlUnknown& unknown )
   return true;
 }
 
+
+#endif

--- a/DDCore/src/XML/tinyxmlerror_inl.h
+++ b/DDCore/src/XML/tinyxmlerror_inl.h
@@ -1,3 +1,6 @@
+#ifndef DDCORE_SRC_XML_TINYXMLERROR_INL_H
+#define DDCORE_SRC_XML_TINYXMLERROR_INL_H
+
 /*
   www.sourceforge.net/projects/tinyxml
   Original code (2.0 and earlier )copyright (c) 2000-2006 Lee Thomason (www.grinninglizard.com)
@@ -55,3 +58,5 @@ const char* TiXmlBase::errorString[ TIXML_ERROR_STRING_COUNT ] =
     "Error parsing CDATA.",
     "Error when TiXmlDocument added to document, because TiXmlDocument can only be at the root.",
   };
+
+#endif

--- a/DDCore/src/XML/tinyxmlparser_inl.h
+++ b/DDCore/src/XML/tinyxmlparser_inl.h
@@ -1,3 +1,6 @@
+#ifndef DDCORE_SRC_XML_TINYXMLPARSER_INL_H
+#define DDCORE_SRC_XML_TINYXMLPARSER_INL_H
+
 /*
   www.sourceforge.net/projects/tinyxml
   Original code (2.0 and earlier )copyright (c) 2000-2002 Lee Thomason (www.grinninglizard.com)
@@ -1630,3 +1633,5 @@ bool TiXmlText::Blank() const
   return true;
 }
 
+
+#endif

--- a/DDCore/src/plugins/LCDDConverter.h
+++ b/DDCore/src/plugins/LCDDConverter.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDCORE_DetectorCONVERTER_H
-#define DD4HEP_DDCORE_DetectorCONVERTER_H
+#ifndef DDCORE_SRC_PLUGINS_LCDDCONVERTER_H
+#define DDCORE_SRC_PLUGINS_LCDDCONVERTER_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -199,4 +199,4 @@ namespace dd4hep {
     };
   }    // End namespace xml
 }      // End namespace dd4hep
-#endif /* DD4HEP_DDCORE_DetectorCONVERTER_H   */
+#endif // DDCORE_SRC_PLUGINS_LCDDCONVERTER_H

--- a/DDDetectors/include/DDDetectors/OtherDetectorHelpers.h
+++ b/DDDetectors/include/DDDetectors/OtherDetectorHelpers.h
@@ -8,8 +8,8 @@
 // For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 //
 //==========================================================================
-#ifndef Other_Helpers_hh
-#define Other_Helpers_hh 1
+#ifndef DDDETECTORS_OTHERDETECTORHELPERS_H
+#define DDDETECTORS_OTHERDETECTORHELPERS_H 1
 
 #include "DD4hep/Printout.h"
 
@@ -111,4 +111,4 @@ namespace ODH {//OtherDetectorHelpers
 
 }//namespace
 
-#endif // Other_Helpers_hh
+#endif // DDDETECTORS_OTHERDETECTORHELPERS_H

--- a/DDDigi/include/DDDigi/DigiAction.h
+++ b/DDDigi/include/DDDigi/DigiAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIACTION_H
-#define DD4HEP_DDDIGI_DIGIACTION_H
+#ifndef DDDIGI_DIGIACTION_H
+#define DDDIGI_DIGIACTION_H
 
 // Framework include files
 #include "DD4hep/Printout.h"
@@ -315,4 +315,4 @@ namespace dd4hep {
   }    // End namespace digi
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDDIGI_DIGIACTION_H
+#endif // DDDIGI_DIGIACTION_H

--- a/DDDigi/include/DDDigi/DigiActionSequence.h
+++ b/DDDigi/include/DDDigi/DigiActionSequence.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIACTIONSEQUENCE_H
-#define DD4HEP_DDDIGI_DIGIACTIONSEQUENCE_H
+#ifndef DDDIGI_DIGIACTIONSEQUENCE_H
+#define DDDIGI_DIGIACTIONSEQUENCE_H
 
 // Framework include files
 #include "DDDigi/DigiSynchronize.h"
@@ -74,4 +74,4 @@ namespace dd4hep {
 
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIACTIONSEQUENCE_H
+#endif // DDDIGI_DIGIACTIONSEQUENCE_H

--- a/DDDigi/include/DDDigi/DigiAttenuator.h
+++ b/DDDigi/include/DDDigi/DigiAttenuator.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIATTENUATOR_H
-#define DD4HEP_DDDIGI_DIGIATTENUATOR_H
+#ifndef DDDIGI_DIGIATTENUATOR_H
+#define DDDIGI_DIGIATTENUATOR_H
 
 /// Framework include files
 #include "DDDigi/DigiSignalProcessor.h"
@@ -51,4 +51,4 @@ namespace dd4hep {
 
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIATTENUATOR_H
+#endif // DDDIGI_DIGIATTENUATOR_H

--- a/DDDigi/include/DDDigi/DigiContext.h
+++ b/DDDigi/include/DDDigi/DigiContext.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGICONTEXT_H
-#define DD4HEP_DDDIGI_DIGICONTEXT_H
+#ifndef DDDIGI_DIGICONTEXT_H
+#define DDDIGI_DIGICONTEXT_H
 
 // Framework incloude files
 #include "DD4hep/Primitives.h"
@@ -129,4 +129,4 @@ namespace dd4hep {
   }    // End namespace digi
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDDIGI_DIGICONTEXT_H
+#endif // DDDIGI_DIGICONTEXT_H

--- a/DDDigi/include/DDDigi/DigiData.h
+++ b/DDDigi/include/DDDigi/DigiData.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIDATA_H
-#define DD4HEP_DDDIGI_DIGIDATA_H
+#ifndef DDDIGI_DIGIDATA_H
+#define DDDIGI_DIGIDATA_H
 
 /// Framework include files
 #include "DD4hep/Any.h"
@@ -336,4 +336,4 @@ namespace dd4hep {
   }    // End namespace digi
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDDIGI_DIGIDATA_H
+#endif // DDDIGI_DIGIDATA_H

--- a/DDDigi/include/DDDigi/DigiEventAction.h
+++ b/DDDigi/include/DDDigi/DigiEventAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIEVENTACTION_H
-#define DD4HEP_DDDIGI_DIGIEVENTACTION_H
+#ifndef DDDIGI_DIGIEVENTACTION_H
+#define DDDIGI_DIGIEVENTACTION_H
 
 // Framework include files
 #include "DDDigi/DigiAction.h"
@@ -60,4 +60,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIEVENTACTION_H
+#endif // DDDIGI_DIGIEVENTACTION_H

--- a/DDDigi/include/DDDigi/DigiExponentialNoise.h
+++ b/DDDigi/include/DDDigi/DigiExponentialNoise.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIEXPONENTIALNOISE_H
-#define DD4HEP_DDDIGI_DIGIEXPONENTIALNOISE_H
+#ifndef DDDIGI_DIGIEXPONENTIALNOISE_H
+#define DDDIGI_DIGIEXPONENTIALNOISE_H
 
 /// Framework include files
 #include "DDDigi/DigiSignalProcessor.h"
@@ -47,4 +47,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIEXPONENTIALNOISE_H
+#endif // DDDIGI_DIGIEXPONENTIALNOISE_H

--- a/DDDigi/include/DDDigi/DigiFactories.h
+++ b/DDDigi/include/DDDigi/DigiFactories.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DDG4_DIGI_DIGIFACTORIES_H
-#define DDG4_DIGI_DIGIFACTORIES_H
+#ifndef DDDIGI_DIGIFACTORIES_H
+#define DDDIGI_DIGIFACTORIES_H
 
 // Framework include files
 #include "DD4hep/Plugins.h"
@@ -75,4 +75,4 @@ typedef name_space :: CellScanner<dd4hep:: seg , dd4hep:: sol > Scanner_##typ##_
 /// Plugin defintion to create DigiCellscanner objects
 #define DECLARE_DIGICELLSCANNER(typ,seg,sol) DECLARE_DIGICELLSCANNER_NS(dd4hep::digi,typ,seg,sol)
 
-#endif // DDG4_DIGI_DIGIFACTORIES_H
+#endif // DDDIGI_DIGIFACTORIES_H

--- a/DDDigi/include/DDDigi/DigiGaussianNoise.h
+++ b/DDDigi/include/DDDigi/DigiGaussianNoise.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIGAUSSIANNOISE_H
-#define DD4HEP_DDDIGI_DIGIGAUSSIANNOISE_H
+#ifndef DDDIGI_DIGIGAUSSIANNOISE_H
+#define DDDIGI_DIGIGAUSSIANNOISE_H
 
 /// Framework include files
 #include "DDDigi/DigiSignalProcessor.h"
@@ -54,4 +54,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIGAUSSIANNOISE_H
+#endif // DDDIGI_DIGIGAUSSIANNOISE_H

--- a/DDDigi/include/DDDigi/DigiHandle.h
+++ b/DDDigi/include/DDDigi/DigiHandle.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIHANDLE_H
-#define DD4HEP_DDDIGI_DIGIHANDLE_H
+#ifndef DDDIGI_DIGIHANDLE_H
+#define DDDIGI_DIGIHANDLE_H
 
 // Framework include files
 #include "DD4hep/ComponentProperties.h"
@@ -119,4 +119,4 @@ namespace dd4hep {
   }    // End namespace digi
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDDIGI_DIGIHANDLE_H
+#endif // DDDIGI_DIGIHANDLE_H

--- a/DDDigi/include/DDDigi/DigiInputAction.h
+++ b/DDDigi/include/DDDigi/DigiInputAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIINPUTACTION_H
-#define DD4HEP_DDDIGI_DIGIINPUTACTION_H
+#ifndef DDDIGI_DIGIINPUTACTION_H
+#define DDDIGI_DIGIINPUTACTION_H
 
 /// Framework include files
 #include "DDDigi/DigiEventAction.h"
@@ -52,4 +52,4 @@ namespace dd4hep {
 
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIINPUTACTION_H
+#endif // DDDIGI_DIGIINPUTACTION_H

--- a/DDDigi/include/DDDigi/DigiKernel.h
+++ b/DDDigi/include/DDDigi/DigiKernel.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIKERNEL_H
-#define DD4HEP_DDDIGI_DIGIKERNEL_H
+#ifndef DDDIGI_DIGIKERNEL_H
+#define DDDIGI_DIGIKERNEL_H
 
 // Framework include files
 #include "DDDigi/DigiEventAction.h"
@@ -151,4 +151,4 @@ namespace dd4hep {
     }
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIKERNEL_H
+#endif // DDDIGI_DIGIKERNEL_H

--- a/DDDigi/include/DDDigi/DigiLandauNoise.h
+++ b/DDDigi/include/DDDigi/DigiLandauNoise.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGILANDAUNOISE_H
-#define DD4HEP_DDDIGI_DIGILANDAUNOISE_H
+#ifndef DDDIGI_DIGILANDAUNOISE_H
+#define DDDIGI_DIGILANDAUNOISE_H
 
 /// Framework include files
 #include "DDDigi/DigiSignalProcessor.h"
@@ -54,4 +54,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGILANDAUNOISE_H
+#endif // DDDIGI_DIGILANDAUNOISE_H

--- a/DDDigi/include/DDDigi/DigiLockedAction.h
+++ b/DDDigi/include/DDDigi/DigiLockedAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGILOCKEDACTION_H
-#define DD4HEP_DDDIGI_DIGILOCKEDACTION_H
+#ifndef DDDIGI_DIGILOCKEDACTION_H
+#define DDDIGI_DIGILOCKEDACTION_H
 
 /// Framework include files
 #include "DDDigi/DigiEventAction.h"
@@ -60,4 +60,4 @@ namespace dd4hep {
 
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGILOCKEDACTION_H
+#endif // DDDIGI_DIGILOCKEDACTION_H

--- a/DDDigi/include/DDDigi/DigiPoissonNoise.h
+++ b/DDDigi/include/DDDigi/DigiPoissonNoise.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIPOISSONNOISE_H
-#define DD4HEP_DDDIGI_DIGIPOISSONNOISE_H
+#ifndef DDDIGI_DIGIPOISSONNOISE_H
+#define DDDIGI_DIGIPOISSONNOISE_H
 
 /// Framework include files
 #include "DDDigi/DigiSignalProcessor.h"
@@ -52,4 +52,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIPOISSONNOISE_H
+#endif // DDDIGI_DIGIPOISSONNOISE_H

--- a/DDDigi/include/DDDigi/DigiRandomEngine.h
+++ b/DDDigi/include/DDDigi/DigiRandomEngine.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIRANDOMENGINE_H
-#define DD4HEP_DDDIGI_DIGIRANDOMENGINE_H
+#ifndef DDDIGI_DIGIRANDOMENGINE_H
+#define DDDIGI_DIGIRANDOMENGINE_H
 #if 0
 /// Framework include files
 
@@ -61,4 +61,4 @@ namespace dd4hep {
   }    // End namespace digi
 }      // End namespace dd4hep
 #endif
-#endif // DD4HEP_DDDIGI_DIGIRANDOMENGINE_H
+#endif // DDDIGI_DIGIRANDOMENGINE_H

--- a/DDDigi/include/DDDigi/DigiRandomGenerator.h
+++ b/DDDigi/include/DDDigi/DigiRandomGenerator.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIRANDOMGENERATOR_H
-#define DD4HEP_DDDIGI_DIGIRANDOMGENERATOR_H
+#ifndef DDDIGI_DIGIRANDOMGENERATOR_H
+#define DDDIGI_DIGIRANDOMGENERATOR_H
 
 /// Framework include files
 
@@ -74,4 +74,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIRANDOMGENERATOR_H
+#endif // DDDIGI_DIGIRANDOMGENERATOR_H

--- a/DDDigi/include/DDDigi/DigiRandomNoise.h
+++ b/DDDigi/include/DDDigi/DigiRandomNoise.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIRANDOMNOISE_H
-#define DD4HEP_DDDIGI_DIGIRANDOMNOISE_H
+#ifndef DDDIGI_DIGIRANDOMNOISE_H
+#define DDDIGI_DIGIRANDOMNOISE_H
 
 /// Framework include files
 #include "DDDigi/DigiSignalProcessor.h"
@@ -68,4 +68,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIRANDOMNOISE_H
+#endif // DDDIGI_DIGIRANDOMNOISE_H

--- a/DDDigi/include/DDDigi/DigiSegmentation.h
+++ b/DDDigi/include/DDDigi/DigiSegmentation.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGISEGMENTATION_H
-#define DD4HEP_DDDIGI_DIGISEGMENTATION_H
+#ifndef DDDIGI_DIGISEGMENTATION_H
+#define DDDIGI_DIGISEGMENTATION_H
 
 /// Framework include files
 #include <DD4hep/Segmentations.h>
@@ -85,4 +85,4 @@ namespace dd4hep {
 
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGISEGMENTATION_H
+#endif // DDDIGI_DIGISEGMENTATION_H

--- a/DDDigi/include/DDDigi/DigiSignalProcessor.h
+++ b/DDDigi/include/DDDigi/DigiSignalProcessor.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGISIGNALPROCESSOR_H
-#define DD4HEP_DDDIGI_DIGISIGNALPROCESSOR_H
+#ifndef DDDIGI_DIGISIGNALPROCESSOR_H
+#define DDDIGI_DIGISIGNALPROCESSOR_H
 
 /// Framework include files
 #include "DDDigi/DigiAction.h"
@@ -71,4 +71,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGISIGNALPROCESSOR_H
+#endif // DDDIGI_DIGISIGNALPROCESSOR_H

--- a/DDDigi/include/DDDigi/DigiSignalProcessorSequence.h
+++ b/DDDigi/include/DDDigi/DigiSignalProcessorSequence.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGISIGNALPROCESSORSEQUENCE_H
-#define DD4HEP_DDDIGI_DIGISIGNALPROCESSORSEQUENCE_H
+#ifndef DDDIGI_DIGISIGNALPROCESSORSEQUENCE_H
+#define DDDIGI_DIGISIGNALPROCESSORSEQUENCE_H
 
 // Framework include files
 #include "DDDigi/DigiSignalProcessor.h"
@@ -62,4 +62,4 @@ namespace dd4hep {
 
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGISIGNALPROCESSORSEQUENCE_H
+#endif // DDDIGI_DIGISIGNALPROCESSORSEQUENCE_H

--- a/DDDigi/include/DDDigi/DigiSubdetectorSequence.h
+++ b/DDDigi/include/DDDigi/DigiSubdetectorSequence.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGISUBDETECTORSEQUENCE_H
-#define DD4HEP_DDDIGI_DIGISUBDETECTORSEQUENCE_H
+#ifndef DDDIGI_DIGISUBDETECTORSEQUENCE_H
+#define DDDIGI_DIGISUBDETECTORSEQUENCE_H
 
 // Framework include files
 #include <DDDigi/DigiActionSequence.h>
@@ -110,4 +110,4 @@ namespace dd4hep {
 
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGISUBDETECTORSEQUENCE_H
+#endif // DDDIGI_DIGISUBDETECTORSEQUENCE_H

--- a/DDDigi/include/DDDigi/DigiSynchronize.h
+++ b/DDDigi/include/DDDigi/DigiSynchronize.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGISYNCHRONIZE_H
-#define DD4HEP_DDDIGI_DIGISYNCHRONIZE_H
+#ifndef DDDIGI_DIGISYNCHRONIZE_H
+#define DDDIGI_DIGISYNCHRONIZE_H
 
 // Framework incloude files
 #include "DDDigi/DigiEventAction.h"
@@ -62,4 +62,4 @@ namespace dd4hep {
   }    // End namespace digi
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDDIGI_DIGISYNCHRONIZE_H
+#endif // DDDIGI_DIGISYNCHRONIZE_H

--- a/DDDigi/include/DDDigi/DigiUniformNoise.h
+++ b/DDDigi/include/DDDigi/DigiUniformNoise.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_DIGIUNIFORMNOISE_H
-#define DD4HEP_DDDIGI_DIGIUNIFORMNOISE_H
+#ifndef DDDIGI_DIGIUNIFORMNOISE_H
+#define DDDIGI_DIGIUNIFORMNOISE_H
 
 /// Framework include files
 #include "DDDigi/DigiSignalProcessor.h"
@@ -49,4 +49,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_DIGIUNIFORMNOISE_H
+#endif // DDDIGI_DIGIUNIFORMNOISE_H

--- a/DDDigi/include/DDDigi/FalphaNoise.h
+++ b/DDDigi/include/DDDigi/FalphaNoise.h
@@ -47,8 +47,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDDIGI_FALPHANOISE_H
-#define DD4HEP_DDDIGI_FALPHANOISE_H
+#ifndef DDDIGI_FALPHANOISE_H
+#define DDDIGI_FALPHANOISE_H
 
 /// C/C++ include files
 #include <vector>
@@ -171,4 +171,4 @@ namespace dd4hep {
     }
   }    // End namespace detail
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_FALPHANOISE_H
+#endif // DDDIGI_FALPHANOISE_H

--- a/DDDigi/include/DDDigi/segmentations/CartesianGridXY.h
+++ b/DDDigi/include/DDDigi/segmentations/CartesianGridXY.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_SEGMENTATION_CARTESIANGRIDXY_H
-#define DD4HEP_DDDIGI_SEGMENTATION_CARTESIANGRIDXY_H
+#ifndef DDDIGI_SEGMENTATIONS_CARTESIANGRIDXY_H
+#define DDDIGI_SEGMENTATIONS_CARTESIANGRIDXY_H
 
 /// Framework include files
 #include <DDDigi/DigiSegmentation.h>
@@ -45,4 +45,4 @@ namespace dd4hep {
 
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_SEGMENTATION_CARTESIANGRIDXY_H
+#endif // DDDIGI_SEGMENTATIONS_CARTESIANGRIDXY_H

--- a/DDDigi/include/DDDigi/segmentations/CartesianGridXYZ.h
+++ b/DDDigi/include/DDDigi/segmentations/CartesianGridXYZ.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_SEGMENTATION_CARTESIANGRIDXYZ_H
-#define DD4HEP_DDDIGI_SEGMENTATION_CARTESIANGRIDXYZ_H
+#ifndef DDDIGI_SEGMENTATIONS_CARTESIANGRIDXYZ_H
+#define DDDIGI_SEGMENTATIONS_CARTESIANGRIDXYZ_H
 
 /// Framework include files
 #include <DDDigi/DigiSegmentation.h>
@@ -47,4 +47,4 @@ namespace dd4hep {
 
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_SEGMENTATION_CARTESIANGRIDXYZ_H
+#endif // DDDIGI_SEGMENTATIONS_CARTESIANGRIDXYZ_H

--- a/DDDigi/include/DDDigi/segmentations/SegmentationScanner.h
+++ b/DDDigi/include/DDDigi/segmentations/SegmentationScanner.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDDIGI_SEGMENTATIONSCANNER_H
-#define DD4HEP_DDDIGI_SEGMENTATIONSCANNER_H
+#ifndef DDDIGI_SEGMENTATIONS_SEGMENTATIONSCANNER_H
+#define DDDIGI_SEGMENTATIONS_SEGMENTATIONSCANNER_H
 
 /// Framework include files
 #include <DDDigi/DigiSegmentation.h>
@@ -47,4 +47,4 @@ namespace dd4hep {
     };
   }    // End namespace digi
 }      // End namespace dd4hep
-#endif // DD4HEP_DDDIGI_SEGMENTATIONSCANNER_H
+#endif // DDDIGI_SEGMENTATIONS_SEGMENTATIONSCANNER_H

--- a/DDEve/include/DDEve/Annotation.h
+++ b/DDEve/include/DDEve/Annotation.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_ANNOTATION_H
-#define DD4HEP_DDEVE_ANNOTATION_H
+#ifndef DDEVE_ANNOTATION_H
+#define DDEVE_ANNOTATION_H
 
 // Framework include files
 #include "TGLAnnotation.h"
@@ -45,5 +45,5 @@ namespace dd4hep {
     static float DefaultMargin();
   };
 }      /* End namespace dd4hep      */
-#endif /* DD4HEP_DDEVE_ANNOTATION_H */
+#endif // DDEVE_ANNOTATION_H
 

--- a/DDEve/include/DDEve/Calo2DProjection.h
+++ b/DDEve/include/DDEve/Calo2DProjection.h
@@ -11,8 +11,8 @@
 // Original Author: Matevz Tadel 2009 (MultiView.C)
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_CALO2DPROJECTION_H
-#define DD4HEP_DDEVE_CALO2DPROJECTION_H
+#ifndef DDEVE_CALO2DPROJECTION_H
+#define DDEVE_CALO2DPROJECTION_H
 
 // Framework include files
 #include "DDEve/Projection.h"
@@ -52,4 +52,4 @@ namespace dd4hep {
   };
 
 }      /* End namespace dd4hep   */
-#endif /* DD4HEP_DDEVE_CALO2DPROJECTION_H */
+#endif // DDEVE_CALO2DPROJECTION_H

--- a/DDEve/include/DDEve/Calo3DProjection.h
+++ b/DDEve/include/DDEve/Calo3DProjection.h
@@ -11,8 +11,8 @@
 // Original Author: Matevz Tadel 2009 (MultiView.C)
 //
 //====================================================================
-#ifndef DD4HEP_DDEVE_CALO3DPROJECTION_H
-#define DD4HEP_DDEVE_CALO3DPROJECTION_H
+#ifndef DDEVE_CALO3DPROJECTION_H
+#define DDEVE_CALO3DPROJECTION_H
 
 // Framework include files
 #include "DDEve/View.h"
@@ -46,5 +46,5 @@ namespace dd4hep {
   };
 
 }      /* End namespace dd4hep            */
-#endif /* DD4HEP_DDEVE_CALO3DPROJECTION_H */
+#endif // DDEVE_CALO3DPROJECTION_H
 

--- a/DDEve/include/DDEve/CaloLego.h
+++ b/DDEve/include/DDEve/CaloLego.h
@@ -11,8 +11,8 @@
 // Original Author: Matevz Tadel 2009 (MultiView.C)
 //
 //====================================================================
-#ifndef DD4HEP_DDEVE_CALOLEGO_H
-#define DD4HEP_DDEVE_CALOLEGO_H
+#ifndef DDEVE_CALOLEGO_H
+#define DDEVE_CALOLEGO_H
 
 // Framework include files
 #include "DDEve/View.h"
@@ -52,4 +52,4 @@ namespace dd4hep {
     ClassDefOverride(CaloLego,0);
   };
 }      /* End namespace dd4hep    */
-#endif /* DD4HEP_DDEVE_CALOLEGO_H */
+#endif // DDEVE_CALOLEGO_H

--- a/DDEve/include/DDEve/ContextMenu.h
+++ b/DDEve/include/DDEve/ContextMenu.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_CONTEXTMENU_H
-#define DD4HEP_DDEVE_CONTEXTMENU_H
+#ifndef DDEVE_CONTEXTMENU_H
+#define DDEVE_CONTEXTMENU_H
 
 // Framework include files
 #include "DD4hep/Callback.h"
@@ -94,4 +94,4 @@ namespace dd4hep {
 } /* End namespace dd4hep   */
 
 
-#endif /* DD4HEP_DDEVE_CONTEXTMENU_H */
+#endif // DDEVE_CONTEXTMENU_H

--- a/DDEve/include/DDEve/DD4hepMenu.h
+++ b/DDEve/include/DDEve/DD4hepMenu.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_DD4HEPMENU_H
-#define DD4HEP_DDEVE_DD4HEPMENU_H
+#ifndef DDEVE_DD4HEPMENU_H
+#define DDEVE_DD4HEPMENU_H
 
 // Framework include files
 #include "DDEve/Display.h"
@@ -71,5 +71,5 @@ namespace dd4hep {
   };
 
 }      /* End namespace dd4hep      */
-#endif /* DD4HEP_DDEVE_DD4HEPMENU_H */
+#endif // DDEVE_DD4HEPMENU_H
 

--- a/DDEve/include/DDEve/DDEveEventData.h
+++ b/DDEve/include/DDEve/DDEveEventData.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_DDEVEHIT_H
-#define DD4HEP_DDEVE_DDEVEHIT_H
+#ifndef DDEVE_DDEVEEVENTDATA_H
+#define DDEVE_DDEVEEVENTDATA_H
 
 // C/C++ include files
 #include <vector>
@@ -71,5 +71,5 @@ namespace dd4hep {
   };
   typedef std::vector<DDEveParticle> DDEveParticles;
 }      /* End namespace dd4hep     */
-#endif /* DD4HEP_DDEVE_DDEVEHIT_H  */
+#endif // DDEVE_DDEVEEVENTDATA_H
 

--- a/DDEve/include/DDEve/DDG4EventHandler.h
+++ b/DDEve/include/DDEve/DDG4EventHandler.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_DDG4EVENTHANDLER_H
-#define DD4HEP_DDEVE_DDG4EVENTHANDLER_H
+#ifndef DDEVE_DDG4EVENTHANDLER_H
+#define DDEVE_DDG4EVENTHANDLER_H
 
 // Framework include files
 #include "DDEve/EventHandler.h"
@@ -86,5 +86,5 @@ namespace dd4hep {
   };
 
 }      /* End namespace dd4hep            */
-#endif /* DD4HEP_DDEVE_DDG4EVENTHANDLER_H */
+#endif // DDEVE_DDG4EVENTHANDLER_H
 

--- a/DDEve/include/DDEve/Dictionary.h
+++ b/DDEve/include/DDEve/Dictionary.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_DICTIONARY_H
-#define DD4HEP_DDEVE_DICTIONARY_H
+#ifndef DDEVE_DICTIONARY_H
+#define DDEVE_DICTIONARY_H
 
 // Framework include files
 #include "DDEve/Display.h"
@@ -116,4 +116,4 @@ using namespace dd4hep;
 
 #endif
 
-#endif /* DD4HEP_DDEVE_DICTIONARY_H */
+#endif // DDEVE_DICTIONARY_H

--- a/DDEve/include/DDEve/Display.h
+++ b/DDEve/include/DDEve/Display.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_DISPLAY_H
-#define DD4HEP_DDEVE_DISPLAY_H
+#ifndef DDEVE_DISPLAY_H
+#define DDEVE_DISPLAY_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -219,5 +219,5 @@ namespace dd4hep {
     ClassDefOverride(Display,0);
   };
 }      /* End namespace dd4hep   */
-#endif /* DD4HEP_DDEVE_DISPLAY_H */
+#endif // DDEVE_DISPLAY_H
 

--- a/DDEve/include/DDEve/DisplayConfiguration.h
+++ b/DDEve/include/DDEve/DisplayConfiguration.h
@@ -11,8 +11,8 @@
 //  Original Author: Matevz Tadel 2009 (MultiView.C)
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_DISPLAYCONFIGURATION_H
-#define DD4HEP_DDEVE_DISPLAYCONFIGURATION_H
+#ifndef DDEVE_DISPLAYCONFIGURATION_H
+#define DDEVE_DISPLAYCONFIGURATION_H
 
 // Framework include files
 #include "TClass.h"
@@ -148,5 +148,5 @@ namespace dd4hep {
     ClassDef(DisplayConfiguration,0);
   };
 }        /* End namespace dd4hep                */
-#endif   /* DD4HEP_DDEVE_DISPLAYCONFIGURATION_H */
+#endif // DDEVE_DISPLAYCONFIGURATION_H
 

--- a/DDEve/include/DDEve/ElementList.h
+++ b/DDEve/include/DDEve/ElementList.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_ELEMENTLIST_H
-#define DD4HEP_DDEVE_ELEMENTLIST_H
+#ifndef DDEVE_ELEMENTLIST_H
+#define DDEVE_ELEMENTLIST_H
 
 // Framework include files
 #include "DDEve/View.h"
@@ -68,4 +68,4 @@ namespace dd4hep {
   };
 
 }      /* End namespace dd4hep       */
-#endif /* DD4HEP_DDEVE_ELEMENTLIST_H */
+#endif // DDEVE_ELEMENTLIST_H

--- a/DDEve/include/DDEve/EvePgonSetProjectedContextMenu.h
+++ b/DDEve/include/DDEve/EvePgonSetProjectedContextMenu.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_EVEPGONSETPROJECTEDCONTEXTMENU_H
-#define DD4HEP_DDEVE_EVEPGONSETPROJECTEDCONTEXTMENU_H
+#ifndef DDEVE_EVEPGONSETPROJECTEDCONTEXTMENU_H
+#define DDEVE_EVEPGONSETPROJECTEDCONTEXTMENU_H
 
 // Framework include files
 #include "DDEve/EveUserContextMenu.h"
@@ -38,4 +38,4 @@ namespace dd4hep {
     ClassDefOverride(EvePgonSetProjectedContextMenu,0);
   };
 }      /* End namespace dd4hep                          */
-#endif /* DD4HEP_DDEVE_EVEPGONSETPROJECTEDCONTEXTMENU_H */
+#endif // DDEVE_EVEPGONSETPROJECTEDCONTEXTMENU_H

--- a/DDEve/include/DDEve/EveShapeContextMenu.h
+++ b/DDEve/include/DDEve/EveShapeContextMenu.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_EVESHAPECONTEXTMENU_H
-#define DD4HEP_DDEVE_EVESHAPECONTEXTMENU_H
+#ifndef DDEVE_EVESHAPECONTEXTMENU_H
+#define DDEVE_EVESHAPECONTEXTMENU_H
 
 // ROOT include files
 #include "DDEve/EveUserContextMenu.h"
@@ -38,4 +38,4 @@ namespace dd4hep {
     ClassDefOverride(EveShapeContextMenu,0);
   };
 }      /* End namespace dd4hep               */
-#endif /* DD4HEP_DDEVE_EVESHAPECONTEXTMENU_H */
+#endif // DDEVE_EVESHAPECONTEXTMENU_H

--- a/DDEve/include/DDEve/EveUserContextMenu.h
+++ b/DDEve/include/DDEve/EveUserContextMenu.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_EVEUSERCONTEXTMENU_H
-#define DD4HEP_DDEVE_EVEUSERCONTEXTMENU_H
+#ifndef DDEVE_EVEUSERCONTEXTMENU_H
+#define DDEVE_EVEUSERCONTEXTMENU_H
 
 // ROOT include files
 #include "TClass.h"
@@ -74,4 +74,4 @@ namespace dd4hep {
     ClassDef(EveUserContextMenu,0);
   };
 }      /* End namespace dd4hep              */
-#endif /* DD4HEP_DDEVE_EVEUSERCONTEXTMENU_H */
+#endif // DDEVE_EVEUSERCONTEXTMENU_H

--- a/DDEve/include/DDEve/EventControl.h
+++ b/DDEve/include/DDEve/EventControl.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_EVENTCONTROL_H
-#define DD4HEP_DDEVE_EVENTCONTROL_H
+#ifndef DDEVE_EVENTCONTROL_H
+#define DDEVE_EVENTCONTROL_H
 
 // Framework include files
 #include "DDEve/FrameControl.h"
@@ -82,5 +82,5 @@ namespace dd4hep {
     ClassDefOverride(EventControl,0)  // Top level window frame
   };
 }      /* End namespace dd4hep        */
-#endif /* DD4HEP_DDEVE_EVENTCONTROL_H */
+#endif // DDEVE_EVENTCONTROL_H
 

--- a/DDEve/include/DDEve/EventHandler.h
+++ b/DDEve/include/DDEve/EventHandler.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_EVENTHANDLER_H
-#define DD4HEP_DDEVE_EVENTHANDLER_H
+#ifndef DDEVE_EVENTHANDLER_H
+#define DDEVE_EVENTHANDLER_H
 
 // Framework include files
 #include "DDEve/DDEveEventData.h"
@@ -138,5 +138,5 @@ namespace dd4hep {
     ClassDef(EventConsumer,0);
   };
 }      /* End namespace dd4hep        */
-#endif /* DD4HEP_DDEVE_EVENTHANDLER_H */
+#endif // DDEVE_EVENTHANDLER_H
 

--- a/DDEve/include/DDEve/Factories.h
+++ b/DDEve/include/DDEve/Factories.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_FACTORIES_H
-#define DD4HEP_DDEVE_FACTORIES_H
+#ifndef DDEVE_FACTORIES_H
+#define DDEVE_FACTORIES_H
 
 #ifndef __CINT__
 #include "DD4hep/Plugins.h"
@@ -30,4 +30,4 @@ namespace {
 #define DECLARE_VIEW_FACTORY(x) \
 DD4HEP_PLUGINSVC_FACTORY(x,dd4hep_DDEve_##x,dd4hep::View*(dd4hep::Display*, const char*),__LINE__)
 
-#endif // DD4HEP_DDEVE_FACTORIES_H
+#endif // DDEVE_FACTORIES_H

--- a/DDEve/include/DDEve/FrameControl.h
+++ b/DDEve/include/DDEve/FrameControl.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_FRAMECONTROL_H
-#define DD4HEP_DDEVE_FRAMECONTROL_H
+#ifndef DDEVE_FRAMECONTROL_H
+#define DDEVE_FRAMECONTROL_H
 
 // ROOT include files
 #include "TGFrame.h"
@@ -66,5 +66,5 @@ namespace dd4hep {
     ClassDefOverride(FrameControl,0)  // Top level window frame
   };
 }      /* End namespace dd4hep        */
-#endif /* DD4HEP_DDEVE_FRAMECONTROL_H */
+#endif // DDEVE_FRAMECONTROL_H
 

--- a/DDEve/include/DDEve/GenericEventHandler.h
+++ b/DDEve/include/DDEve/GenericEventHandler.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_GENERICEVENTHANDLER_H
-#define DD4HEP_DDEVE_GENERICEVENTHANDLER_H
+#ifndef DDEVE_GENERICEVENTHANDLER_H
+#define DDEVE_GENERICEVENTHANDLER_H
 
 // Framework include files
 #include "DDEve/EventHandler.h"
@@ -76,5 +76,5 @@ namespace dd4hep {
   };
 } /* End namespace dd4hep   */
 
-#endif /* DD4HEP_DDEVE_GENERICEVENTHANDLER_H */
+#endif // DDEVE_GENERICEVENTHANDLER_H
 

--- a/DDEve/include/DDEve/HitActors.h
+++ b/DDEve/include/DDEve/HitActors.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_HITHANDLERS_H
-#define DD4HEP_DDEVE_HITHANDLERS_H
+#ifndef DDEVE_HITACTORS_H
+#define DDEVE_HITACTORS_H
 
 // Framework include files
 #include "DDEve/EventHandler.h"
@@ -106,5 +106,5 @@ namespace dd4hep {
 } /* End namespace dd4hep   */
 
 
-#endif /* DD4HEP_DDEVE_HITHANDLERS_H */
+#endif // DDEVE_HITACTORS_H
 

--- a/DDEve/include/DDEve/MultiView.h
+++ b/DDEve/include/DDEve/MultiView.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_MULTIVIEW_H
-#define DD4HEP_DDEVE_MULTIVIEW_H
+#ifndef DDEVE_MULTIVIEW_H
+#define DDEVE_MULTIVIEW_H
 
 // Framework include files
 #include "DDEve/View.h"
@@ -41,4 +41,4 @@ namespace dd4hep {
     ClassDefOverride(MultiView,0);
   };
 }      /* End namespace dd4hep     */
-#endif /* DD4HEP_DDEVE_MULTIVIEW_H */
+#endif // DDEVE_MULTIVIEW_H

--- a/DDEve/include/DDEve/ParticleActors.h
+++ b/DDEve/include/DDEve/ParticleActors.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_PARTICLEHANDLERS_H
-#define DD4HEP_DDEVE_PARTICLEHANDLERS_H
+#ifndef DDEVE_PARTICLEACTORS_H
+#define DDEVE_PARTICLEACTORS_H
 
 // Framework include files
 #include "DDEve/EventHandler.h"
@@ -57,5 +57,5 @@ namespace dd4hep {
 } /* End namespace dd4hep   */
 
 
-#endif /* DD4HEP_DDEVE_PARTICLEHANDLERS_H */
+#endif // DDEVE_PARTICLEACTORS_H
 

--- a/DDEve/include/DDEve/PopupMenu.h
+++ b/DDEve/include/DDEve/PopupMenu.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_POPUPMENU_H
-#define DD4HEP_DDEVE_POPUPMENU_H
+#ifndef DDEVE_POPUPMENU_H
+#define DDEVE_POPUPMENU_H
 
 // Framework include files
 #include "DD4hep/Callback.h"
@@ -83,5 +83,5 @@ namespace dd4hep {
     ClassDef(PopupMenu,0);
   };
 }      /* End namespace dd4hep     */
-#endif /* DD4HEP_DDEVE_POPUPMENU_H */
+#endif // DDEVE_POPUPMENU_H
 

--- a/DDEve/include/DDEve/Projection.h
+++ b/DDEve/include/DDEve/Projection.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_PROJECTION_H
-#define DD4HEP_DDEVE_PROJECTION_H
+#ifndef DDEVE_PROJECTION_H
+#define DDEVE_PROJECTION_H
 
 // Framework include files
 #include "DDEve/View.h"
@@ -65,4 +65,4 @@ namespace dd4hep {
     ClassDefOverride(Projection,0);
   };
 }      /* End namespace dd4hep      */
-#endif /* DD4HEP_DDEVE_PROJECTION_H */
+#endif // DDEVE_PROJECTION_H

--- a/DDEve/include/DDEve/RhoPhiProjection.h
+++ b/DDEve/include/DDEve/RhoPhiProjection.h
@@ -11,8 +11,8 @@
 //  Original Author: Matevz Tadel 2009 (MultiView.C)
 //
 //====================================================================
-#ifndef DD4HEP_DDEVE_RHOPHIPROJECTION_H
-#define DD4HEP_DDEVE_RHOPHIPROJECTION_H
+#ifndef DDEVE_RHOPHIPROJECTION_H
+#define DDEVE_RHOPHIPROJECTION_H
 
 // Framework include files
 #include "DDEve/Projection.h"
@@ -38,5 +38,5 @@ namespace dd4hep {
     ClassDefOverride(RhoPhiProjection,0);
   };
 }      /* End namespace dd4hep            */
-#endif /* DD4HEP_DDEVE_RHOPHIPROJECTION_H */
+#endif // DDEVE_RHOPHIPROJECTION_H
 

--- a/DDEve/include/DDEve/RhoZProjection.h
+++ b/DDEve/include/DDEve/RhoZProjection.h
@@ -11,8 +11,8 @@
 //  Original Author: Matevz Tadel 2009 (MultiView.C)
 //
 //====================================================================
-#ifndef DD4HEP_DDEVE_RHOZPROJECTION_H
-#define DD4HEP_DDEVE_RHOZPROJECTION_H
+#ifndef DDEVE_RHOZPROJECTION_H
+#define DDEVE_RHOZPROJECTION_H
 
 // Framework include files
 #include "DDEve/Projection.h"
@@ -38,5 +38,5 @@ namespace dd4hep {
     ClassDefOverride(RhoZProjection,0);
   };
 }      /* End namespace dd4hep          */
-#endif /* DD4HEP_DDEVE_RHOZPROJECTION_H */
+#endif // DDEVE_RHOZPROJECTION_H
 

--- a/DDEve/include/DDEve/Utilities.h
+++ b/DDEve/include/DDEve/Utilities.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_UTILITIES_H
-#define DD4HEP_DDEVE_UTILITIES_H
+#ifndef DDEVE_UTILITIES_H
+#define DDEVE_UTILITIES_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -48,5 +48,5 @@ namespace dd4hep {
     }
   }
 }      /* End namespace dd4hep     */
-#endif /* DD4HEP_DDEVE_UTILITIES_H */
+#endif // DDEVE_UTILITIES_H
 

--- a/DDEve/include/DDEve/View.h
+++ b/DDEve/include/DDEve/View.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_VIEW_H
-#define DD4HEP_DDEVE_VIEW_H
+#ifndef DDEVE_VIEW_H
+#define DDEVE_VIEW_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -153,4 +153,4 @@ namespace dd4hep {
     ClassDef(View,0);
   };
 }      /* End namespace dd4hep   */
-#endif /* DD4HEP_DDEVE_VIEW_H    */
+#endif // DDEVE_VIEW_H

--- a/DDEve/include/DDEve/View3D.h
+++ b/DDEve/include/DDEve/View3D.h
@@ -12,8 +12,8 @@
 //  Original Author: Matevz Tadel 2009 (MultiView.C)
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_VIEW3D_H
-#define DD4HEP_DDEVE_VIEW3D_H
+#ifndef DDEVE_VIEW3D_H
+#define DDEVE_VIEW3D_H
 
 // Framework include files
 #include "DDEve/View.h"
@@ -42,4 +42,4 @@ namespace dd4hep {
     ClassDefOverride(View3D,0);
   };
 }      /* End namespace dd4hep   */
-#endif /* DD4HEP_DDEVE_VIEW3D_H  */
+#endif // DDEVE_VIEW3D_H

--- a/DDEve/include/DDEve/ViewMenu.h
+++ b/DDEve/include/DDEve/ViewMenu.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_VIEWMENU_H
-#define DD4HEP_DDEVE_VIEWMENU_H
+#ifndef DDEVE_VIEWMENU_H
+#define DDEVE_VIEWMENU_H
 
 // Framework include files
 #include "DDEve/Display.h"
@@ -68,5 +68,5 @@ namespace dd4hep {
     ClassDefOverride(ViewMenu,0);
   };
 }      /* End namespace dd4hep    */
-#endif /* DD4HEP_DDEVE_VIEWMENU_H */
+#endif // DDEVE_VIEWMENU_H
 

--- a/DDEve/lcio/LCIOEventHandler.h
+++ b/DDEve/lcio/LCIOEventHandler.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDEVE_LCIOEVENTHANDLER_H
-#define DD4HEP_DDEVE_LCIOEVENTHANDLER_H
+#ifndef DDEVE_LCIO_LCIOEVENTHANDLER_H
+#define DDEVE_LCIO_LCIOEVENTHANDLER_H
 
 // Framework include files
 #include "DDEve/EventHandler.h"
@@ -80,5 +80,5 @@ namespace dd4hep {
 
 } /* End namespace dd4hep   */
 
-#endif /* DD4HEP_DDEVE_LCIOEVENTHANDLER_H */
+#endif // DDEVE_LCIO_LCIOEVENTHANDLER_H
 

--- a/DDG4/hepmc/HepMC3EventReader.h
+++ b/DDG4/hepmc/HepMC3EventReader.h
@@ -9,8 +9,8 @@
 //
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_HEPMC3EVENTREADER_H
-#define DD4HEP_DDG4_HEPMC3EVENTREADER_H
+#ifndef DDG4_HEPMC_HEPMC3EVENTREADER_H
+#define DDG4_HEPMC_HEPMC3EVENTREADER_H
 
 // Framework include files
 #include "DDG4/Geant4InputAction.h"
@@ -52,4 +52,4 @@ namespace dd4hep  {
 
   }     /* End namespace sim   */
 }       /* End namespace dd4hep */
-#endif  /* DD4HEP_DDG4_HEPMC3EVENTREADER_H  */
+#endif // DDG4_HEPMC_HEPMC3EVENTREADER_H

--- a/DDG4/include/DDG4/ComponentUtils.h
+++ b/DDG4/include/DDG4/ComponentUtils.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_COMPONENTTUILS_H
-#define DD4HEP_DDG4_COMPONENTTUILS_H
+#ifndef DDG4_COMPONENTUTILS_H
+#define DDG4_COMPONENTUTILS_H
 
 // Framework include files
 #include "DD4hep/Primitives.h"
@@ -24,4 +24,4 @@ namespace dd4hep {
 
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_COMPONENTTUILS_H
+#endif // DDG4_COMPONENTUTILS_H

--- a/DDG4/include/DDG4/DDG4Dict.h
+++ b/DDG4/include/DDG4/DDG4Dict.h
@@ -15,8 +15,8 @@
 //  which are created by the DDG4 examples.
 //
 //====================================================================
-#ifndef DD4HEP_DDG4_DDG4DICT_H
-#define DD4HEP_DDG4_DDG4DICT_H
+#ifndef DDG4_DDG4DICT_H
+#define DDG4_DDG4DICT_H
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -163,4 +163,4 @@ namespace dd4hep {
 
 #endif // __DDG4_STANDALONE_DICTIONARIES__
 
-#endif /* DD4HEP_DDG4_DDG4DICT_H */
+#endif // DDG4_DDG4DICT_H

--- a/DDG4/include/DDG4/EventParameters.h
+++ b/DDG4/include/DDG4/EventParameters.h
@@ -9,8 +9,8 @@
 //
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_EVENTPARAMETERS_H
-#define DD4HEP_DDG4_EVENTPARAMETERS_H
+#ifndef DDG4_EVENTPARAMETERS_H
+#define DDG4_EVENTPARAMETERS_H
 
 #include <map>
 #include <string>
@@ -66,4 +66,4 @@ namespace dd4hep  {
 
   }     /* End namespace sim   */
 }       /* End namespace dd4hep */
-#endif  /* DD4HEP_DDG4_EVENTPARAMETERS_H  */
+#endif // DDG4_EVENTPARAMETERS_H

--- a/DDG4/include/DDG4/Geant4Action.h
+++ b/DDG4/include/DDG4/Geant4Action.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4ACTION_H
-#define DD4HEP_DDG4_GEANT4ACTION_H
+#ifndef DDG4_GEANT4ACTION_H
+#define DDG4_GEANT4ACTION_H
 
 // Framework include files
 #include "DD4hep/Printout.h"
@@ -385,4 +385,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4ACTION_H
+#endif // DDG4_GEANT4ACTION_H

--- a/DDG4/include/DDG4/Geant4ActionContainer.h
+++ b/DDG4/include/DDG4/Geant4ActionContainer.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4ACTIONCONTAINER_H
-#define DD4HEP_DDG4_GEANT4ACTIONCONTAINER_H
+#ifndef DDG4_GEANT4ACTIONCONTAINER_H
+#define DDG4_GEANT4ACTIONCONTAINER_H
 
 // Framework include files
 #include "DD4hep/Printout.h"
@@ -174,4 +174,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4KERNEL_H
+#endif // DDG4_GEANT4ACTIONCONTAINER_H

--- a/DDG4/include/DDG4/Geant4ActionPhase.h
+++ b/DDG4/include/DDG4/Geant4ActionPhase.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4ACTIONPHASE_H
-#define DD4HEP_DDG4_GEANT4ACTIONPHASE_H
+#ifndef DDG4_GEANT4ACTIONPHASE_H
+#define DDG4_GEANT4ACTIONPHASE_H
 
 // Framework include files
 #include "DD4hep/Exceptions.h"
@@ -144,4 +144,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4ACTIONPHASE_H
+#endif // DDG4_GEANT4ACTIONPHASE_H

--- a/DDG4/include/DDG4/Geant4AssemblyVolume.h
+++ b/DDG4/include/DDG4/Geant4AssemblyVolume.h
@@ -1,3 +1,6 @@
+#ifndef DDG4_GEANT4ASSEMBLYVOLUME_H
+#define DDG4_GEANT4ASSEMBLYVOLUME_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -78,3 +81,5 @@ namespace dd4hep {
     };
   }
 }
+
+#endif

--- a/DDG4/include/DDG4/Geant4Call.h
+++ b/DDG4/include/DDG4/Geant4Call.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4CALL_H
-#define DD4HEP_DDG4_GEANT4CALL_H
+#ifndef DDG4_GEANT4CALL_H
+#define DDG4_GEANT4CALL_H
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -36,4 +36,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4CALL_H
+#endif // DDG4_GEANT4CALL_H

--- a/DDG4/include/DDG4/Geant4Callback.h
+++ b/DDG4/include/DDG4/Geant4Callback.h
@@ -11,10 +11,10 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4CALLBACK_H
-#define DD4HEP_DDG4_GEANT4CALLBACK_H
+#ifndef DDG4_GEANT4CALLBACK_H
+#define DDG4_GEANT4CALLBACK_H
 
 // Just forward header for dd4hep callbacks
 #include "DD4hep/Callback.h"
 
-#endif  // DD4HEP_DDG4_GEANT4CALLBACK_H
+#endif // DDG4_GEANT4CALLBACK_H

--- a/DDG4/include/DDG4/Geant4Context.h
+++ b/DDG4/include/DDG4/Geant4Context.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4CONTEXT_H
-#define DD4HEP_DDG4_GEANT4CONTEXT_H
+#ifndef DDG4_GEANT4CONTEXT_H
+#define DDG4_GEANT4CONTEXT_H
 
 // Framework incloude files
 #include "DD4hep/Primitives.h"
@@ -263,4 +263,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4CONTEXT_H
+#endif // DDG4_GEANT4CONTEXT_H

--- a/DDG4/include/DDG4/Geant4Converter.h
+++ b/DDG4/include/DDG4/Geant4Converter.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_GEANT4CONVERTER_H
-#define DD4HEP_GEANT4CONVERTER_H
+#ifndef DDG4_GEANT4CONVERTER_H
+#define DDG4_GEANT4CONVERTER_H
 
 // Framework include files
 #include "DD4hep/Printout.h"
@@ -125,4 +125,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_GEANT4CONVERTER_H
+#endif // DDG4_GEANT4CONVERTER_H

--- a/DDG4/include/DDG4/Geant4Data.h
+++ b/DDG4/include/DDG4/Geant4Data.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_GEANT4DATA_H
-#define DD4HEP_GEANT4DATA_H
+#ifndef DDG4_GEANT4DATA_H
+#define DDG4_GEANT4DATA_H
 
 // Framework include files
 #include "DD4hep/Memory.h"
@@ -294,4 +294,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_GEANT4DATA_H
+#endif // DDG4_GEANT4DATA_H

--- a/DDG4/include/DDG4/Geant4DataConversion.h
+++ b/DDG4/include/DDG4/Geant4DataConversion.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4CONVERSION_H
-#define DD4HEP_DDG4_GEANT4CONVERSION_H
+#ifndef DDG4_GEANT4DATACONVERSION_H
+#define DDG4_GEANT4DATACONVERSION_H
 
 // Framework include files
 #include "DD4hep/VolumeManager.h"
@@ -146,4 +146,4 @@ namespace dd4hep {
 
 #endif
 
-#endif // DD4HEP_DDG4_GEANT4CONVERSION_H
+#endif // DDG4_GEANT4DATACONVERSION_H

--- a/DDG4/include/DDG4/Geant4DataDump.h
+++ b/DDG4/include/DDG4/Geant4DataDump.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4DATADUMP_H
-#define DD4HEP_DDG4_GEANT4DATADUMP_H
+#ifndef DDG4_GEANT4DATADUMP_H
+#define DDG4_GEANT4DATADUMP_H
 
 // Framework include files
 #include "DD4hep/Printout.h"
@@ -80,4 +80,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif /* DD4HEP_DDG4_GEANT4DATADUMP_H */
+#endif // DDG4_GEANT4DATADUMP_H

--- a/DDG4/include/DDG4/Geant4DetectorConstruction.h
+++ b/DDG4/include/DDG4/Geant4DetectorConstruction.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_GEANT4DETECTORCONSTRUCTION_H
-#define DD4HEP_GEANT4DETECTORCONSTRUCTION_H
+#ifndef DDG4_GEANT4DETECTORCONSTRUCTION_H
+#define DDG4_GEANT4DETECTORCONSTRUCTION_H
 
 // Framework include files
 #include "DD4hep/DetElement.h"
@@ -180,4 +180,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4DETECTORCONSTRUCTION_H
+#endif // DDG4_GEANT4DETECTORCONSTRUCTION_H

--- a/DDG4/include/DDG4/Geant4EventAction.h
+++ b/DDG4/include/DDG4/Geant4EventAction.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4EVENTACTION_H
-#define DD4HEP_DDG4_GEANT4EVENTACTION_H
+#ifndef DDG4_GEANT4EVENTACTION_H
+#define DDG4_GEANT4EVENTACTION_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -172,4 +172,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4EVENTACTION_H
+#endif // DDG4_GEANT4EVENTACTION_H

--- a/DDG4/include/DDG4/Geant4Field.h
+++ b/DDG4/include/DDG4/Geant4Field.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4FIELD_H
-#define DD4HEP_DDG4_GEANT4FIELD_H
+#ifndef DDG4_GEANT4FIELD_H
+#define DDG4_GEANT4FIELD_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -54,4 +54,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4FIELD_H
+#endif // DDG4_GEANT4FIELD_H

--- a/DDG4/include/DDG4/Geant4GDMLDetector.h
+++ b/DDG4/include/DDG4/Geant4GDMLDetector.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_Geant4GDMLDetector_H
-#define DD4HEP_Geant4GDMLDetector_H
+#ifndef DDG4_GEANT4GDMLDETECTOR_H
+#define DDG4_GEANT4GDMLDETECTOR_H
 
 #include "G4VUserDetectorConstruction.hh"
 #include <string>

--- a/DDG4/include/DDG4/Geant4GeneratorAction.h
+++ b/DDG4/include/DDG4/Geant4GeneratorAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4GENERATORACTION_H
-#define DD4HEP_DDG4_GEANT4GENERATORACTION_H
+#ifndef DDG4_GEANT4GENERATORACTION_H
+#define DDG4_GEANT4GENERATORACTION_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -146,4 +146,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4GENERATORACTION_H
+#endif // DDG4_GEANT4GENERATORACTION_H

--- a/DDG4/include/DDG4/Geant4GeneratorActionInit.h
+++ b/DDG4/include/DDG4/Geant4GeneratorActionInit.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4GENERATORACTIONINIT_H
-#define DD4HEP_DDG4_GEANT4GENERATORACTIONINIT_H
+#ifndef DDG4_GEANT4GENERATORACTIONINIT_H
+#define DDG4_GEANT4GENERATORACTIONINIT_H
 
 // Framework include files
 #include "DDG4/Geant4GeneratorAction.h"
@@ -75,4 +75,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4GENERATORACTIONINIT_H
+#endif // DDG4_GEANT4GENERATORACTIONINIT_H

--- a/DDG4/include/DDG4/Geant4GeneratorWrapper.h
+++ b/DDG4/include/DDG4/Geant4GeneratorWrapper.h
@@ -21,8 +21,8 @@
 @}
  */
 
-#ifndef DD4HEP_DDG4_GEANT4GENERATORWRAPPER_H
-#define DD4HEP_DDG4_GEANT4GENERATORWRAPPER_H
+#ifndef DDG4_GEANT4GENERATORWRAPPER_H
+#define DDG4_GEANT4GENERATORWRAPPER_H
 
 // Framework include files
 #include "DDG4/Geant4GeneratorAction.h"
@@ -67,4 +67,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4GENERATORWRAPPER_H
+#endif // DDG4_GEANT4GENERATORWRAPPER_H

--- a/DDG4/include/DDG4/Geant4GeometryInfo.h
+++ b/DDG4/include/DDG4/Geant4GeometryInfo.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4GEOMETRYINFO_H
-#define DD4HEP_DDG4_GEANT4GEOMETRYINFO_H
+#ifndef DDG4_GEANT4GEOMETRYINFO_H
+#define DDG4_GEANT4GEOMETRYINFO_H
 
 // Framework include files
 #include "DD4hep/Objects.h"
@@ -143,4 +143,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4GEOMETRYINFO_H
+#endif // DDG4_GEANT4GEOMETRYINFO_H

--- a/DDG4/include/DDG4/Geant4Handle.h
+++ b/DDG4/include/DDG4/Geant4Handle.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4SETUP_H
-#define DD4HEP_DDG4_GEANT4SETUP_H
+#ifndef DDG4_GEANT4HANDLE_H
+#define DDG4_GEANT4HANDLE_H
 
 // Framework include files
 #include "DD4hep/ComponentProperties.h"
@@ -120,4 +120,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4SETUP_H
+#endif // DDG4_GEANT4HANDLE_H

--- a/DDG4/include/DDG4/Geant4HierarchyDump.h
+++ b/DDG4/include/DDG4/Geant4HierarchyDump.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4HIERARCHYDUMP_H
-#define DD4HEP_DDG4_GEANT4HIERARCHYDUMP_H
+#ifndef DDG4_GEANT4HIERARCHYDUMP_H
+#define DDG4_GEANT4HIERARCHYDUMP_H
 
 // Geant 4 include files
 #include "G4VPhysicalVolume.hh"
@@ -46,4 +46,4 @@ namespace dd4hep {
   }
 }
 
-#endif  // DD4HEP_DDG4_GEANT4HIERARCHYDUMP_H
+#endif // DDG4_GEANT4HIERARCHYDUMP_H

--- a/DDG4/include/DDG4/Geant4HitCollection.h
+++ b/DDG4/include/DDG4/Geant4HitCollection.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4HITCOLLECTION_H
-#define DD4HEP_DDG4_GEANT4HITCOLLECTION_H
+#ifndef DDG4_GEANT4HITCOLLECTION_H
+#define DDG4_GEANT4HITCOLLECTION_H
 
 // Framework include files
 #include "DD4hep/Handle.h"
@@ -435,4 +435,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4HITCOLLECTION_H
+#endif // DDG4_GEANT4HITCOLLECTION_H

--- a/DDG4/include/DDG4/Geant4Hits.h
+++ b/DDG4/include/DDG4/Geant4Hits.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_GEANT4HITS_H
-#define DD4HEP_GEANT4HITS_H
+#ifndef DDG4_GEANT4HITS_H
+#define DDG4_GEANT4HITS_H
 
 // Framework include files
 #include "DD4hep/Objects.h"
@@ -198,4 +198,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_GEANT4HITS_H
+#endif // DDG4_GEANT4HITS_H

--- a/DDG4/include/DDG4/Geant4InputAction.h
+++ b/DDG4/include/DDG4/Geant4InputAction.h
@@ -21,8 +21,8 @@
 @}
  */
 
-#ifndef DD4HEP_DDG4_GEANT4INPUTACTION_H
-#define DD4HEP_DDG4_GEANT4INPUTACTION_H
+#ifndef DDG4_GEANT4INPUTACTION_H
+#define DDG4_GEANT4INPUTACTION_H
 
 // Framework include files
 #include "DDG4/Geant4Vertex.h"
@@ -193,4 +193,4 @@ namespace dd4hep  {
     };
   }     /* End namespace sim   */
 }       /* End namespace dd4hep */
-#endif  /* DD4HEP_DDG4_GEANT4INPUTACTION_H  */
+#endif // DDG4_GEANT4INPUTACTION_H

--- a/DDG4/include/DDG4/Geant4InputHandling.h
+++ b/DDG4/include/DDG4/Geant4InputHandling.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4INPUTHANDLING_H
-#define DD4HEP_DDG4_GEANT4INPUTHANDLING_H
+#ifndef DDG4_GEANT4INPUTHANDLING_H
+#define DDG4_GEANT4INPUTHANDLING_H
 
 // Framework include files
 #include "DDG4/Geant4Primary.h"
@@ -68,4 +68,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif /* DD4HEP_DDG4_GEANT4INPUTHANDLING_H  */
+#endif // DDG4_GEANT4INPUTHANDLING_H

--- a/DDG4/include/DDG4/Geant4InteractionMerger.h
+++ b/DDG4/include/DDG4/Geant4InteractionMerger.h
@@ -19,8 +19,8 @@
 @}
  */
 
-#ifndef DD4HEP_DDG4_GEANT4INTERACTIONMERGER_H
-#define DD4HEP_DDG4_GEANT4INTERACTIONMERGER_H
+#ifndef DDG4_GEANT4INTERACTIONMERGER_H
+#define DDG4_GEANT4INTERACTIONMERGER_H
 
 // Framework include files
 #include "DDG4/Geant4GeneratorAction.h"
@@ -58,4 +58,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4INTERACTIONMERGER_H
+#endif // DDG4_GEANT4INTERACTIONMERGER_H

--- a/DDG4/include/DDG4/Geant4InteractionVertexBoost.h
+++ b/DDG4/include/DDG4/Geant4InteractionVertexBoost.h
@@ -20,8 +20,8 @@
 @}
  */
 
-#ifndef DD4HEP_DDG4_GEANT4INTERACTIONVERTEXBOOST_H
-#define DD4HEP_DDG4_GEANT4INTERACTIONVERTEXBOOST_H
+#ifndef DDG4_GEANT4INTERACTIONVERTEXBOOST_H
+#define DDG4_GEANT4INTERACTIONVERTEXBOOST_H
 
 // Framework include files
 #include "DDG4/Geant4GeneratorAction.h"
@@ -67,4 +67,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif /* DD4HEP_DDG4_GEANT4INTERACTIONVERTEXBOOST_H  */
+#endif // DDG4_GEANT4INTERACTIONVERTEXBOOST_H

--- a/DDG4/include/DDG4/Geant4InteractionVertexSmear.h
+++ b/DDG4/include/DDG4/Geant4InteractionVertexSmear.h
@@ -21,8 +21,8 @@
 @}
  */
 
-#ifndef DD4HEP_DDG4_GEANT4INTERACTIONVERTEXSMEAR_H
-#define DD4HEP_DDG4_GEANT4INTERACTIONVERTEXSMEAR_H
+#ifndef DDG4_GEANT4INTERACTIONVERTEXSMEAR_H
+#define DDG4_GEANT4INTERACTIONVERTEXSMEAR_H
 
 // Framework include files
 #include "DDG4/Geant4GeneratorAction.h"
@@ -79,4 +79,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif /* DD4HEP_DDG4_GEANT4INTERACTIONVERTEXSMEAR_H  */
+#endif // DDG4_GEANT4INTERACTIONVERTEXSMEAR_H

--- a/DDG4/include/DDG4/Geant4IsotropeGenerator.h
+++ b/DDG4/include/DDG4/Geant4IsotropeGenerator.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4ISOTROPEGENERATOR_H
-#define DD4HEP_DDG4_GEANT4ISOTROPEGENERATOR_H
+#ifndef DDG4_GEANT4ISOTROPEGENERATOR_H
+#define DDG4_GEANT4ISOTROPEGENERATOR_H
 
 // Framework include files
 #include "DDG4/Geant4ParticleGenerator.h"
@@ -67,4 +67,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif /* DD4HEP_DDG4_GEANT4ISOTROPEGENERATOR_H  */
+#endif // DDG4_GEANT4ISOTROPEGENERATOR_H

--- a/DDG4/include/DDG4/Geant4Kernel.h
+++ b/DDG4/include/DDG4/Geant4Kernel.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4KERNEL_H
-#define DD4HEP_DDG4_GEANT4KERNEL_H
+#ifndef DDG4_GEANT4KERNEL_H
+#define DDG4_GEANT4KERNEL_H
 
 // Framework include files
 #include "DDG4/Geant4ActionContainer.h"
@@ -322,4 +322,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4KERNEL_H
+#endif // DDG4_GEANT4KERNEL_H

--- a/DDG4/include/DDG4/Geant4Mapping.h
+++ b/DDG4/include/DDG4/Geant4Mapping.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4MAPPING_H
-#define DD4HEP_DDG4_GEANT4MAPPING_H
+#ifndef DDG4_GEANT4MAPPING_H
+#define DDG4_GEANT4MAPPING_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -82,4 +82,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4MAPPING_H
+#endif // DDG4_GEANT4MAPPING_H

--- a/DDG4/include/DDG4/Geant4MonteCarloTruth.h
+++ b/DDG4/include/DDG4/Geant4MonteCarloTruth.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4MONTECARLOTRUTH_H
-#define DD4HEP_DDG4_GEANT4MONTECARLOTRUTH_H
+#ifndef DDG4_GEANT4MONTECARLOTRUTH_H
+#define DDG4_GEANT4MONTECARLOTRUTH_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -82,4 +82,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4MONTECARLOTRUTH_H
+#endif // DDG4_GEANT4MONTECARLOTRUTH_H

--- a/DDG4/include/DDG4/Geant4Output2ROOT.h
+++ b/DDG4/include/DDG4/Geant4Output2ROOT.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4OUTPUT2ROOT_H
-#define DD4HEP_DDG4_GEANT4OUTPUT2ROOT_H
+#ifndef DDG4_GEANT4OUTPUT2ROOT_H
+#define DDG4_GEANT4OUTPUT2ROOT_H
 
 // Framework include files
 #include "DDG4/Geant4OutputAction.h"
@@ -78,4 +78,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4OUTPUT2ROOT_H
+#endif // DDG4_GEANT4OUTPUT2ROOT_H

--- a/DDG4/include/DDG4/Geant4OutputAction.h
+++ b/DDG4/include/DDG4/Geant4OutputAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4OUTPUTACTION_H
-#define DD4HEP_DDG4_GEANT4OUTPUTACTION_H
+#ifndef DDG4_GEANT4OUTPUTACTION_H
+#define DDG4_GEANT4OUTPUTACTION_H
 
 // Framework include files
 #include "DDG4/Geant4EventAction.h"
@@ -91,4 +91,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4OUTPUTACTION_H
+#endif // DDG4_GEANT4OUTPUTACTION_H

--- a/DDG4/include/DDG4/Geant4Particle.h
+++ b/DDG4/include/DDG4/Geant4Particle.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_GEANT4PARTICLE_H
-#define DD4HEP_GEANT4PARTICLE_H
+#ifndef DDG4_GEANT4PARTICLE_H
+#define DDG4_GEANT4PARTICLE_H
 
 // Framework include files
 #include "DD4hep/Memory.h"
@@ -348,4 +348,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_GEANT4PARTICLE_H
+#endif // DDG4_GEANT4PARTICLE_H

--- a/DDG4/include/DDG4/Geant4ParticleGenerator.h
+++ b/DDG4/include/DDG4/Geant4ParticleGenerator.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4PARTICLEGENERATOR_H
-#define DD4HEP_DDG4_GEANT4PARTICLEGENERATOR_H
+#ifndef DDG4_GEANT4PARTICLEGENERATOR_H
+#define DDG4_GEANT4PARTICLEGENERATOR_H
 
 // Framework include files
 #include "DDG4/Geant4GeneratorAction.h"
@@ -81,4 +81,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif /* DD4HEP_DDG4_GEANT4PARTICLEGENERATOR_H  */
+#endif // DDG4_GEANT4PARTICLEGENERATOR_H

--- a/DDG4/include/DDG4/Geant4ParticleGun.h
+++ b/DDG4/include/DDG4/Geant4ParticleGun.h
@@ -20,8 +20,8 @@
 @}
  */
 
-#ifndef DD4HEP_DDG4_GEANT4PARTICLEGUN_H
-#define DD4HEP_DDG4_GEANT4PARTICLEGUN_H
+#ifndef DDG4_GEANT4PARTICLEGUN_H
+#define DDG4_GEANT4PARTICLEGUN_H
 
 // Framework include files
 #include "DDG4/Geant4IsotropeGenerator.h"
@@ -78,4 +78,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif /* DD4HEP_DDG4_GEANT4PARTICLEGUN_H  */
+#endif // DDG4_GEANT4PARTICLEGUN_H

--- a/DDG4/include/DDG4/Geant4ParticleHandler.h
+++ b/DDG4/include/DDG4/Geant4ParticleHandler.h
@@ -21,8 +21,8 @@
 @}
  */
 
-#ifndef DD4HEP_DDG4_GEANT4PARTICLEHANDLER_H
-#define DD4HEP_DDG4_GEANT4PARTICLEHANDLER_H
+#ifndef DDG4_GEANT4PARTICLEHANDLER_H
+#define DDG4_GEANT4PARTICLEHANDLER_H
 
 // Framework include files
 #include "DDG4/Geant4Primary.h"
@@ -173,4 +173,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4PARTICLEHANDLER_H
+#endif // DDG4_GEANT4PARTICLEHANDLER_H

--- a/DDG4/include/DDG4/Geant4ParticlePrint.h
+++ b/DDG4/include/DDG4/Geant4ParticlePrint.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4PARTICLEPRINT_H
-#define DD4HEP_DDG4_GEANT4PARTICLEPRINT_H
+#ifndef DDG4_GEANT4PARTICLEPRINT_H
+#define DDG4_GEANT4PARTICLEPRINT_H
 
 // Framework include files
 #include "DDG4/Geant4EventAction.h"
@@ -79,4 +79,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4PARTICLEPRINT_H
+#endif // DDG4_GEANT4PARTICLEPRINT_H

--- a/DDG4/include/DDG4/Geant4PhysicsList.h
+++ b/DDG4/include/DDG4/Geant4PhysicsList.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4PHYSICSLIST_H
-#define DD4HEP_DDG4_GEANT4PHYSICSLIST_H
+#ifndef DDG4_GEANT4PHYSICSLIST_H
+#define DDG4_GEANT4PHYSICSLIST_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -285,4 +285,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4PHYSICSLIST_H
+#endif // DDG4_GEANT4PHYSICSLIST_H

--- a/DDG4/include/DDG4/Geant4Primary.h
+++ b/DDG4/include/DDG4/Geant4Primary.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_GEANT4PRIMARY_H
-#define DD4HEP_GEANT4PRIMARY_H
+#ifndef DDG4_GEANT4PRIMARY_H
+#define DDG4_GEANT4PRIMARY_H
 
 // Framework include files
 #include "DD4hep/Memory.h"
@@ -177,4 +177,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_GEANT4PRIMARY_H
+#endif // DDG4_GEANT4PRIMARY_H

--- a/DDG4/include/DDG4/Geant4PrimaryHandler.h
+++ b/DDG4/include/DDG4/Geant4PrimaryHandler.h
@@ -21,8 +21,8 @@
 @}
  */
 
-#ifndef DD4HEP_DDG4_GEANT4PRIMARYHANDLER_H
-#define DD4HEP_DDG4_GEANT4PRIMARYHANDLER_H
+#ifndef DDG4_GEANT4PRIMARYHANDLER_H
+#define DDG4_GEANT4PRIMARYHANDLER_H
 
 // Framework include files
 #include "DDG4/Geant4GeneratorAction.h"
@@ -75,4 +75,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4PRIMARYHANDLER_H
+#endif // DDG4_GEANT4PRIMARYHANDLER_H

--- a/DDG4/include/DDG4/Geant4Primitives.h
+++ b/DDG4/include/DDG4/Geant4Primitives.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4PRIMITIVES_H
-#define DD4HEP_DDG4_GEANT4PRIMITIVES_H
+#ifndef DDG4_GEANT4PRIMITIVES_H
+#define DDG4_GEANT4PRIMITIVES_H
 
 // Framework include files
 #include "DD4hep/Primitives.h"
@@ -26,4 +26,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4PRIMITIVES_H
+#endif // DDG4_GEANT4PRIMITIVES_H

--- a/DDG4/include/DDG4/Geant4Random.h
+++ b/DDG4/include/DDG4/Geant4Random.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_GEANT4RANDOM_H
-#define DD4HEP_GEANT4RANDOM_H
+#ifndef DDG4_GEANT4RANDOM_H
+#define DDG4_GEANT4RANDOM_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -163,4 +163,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_GEANT4RANDOM_H
+#endif // DDG4_GEANT4RANDOM_H

--- a/DDG4/include/DDG4/Geant4ReadoutVolumeFilter.h
+++ b/DDG4/include/DDG4/Geant4ReadoutVolumeFilter.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4READOUTVOLUMEFILTER_H
-#define DD4HEP_DDG4_GEANT4READOUTVOLUMEFILTER_H
+#ifndef DDG4_GEANT4READOUTVOLUMEFILTER_H
+#define DDG4_GEANT4READOUTVOLUMEFILTER_H
 
 // Framework include files
 #include "DD4hep/Readout.h"
@@ -53,4 +53,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4READOUTVOLUMEFILTER_H
+#endif // DDG4_GEANT4READOUTVOLUMEFILTER_H

--- a/DDG4/include/DDG4/Geant4RunAction.h
+++ b/DDG4/include/DDG4/Geant4RunAction.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4RUNACTION_H
-#define DD4HEP_DDG4_GEANT4RUNACTION_H
+#ifndef DDG4_GEANT4RUNACTION_H
+#define DDG4_GEANT4RUNACTION_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -160,4 +160,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4RUNACTION_H
+#endif // DDG4_GEANT4RUNACTION_H

--- a/DDG4/include/DDG4/Geant4SensDetAction.h
+++ b/DDG4/include/DDG4/Geant4SensDetAction.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4SENSDETACTION_H
-#define DD4HEP_DDG4_GEANT4SENSDETACTION_H
+#ifndef DDG4_GEANT4SENSDETACTION_H
+#define DDG4_GEANT4SENSDETACTION_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -533,4 +533,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4RUNACTION_H
+#endif // DDG4_GEANT4SENSDETACTION_H

--- a/DDG4/include/DDG4/Geant4SensitiveDetector.h
+++ b/DDG4/include/DDG4/Geant4SensitiveDetector.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_GEANT4SENSITIVEDETECTOR_H
-#define DD4HEP_GEANT4SENSITIVEDETECTOR_H
+#ifndef DDG4_GEANT4SENSITIVEDETECTOR_H
+#define DDG4_GEANT4SENSITIVEDETECTOR_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -174,4 +174,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_GEANT4SENSITIVEDETECTOR_H
+#endif // DDG4_GEANT4SENSITIVEDETECTOR_H

--- a/DDG4/include/DDG4/Geant4SensitiveDetector_inline.h
+++ b/DDG4/include/DDG4/Geant4SensitiveDetector_inline.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_GEANT4SENSITIVEDETECTOR_INLINE_H
-#define DD4HEP_GEANT4SENSITIVEDETECTOR_INLINE_H
+#ifndef DDG4_GEANT4SENSITIVEDETECTOR_INLINE_H
+#define DDG4_GEANT4SENSITIVEDETECTOR_INLINE_H
 
 // Framework include files
 #include "DDG4/Geant4SensitiveDetector.h"
@@ -56,4 +56,4 @@ template <class SD> bool dd4hep::sim::Geant4GenericSD<SD>::buildHits(G4Step*, G4
   return true;
 }
 
-#endif // DD4HEP_GEANT4SENSITIVEDETECTOR_INLINE_H
+#endif // DDG4_GEANT4SENSITIVEDETECTOR_INLINE_H

--- a/DDG4/include/DDG4/Geant4StackingAction.h
+++ b/DDG4/include/DDG4/Geant4StackingAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4STACKINGACTION_H
-#define DD4HEP_DDG4_GEANT4STACKINGACTION_H
+#ifndef DDG4_GEANT4STACKINGACTION_H
+#define DDG4_GEANT4STACKINGACTION_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -142,4 +142,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4STACKINGACTION_H
+#endif // DDG4_GEANT4STACKINGACTION_H

--- a/DDG4/include/DDG4/Geant4StepHandler.h
+++ b/DDG4/include/DDG4/Geant4StepHandler.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_GEANT4STEPHANDLER_H
-#define DD4HEP_GEANT4STEPHANDLER_H
+#ifndef DDG4_GEANT4STEPHANDLER_H
+#define DDG4_GEANT4STEPHANDLER_H
 
 // Framework include files
 #include "DDG4/Defs.h"
@@ -257,4 +257,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_GEANT4STEPHANDLER_H
+#endif // DDG4_GEANT4STEPHANDLER_H

--- a/DDG4/include/DDG4/Geant4SteppingAction.h
+++ b/DDG4/include/DDG4/Geant4SteppingAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4STEPPINGACTION_H
-#define DD4HEP_DDG4_GEANT4STEPPINGACTION_H
+#ifndef DDG4_GEANT4STEPPINGACTION_H
+#define DDG4_GEANT4STEPPINGACTION_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -136,4 +136,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4STEPPINGACTION_H
+#endif // DDG4_GEANT4STEPPINGACTION_H

--- a/DDG4/include/DDG4/Geant4TestActions.h
+++ b/DDG4/include/DDG4/Geant4TestActions.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4TESTACTIONS_H
-#define DD4HEP_DDG4_GEANT4TESTACTIONS_H
+#ifndef DDG4_GEANT4TESTACTIONS_H
+#define DDG4_GEANT4TESTACTIONS_H
 
 // Framework include files
 #include "DDG4/Geant4Handle.h"
@@ -173,4 +173,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4TESTACTIONS_H
+#endif // DDG4_GEANT4TESTACTIONS_H

--- a/DDG4/include/DDG4/Geant4TouchableHandler.h
+++ b/DDG4/include/DDG4/Geant4TouchableHandler.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_GEANT4TOUCHABLEHANDLER_H
-#define DD4HEP_GEANT4TOUCHABLEHANDLER_H
+#ifndef DDG4_GEANT4TOUCHABLEHANDLER_H
+#define DDG4_GEANT4TOUCHABLEHANDLER_H
 
 // C/C++ include files
 #include <vector>
@@ -66,4 +66,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_GEANT4TOUCHABLEHANDLER_H
+#endif // DDG4_GEANT4TOUCHABLEHANDLER_H

--- a/DDG4/include/DDG4/Geant4TrackHandler.h
+++ b/DDG4/include/DDG4/Geant4TrackHandler.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4TRACKHANDLER_H
-#define DD4HEP_DDG4_GEANT4TRACKHANDLER_H
+#ifndef DDG4_GEANT4TRACKHANDLER_H
+#define DDG4_GEANT4TRACKHANDLER_H
 
 // Framework include files
 #include "DDG4/Defs.h"
@@ -204,4 +204,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4TRACKHANDLER_H
+#endif // DDG4_GEANT4TRACKHANDLER_H

--- a/DDG4/include/DDG4/Geant4TrackInformation.h
+++ b/DDG4/include/DDG4/Geant4TrackInformation.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4TRACKINFORMATION_H
-#define DD4HEP_DDG4_GEANT4TRACKINFORMATION_H
+#ifndef DDG4_GEANT4TRACKINFORMATION_H
+#define DDG4_GEANT4TRACKINFORMATION_H
 
 // Framework include files
 #include "G4VUserTrackInformation.hh"
@@ -54,4 +54,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4TRACKINFORMATION_H
+#endif // DDG4_GEANT4TRACKINFORMATION_H

--- a/DDG4/include/DDG4/Geant4TrackingAction.h
+++ b/DDG4/include/DDG4/Geant4TrackingAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4TRACKINGACTION_H
-#define DD4HEP_DDG4_GEANT4TRACKINGACTION_H
+#ifndef DDG4_GEANT4TRACKINGACTION_H
+#define DDG4_GEANT4TRACKINGACTION_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -173,4 +173,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4TRACKINGACTION_H
+#endif // DDG4_GEANT4TRACKINGACTION_H

--- a/DDG4/include/DDG4/Geant4TrackingPostAction.h
+++ b/DDG4/include/DDG4/Geant4TrackingPostAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4TRACKINGPOSTACTION_H
-#define DD4HEP_DDG4_GEANT4TRACKINGPOSTACTION_H
+#ifndef DDG4_GEANT4TRACKINGPOSTACTION_H
+#define DDG4_GEANT4TRACKINGPOSTACTION_H
 
 // Framework include files
 #include "DDG4/Geant4TrackingAction.h"
@@ -52,4 +52,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4TRACKINGPOSTACTION_H
+#endif // DDG4_GEANT4TRACKINGPOSTACTION_H

--- a/DDG4/include/DDG4/Geant4TrackingPreAction.h
+++ b/DDG4/include/DDG4/Geant4TrackingPreAction.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4TRACKINGPREACTION_H
-#define DD4HEP_DDG4_GEANT4TRACKINGPREACTION_H
+#ifndef DDG4_GEANT4TRACKINGPREACTION_H
+#define DDG4_GEANT4TRACKINGPREACTION_H
 
 // Framework include files
 #include "DDG4/Geant4TrackingAction.h"
@@ -42,4 +42,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4TRACKINGPREACTION_H
+#endif // DDG4_GEANT4TRACKINGPREACTION_H

--- a/DDG4/include/DDG4/Geant4UIManager.h
+++ b/DDG4/include/DDG4/Geant4UIManager.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4UIMANAGER_H
-#define DD4HEP_DDG4_GEANT4UIMANAGER_H
+#ifndef DDG4_GEANT4UIMANAGER_H
+#define DDG4_GEANT4UIMANAGER_H
 
 // Framework include files
 #include "DDG4/Geant4Call.h"
@@ -97,4 +97,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4UIMANAGER_H
+#endif // DDG4_GEANT4UIMANAGER_H

--- a/DDG4/include/DDG4/Geant4UIMessenger.h
+++ b/DDG4/include/DDG4/Geant4UIMessenger.h
@@ -11,8 +11,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDG4_GEANT4UIMESSENGER_H
-#define DD4HEP_DDG4_GEANT4UIMESSENGER_H
+#ifndef DDG4_GEANT4UIMESSENGER_H
+#define DDG4_GEANT4UIMESSENGER_H
 
 // Framework include files
 #include "DD4hep/ComponentProperties.h"
@@ -80,4 +80,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4UIMESSENGER_H
+#endif // DDG4_GEANT4UIMESSENGER_H

--- a/DDG4/include/DDG4/Geant4UserInitialization.h
+++ b/DDG4/include/DDG4/Geant4UserInitialization.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4USERINITIALIZATION_H
-#define DD4HEP_DDG4_GEANT4USERINITIALIZATION_H
+#ifndef DDG4_GEANT4USERINITIALIZATION_H
+#define DDG4_GEANT4USERINITIALIZATION_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -84,4 +84,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4USERINITIALIZATION_H
+#endif // DDG4_GEANT4USERINITIALIZATION_H

--- a/DDG4/include/DDG4/Geant4UserLimits.h
+++ b/DDG4/include/DDG4/Geant4UserLimits.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4USERLIMITS_H
-#define DD4HEP_DDG4_GEANT4USERLIMITS_H
+#ifndef DDG4_GEANT4USERLIMITS_H
+#define DDG4_GEANT4USERLIMITS_H
 
 // Framework include files
 #include "DD4hep/Objects.h"
@@ -100,4 +100,4 @@ namespace dd4hep {
   }
 }
 
-#endif  // DD4HEP_DDG4_GEANT4USERLIMITS_H
+#endif // DDG4_GEANT4USERLIMITS_H

--- a/DDG4/include/DDG4/Geant4UserParticleHandler.h
+++ b/DDG4/include/DDG4/Geant4UserParticleHandler.h
@@ -22,8 +22,8 @@
  */
 
 
-#ifndef DD4HEP_DDG4_GEANT4USERPARTICLEHANDLER_H
-#define DD4HEP_DDG4_GEANT4USERPARTICLEHANDLER_H
+#ifndef DDG4_GEANT4USERPARTICLEHANDLER_H
+#define DDG4_GEANT4USERPARTICLEHANDLER_H
 
 // Framework include files
 #include "DDG4/Geant4Data.h"
@@ -134,4 +134,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4USERPARTICLEHANDLER_H
+#endif // DDG4_GEANT4USERPARTICLEHANDLER_H

--- a/DDG4/include/DDG4/Geant4Vertex.h
+++ b/DDG4/include/DDG4/Geant4Vertex.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_GEANT4VERTEX_H
-#define DD4HEP_GEANT4VERTEX_H
+#ifndef DDG4_GEANT4VERTEX_H
+#define DDG4_GEANT4VERTEX_H
 
 // Framework include files
 #include "DD4hep/Memory.h"
@@ -73,4 +73,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_GEANT4VERTEX_H
+#endif // DDG4_GEANT4VERTEX_H

--- a/DDG4/include/DDG4/Geant4VolumeManager.h
+++ b/DDG4/include/DDG4/Geant4VolumeManager.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4VOLUMEMANAGER_H
-#define DD4HEP_DDG4_GEANT4VOLUMEMANAGER_H
+#ifndef DDG4_GEANT4VOLUMEMANAGER_H
+#define DDG4_GEANT4VOLUMEMANAGER_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -85,4 +85,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4VOLUMEMANAGER_H
+#endif // DDG4_GEANT4VOLUMEMANAGER_H

--- a/DDG4/include/DDG4/IoStreams.h
+++ b/DDG4/include/DDG4/IoStreams.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DD4HEP_IOSTREAMS_H
-#define DD4HEP_DD4HEP_IOSTREAMS_H
+#ifndef DDG4_IOSTREAMS_H
+#define DDG4_IOSTREAMS_H
 
 // C/C++ include files
 #include <string>
@@ -260,4 +260,4 @@ namespace dd4hep {
 #pragma GCC diagnostic pop
 #endif
 
-#endif // DD4HEP_DD4HEP_IOSTREAMs_H
+#endif // DDG4_IOSTREAMS_H

--- a/DDG4/include/DDG4/Python/DDPython.h
+++ b/DDG4/include/DDG4/Python/DDPython.h
@@ -11,8 +11,8 @@
 //  \date   2015-11-07
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_DDPYTHON_H 
-#define DD4HEP_DDG4_DDPYTHON_H 1
+#ifndef DDG4_PYTHON_DDPYTHON_H
+#define DDG4_PYTHON_DDPYTHON_H 1
 
 // C/C++ include files
 #include <string>
@@ -114,4 +114,4 @@ namespace dd4hep  {
   };
 }
 
-#endif // DD4HEP_DDG4_DDPYTHON_H
+#endif // DDG4_PYTHON_DDPYTHON_H

--- a/DDG4/include/DDG4/Python/Geant4PythonAction.h
+++ b/DDG4/include/DDG4/Python/Geant4PythonAction.h
@@ -11,8 +11,8 @@
 //  \date   2015-11-03
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4PYTHONACTION_H
-#define DD4HEP_DDG4_GEANT4PYTHONACTION_H
+#ifndef DDG4_PYTHON_GEANT4PYTHONACTION_H
+#define DDG4_PYTHON_GEANT4PYTHONACTION_H
 
 // Framework include files
 #include "DDG4/Geant4Action.h"
@@ -51,4 +51,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4PYTHONACTION_H
+#endif // DDG4_PYTHON_GEANT4PYTHONACTION_H

--- a/DDG4/include/DDG4/Python/Geant4PythonCall.h
+++ b/DDG4/include/DDG4/Python/Geant4PythonCall.h
@@ -11,8 +11,8 @@
 //  \date   2015-11-03
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4PYTHONCALL_H
-#define DD4HEP_DDG4_GEANT4PYTHONCALL_H
+#ifndef DDG4_PYTHON_GEANT4PYTHONCALL_H
+#define DDG4_PYTHON_GEANT4PYTHONCALL_H
 
 // ROOT include files
 #include "TPyReturn.h"
@@ -60,4 +60,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4PYTHONCALL_H
+#endif // DDG4_PYTHON_GEANT4PYTHONCALL_H

--- a/DDG4/include/DDG4/Python/Geant4PythonDetectorConstruction.h
+++ b/DDG4/include/DDG4/Python/Geant4PythonDetectorConstruction.h
@@ -11,8 +11,8 @@
 //  \date   2015-11-03
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4PYTHONDETECTORCONSTRUCTION_H
-#define DD4HEP_DDG4_GEANT4PYTHONDETECTORCONSTRUCTION_H
+#ifndef DDG4_PYTHON_GEANT4PYTHONDETECTORCONSTRUCTION_H
+#define DDG4_PYTHON_GEANT4PYTHONDETECTORCONSTRUCTION_H
 
 // Framework include files
 #include "DDG4/Geant4DetectorConstruction.h"
@@ -92,4 +92,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4PYTHONDETECTORCONSTRUCTION_H
+#endif // DDG4_PYTHON_GEANT4PYTHONDETECTORCONSTRUCTION_H

--- a/DDG4/include/DDG4/Python/Geant4PythonInitialization.h
+++ b/DDG4/include/DDG4/Python/Geant4PythonInitialization.h
@@ -11,8 +11,8 @@
 //  \date   2015-11-03
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4PYTHONINITIALIZATION_H
-#define DD4HEP_DDG4_GEANT4PYTHONINITIALIZATION_H
+#ifndef DDG4_PYTHON_GEANT4PYTHONINITIALIZATION_H
+#define DDG4_PYTHON_GEANT4PYTHONINITIALIZATION_H
 
 // Framework include files
 #include "DDG4/Geant4UserInitialization.h"
@@ -83,4 +83,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4PYTHONINITIALIZATION_H
+#endif // DDG4_PYTHON_GEANT4PYTHONINITIALIZATION_H

--- a/DDG4/include/DDG4/Python/PyDDG4.h
+++ b/DDG4/include/DDG4/Python/PyDDG4.h
@@ -11,8 +11,8 @@
 //  \date   2015-11-03
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_PYDDG4_H
-#define DD4HEP_DDG4_PYDDG4_H
+#ifndef DDG4_PYTHON_PYDDG4_H
+#define DDG4_PYTHON_PYDDG4_H
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -38,4 +38,4 @@ struct PyDDG4  {
   static int run(Kernel& kernel);
   static int run(const char* fname);
 };
-#endif // DD4HEP_DDG4_PYDDG4_H
+#endif // DDG4_PYTHON_PYDDG4_H

--- a/DDG4/lcio/LCIOEventReader.h
+++ b/DDG4/lcio/LCIOEventReader.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_LCIOEVENTREADER_H
-#define DD4HEP_DDG4_LCIOEVENTREADER_H
+#ifndef DDG4_LCIO_LCIOEVENTREADER_H
+#define DDG4_LCIO_LCIOEVENTREADER_H
 
 // Framework include files
 #include "DDG4/Geant4InputAction.h"
@@ -49,4 +49,4 @@ namespace dd4hep  {
 
   }     /* End namespace sim   */
 }       /* End namespace dd4hep */
-#endif  /* DD4HEP_DDG4_LCIOEVENTREADER_H  */
+#endif // DDG4_LCIO_LCIOEVENTREADER_H

--- a/DDG4/plugins/Geant4.10.PhysicsConstructors.h
+++ b/DDG4/plugins/Geant4.10.PhysicsConstructors.h
@@ -1,3 +1,6 @@
+#ifndef DDG4_PLUGINS_GEANT4_10_PHYSICSCONSTRUCTORS_H
+#define DDG4_PLUGINS_GEANT4_10_PHYSICSCONSTRUCTORS_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -103,3 +106,5 @@ DECLARE_GEANT4_PHYSICS(G4NeutronTrackingCut)
 // Optical physics
 #include "G4OpticalPhysics.hh"
 DECLARE_GEANT4_PHYSICS(G4OpticalPhysics)
+
+#endif

--- a/DDG4/plugins/Geant4.9.PhysicsConstructors.h
+++ b/DDG4/plugins/Geant4.9.PhysicsConstructors.h
@@ -1,3 +1,6 @@
+#ifndef DDG4_PLUGINS_GEANT4_9_PHYSICSCONSTRUCTORS_H
+#define DDG4_PLUGINS_GEANT4_9_PHYSICSCONSTRUCTORS_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -151,3 +154,5 @@ DECLARE_GEANT4_PHYSICS(HadronPhysicsQGSP_BIC_HP)
 DECLARE_GEANT4_PHYSICS(HadronPhysicsQGSP_FTFP_BERT)
 #include "HadronPhysicsQGSP.hh"
 DECLARE_GEANT4_PHYSICS(HadronPhysicsQGSP)
+
+#endif

--- a/DDG4/plugins/Geant4EventSeed.h
+++ b/DDG4/plugins/Geant4EventSeed.h
@@ -10,8 +10,8 @@
 // Author     : A.Sailer
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4EVENTSEED_H
-#define DD4HEP_DDG4_GEANT4EVENTSEED_H
+#ifndef DDG4_PLUGINS_GEANT4EVENTSEED_H
+#define DDG4_PLUGINS_GEANT4EVENTSEED_H
 
 // Framework include files
 #include "DDG4/Geant4RunAction.h"
@@ -215,4 +215,4 @@ namespace dd4hep {
   }    // End namespace sim
 }      // End namespace dd4hep
 
-#endif // DD4HEP_DDG4_GEANT4EVENTSEED_H
+#endif // DDG4_PLUGINS_GEANT4EVENTSEED_H

--- a/DDG4/plugins/Geant4ExtraParticles.h
+++ b/DDG4/plugins/Geant4ExtraParticles.h
@@ -3,8 +3,8 @@
 //          Taikan Suehara <suehara@icepp.s.u-tokyo.ac.jp>
 // Proted from Mokka by A.Sailer (CERN )
 //
-#ifndef ExtraParticles_hh
-#define ExtraParticles_hh 1
+#ifndef DDG4_PLUGINS_GEANT4EXTRAPARTICLES_H
+#define DDG4_PLUGINS_GEANT4EXTRAPARTICLES_H 1
 
 #include "DDG4/Geant4PhysicsConstructor.h"
 

--- a/DDG4/src/Geant4ShapeConverter.h
+++ b/DDG4/src/Geant4ShapeConverter.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDG4_GEANT4SHAPECONVERTER_H
-#define DD4HEP_DDG4_GEANT4SHAPECONVERTER_H
+#ifndef DDG4_SRC_GEANT4SHAPECONVERTER_H
+#define DDG4_SRC_GEANT4SHAPECONVERTER_H
 
 // Framework include files
 
@@ -32,4 +32,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // DD4HEP_DDG4_GEANT4SHAPECONVERTER_H
+#endif // DDG4_SRC_GEANT4SHAPECONVERTER_H

--- a/DDParsers/include/Evaluator/DD4hepUnits.h
+++ b/DDParsers/include/Evaluator/DD4hepUnits.h
@@ -24,8 +24,8 @@
 // radian             rad=1                 rad = 1  //NB: different from TGeo
 //
 //
-#ifndef DD4HEP_TGEOUNITS_H
-#define DD4HEP_TGEOUNITS_H
+#ifndef EVALUATOR_DD4HEPUNITS_H
+#define EVALUATOR_DD4HEPUNITS_H
 
 #include "RVersion.h"
 
@@ -426,4 +426,4 @@ namespace dd4hep {
 }
 #endif
 
-#endif /* DD4HEP_TGEOUNITS_H */
+#endif // EVALUATOR_DD4HEPUNITS_H

--- a/DDParsers/include/Evaluator/Evaluator.h
+++ b/DDParsers/include/Evaluator/Evaluator.h
@@ -11,8 +11,8 @@
 // -*- C++ -*-
 // ---------------------------------------------------------------------------
 
-#ifndef XMLTOOLS_EVALUATOR_H
-#define XMLTOOLS_EVALUATOR_H
+#ifndef EVALUATOR_EVALUATOR_H
+#define EVALUATOR_EVALUATOR_H
 
 #include <ostream>
 
@@ -284,4 +284,4 @@ namespace dd4hep  {
   }   // namespace tools
 }  // namespace dd4hep
 
-#endif /* XMLTOOLS_EVALUATOR_H */
+#endif // EVALUATOR_EVALUATOR_H

--- a/DDParsers/include/Parsers/Parsers.h
+++ b/DDParsers/include/Parsers/Parsers.h
@@ -14,8 +14,8 @@
 // Setup XML parsing for the use of Apache Xerces-C and TiXml
 //
 //==========================================================================
-#ifndef DD4HEP_PARSERS_PARSERS_H
-#define DD4HEP_PARSERS_PARSERS_H
+#ifndef PARSERS_PARSERS_H
+#define PARSERS_PARSERS_H
 
 #include "Parsers/config.h"
 #include <iostream>
@@ -31,4 +31,4 @@ namespace dd4hep {
     template <typename TYPE> std::ostream& toStream(const TYPE& obj, std::ostream& s);
   }    // End namespace Parsers
 }      // End namespace dd4hep
-#endif // DD4HEP_PARSERS_PARSERS_H
+#endif // PARSERS_PARSERS_H

--- a/DDParsers/include/Parsers/config.h
+++ b/DDParsers/include/Parsers/config.h
@@ -14,9 +14,9 @@
 // Setup XML parsing for the use of Apache Xerces-C and TiXml
 //
 //==========================================================================
-#ifndef DD4HEP_PARSERS_CONFIG_H
-#define DD4HEP_PARSERS_CONFIG_H
+#ifndef PARSERS_CONFIG_H
+#define PARSERS_CONFIG_H
 
 //#define dd4hep Online
 
-#endif // DD4HEP_PARSERS_CONFIG_H
+#endif // PARSERS_CONFIG_H

--- a/DDParsers/include/Parsers/spirit/GrammarsV2.h
+++ b/DDParsers/include/Parsers/spirit/GrammarsV2.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEPKERNEL_GRAMMARSV2_H
-#define DD4HEPKERNEL_GRAMMARSV2_H 1
+#ifndef PARSERS_SPIRIT_GRAMMARSV2_H
+#define PARSERS_SPIRIT_GRAMMARSV2_H 1
 #ifdef __GNUC__
 #pragma GCC system_header
 #endif

--- a/DDParsers/include/Parsers/spirit/ParsersFactory.h
+++ b/DDParsers/include/Parsers/spirit/ParsersFactory.h
@@ -8,8 +8,8 @@
 // For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 //
 //==========================================================================
-#ifndef DD4HEPPROPERTYPARSERS_PARSERSGENERATOR_H
-#define DD4HEPPROPERTYPARSERS_PARSERSGENERATOR_H 1
+#ifndef PARSERS_SPIRIT_PARSERSFACTORY_H
+#define PARSERS_SPIRIT_PARSERSFACTORY_H 1
 // ============================================================================
 // Include files
 // ============================================================================
@@ -83,5 +83,5 @@ namespace dd4hep {
     {  return toStream_(obj, s); }}}
 // ============================================================================
 
-#endif // DD4HEPPROPERTYPARSERS_PARSERSGENERATOR_H
+#endif // PARSERS_SPIRIT_PARSERSFACTORY_H
 

--- a/DDParsers/include/Parsers/spirit/ParsersStandardListCommon.h
+++ b/DDParsers/include/Parsers/spirit/ParsersStandardListCommon.h
@@ -8,8 +8,8 @@
 // For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 //
 //==========================================================================
-#ifndef PARSERS_STANDARD_LIST_COMMON_H
-#define PARSERS_STANDARD_LIST_COMMON_H 1
+#ifndef PARSERS_SPIRIT_PARSERSSTANDARDLISTCOMMON_H
+#define PARSERS_SPIRIT_PARSERSSTANDARDLISTCOMMON_H 1
 // ============================================================================
 // Include files
 // ============================================================================
@@ -89,4 +89,4 @@ namespace dd4hep {
       IMPLEMENT_MAPPED_PARSERS(pair,InnerType)            }}
 
 // ============================================================================
-#endif /* PARSERS_STANDARD_LIST_COMMON_H */
+#endif // PARSERS_SPIRIT_PARSERSSTANDARDLISTCOMMON_H

--- a/DDParsers/include/Parsers/spirit/ParsersStandardMiscCommon.h
+++ b/DDParsers/include/Parsers/spirit/ParsersStandardMiscCommon.h
@@ -8,11 +8,11 @@
 // For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 //
 //==========================================================================
-#ifndef PARSERS_STANDARD_MISC_COMMON_H
-#define PARSERS_STANDARD_MISC_COMMON_H 1
+#ifndef PARSERS_SPIRIT_PARSERSSTANDARDMISCCOMMON_H
+#define PARSERS_SPIRIT_PARSERSSTANDARDMISCCOMMON_H 1
 // ============================================================================
 // Include files
 // ============================================================================
 #include "Parsers/spirit/ParsersFactory.h"
 // ============================================================================
-#endif /* PARSERS_STANDARD_MISC_COMMON_H */
+#endif // PARSERS_SPIRIT_PARSERSSTANDARDMISCCOMMON_H

--- a/DDParsers/include/Parsers/spirit/ToStream.h
+++ b/DDParsers/include/Parsers/spirit/ToStream.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEPPROPERTYPARSERS_PARSERVALUETOSTREAM_H
-#define DD4HEPPROPERTYPARSERS_PARSERVALUETOSTREAM_H 1
+#ifndef PARSERS_SPIRIT_TOSTREAM_H
+#define PARSERS_SPIRIT_TOSTREAM_H 1
 // ============================================================================
 // Include files
 #include "Parsers/config.h"

--- a/DDParsers/include/Parsers/spirit/UsedParser.h
+++ b/DDParsers/include/Parsers/spirit/UsedParser.h
@@ -8,8 +8,8 @@
 // For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_PARSERS_USEDPARSERS_H
-#define DD4HEP_DDCORE_PARSERS_USEDPARSERS_H
+#ifndef PARSERS_SPIRIT_USEDPARSER_H
+#define PARSERS_SPIRIT_USEDPARSER_H
 
 #include "Parsers/config.h"
 
@@ -25,4 +25,4 @@
 
 #endif
 
-#endif //  DD4HEP_DDCORE_PARSERS_USEDPARSERS_H
+#endif // PARSERS_SPIRIT_USEDPARSER_H

--- a/DDParsers/src/ParsersDictionary.h
+++ b/DDParsers/src/ParsersDictionary.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef PARSERDICTIONARY_H 
-#define PARSERDICTIONARY_H 1
+#ifndef DDPARSERS_SRC_PARSERSDICTIONARY_H
+#define DDPARSERS_SRC_PARSERSDICTIONARY_H 1
 
 
-#endif  // PARSERDICTIONARY_H 
+#endif // DDPARSERS_SRC_PARSERSDICTIONARY_H

--- a/DDRec/include/DDRec/CellIDPositionConverter.h
+++ b/DDRec/include/DDRec/CellIDPositionConverter.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef CellIDPositionConverter_H_
-#define CellIDPositionConverter_H_
+#ifndef DDREC_CELLIDPOSITIONCONVERTER_H
+#define DDREC_CELLIDPOSITIONCONVERTER_H
 
 #include "DD4hep/Detector.h"
 #include "DD4hep/Readout.h"
@@ -131,4 +131,4 @@ namespace dd4hep {
 
 
 
-#endif /* CellIDPositionConverter_H_ */
+#endif // DDREC_CELLIDPOSITIONCONVERTER_H

--- a/DDRec/include/DDRec/DDGear.h
+++ b/DDRec/include/DDRec/DDGear.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef DDGear_H
-#define DDGear_H
+#ifndef DDREC_DDGEAR_H
+#define DDREC_DDGEAR_H
 
 #include "DD4hep/Detector.h"
 #include "DD4hep/DetElement.h"

--- a/DDRec/include/DDRec/DetectorData.h
+++ b/DDRec/include/DDRec/DetectorData.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef rec_DetectorData_H_
-#define rec_DetectorData_H_
+#ifndef DDREC_DETECTORDATA_H
+#define DDREC_DETECTORDATA_H
 
 #include <map>
 #include <bitset>
@@ -507,4 +507,4 @@ namespace dd4hep {
   } /* namespace rec */
 } /* namespace dd4hep */
 
-#endif // rec_DetectorData_H_
+#endif // DDREC_DETECTORDATA_H

--- a/DDRec/include/DDRec/DetectorSurfaces.h
+++ b/DDRec/include/DDRec/DetectorSurfaces.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef rec_DetectorSurfaces_H_
-#define rec_DetectorSurfaces_H_
+#ifndef DDREC_DETECTORSURFACES_H
+#define DDREC_DETECTORSURFACES_H
 
 #include "DDRec/Surface.h"
 
@@ -50,4 +50,4 @@ namespace dd4hep {
 
 
 
-#endif // rec_DetectorSurfaces_H_
+#endif // DDREC_DETECTORSURFACES_H

--- a/DDRec/include/DDRec/IMaterial.h
+++ b/DDRec/include/DDRec/IMaterial.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef DDRec_IMaterial_H_
-#define DDRec_IMaterial_H_
+#ifndef DDREC_IMATERIAL_H
+#define DDREC_IMATERIAL_H
 
 #include <string>
 #include <ostream>
@@ -69,4 +69,4 @@ namespace dd4hep { namespace rec {
 
 
 
-#endif /* DDRec_MATERIAL_H_ */
+#endif // DDREC_IMATERIAL_H

--- a/DDRec/include/DDRec/ISurface.h
+++ b/DDRec/include/DDRec/ISurface.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef DDRec_ISurface_H
-#define DDRec_ISurface_H
+#ifndef DDREC_ISURFACE_H
+#define DDREC_ISURFACE_H
 
 
 #include "DDRec/IMaterial.h"
@@ -335,4 +335,4 @@ namespace dd4hep { namespace rec {
 
 
 
-#endif /* DDRec_ISurface_H */
+#endif // DDREC_ISURFACE_H

--- a/DDRec/include/DDRec/Material.h
+++ b/DDRec/include/DDRec/Material.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef rec_Material_H
-#define rec_Material_H
+#ifndef DDREC_MATERIAL_H
+#define DDREC_MATERIAL_H
 
 #include "DD4hep/Detector.h"
 #include "DDRec/IMaterial.h"
@@ -180,4 +180,4 @@ namespace dd4hep {
 
 
 
-#endif /* rec_Material_H */
+#endif // DDREC_MATERIAL_H

--- a/DDRec/include/DDRec/MaterialManager.h
+++ b/DDRec/include/DDRec/MaterialManager.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef rec_MaterialManager_H_
-#define rec_MaterialManager_H_
+#ifndef DDREC_MATERIALMANAGER_H
+#define DDREC_MATERIALMANAGER_H
 
 #include "DD4hep/Detector.h"
 #include "DD4hep/Objects.h"
@@ -112,4 +112,4 @@ namespace dd4hep {
 
 
 
-#endif // rec_MaterialManager_H_
+#endif // DDREC_MATERIALMANAGER_H

--- a/DDRec/include/DDRec/MaterialScan.h
+++ b/DDRec/include/DDRec/MaterialScan.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDREC_MATERIALSCAN_H
-#define DD4HEP_DDREC_MATERIALSCAN_H
+#ifndef DDREC_MATERIALSCAN_H
+#define DDREC_MATERIALSCAN_H
 
 // Framework include files
 #include "DDRec/MaterialManager.h"
@@ -97,4 +97,4 @@ namespace dd4hep {
     };
   }    // End namespace rec
 }      // End namespace dd4hep
-#endif // DD4HEP_DDREC_MATERIALSCAN_H
+#endif // DDREC_MATERIALSCAN_H

--- a/DDRec/include/DDRec/Surface.h
+++ b/DDRec/include/DDRec/Surface.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef rec_Surface_H
-#define rec_Surface_H
+#ifndef DDREC_SURFACE_H
+#define DDREC_SURFACE_H
 
 #include "DD4hep/Objects.h"
 #include "DD4hep/Volumes.h"
@@ -708,4 +708,4 @@ namespace dd4hep {
 
 
 
-#endif /* Surface */
+#endif // DDREC_SURFACE_H

--- a/DDRec/include/DDRec/SurfaceHelper.h
+++ b/DDRec/include/DDRec/SurfaceHelper.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef rec_SurfaceHelper_H_
-#define rec_SurfaceHelper_H_
+#ifndef DDREC_SURFACEHELPER_H
+#define DDREC_SURFACEHELPER_H
 
 #include "DDRec/Surface.h"
 
@@ -53,4 +53,4 @@ namespace dd4hep {
 
 
 
-#endif // rec_SurfaceHelper_H_
+#endif // DDREC_SURFACEHELPER_H

--- a/DDRec/include/DDRec/SurfaceManager.h
+++ b/DDRec/include/DDRec/SurfaceManager.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef rec_SurfaceManager_H_
-#define rec_SurfaceManager_H_
+#ifndef DDREC_SURFACEMANAGER_H
+#define DDREC_SURFACEMANAGER_H
 
 #include "DDRec/ISurface.h"
 #include "DD4hep/Detector.h"
@@ -79,4 +79,4 @@ namespace dd4hep {
 
 
 
-#endif // rec_SurfaceManager_H_
+#endif // DDREC_SURFACEMANAGER_H

--- a/DDRec/include/DDRec/Vector2D.h
+++ b/DDRec/include/DDRec/Vector2D.h
@@ -10,10 +10,11 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef DDRec_Vector2D_h
-#define DDRec_Vector2D_h 1
+#ifndef DDREC_VECTOR2D_H
+#define DDREC_VECTOR2D_H 1
 
-namespace dd4hep { namespace rec {
+namespace dd4hep {
+  namespace rec {
   
   /** Simple 2D vector helper class; moved out of ISurface definition.
    *

--- a/DDRec/include/DDRec/Vector3D.h
+++ b/DDRec/include/DDRec/Vector3D.h
@@ -10,8 +10,8 @@
 // Author     : F.Gaede
 //
 //==========================================================================
-#ifndef DDRec_Vector3D_h
-#define DDRec_Vector3D_h 1
+#ifndef DDREC_VECTOR3D_H
+#define DDREC_VECTOR3D_H 1
 
 #include <cmath>
 #include <iostream> 

--- a/DDRec/src/RecDictionary.h
+++ b/DDRec/src/RecDictionary.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_REC_RECDICTIONARY_H
-#define DD4HEP_REC_RECDICTIONARY_H
+#ifndef DDREC_SRC_RECDICTIONARY_H
+#define DDREC_SRC_RECDICTIONARY_H
 
 // Framework include files
 #include "DDRec/Material.h"
@@ -107,4 +107,4 @@ using namespace dd4hep::rec;
 
 #endif
 
-#endif /* DD4HEP_REC_RECDICTIONARY_H  */
+#endif // DDREC_SRC_RECDICTIONARY_H

--- a/DDTest/include/DD4hep/DDTest.h
+++ b/DDTest/include/DD4hep/DDTest.h
@@ -1,3 +1,6 @@
+#ifndef DD4HEP_DDTEST_H
+#define DD4HEP_DDTEST_H
+
 #include <iostream>
 #include <sstream>
 #include <stdlib.h>
@@ -174,3 +177,5 @@ namespace dd4hep{
 
 
 } // end namespace
+
+#endif

--- a/DDTest/src/STR.h
+++ b/DDTest/src/STR.h
@@ -12,8 +12,8 @@
 //
 //==========================================================================
 // $Id$
-#ifndef STR_H 
-#define STR_H 1
+#ifndef DDTEST_SRC_STR_H
+#define DDTEST_SRC_STR_H 1
 
 #include <sstream>
 #include <string>
@@ -53,4 +53,4 @@ namespace  {
   } 
 }
 
-#endif // STR_H
+#endif // DDTEST_SRC_STR_H

--- a/GaudiPluginService/Gaudi/Details/PluginServiceCommon.h
+++ b/GaudiPluginService/Gaudi/Details/PluginServiceCommon.h
@@ -1,3 +1,6 @@
+#ifndef GAUDIPLUGINSERVICE_GAUDI_DETAILS_PLUGINSERVICECOMMON_H
+#define GAUDIPLUGINSERVICE_GAUDI_DETAILS_PLUGINSERVICECOMMON_H
+
 #ifndef _GAUDI_PLUGIN_SERVICE_COMMON_H_
 /*****************************************************************************\
 * (c) Copyright 2013 CERN                                                     *
@@ -43,5 +46,7 @@
 #  else
 #    define GAUDIPS_API GAUDIPS_IMPORT
 #  endif
+
+#endif
 
 #endif

--- a/GaudiPluginService/Gaudi/Details/PluginServiceDetailsV1.h
+++ b/GaudiPluginService/Gaudi/Details/PluginServiceDetailsV1.h
@@ -1,5 +1,5 @@
-#ifndef _GAUDI_PLUGIN_SERVICE_DETAILS_V1_H_
-#define _GAUDI_PLUGIN_SERVICE_DETAILS_V1_H_
+#ifndef GAUDIPLUGINSERVICE_GAUDI_DETAILS_PLUGINSERVICEDETAILSV1_H
+#define GAUDIPLUGINSERVICE_GAUDI_DETAILS_PLUGINSERVICEDETAILSV1_H
 /*****************************************************************************\
 * (c) Copyright 2013 CERN                                                     *
 *                                                                             *
@@ -235,4 +235,4 @@ namespace Gaudi {
   _PS_V1_INTERNAL_DECLARE_FACTORY_WITH_CREATOR( type, ::Gaudi::PluginService::v1::Details::Factory<type>, id, factory, \
                                                 serial )
 
-#endif //_GAUDI_PLUGIN_SERVICE_DETAILS_H_
+#endif // GAUDIPLUGINSERVICE_GAUDI_DETAILS_PLUGINSERVICEDETAILSV1_H

--- a/GaudiPluginService/Gaudi/Details/PluginServiceDetailsV2.h
+++ b/GaudiPluginService/Gaudi/Details/PluginServiceDetailsV2.h
@@ -1,5 +1,5 @@
-#ifndef _GAUDI_PLUGIN_SERVICE_DETAILS_V2_H_
-#define _GAUDI_PLUGIN_SERVICE_DETAILS_V2_H_
+#ifndef GAUDIPLUGINSERVICE_GAUDI_DETAILS_PLUGINSERVICEDETAILSV2_H
+#define GAUDIPLUGINSERVICE_GAUDI_DETAILS_PLUGINSERVICEDETAILSV2_H
 /*****************************************************************************\
 * (c) Copyright 2013 CERN                                                     *
 *                                                                             *
@@ -224,4 +224,4 @@ namespace Gaudi {
   _PS_V2_INTERNAL_FACTORY_MAKE_REGISTER_CNAME_TOKEN( serial )
 #define _PS_V2_INTERNAL_FACTORY_REGISTER_CNAME _PS_V2_INTERNAL_FACTORY_MAKE_REGISTER_CNAME( __LINE__ )
 
-#endif //_GAUDI_PLUGIN_SERVICE_DETAILS_H_
+#endif // GAUDIPLUGINSERVICE_GAUDI_DETAILS_PLUGINSERVICEDETAILSV2_H

--- a/GaudiPluginService/Gaudi/PluginService.h
+++ b/GaudiPluginService/Gaudi/PluginService.h
@@ -1,5 +1,5 @@
-#ifndef _GAUDI_PLUGIN_SERVICE_H_
-#define _GAUDI_PLUGIN_SERVICE_H_
+#ifndef GAUDIPLUGINSERVICE_GAUDI_PLUGINSERVICE_H
+#define GAUDIPLUGINSERVICE_GAUDI_PLUGINSERVICE_H
 /*****************************************************************************\
 * (c) Copyright 2013 CERN                                                     *
 *                                                                             *

--- a/GaudiPluginService/Gaudi/PluginServiceV1.h
+++ b/GaudiPluginService/Gaudi/PluginServiceV1.h
@@ -1,5 +1,5 @@
-#ifndef _GAUDI_PLUGIN_SERVICE_V1_H_
-#define _GAUDI_PLUGIN_SERVICE_V1_H_
+#ifndef GAUDIPLUGINSERVICE_GAUDI_PLUGINSERVICEV1_H
+#define GAUDIPLUGINSERVICE_GAUDI_PLUGINSERVICEV1_H
 /*****************************************************************************\
 * (c) Copyright 2013 CERN                                                     *
 *                                                                             *
@@ -83,4 +83,4 @@ namespace Gaudi {
   } // namespace PluginService
 } // namespace Gaudi
 
-#endif //_GAUDI_PLUGIN_SERVICE_H_
+#endif // GAUDIPLUGINSERVICE_GAUDI_PLUGINSERVICEV1_H

--- a/GaudiPluginService/Gaudi/PluginServiceV2.h
+++ b/GaudiPluginService/Gaudi/PluginServiceV2.h
@@ -1,5 +1,5 @@
-#ifndef _GAUDI_PLUGIN_SERVICE_V2_H_
-#define _GAUDI_PLUGIN_SERVICE_V2_H_
+#ifndef GAUDIPLUGINSERVICE_GAUDI_PLUGINSERVICEV2_H
+#define GAUDIPLUGINSERVICE_GAUDI_PLUGINSERVICEV2_H
 /*****************************************************************************\
 * (c) Copyright 2013 CERN                                                     *
 *                                                                             *
@@ -137,4 +137,4 @@ namespace Gaudi {
 #  define DECLARE_FACTORY_WITH_ID( type, id, factory ) _PS_V2_DECLARE_FACTORY_WITH_ID( type, id, factory )
 #endif
 
-#endif //_GAUDI_PLUGIN_SERVICE_H_
+#endif // GAUDIPLUGINSERVICE_GAUDI_PLUGINSERVICEV2_H

--- a/GaudiPluginService/interface/DD4hep.h
+++ b/GaudiPluginService/interface/DD4hep.h
@@ -1,3 +1,6 @@
+#ifndef GAUDIPLUGINSERVICE_INTERFACE_DD4HEP_H
+#define GAUDIPLUGINSERVICE_INTERFACE_DD4HEP_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -86,3 +89,5 @@ extern "C"  {
   }
 #endif
 }
+
+#endif

--- a/GaudiPluginService/src/capi_pluginservice.h
+++ b/GaudiPluginService/src/capi_pluginservice.h
@@ -1,5 +1,5 @@
-#ifndef _GAUDI_C_PLUGIN_SERVICE_H_
-#define _GAUDI_C_PLUGIN_SERVICE_H_ 1
+#ifndef GAUDIPLUGINSERVICE_SRC_CAPI_PLUGINSERVICE_H
+#define GAUDIPLUGINSERVICE_SRC_CAPI_PLUGINSERVICE_H 1
 /*****************************************************************************\
 * (c) Copyright 2013 CERN                                                     *
 *                                                                             *
@@ -84,4 +84,4 @@ const char* cgaudi_property_get_value( cgaudi_property_t self );
 } /* extern "C" */
 #endif
 
-#endif /* !_GAUDI_C_PLUGIN_SERVICE_H_ */
+#endif // GAUDIPLUGINSERVICE_SRC_CAPI_PLUGINSERVICE_H

--- a/UtilityApps/src/EvNavHandler.h
+++ b/UtilityApps/src/EvNavHandler.h
@@ -9,8 +9,8 @@
 //
 //==========================================================================
 
-#ifndef EvNavHandler_h
-#define EvNavHandler_h
+#ifndef UTILITYAPPS_SRC_EVNAVHANDLER_H
+#define UTILITYAPPS_SRC_EVNAVHANDLER_H
 
 
 void next_event() ;

--- a/UtilityApps/src/LinkDef.h
+++ b/UtilityApps/src/LinkDef.h
@@ -1,3 +1,6 @@
+#ifndef UTILITYAPPS_SRC_LINKDEF_H
+#define UTILITYAPPS_SRC_LINKDEF_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -17,5 +20,7 @@
 
 
 #pragma link C++ class EvNavHandler ;
+
+#endif
 
 #endif

--- a/UtilityApps/src/MultiView.h
+++ b/UtilityApps/src/MultiView.h
@@ -9,8 +9,8 @@
 //
 //==========================================================================
 
-#ifndef MultiView_h
-#define MultiView_h
+#ifndef UTILITYAPPS_SRC_MULTIVIEW_H
+#define UTILITYAPPS_SRC_MULTIVIEW_H
 
 #include <TEveManager.h>
 #include <TEveViewer.h>

--- a/UtilityApps/src/main.h
+++ b/UtilityApps/src/main.h
@@ -1,3 +1,6 @@
+#ifndef UTILITYAPPS_SRC_MAIN_H
+#define UTILITYAPPS_SRC_MAIN_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -28,3 +31,5 @@ int main(int argc, char** argv)  {
   }
   return EINVAL;    
 }
+
+#endif

--- a/UtilityApps/src/run_plugin.h
+++ b/UtilityApps/src/run_plugin.h
@@ -1,3 +1,6 @@
+#ifndef UTILITYAPPS_SRC_RUN_PLUGIN_H
+#define UTILITYAPPS_SRC_RUN_PLUGIN_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -434,3 +437,5 @@ namespace dd4hep  {
     }
   }
 }
+
+#endif

--- a/doc/reference/classes/DD4hepGroups.h
+++ b/doc/reference/classes/DD4hepGroups.h
@@ -1,3 +1,6 @@
+#ifndef DOC_REFERENCE_CLASSES_DD4HEPGROUPS_H
+#define DOC_REFERENCE_CLASSES_DD4HEPGROUPS_H
+
 
 /// Generic shared objects and functions for all dd4hep areas
 /**
@@ -112,3 +115,5 @@ namespace UTIL {}
  \brief Plugins to manipulate surfaces automatically
 
  @}*/
+
+#endif

--- a/doc/reference/classes/Geant4Classes.h
+++ b/doc/reference/classes/Geant4Classes.h
@@ -1,3 +1,6 @@
+#ifndef DOC_REFERENCE_CLASSES_GEANT4CLASSES_H
+#define DOC_REFERENCE_CLASSES_GEANT4CLASSES_H
+
 
 /// Class of the Geant4 toolkit. See http://www-geant4.kek.jp/Reference
 /** Class of the Geant4 toolkit. \see http://www-geant4.kek.jp/Reference  */
@@ -70,3 +73,5 @@ class G4VUserPrimaryGeneratorAction	{};
 /// Class of the Geant4 toolkit. See http://www-geant4.kek.jp/Reference
 /** Class of the Geant4 toolkit. \see http://www-geant4.kek.jp/Reference  */
 class G4VUserTrackInformation		{};
+
+#endif

--- a/doc/reference/classes/ROOTClasses.h
+++ b/doc/reference/classes/ROOTClasses.h
@@ -1,3 +1,6 @@
+#ifndef DOC_REFERENCE_CLASSES_ROOTCLASSES_H
+#define DOC_REFERENCE_CLASSES_ROOTCLASSES_H
+
 
 /// ROOT stuff
 /**
@@ -44,3 +47,5 @@ namespace ROOT {
   namespace Math {
   }
 }
+
+#endif

--- a/doc/reference/classes/TiXMLClasses.h
+++ b/doc/reference/classes/TiXMLClasses.h
@@ -1,3 +1,6 @@
+#ifndef DOC_REFERENCE_CLASSES_TIXMLCLASSES_H
+#define DOC_REFERENCE_CLASSES_TIXMLCLASSES_H
+
 
 /// TinyXML class. See http://www.grinninglizard.com/tinyxml
 /** See \see http://www.grinninglizard.com/tinyxml   */
@@ -78,3 +81,5 @@ class TiXmlUnknown			{};
 /// TinyXML class. See http://www.grinninglizard.com/tinyxml
 /** See \see http://www.grinninglizard.com/tinyxml   */
 class TiXmlVisitor		{};
+
+#endif

--- a/etc/externalize/Printout.h
+++ b/etc/externalize/Printout.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_DDCORE_XML_PRINTOUT_H
-#define DD4HEP_DDCORE_XML_PRINTOUT_H
+#ifndef ETC_EXTERNALIZE_PRINTOUT_H
+#define ETC_EXTERNALIZE_PRINTOUT_H
 
 // C/C++ include files
 #include <cstdarg>
@@ -61,4 +61,4 @@ namespace dd4hep {
   int except(const char* src, const char* fmt, ...);
 }
 
-#endif   /* DD4HEP_DDCORE_XML_PRINTOUT_H  */
+#endif // ETC_EXTERNALIZE_PRINTOUT_H

--- a/etc/externalize/config.h
+++ b/etc/externalize/config.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_XML_CONFIG_H
-#define DD4HEP_XML_CONFIG_H
+#ifndef ETC_EXTERNALIZE_CONFIG_H
+#define ETC_EXTERNALIZE_CONFIG_H
 
 #if      defined(DD4HEP_USE_TINYXML)
 #define  __TIXML__
@@ -50,4 +50,4 @@ namespace dd4hep {
 #else   // Xerces-C
 #define XML_IMPLEMENTATION_TYPE " Apache Xerces-C DOM Parser"
 #endif  // __TIXML__
-#endif // DD4HEP_XML_CONFIG_H
+#endif // ETC_EXTERNALIZE_CONFIG_H

--- a/examples/AlignDet/src/AlignmentExampleObjects.h
+++ b/examples/AlignDet/src/AlignmentExampleObjects.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_ALIGNDET_ALIGNMENTEXAMPLEOBJECTS_H
-#define DD4HEP_ALIGNDET_ALIGNMENTEXAMPLEOBJECTS_H
+#ifndef EXAMPLES_ALIGNDET_SRC_ALIGNMENTEXAMPLEOBJECTS_H
+#define EXAMPLES_ALIGNDET_SRC_ALIGNMENTEXAMPLEOBJECTS_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -92,4 +92,4 @@ namespace dd4hep {
     ConditionsManager installManager(Detector& description);
   }       /* End namespace AlignmentExamples           */
 }         /* End namespace dd4hep                      */
-#endif    /* DD4HEP_ALIGNDET_ALIGNMENTEXAMPLEOBJECTS_H */
+#endif // EXAMPLES_ALIGNDET_SRC_ALIGNMENTEXAMPLEOBJECTS_H

--- a/examples/ClientTests/src/SectorBarrelCalorimeter.h
+++ b/examples/ClientTests/src/SectorBarrelCalorimeter.h
@@ -5,8 +5,8 @@
  *      Author: Nikiforos Nikiforou, CERN
  */
 
-#ifndef SECTORBARRELCALORIMETER_H_
-#define SECTORBARRELCALORIMETER_H_
+#ifndef EXAMPLES_CLIENTTESTS_SRC_SECTORBARRELCALORIMETER_H
+#define EXAMPLES_CLIENTTESTS_SRC_SECTORBARRELCALORIMETER_H
 
 #include "BarrelDetector.h"
 #include "PolyhedralCalorimeter.h"
@@ -22,4 +22,4 @@ public:
 
 } /* namespace detail */
 } /* namespace dd4hep */
-#endif /* SECTORBARRELCALORIMETER_H_ */
+#endif // EXAMPLES_CLIENTTESTS_SRC_SECTORBARRELCALORIMETER_H

--- a/examples/Conditions/src/ConditionExampleObjects.h
+++ b/examples/Conditions/src/ConditionExampleObjects.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_CONDITIONS_CONDITIONSEXAMPLEOBJECTS_H
-#define DD4HEP_CONDITIONS_CONDITIONSEXAMPLEOBJECTS_H
+#ifndef EXAMPLES_CONDITIONS_SRC_CONDITIONEXAMPLEOBJECTS_H
+#define EXAMPLES_CONDITIONS_SRC_CONDITIONEXAMPLEOBJECTS_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -267,4 +267,4 @@ namespace dd4hep {
     ConditionsManager installManager(Detector& description);
   }       /* End namespace condExamples             */
 }         /* End namespace dd4hep                         */
-#endif    /* DD4HEP_CONDITIONS_CONDITIONSEXAMPLEOBJECTS_H */
+#endif // EXAMPLES_CONDITIONS_SRC_CONDITIONEXAMPLEOBJECTS_H

--- a/examples/Conditions/src/ConditionsTest.h
+++ b/examples/Conditions/src/ConditionsTest.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DDCOND_CONDITIONSTEST_H
-#define DDCOND_CONDITIONSTEST_H
+#ifndef EXAMPLES_CONDITIONS_SRC_CONDITIONSTEST_H
+#define EXAMPLES_CONDITIONS_SRC_CONDITIONSTEST_H
 
 // Framework include files
 #include "DD4hep/Detector.h"
@@ -64,4 +64,4 @@ namespace dd4hep {
     }
   }
 }
-#endif // DDCOND_CONDITIONSTEST_H
+#endif // EXAMPLES_CONDITIONS_SRC_CONDITIONSTEST_H

--- a/examples/DDCMS/include/DDCMS/DDCMS.h
+++ b/examples/DDCMS/include/DDCMS/DDCMS.h
@@ -14,8 +14,8 @@
 // DDCMS is a detector description convention developed by the CMS experiment.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCMS_DDCMS_H
-#define DD4HEP_DDCMS_DDCMS_H
+#ifndef DDCMS_DDCMS_H
+#define DDCMS_DDCMS_H
 
 // Framework includes
 #include "XML/XML.h"
@@ -249,4 +249,4 @@ namespace dd4hep {
 
 #define NAMESPACE_SEP ':'
 
-#endif /* DD4HEP_DDCMS_DDCMS_H  */
+#endif // DDCMS_DDCMS_H

--- a/examples/DDCMS/include/DDCMS/DDCMSPlugins.h
+++ b/examples/DDCMS/include/DDCMS/DDCMSPlugins.h
@@ -14,8 +14,8 @@
 // DDCMS is a detector description convention developed by the CMS experiment.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCMS_DDCMSPLUGINS_H
-#define DD4HEP_DDCMS_DDCMSPLUGINS_H
+#ifndef DDCMS_DDCMSPLUGINS_H
+#define DDCMS_DDCMSPLUGINS_H
 
 // Framework includes
 #include "DDCMS/DDCMS.h"
@@ -65,4 +65,4 @@ namespace {
                              long(dd4hep::Detector*,dd4hep::cms::ParsingContext*, \
                                   ns::xml_h*,dd4hep::SensitiveDetector*),__LINE__)  }
 
-#endif /* DD4HEP_DDCMS_DDCMSPLUGINS_H  */
+#endif // DDCMS_DDCMSPLUGINS_H

--- a/examples/DDCMS/include/DDCMS/DDCMSTags.h
+++ b/examples/DDCMS/include/DDCMS/DDCMSTags.h
@@ -16,8 +16,8 @@
 //==========================================================================
 
 // Framework includes
-#ifndef DD4HEP_DDCMS_DDCMSTAGS_H
-#define DD4HEP_DDCMS_DDCMSTAGS_H
+#ifndef DDCMS_DDCMSTAGS_H
+#define DDCMS_DDCMSTAGS_H
 
 // Framework include files
 #include "XML/XMLElements.h"
@@ -193,4 +193,4 @@ namespace dd4hep {
 
 #define _CMU(a) ::dd4hep::DDCMS::Unicode_##a
 
-#endif /* DD4HEP_DDCMS_DDCMSTAGS_H  */
+#endif // DDCMS_DDCMSTAGS_H

--- a/examples/DDCMS/include/DDCMS/DDShapes.h
+++ b/examples/DDCMS/include/DDCMS/DDShapes.h
@@ -14,8 +14,8 @@
 // DDCMS is a detector description convention developed by the CMS experiment.
 //
 //==========================================================================
-#ifndef DD4HEP_DDCMS_DDSHAPES_H
-#define DD4HEP_DDCMS_DDSHAPES_H
+#ifndef DDCMS_DDSHAPES_H
+#define DDCMS_DDSHAPES_H
 
 // Framework includes
 #include <DD4hep/Shapes.h>
@@ -103,4 +103,4 @@ namespace dd4hep {
 
   }    /* End namespace cms          */
 }      /* End namespace dd4hep       */
-#endif /* DD4HEP_DDCMS_DDSHAPES_H    */
+#endif // DDCMS_DDSHAPES_H

--- a/examples/DDDB/include/DDDB/DDDBConditionsLoader.h
+++ b/examples/DDDB/include/DDDB/DDDBConditionsLoader.h
@@ -19,8 +19,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDDB_DDDBCONDITONSLOADER_H
-#define DD4HEP_DDDB_DDDBCONDITONSLOADER_H
+#ifndef DDDB_DDDBCONDITIONSLOADER_H
+#define DDDB_DDDBCONDITIONSLOADER_H
 
 // Framework include files
 #include "DDCond/ConditionsDataLoader.h"
@@ -89,4 +89,4 @@ namespace dd4hep {
   } /* End namespace DDDB                    */
 } /* End namespace dd4hep                    */
 
-#endif /* DD4HEP_DDDB_DDDBCONDITONSLOADER_H  */
+#endif // DDDB_DDDBCONDITIONSLOADER_H

--- a/examples/DDDB/include/DDDB/DDDBConversion.h
+++ b/examples/DDDB/include/DDDB/DDDBConversion.h
@@ -16,8 +16,8 @@
 // http://lhcb-comp.web.cern.ch/lhcb-comp/Frameworks/DetDesc/Documents/lhcbDtd.pdf
 //
 //==========================================================================
-#ifndef DD4HEP_DDDB_DDDBCONVERSION_H
-#define DD4HEP_DDDB_DDDBCONVERSION_H
+#ifndef DDDB_DDDBCONVERSION_H
+#define DDDB_DDDBCONVERSION_H
 
 /// Framework include files
 #include <DD4hep/Objects.h>
@@ -631,4 +631,4 @@ namespace dd4hep {
 
 } /* End namespace dd4hep    */
 
-#endif /* DD4HEP_DDDB_DDDBCONVERSION_H  */
+#endif // DDDB_DDDBCONVERSION_H

--- a/examples/DDDB/include/DDDB/DDDBDimension.h
+++ b/examples/DDDB/include/DDDB/DDDBDimension.h
@@ -17,8 +17,8 @@
 //
 //==========================================================================
 
-#ifndef DD4HEP_DDDB_DIMENSION_H
-#define DD4HEP_DDDB_DIMENSION_H
+#ifndef DDDB_DDDBDIMENSION_H
+#define DDDB_DDDBDIMENSION_H
 
 // Framework include files
 #include "XML/XMLTags.h"
@@ -152,4 +152,4 @@ namespace dd4hep {
     };
   } /* End namespace DDDB    */
 } /* End namespace dd4hep    */
-#endif    /* DD4HEP_DDDB_XMLDIMENSION_H   */
+#endif // DDDB_DDDBDIMENSION_H

--- a/examples/DDDB/include/DDDB/DDDBHelper.h
+++ b/examples/DDDB/include/DDDB/DDDBHelper.h
@@ -16,8 +16,8 @@
 // http://lhcb-comp.web.cern.ch/lhcb-comp/Frameworks/DetDesc/Documents/lhcbDtd.pdf
 //
 //==========================================================================
-#ifndef DD4HEP_DDDB_DDDBHELPER_H
-#define DD4HEP_DDDB_DDDBHELPER_H
+#ifndef DDDB_DDDBHELPER_H
+#define DDDB_DDDBHELPER_H
 
 // Framework includes
 #include "DD4hep/ComponentProperties.h"
@@ -98,4 +98,4 @@ namespace dd4hep {
 
   }    /* End namespace DDDB        */
 }      /* End namespace dd4hep      */
-#endif /* DD4HEP_DDDB_DDDBHELPER_H  */
+#endif // DDDB_DDDBHELPER_H

--- a/examples/DDDB/include/DDDB/DDDBReader.h
+++ b/examples/DDDB/include/DDDB/DDDBReader.h
@@ -16,8 +16,8 @@
 // http://lhcb-comp.web.cern.ch/lhcb-comp/Frameworks/DetDesc/Documents/lhcbDtd.pdf
 //
 //==========================================================================
-#ifndef DD4HEP_DDDB_DDDBFILEREADER_H
-#define DD4HEP_DDDB_DDDBFILEREADER_H
+#ifndef DDDB_DDDBREADER_H
+#define DDDB_DDDBREADER_H
 
 // Framework includes
 #include "XML/UriReader.h"
@@ -95,4 +95,4 @@ namespace dd4hep {
     };
     }    /* End namespace DDDB            */
   }      /* End namespace dd4hep          */
-#endif /* DD4HEP_DDDB_DDDBFILEREADER_H  */
+#endif // DDDB_DDDBREADER_H

--- a/examples/DDDB/include/DDDB/DDDBReaderContext.h
+++ b/examples/DDDB/include/DDDB/DDDBReaderContext.h
@@ -16,8 +16,8 @@
 // http://lhcb-comp.web.cern.ch/lhcb-comp/Frameworks/DetDesc/Documents/lhcbDtd.pdf
 //
 //==========================================================================
-#ifndef DD4HEP_DDDB_DDDBREADERCONTEXT_H
-#define DD4HEP_DDDB_DDDBREADERCONTEXT_H
+#ifndef DDDB_DDDBREADERCONTEXT_H
+#define DDDB_DDDBREADERCONTEXT_H
 
 // Framework includes
 #include "XML/UriReader.h"
@@ -58,4 +58,4 @@ namespace dd4hep {
     };
   }    /* End namespace DDDB              */
 }      /* End namespace dd4hep            */
-#endif /* DD4HEP_DDDB_DDDBREADERCONTEXT_H */
+#endif // DDDB_DDDBREADERCONTEXT_H

--- a/examples/DDDB/include/DDDB/DDDBTags.h
+++ b/examples/DDDB/include/DDDB/DDDBTags.h
@@ -16,8 +16,8 @@
 // http://lhcb-comp.web.cern.ch/lhcb-comp/Frameworks/DetDesc/Documents/lhcbDtd.pdf
 //
 //==========================================================================
-#ifndef DD4HEP_DDDB_DDDBTAGS_H
-#define DD4HEP_DDDB_DDDBTAGS_H
+#ifndef DDDB_DDDBTAGS_H
+#define DDDB_DDDBTAGS_H
 
 // Framework include files
 #include "XML/XMLElements.h"
@@ -159,4 +159,4 @@ namespace dd4hep {
 
 #define _LBU(a) ::dd4hep::DDDB::Unicode_##a
 
-#endif /* DD4HEP_DDDB_DDDBTAGS_H  */
+#endif // DDDB_DDDBTAGS_H

--- a/examples/DDDB/include/Detector/DeAlignmentCall.h
+++ b/examples/DDDB/include/Detector/DeAlignmentCall.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==============================================================================
-#ifndef DETECTOR_DEALIGNMENTCALLS_H 
-#define DETECTOR_DEALIGNMENTCALLS_H 1
+#ifndef DETECTOR_DEALIGNMENTCALL_H
+#define DETECTOR_DEALIGNMENTCALL_H 1
 
 // Framework include files
 #include "DD4hep/Conditions.h"
@@ -42,4 +42,4 @@ namespace gaudi   {
   };
   
 }      // End namespace gaudi
-#endif // DETECTOR_DEALIGNMENTCALLS_H
+#endif // DETECTOR_DEALIGNMENTCALL_H

--- a/examples/DDDB/include/Detector/DeVPSensor.h
+++ b/examples/DDDB/include/Detector/DeVPSensor.h
@@ -172,4 +172,4 @@ namespace gaudi   {
   typedef  DetectorElement<DeVPSensorElement>  DeVPSensor;
 
 }      // End namespace gaudi
-#endif // DETECTOR_DEVPSENSORIOV_H
+#endif // DETECTOR_DEVPSENSOR_H

--- a/examples/DDDB/include/Detector/DeVeloSensor.h
+++ b/examples/DDDB/include/Detector/DeVeloSensor.h
@@ -486,4 +486,4 @@ namespace gaudi   {
   };
   
 }      // End namespace gaudi
-#endif // DETECTOR_DEVELOSENSORIOV_H
+#endif // DETECTOR_DEVELOSENSOR_H

--- a/examples/DDDB/include/Detector/DetectorElement_inl.h
+++ b/examples/DDDB/include/Detector/DetectorElement_inl.h
@@ -38,4 +38,4 @@ gaudi::DeHelpers::getChildConditions(ConditionsMap& m, DetElement de, itemkey_ty
   return cache;
 }
 
-#endif // #ifndef DETECTOR_DETECTORELEMENT_INL_H
+#endif // DETECTOR_DETECTORELEMENT_INL_H

--- a/examples/DDDB/include/Detector/IDetService.h
+++ b/examples/DDDB/include/Detector/IDetService.h
@@ -16,8 +16,8 @@
 // http://lhcb-comp.web.cern.ch/lhcb-comp/Frameworks/DetDesc/Documents/lhcbDtd.pdf
 //
 //==========================================================================
-#ifndef DD4HEP_IDETSERVICE_H
-#define DD4HEP_IDETSERVICE_H
+#ifndef DETECTOR_IDETSERVICE_H
+#define DETECTOR_IDETSERVICE_H
 
 // Framework includes
 #include "DDCond/ConditionsSlice.h"
@@ -107,4 +107,4 @@ namespace gaudi   {
     virtual void cleanup(const Cleanup& cleaner) = 0;
   };
 }      // End namespace gaudi
-#endif // DD4HEP_IDETSERVICE_H
+#endif // DETECTOR_IDETSERVICE_H

--- a/examples/DDDB/src/plugins/DDDBConfig.h
+++ b/examples/DDDB/src/plugins/DDDBConfig.h
@@ -16,8 +16,8 @@
 // http://lhcb-comp.web.cern.ch/lhcb-comp/Frameworks/DetDesc/Documents/lhcbDtd.pdf
 //
 //==========================================================================
-#ifndef DD4HEP_DDDB_DDDBCONFIG_H
-#define DD4HEP_DDDB_DDDBCONFIG_H
+#ifndef EXAMPLES_DDDB_SRC_PLUGINS_DDDBCONFIG_H
+#define EXAMPLES_DDDB_SRC_PLUGINS_DDDBCONFIG_H
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -72,5 +72,5 @@ namespace dd4hep {
     };
   }
 }
-#endif /*  DD4HEP_DDDB_DDDBCONFIG_H  */
+#endif // EXAMPLES_DDDB_SRC_PLUGINS_DDDBCONFIG_H
   

--- a/examples/DDDB/src/plugins/DetService.h
+++ b/examples/DDDB/src/plugins/DetService.h
@@ -16,8 +16,8 @@
 // http://lhcb-comp.web.cern.ch/lhcb-comp/Frameworks/DetDesc/Documents/lhcbDtd.pdf
 //
 //==========================================================================
-#ifndef DD4HEP_DETSERVICE_H
-#define DD4HEP_DETSERVICE_H
+#ifndef EXAMPLES_DDDB_SRC_PLUGINS_DETSERVICE_H
+#define EXAMPLES_DDDB_SRC_PLUGINS_DETSERVICE_H
 
 // Framework includes
 #include "Detector/IDetService.h"
@@ -158,4 +158,4 @@ namespace gaudi  {
     virtual void cleanup(const Cleanup &cleaner)  override;
   };
 }
-#endif // DD4HEP_DETSERVICE_H
+#endif // EXAMPLES_DDDB_SRC_PLUGINS_DETSERVICE_H

--- a/examples/DDG4/src/Dictionary.h
+++ b/examples/DDG4/src/Dictionary.h
@@ -1,3 +1,6 @@
+#ifndef EXAMPLES_DDG4_SRC_DICTIONARY_H
+#define EXAMPLES_DDG4_SRC_DICTIONARY_H
+
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -34,3 +37,5 @@ struct Disctionary {};
 
 
 #endif   // DD4HEP_DICTIONARY_MODE
+
+#endif

--- a/examples/DDG4_MySensDet/src/MyTrackerHit.h
+++ b/examples/DDG4_MySensDet/src/MyTrackerHit.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef SOMEEXPERIMENT_MYTRACKERHIT_H
-#define SOMEEXPERIMENT_MYTRACKERHIT_H
+#ifndef EXAMPLES_DDG4_MYSENSDET_SRC_MYTRACKERHIT_H
+#define EXAMPLES_DDG4_MYSENSDET_SRC_MYTRACKERHIT_H
 
 /// Framework include files
 #include "DDG4/Geant4Data.h"
@@ -88,4 +88,4 @@ namespace SomeExperiment {
 #pragma link C++ class     SomeExperiment::MyTrackerHit+;
 #endif
 
-#endif /* SOMEEXPERIMENT_MYTRACKERHIT_H */
+#endif // EXAMPLES_DDG4_MYSENSDET_SRC_MYTRACKERHIT_H

--- a/examples/Persistency/src/PersistencySetup.h
+++ b/examples/Persistency/src/PersistencySetup.h
@@ -10,8 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#ifndef DD4HEP_PERSISTENCYEXAMPLE_PERSISTENCYSETUP_H
-#define DD4HEP_PERSISTENCYEXAMPLE_PERSISTENCYSETUP_H
+#ifndef EXAMPLES_PERSISTENCY_SRC_PERSISTENCYSETUP_H
+#define EXAMPLES_PERSISTENCY_SRC_PERSISTENCYSETUP_H
 
 #include "DD4hep/Detector.h"
 #include "DD4hep/Printout.h"
@@ -59,4 +59,4 @@ namespace dd4hep {
   }       /* End namespace persistencyexamples            */
 }         /* End namespace dd4hep                         */
 
-#endif  // DD4HEP_PERSISTENCYEXAMPLE_PERSISTENCYSETUP_H
+#endif // EXAMPLES_PERSISTENCY_SRC_PERSISTENCYSETUP_H


### PR DESCRIPTION
I though we might have overlooked something with the header guards so I have re-done it with clang-tidy, but it does not have any effect on #700 

Now the guards are based on the filename e.g. `include/DDCore/foo/bar.h` will give you:
```cpp
#ifndef DDCORE_FOO_BAR_H
#define DDCORE_FOO_BAR_H
//...
#endif // DDCORE_FOO_BAR_H
```

BEGINRELEASENOTES
- Apply `clang-tidy` `llvm-header-guard` fixer

ENDRELEASENOTES