### PR TITLE
DDSim tweaks

### DIFF
--- a/DDDetectors/compact/SiD.xml
+++ b/DDDetectors/compact/SiD.xml
@@ -44,8 +44,6 @@
     </limitset>
     <limitset name="SiTrackerBarrelRegionLimitSet">
       <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
-      <limit name="track_length_max" particles="*" value="5.0" unit="mm" />
-      <limit name="time_max" particles="*" value="5.0" unit="ns" />
       <limit name="ekin_min" particles="*" value="0.01" unit="MeV" />
       <limit name="range_min" particles="*" value="5.0" unit="mm" />
     </limitset>

--- a/DDDetectors/compact/SiDConstants.xml
+++ b/DDDetectors/compact/SiDConstants.xml
@@ -18,6 +18,9 @@
     <!-- Correction from going from inner circle to outer circle -->
     <constant name="EcalEndcap_rmax" value="(EcalBarrel_rmin - 1.5*cm) / (cos(pi/CaloSides))"/> 
     <constant name="EcalEndcap_zmin" value="165.70*cm"/>
+
+    <constant name="tracker_region_zmax" value="EcalEndcap_zmin"/>
+    <constant name="tracker_region_rmax" value="EcalEndcap_rmin"/>
     
     <constant name="HcalBarrel_ID" value="8"/>
     <constant name="HcalBarrel_rmin" value="141.90*cm"/>

--- a/DDG4/examples/SiDSim.py
+++ b/DDG4/examples/SiDSim.py
@@ -170,11 +170,13 @@ def run():
 
   logger.info("#  Now build the physics list:")
   phys = geant4.setupPhysics('QGSP_BERT')
-  geant4.addPhysics(str('Geant4PhysicsList/Myphysics'))
+  ph = geant4.addPhysics(str('Geant4PhysicsList/Myphysics'))
+  ph.addPhysicsConstructor(str('G4StepLimiterPhysics'))
+  phys.add(ph)
 
   # Add special particle types from specialized physics constructor
   part = geant4.addPhysics('Geant4ExtraParticles/ExtraParticles')
-  part.pdgfile = 'checkout/DDG4/examples/particle.tbl'
+  part.pdgfile = os.path.join(install_dir, 'examples/DDG4/examples/particle.tbl')
 
   # Add global range cut
   rg = geant4.addPhysics('Geant4DefaultRangeCut/GlobalRangeCut')

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -263,8 +263,7 @@ class DD4hepSimulation(object):
       self.__printSteeringFile(parser)
       exit(1)
 
-  @staticmethod
-  def getDetectorLists(detectorDescription):
+  def getDetectorLists(self, detectorDescription):
     ''' get lists of trackers and calorimeters that are defined in detectorDescription (the compact xml file)'''
     import DDG4
     trackers, calos = [], []
@@ -274,13 +273,13 @@ class DD4hepSimulation(object):
       sd = detectorDescription.sensitiveDetector(name)
       if sd.isValid():
         detType = sd.type()
-  #      if len(detectorList) and not(name in detectorList):
-  #        continue
-        logger.info('getDetectorLists - found active detctor %s type: %s', name, detType)
-        if detType == "tracker":
+        logger.info('getDetectorLists - found active detector %s type: %s', name, detType)
+        if any(pat in detType.lower() for pat in self.action.trackerSDTypes):
           trackers.append(det.name())
-        if detType == "calorimeter":
+        elif any(pat in detType.lower() for pat in self.action.calorimeterSDTypes):
           calos.append(det.name())
+        else:
+          logger.warn('Unknown sensitive detector type: %s', detType)
 
     return trackers, calos
 

--- a/DDG4/python/DDSim/Helper/Action.py
+++ b/DDG4/python/DDSim/Helper/Action.py
@@ -32,6 +32,8 @@ class Action(ConfigHelper):
     self._tracker = ('Geant4TrackerWeightedAction', {'HitPositionCombination': 2, 'CollectSingleDeposits': False})
     self._calo = 'Geant4ScintillatorCalorimeterAction'
     self._mapActions = dict()
+    self._trackerSDTypes = ['tracker']
+    self._calorimeterSDTypes = ['calorimeter']
 
   @property
   def tracker(self):
@@ -78,3 +80,21 @@ class Action(ConfigHelper):
   def clearMapActions(self):
     """empty the mapActions dictionary"""
     self._mapActions = dict()
+
+  @property
+  def trackerSDTypes(self):
+    """List of patterns matching sensitive detectors of type Tracker."""
+    return self._trackerSDTypes
+
+  @trackerSDTypes.setter
+  def trackerSDTypes(self, val):
+    self._trackerSDTypes = ConfigHelper.makeList(val)
+
+  @property
+  def calorimeterSDTypes(self):
+    """List of patterns matching sensitive detectors of type Calorimeter."""
+    return self._calorimeterSDTypes
+
+  @calorimeterSDTypes.setter
+  def calorimeterSDTypes(self, val):
+    self._calorimeterSDTypes = ConfigHelper.makeList(val)

--- a/DDG4/python/DDSim/bin/ddsim.py
+++ b/DDG4/python/DDSim/bin/ddsim.py
@@ -9,12 +9,13 @@ Based on M. Frank and F. Gaede runSim.py
 """
 from __future__ import absolute_import, unicode_literals
 import logging
+import sys
 
 from DDSim.DD4hepSimulation import DD4hepSimulation
 
 
 if __name__ == "__main__":
-  logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+  logging.basicConfig(format='%(name)-16s %(levelname)s %(message)s', level=logging.INFO, stream=sys.stdout)
   logger = logging.getLogger('DDSim')
 
   RUNNER = DD4hepSimulation()


### PR DESCRIPTION
BEGINRELEASENOTES
- DDSim: add options to select which sensitive detectors are trackers and calorimeters, defaults unchanged
- DDSim: tweak log output formatting, logging goes now to stdout instead of stderr
- SiD example: remove `track_length_max` and `time_max` from silicon limits (fixes part of #703 )

ENDRELEASENOTES