### PR TITLE
HepEvtReader: fix units, fix treating inputs

### DIFF
--- a/DDG4/plugins/Geant4EventReaderHepEvt.cpp
+++ b/DDG4/plugins/Geant4EventReaderHepEvt.cpp
@@ -257,8 +257,8 @@ Geant4EventReaderHepEvt::readParticles(int /* event_number */,
     p->vez = 0.0;
     //
     //  Creation time (note the units [1/c_light])
-    p->time       = VHEP4*CLHEP::ns;
-    p->properTime = VHEP4*CLHEP::ns;
+    p->time       = VHEP4 * CLHEP::mm / CLHEP::c_light;
+    p->properTime = VHEP4 * CLHEP::mm / CLHEP::c_light;
     //
     //  Generator status
     //  Simulator status 0 until simulator acts on it

--- a/examples/ClientTests/scripts/MiniTel_hepmc.py
+++ b/examples/ClientTests/scripts/MiniTel_hepmc.py
@@ -23,7 +23,7 @@ def run():
   m.configure()
   m.defineOutput()
   fname = os.environ['DD4hepExamplesINSTALL'] + '/examples/DDG4/data/Muons10GeV.HEPEvt'
-  m.setupInput("Geant4EventReaderHepEvtLong|" + fname)
+  m.setupInput("Geant4EventReaderHepEvtShort|" + fname)
   m.setupGenerator()
   m.setupPhysics(model='FTFP_BERT')
   m.phys.decays = True


### PR DESCRIPTION
List of daughters was not populated so the InputHandling/PrimaryHandler never passed anything to Geant4
The adding particles is done the same as in the LCIOEventReader

BEGINRELEASENOTES
- DDG4.HepEvtReader: fix reading of input particles, fixes #706 
- DDG4.HepEvtReader: fix the units, expecting GeV, mm as units of input files.
- DDG4.HepEvtReader: add abort if the file cannot be read, e.g., when the content doesn't match what is expected

ENDRELEASENOTES