### PR TITLE
Debug def

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,12 @@ OPTION(DD4HEP_DEBUG_CMAKE "Print debugging information for DD4hep CMAKE" OFF)
 SET(DD4HEP_USE_EXISTING_DD4HEP "" CACHE STRING "Build some parts of DD4hep against an existing installation")
 SET(DD4HEP_HIGH_MEM_POOL_DEPTH "${DD4HEP_HIGH_MEM_POOL_DEPTH}" CACHE STRING "Number of build slots for high memory compile units (DDParsers), Ninja only")
 
+SET(DD4HEP_BUILD_DEBUG "" CACHE STRING "Enable some DEBUG features in DD4hep. Set to 'ON' or 'OFF' to override default handling")
+
+IF(DD4HEP_BUILD_DEBUG AND NOT DD4HEP_BUILD_DEBUG MATCHES "ON|OFF")
+  MESSAGE(FATAL_ERROR "Invalid value for DD4HEP_BUILD_DEBUG, ${DD4HEP_BUILD_DEBUG}, use '', 'ON', 'OFF'")
+ENDIF()
+
 # create the job pool
 set_property(GLOBAL PROPERTY JOB_POOLS HIGH_MEM_POOL=${DD4HEP_HIGH_MEM_POOL_DEPTH})
 #####################
@@ -197,6 +203,9 @@ ELSE()
     dd4hep_print("|> Building ${DDPackage}")
     add_subdirectory(${DDPackage})
   ENDFOREACH()
+  IF(DD4HEP_BUILD_DEBUG MATCHES "ON" OR (CMAKE_BUILD_TYPE MATCHES "DEBUG|Debug" AND NOT DD4HEP_BUILD_DEBUG MATCHES "OFF"))
+    target_compile_definitions(DDCore PUBLIC DD4HEP_DEBUG)
+  ENDIF()
 
   message(STATUS "BUILD Packages: ${DD4HEP_BUILD_PACKAGES}")
   FOREACH(DDPackage IN LISTS DD4HEP_BUILD_PACKAGES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,28 +189,29 @@ IF(DD4HEP_USE_EXISTING_DD4HEP)
   LIST(GET DD4HEP_BUILD_PACKAGES 0 DD4HEP_SELECTED_PACKAGE)
 ELSE()
 
-include(DD4hep_XML_setup)
+  include(DD4hep_XML_setup)
 
-#These pacakges are mandatory
-SET(DD4HEP_SELECTED_PACKAGE DDCore)
-FOREACH(DDPackage GaudiPluginService DDParsers DDCore)
-  dd4hep_print("|> Building ${DDPackage}")
-  add_subdirectory(${DDPackage})
-ENDFOREACH()
-message(STATUS "BUILD Packages: ${DD4HEP_BUILD_PACKAGES}")
-FOREACH(DDPackage IN LISTS DD4HEP_BUILD_PACKAGES)
-  dd4hep_print("|> Building ${DDPackage}")
-  add_subdirectory(${DDPackage})
-ENDFOREACH()
+  #These packages are mandatory
+  SET(DD4HEP_SELECTED_PACKAGE DDCore)
+  FOREACH(DDPackage GaudiPluginService DDParsers DDCore)
+    dd4hep_print("|> Building ${DDPackage}")
+    add_subdirectory(${DDPackage})
+  ENDFOREACH()
 
-if(BUILD_TESTING)
-  dd4hep_enable_tests()
-  add_subdirectory(DDTest)
-endif()
+  message(STATUS "BUILD Packages: ${DD4HEP_BUILD_PACKAGES}")
+  FOREACH(DDPackage IN LISTS DD4HEP_BUILD_PACKAGES)
+    dd4hep_print("|> Building ${DDPackage}")
+    add_subdirectory(${DDPackage})
+  ENDFOREACH()
 
-if(DD4HEP_BUILD_EXAMPLES)
-  add_subdirectory(examples)
-endif()
+  if(BUILD_TESTING)
+    dd4hep_enable_tests()
+    add_subdirectory(DDTest)
+  endif()
+
+  if(DD4HEP_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+  endif()
 
 
 ENDIF(DD4HEP_USE_EXISTING_DD4HEP)


### PR DESCRIPTION

BEGINRELEASENOTES
- Cmake: add configuration option DD4HEP_BUILD_DEBUG, if ON or OFF enable or disable the DD4HEP_DEBUG definition
if not set, enable if BuildType is Debug, fixes #708 



ENDRELEASENOTES