### PR TITLE
Enable conditions to have name in DEBUG build

### DIFF
--- a/DDCore/include/DD4hep/config.h
+++ b/DDCore/include/DD4hep/config.h
@@ -16,15 +16,18 @@
 #define DD4HEP_INSTANCE_COUNTS 1
 #define DD4HEP_USE_SAFE_CAST   1
 
-/// Enable to have more debugging information for conditions and keys
-/// If enabled it overrides DD4HEP_MINIMAL_CONDITIONS and sets it to true
-/// If enabled it overrides DD4HEP_CONDITIONKEY_HAVE_NAME and sets it to true
-#define DD4HEP_CONDITIONS_DEBUG  1
+#ifdef DD4HEP_DEBUG
+  /// Enable to have more debugging information for conditions and keys
+  /// If enabled it overrides DD4HEP_MINIMAL_CONDITIONS and sets it to true
+  /// If enabled it overrides DD4HEP_CONDITIONKEY_HAVE_NAME and sets it to true
+  #define DD4HEP_CONDITIONS_DEBUG  1
 
-/// Enable this if you want to minimize the footprint of conditions
-//#define DD4HEP_MINIMAL_CONDITIONS 1
-/// Enable flag to store conditions names to keys (needs some support from user code!)
-//#define DD4HEP_CONDITIONKEY_HAVE_NAME 1
+  /// Enable flag to store conditions names to keys (needs some support from user code!)
+  #define DD4HEP_CONDITIONKEY_HAVE_NAME 1
+#else
+  /// Enable this if you want to minimize the footprint of conditions
+  #define DD4HEP_MINIMAL_CONDITIONS 1
+#endif
 
 /// Valid implementations of the Gaudi plugin service are 1 and 2
 #define DD4HEP_PLUGINSVC_VERSION 2

--- a/DDCore/src/Conditions.cpp
+++ b/DDCore/src/Conditions.cpp
@@ -206,7 +206,7 @@ ConditionKey::KeyMaker::KeyMaker(Condition::detkey_type det, const std::string& 
 /// Constructor from string
 ConditionKey::ConditionKey(DetElement detector, const string& value)  {
   hash = KeyMaker(detector,value).hash;
-#ifdef DD4HEP_CONDITIONKEY_HAVE_NAME
+#if defined(DD4HEP_CONDITIONS_DEBUG) || defined(DD4HEP_CONDITIONKEY_HAVE_NAME)
   name = detector.path()+"#"+value;
 #endif
 }
@@ -214,7 +214,7 @@ ConditionKey::ConditionKey(DetElement detector, const string& value)  {
 /// Constructor from detector element key and item sub-key
 ConditionKey::ConditionKey(Condition::detkey_type det_key, const string& value)    {
   hash = KeyMaker(det_key,value).hash;
-#ifdef DD4HEP_CONDITIONKEY_HAVE_NAME
+#if defined(DD4HEP_CONDITIONS_DEBUG) || defined(DD4HEP_CONDITIONKEY_HAVE_NAME)
   char text[32];
   ::snprintf(text,sizeof(text),"%08X#",det_key);
   name = text+value;
@@ -224,7 +224,7 @@ ConditionKey::ConditionKey(Condition::detkey_type det_key, const string& value) 
 /// Constructor from detector element key and item sub-key
 ConditionKey::ConditionKey(DetElement detector, Condition::itemkey_type item_key)  {
   hash = KeyMaker(detector.key(),item_key).hash;
-#ifdef DD4HEP_CONDITIONKEY_HAVE_NAME
+#if defined(DD4HEP_CONDITIONS_DEBUG) || defined(DD4HEP_CONDITIONKEY_HAVE_NAME)
   char text[32];
   ::snprintf(text,sizeof(text),"#%08X",item_key);
   name = detector.path()+text;


### PR DESCRIPTION
BEGINRELEASENOTES
- Enable conditions to have name in `CMAKE_BUILD_TYPE=DEBUG` or if cmake flag `DD4HEP_BUILD_DEBUG=1`
- In normal build conditions have now `DD4HEP_MINIMAL_CONDITIONS` turned on

ENDRELEASENOTES