### PR TITLE
Propagate condition names for printouts. Names are enabled by default

### DIFF
--- a/DDCond/include/DDCond/ConditionsSlice.h
+++ b/DDCond/include/DDCond/ConditionsSlice.h
@@ -81,8 +81,8 @@ namespace dd4hep {
           iov_pool = s.manager.registerIOV(*iov.iovType,iov.key());
         }
         template <typename T> Inserter(ConditionsSlice& s, const T& data) : slice(s) {
-          const IOV& iov = s.pool->validity();
-          iov_pool = s.manager.registerIOV(*iov.iovType,iov.key());
+          const IOV& iov = slice.pool->validity();
+          iov_pool = slice.manager.registerIOV(*iov.iovType,iov.key());
           std::for_each(std::begin(data), std::end(data), *this);
         }
         void operator()(Condition c) const  {

--- a/DDCond/include/DDCond/ConditionsTags.h
+++ b/DDCond/include/DDCond/ConditionsTags.h
@@ -50,6 +50,7 @@ namespace dd4hep {
       UNICODE(mapping);
       UNICODE(sequence);
       UNICODE(alignment);
+      UNICODE(alignment_delta);
       UNICODE(repository);
     }
     // User must ensure there are no clashes. If yes, then the clashing entry is unnecessary.

--- a/DDCond/src/ConditionsContent.cpp
+++ b/DDCond/src/ConditionsContent.cpp
@@ -98,6 +98,7 @@ bool ConditionsContent::remove(Condition::key_type hash)   {
 pair<Condition::key_type, ConditionsLoadInfo*>
 ConditionsContent::insertKey(Condition::key_type hash)   {
   auto ret = m_conditions.emplace(hash,(ConditionsLoadInfo*)0);
+  //printout(DEBUG,"ConditionsContent","++ Insert key: %016X",hash);
   if ( ret.second )  return pair<Condition::key_type, ConditionsLoadInfo*>(hash,0);
   return pair<Condition::key_type, ConditionsLoadInfo*>(0,0);
 }
@@ -106,6 +107,7 @@ ConditionsContent::insertKey(Condition::key_type hash)   {
 pair<Condition::key_type, ConditionsLoadInfo*>
 ConditionsContent::addLocationInfo(Condition::key_type hash, ConditionsLoadInfo* info)   {
   if ( info )   {
+    //printout(DEBUG,"ConditionsContent","++ Add location key: %016X",hash);
     auto ret = m_conditions.emplace(hash,info);
     if ( ret.second )  {
       info->addRef();
@@ -122,6 +124,7 @@ ConditionsContent::addDependency(ConditionDependency* dep)
 {
   auto ret = m_derived.emplace(dep->key(),dep);
   if ( ret.second )  {
+    //printout(DEBUG,"ConditionsContent","++ Add dependency key: %016X",dep->key());
     dep->addRef();
     return *(ret.first);
   }

--- a/DDCond/src/ConditionsRepository.cpp
+++ b/DDCond/src/ConditionsRepository.cpp
@@ -103,7 +103,12 @@ namespace {
     return 1;
   }
   
-  int createText(const string& output, const AllConditions& all, char sep)   {
+#if defined(DD4HEP_MINIMAL_CONDITIONS)
+  int createText(const string& output, const AllConditions&, char)
+#else
+  int createText(const string& output, const AllConditions& all, char sep)
+#endif
+  {
     ofstream out(output);
 #if !defined(DD4HEP_MINIMAL_CONDITIONS)
     size_t siz_nam=0, siz_add=0, siz_tot=0;

--- a/DDCond/src/ConditionsSlice.cpp
+++ b/DDCond/src/ConditionsSlice.cpp
@@ -189,4 +189,3 @@ void dd4hep::cond::fill_content(ConditionsManager mgr,
   ConditionsIOVPool::Elements& pools = iovPool->elements;
   for_each(begin(pools),end(pools),SliceOper(content));
 }
-

--- a/DDCond/src/ConditionsTextRepository.cpp
+++ b/DDCond/src/ConditionsTextRepository.cpp
@@ -101,7 +101,12 @@ namespace {
     return 1;
   }
   
-  int createText(const string& output, const AllConditions& all, char sep)   {
+#if defined(DD4HEP_MINIMAL_CONDITIONS)
+  int createText(const string& output, const AllConditions&, char)
+#else
+  int createText(const string& output, const AllConditions& all, char sep)
+#endif
+  {
     ofstream out(output);
 #if !defined(DD4HEP_MINIMAL_CONDITIONS)
     size_t siz_nam=0, siz_add=0, siz_tot=0;

--- a/DDCond/src/Type1/Manager_Type1.cpp
+++ b/DDCond/src/Type1/Manager_Type1.cpp
@@ -246,9 +246,12 @@ bool Manager_Type1::registerUnlocked(ConditionsPool& pool, Condition cond)   {
     cond->iov  = pool.iov;
     cond->setFlag(Condition::ACTIVE);
     pool.insert(cond);
-#if 0
-    printout(INFO,"ConditionsMgr","Register condition %016lX %s [%s] IOV:%s",
-             cond->hash, cond.name(), cond->address.c_str(), pool.iov->str().c_str());
+#if !defined(DD4HEP_MINIMAL_CONDITIONS)
+    printout(DEBUG,"ConditionsMgr","Register condition %016lX %s [%s] IOV:%s",
+             cond.key(), cond.name(), cond->address.c_str(), pool.iov->str().c_str());
+#else
+    printout(DEBUG,"ConditionsMgr","Register condition %016lX %s IOV:%s",
+             cond.key(), cond.name(), pool.iov->str().c_str());
 #endif
     if ( !m_onRegister.empty() )   {
       __callListeners(m_onRegister, &ConditionsListener::onRegisterCondition, cond);

--- a/DDCond/src/Type1/Manager_Type1.cpp
+++ b/DDCond/src/Type1/Manager_Type1.cpp
@@ -246,12 +246,15 @@ bool Manager_Type1::registerUnlocked(ConditionsPool& pool, Condition cond)   {
     cond->iov  = pool.iov;
     cond->setFlag(Condition::ACTIVE);
     pool.insert(cond);
-#if !defined(DD4HEP_MINIMAL_CONDITIONS)
+#if !defined(DD4HEP_MINIMAL_CONDITIONS) && defined(DD4HEP_CONDITIONS_HAVE_NAME)
     printout(DEBUG,"ConditionsMgr","Register condition %016lX %s [%s] IOV:%s",
              cond.key(), cond.name(), cond->address.c_str(), pool.iov->str().c_str());
-#else
+#elif defined(DD4HEP_CONDITIONS_HAVE_NAME)
     printout(DEBUG,"ConditionsMgr","Register condition %016lX %s IOV:%s",
              cond.key(), cond.name(), pool.iov->str().c_str());
+#else
+    printout(DEBUG,"ConditionsMgr","Register condition %016lX IOV:%s",
+             cond.key(), pool.iov->str().c_str());
 #endif
     if ( !m_onRegister.empty() )   {
       __callListeners(m_onRegister, &ConditionsListener::onRegisterCondition, cond);

--- a/DDCond/src/plugins/ConditionsRepositoryParser.cpp
+++ b/DDCond/src/plugins/ConditionsRepositoryParser.cpp
@@ -150,10 +150,10 @@ namespace {
     string add = xml::DocumentHandler::system_path(e);
     string cond_nam = det.path()+"#"+nam;
     Condition cond(cond_nam, typ);
-    printout(s_parseLevel,"XMLConditions","++ Processing condition tag:%s name:%s type:%s [%s]",
-             tag.c_str(), nam.c_str(), typ.c_str(),
-             Path(add).filename().c_str());
-    cond->hash     = ConditionKey::hashCode(det,cond_nam);
+    cond->hash = ConditionKey::hashCode(det, nam);
+    printout(s_parseLevel,"XMLConditions","++ Processing condition tag:%s name:%s type:%s [%s] hash:%016X det:%p",
+             tag.c_str(), cond.name(), typ.c_str(),
+             Path(add).filename().c_str(), cond.key(), det.ptr());
 #if !defined(DD4HEP_MINIMAL_CONDITIONS)
     cond->address  = add;
     cond->value    = "";
@@ -370,7 +370,7 @@ namespace dd4hep {
     xml_coll_t(e,_UC(mapping)).for_each(Converter<mapping>(description,param,optional));
     xml_coll_t(e,_UC(sequence)).for_each(Converter<sequence>(description,param,optional));
     xml_coll_t(e,_UC(pressure)).for_each(Converter<pressure>(description,param,optional));
-    xml_coll_t(e,_UC(alignment)).for_each(Converter<alignment>(description,param,optional));
+    xml_coll_t(e,_UC(alignment_delta)).for_each(Converter<alignment>(description,param,optional));
     xml_coll_t(e,_UC(temperature)).for_each(Converter<temperature>(description,param,optional));
     xml_coll_t(e,_UC(detelement)).for_each(Converter<detelement>(description,param,optional));
   }

--- a/DDCond/src/plugins/ConditionsRepositoryWriter.cpp
+++ b/DDCond/src/plugins/ConditionsRepositoryWriter.cpp
@@ -416,8 +416,8 @@ size_t ConditionsXMLRepositoryWriter::collect(xml::Element root,
         ++m_numConverted;
       }
       else if ( cond_delta.isValid() )   {
-        //conditions.append(_convert<Delta>(conditions,cond_delta));
-        //++m_numConverted;
+        conditions.append(_convert<Delta>(conditions,cond_delta));
+        ++m_numConverted;
       }
     }
     for (const auto& i : detector.children())

--- a/DDCond/src/plugins/ConditionsRepositoryWriter.cpp
+++ b/DDCond/src/plugins/ConditionsRepositoryWriter.cpp
@@ -146,7 +146,7 @@ namespace {
   };
   
   template <typename T> xml::Element _convert(xml::Element par, Condition c);
-
+  
   xml::Element make(xml::Element e, Condition c)  {
     char hash[64];
     std::string nam = c.name();
@@ -200,7 +200,7 @@ namespace {
     return temp;
   }
   template <> xml::Element _convert<Delta>(xml::Element par, Condition c)  {
-    xml::Element       align = make(xml::Element(par.document(),_UC(alignment)),c);
+    xml::Element       align = make(xml::Element(par.document(),_UC(alignment_delta)),c);
     const Delta&       delta = c.get<Delta>();
     if ( delta.flags&Delta::HAVE_TRANSLATION )
       align.append(_convert(align,delta.translation));
@@ -211,9 +211,16 @@ namespace {
     return align;
   }
   template <> xml::Element _convert<Alignment>(xml::Element par, Condition c)  {
-    xml::Element       align = make(xml::Element(par.document(),_UC(alignment)),c);
-    AlignmentCondition acond = c;
-    const Delta&       delta = acond.data().delta;
+    char hash[64];
+    typedef ConditionKey::KeyMaker KM;
+    AlignmentCondition  acond = c;
+    KM                  km(c.key());
+    const Delta&        delta = acond.data().delta;
+    xml::Element        align(xml::Element(par.document(),_UC(alignment_delta)));
+    Condition::key_type key = KM(km.values.det_key,align::Keys::deltaKey).hash;
+    ::snprintf(hash,sizeof(hash),"%llX",key);
+    align.setAttr(_U(name),align::Keys::deltaName);
+    align.setAttr(_U(key),hash);
     if ( delta.flags&Delta::HAVE_TRANSLATION )
       align.append(_convert(align,delta.translation));
     if ( delta.flags&Delta::HAVE_ROTATION )
@@ -409,8 +416,8 @@ size_t ConditionsXMLRepositoryWriter::collect(xml::Element root,
         ++m_numConverted;
       }
       else if ( cond_delta.isValid() )   {
-        conditions.append(_convert<Delta>(conditions,cond_delta));
-        ++m_numConverted;
+        //conditions.append(_convert<Delta>(conditions,cond_delta));
+        //++m_numConverted;
       }
     }
     for (const auto& i : detector.children())

--- a/DDCond/src/plugins/ConditionsUserPool.cpp
+++ b/DDCond/src/plugins/ConditionsUserPool.cpp
@@ -244,12 +244,12 @@ template<typename MAPPING> inline bool
 ConditionsMappedUserPool<MAPPING>::i_insert(Condition::Object* o)   {
   int ret = m_conditions.emplace(o->hash,o).second;
   if ( flags&PRINT_INSERT )  {
-    printout(INFO,"UserPool","++ %s condition [%016llX]: %s.",
+    printout(INFO,"UserPool","++ %s condition [%016llX]: %s [%s].",
              ret ? "Successfully inserted" : "FAILED to insert", o->hash,
-#if defined(DD4HEP_MINIMAL_CONDITIONS)
-             "");
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
+             o->GetName(), o->GetTitle());
 #else
-             o->name.c_str());
+             "");
 #endif
   }
   return ret;

--- a/DDCond/src/plugins/ConditionsUserPool.cpp
+++ b/DDCond/src/plugins/ConditionsUserPool.cpp
@@ -249,7 +249,7 @@ ConditionsMappedUserPool<MAPPING>::i_insert(Condition::Object* o)   {
 #if defined(DD4HEP_CONDITIONS_HAVE_NAME)
              o->GetName(), o->GetTitle());
 #else
-             "");
+    "", "");
 #endif
   }
   return ret;

--- a/DDCore/include/DD4hep/ConditionDerived.h
+++ b/DDCore/include/DD4hep/ConditionDerived.h
@@ -348,7 +348,7 @@ namespace dd4hep {
       ConditionDependency();
       /// Access the dependency key
       Condition::key_type key()  const    {  return target.hash;                   }
-#if defined(DD4HEP_CONDITIONS_DEBUG) || defined(DD4HEP_CONDITIONKEY_HAVE_NAME)
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
       /// Access the dependency key
       const char* name()  const           {  return target.name.c_str();           }
 #endif

--- a/DDCore/include/DD4hep/Conditions.h
+++ b/DDCore/include/DD4hep/Conditions.h
@@ -268,7 +268,7 @@ namespace dd4hep {
    */
   class ConditionKey  {
   public:
-#if defined(DD4HEP_CONDITIONS_DEBUG) || defined(DD4HEP_CONDITIONKEY_HAVE_NAME)
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
     /// Optional string identifier. Helps debugging a lot!
     std::string  name;
 #endif

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -962,8 +962,6 @@ namespace dd4hep {
                         double h1, double bl1, double tl1, double alpha1,
                         double h2, double bl2, double tl2, double alpha2);
 
-    /// Accessor: z-half value
-    double dZ() const                      { return access()->GetDz();                 }
     /// Accessor: phi value
     double phi() const                     { return access()->GetPhi()*dd4hep::deg;    }
     /// Accessor: theta value

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -712,7 +712,7 @@ namespace dd4hep {
    *
    *   The Solid::dimension() and Solid::setDimension() calls for the TruncatedTube
    *   deliver/expect the parameters in the same order as the constructor:
-   *   (zhalf, rmin, rmax, startPhi, deltaPhi, cutAtStart, cutAtDelta, cutInside)
+   *   (dz, rmin, rmax, startPhi, deltaPhi, cutAtStart, cutAtDelta, cutInside)
    *
    *   \author  M.Frank
    *   \version 1.0
@@ -722,7 +722,7 @@ namespace dd4hep {
   protected:
     /// Internal helper method to support object construction
     void make(const std::string& name,
-              double zhalf, double rmin, double rmax, double startPhi, double deltaPhi,
+              double dz, double rmin, double rmax, double startPhi, double deltaPhi,
               double cutAtStart, double cutAtDelta, bool cutInside);
 
   public:
@@ -738,12 +738,12 @@ namespace dd4hep {
     template <typename Q> TruncatedTube(const Handle<Q>& e) : Solid_type<Object>(e) {  }
 
     /// Constructor to create a truncated tube object with attribute initialization
-    TruncatedTube(double zhalf, double rmin, double rmax, double startPhi, double deltaPhi,
+    TruncatedTube(double dz, double rmin, double rmax, double startPhi, double deltaPhi,
                   double cutAtStart, double cutAtDelta, bool cutInside);
 
     /// Constructor to create a truncated tube object with attribute initialization
     TruncatedTube(const std::string& name,
-                  double zhalf, double rmin, double rmax, double startPhi, double deltaPhi,
+                  double dz, double rmin, double rmax, double startPhi, double deltaPhi,
                   double cutAtStart, double cutAtDelta, bool cutInside);
 
     /// Move Assignment operator
@@ -962,6 +962,8 @@ namespace dd4hep {
                         double h1, double bl1, double tl1, double alpha1,
                         double h2, double bl2, double tl2, double alpha2);
 
+    /// Accessor: z-half value
+    double dZ() const                      { return access()->GetDz();                 }
     /// Accessor: phi value
     double phi() const                     { return access()->GetPhi()*dd4hep::deg;    }
     /// Accessor: theta value

--- a/DDCore/include/DD4hep/config.h
+++ b/DDCore/include/DD4hep/config.h
@@ -23,12 +23,12 @@
 #define DD4HEP_CONDITIONS_DEBUG     1
 #endif
 
-/// Enable flag to store conditions names to keys (needs some support from user code!)
-#define DD4HEP_CONDITIONS_HAVE_NAME 1
-
 #if !defined(DD4HEP_CONDITIONS_DEBUG)
 /// Enable this if you want to minimize the footprint of conditions
 #define DD4HEP_MINIMAL_CONDITIONS   1
+#else
+/// Enable flag to store conditions names to keys (needs some support from user code!)
+#define DD4HEP_CONDITIONS_HAVE_NAME 1
 #endif
 
 /// Valid implementations of the Gaudi plugin service are 1 and 2

--- a/DDCore/include/DD4hep/config.h
+++ b/DDCore/include/DD4hep/config.h
@@ -32,7 +32,7 @@
 #define DD4HEP_CONDITIONS_HAVE_NAME 1
 
 /// Valid implementations of the Gaudi plugin service are 1 and 2
-#define DD4HEP_PLUGINSVC_VERSION 2
+#define DD4HEP_PLUGINSVC_VERSION    2
 
 #ifdef DD4HEP_INSTANCE_COUNTS
 #define INCREMENT_COUNTER InstanceCount::increment(this)

--- a/DDCore/include/DD4hep/config.h
+++ b/DDCore/include/DD4hep/config.h
@@ -20,13 +20,13 @@
 /// If enabled it overrides DD4HEP_MINIMAL_CONDITIONS and sets it to true
 /// If enabled it overrides DD4HEP_CONDITIONS_HAVE_NAME and sets it to true
 #if defined(DD4HEP_DEBUG)
-#define DD4HEP_CONDITIONS_DEBUG  1
+#define DD4HEP_CONDITIONS_DEBUG     1
 #endif
 
-#if defined(DD4HEP_CONDITIONS_DEBUG)
 /// Enable flag to store conditions names to keys (needs some support from user code!)
 #define DD4HEP_CONDITIONS_HAVE_NAME 1
-#else
+
+#if !defined(DD4HEP_CONDITIONS_DEBUG)
 /// Enable this if you want to minimize the footprint of conditions
 #define DD4HEP_MINIMAL_CONDITIONS   1
 #endif

--- a/DDCore/include/DD4hep/config.h
+++ b/DDCore/include/DD4hep/config.h
@@ -26,10 +26,10 @@
 #if !defined(DD4HEP_CONDITIONS_DEBUG)
 /// Enable this if you want to minimize the footprint of conditions
 #define DD4HEP_MINIMAL_CONDITIONS   1
-#else
+#endif
+
 /// Enable flag to store conditions names to keys (needs some support from user code!)
 #define DD4HEP_CONDITIONS_HAVE_NAME 1
-#endif
 
 /// Valid implementations of the Gaudi plugin service are 1 and 2
 #define DD4HEP_PLUGINSVC_VERSION 2

--- a/DDCore/include/DD4hep/config.h
+++ b/DDCore/include/DD4hep/config.h
@@ -18,13 +18,18 @@
 
 /// Enable to have more debugging information for conditions and keys
 /// If enabled it overrides DD4HEP_MINIMAL_CONDITIONS and sets it to true
-/// If enabled it overrides DD4HEP_CONDITIONKEY_HAVE_NAME and sets it to true
+/// If enabled it overrides DD4HEP_CONDITIONS_HAVE_NAME and sets it to true
+#if defined(DD4HEP_DEBUG)
 #define DD4HEP_CONDITIONS_DEBUG  1
+#endif
 
-/// Enable this if you want to minimize the footprint of conditions
-//#define DD4HEP_MINIMAL_CONDITIONS 1
+#if defined(DD4HEP_CONDITIONS_DEBUG)
 /// Enable flag to store conditions names to keys (needs some support from user code!)
-//#define DD4HEP_CONDITIONKEY_HAVE_NAME 1
+#define DD4HEP_CONDITIONS_HAVE_NAME 1
+#else
+/// Enable this if you want to minimize the footprint of conditions
+#define DD4HEP_MINIMAL_CONDITIONS   1
+#endif
 
 /// Valid implementations of the Gaudi plugin service are 1 and 2
 #define DD4HEP_PLUGINSVC_VERSION 2

--- a/DDCore/include/DD4hep/detail/ConditionsInterna.h
+++ b/DDCore/include/DD4hep/detail/ConditionsInterna.h
@@ -56,7 +56,7 @@ namespace dd4hep {
      *  \ingroup DD4HEP_CONDITIONS
      */
     class ConditionObject
-#if defined(DD4HEP_CONDITIONS_DEBUG) || !defined(DD4HEP_MINIMAL_CONDITIONS)
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
       : public NamedObject
 #endif
     {

--- a/DDCore/src/AlignmentsCalculator.cpp
+++ b/DDCore/src/AlignmentsCalculator.cpp
@@ -130,7 +130,7 @@ Result Calculator::compute(Context& context, Entry& e)   const  {
     return result;
   }
   AlignmentCondition c = context.mapping.get(det, Keys::alignmentKey);
-  AlignmentCondition cond = c.isValid() ? c : AlignmentCondition("alignment");
+  AlignmentCondition cond = c.isValid() ? c : AlignmentCondition(det.path()+"#alignment");
   AlignmentData&     align = cond.data();
   const Delta*       delta = e.delta ? e.delta : &identity_delta;
   TGeoHMatrix        transform_for_delta;
@@ -165,6 +165,7 @@ Result Calculator::compute(Context& context, Entry& e)   const  {
   // Update mapping if the condition is freshly created
   if ( !c.isValid() )  {
     e.created = 1;
+    cond->flags |= Condition::ALIGNMENT_DERIVED;
     cond->hash = ConditionKey(e.det,Keys::alignmentKey).hash;
     context.mapping.insert(e.det, Keys::alignmentKey, cond);
   }

--- a/DDCore/src/ConditionDerived.cpp
+++ b/DDCore/src/ConditionDerived.cpp
@@ -55,7 +55,7 @@ Condition ConditionUpdateContext::condition(const ConditionKey& key_value)  cons
     iov->iov_intersection(c.iov());
     return c;
   }
-#if defined(DD4HEP_CONDITIONS_DEBUG) || defined(DD4HEP_CONDITIONKEY_HAVE_NAME)
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
   except("ConditionUpdateCall:","Failed to access non-existing condition:"+key_value.name);
 #else
   ConditionKey::KeyMaker key(key_value.hash);
@@ -117,7 +117,7 @@ ConditionResolver::~ConditionResolver()  {
 
 /// Throw exception on conditions access failure
 void ConditionUpdateContext::accessFailure(const ConditionKey& key_value)  const   {
-#if defined(DD4HEP_CONDITIONS_DEBUG) || defined(DD4HEP_CONDITIONKEY_HAVE_NAME)
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
   except("ConditionUpdateCall",
          "%s [%016llX]: FAILED to access non-existing item:%s [%016llX]",
          dependency->target.name.c_str(), dependency->target.hash,

--- a/DDCore/src/Conditions.cpp
+++ b/DDCore/src/Conditions.cpp
@@ -23,14 +23,6 @@
 using namespace std;
 using namespace dd4hep;
 
-#if defined(DD4HEP_CONDITIONS_DEBUG) && !defined(DD4HEP_CONDITIONKEY_HAVE_NAME)
-#define DD4HEP_CONDITIONKEY_HAVE_NAME 1
-#endif
-
-#if defined(DD4HEP_CONDITIONS_DEBUG) && defined(DD4HEP_MINIMAL_CONDITIONS)
-#undef DD4HEP_MINIMAL_CONDITIONS
-#endif
-
 /// Initializing constructor for a pure, undecorated conditions object
 Condition::Condition(key_type hash_key) : Handle<Object>()
 {
@@ -65,7 +57,7 @@ Condition::Condition(const string& nam,const string& typ, size_t memory)
 string Condition::str(int flags)  const   {
   stringstream output;
   Object* o = access(); 
-#if !defined(DD4HEP_MINIMAL_CONDITIONS)
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
   if ( 0 == (flags&NO_NAME) )
     output << setw(16) << left << o->name;
 #endif
@@ -206,7 +198,7 @@ ConditionKey::KeyMaker::KeyMaker(Condition::detkey_type det, const std::string& 
 /// Constructor from string
 ConditionKey::ConditionKey(DetElement detector, const string& value)  {
   hash = KeyMaker(detector,value).hash;
-#ifdef DD4HEP_CONDITIONKEY_HAVE_NAME
+#ifdef DD4HEP_CONDITIONS_HAVE_NAME
   name = detector.path()+"#"+value;
 #endif
 }
@@ -214,7 +206,7 @@ ConditionKey::ConditionKey(DetElement detector, const string& value)  {
 /// Constructor from detector element key and item sub-key
 ConditionKey::ConditionKey(Condition::detkey_type det_key, const string& value)    {
   hash = KeyMaker(det_key,value).hash;
-#ifdef DD4HEP_CONDITIONKEY_HAVE_NAME
+#ifdef DD4HEP_CONDITIONS_HAVE_NAME
   char text[32];
   ::snprintf(text,sizeof(text),"%08X#",det_key);
   name = text+value;
@@ -224,7 +216,7 @@ ConditionKey::ConditionKey(Condition::detkey_type det_key, const string& value) 
 /// Constructor from detector element key and item sub-key
 ConditionKey::ConditionKey(DetElement detector, Condition::itemkey_type item_key)  {
   hash = KeyMaker(detector.key(),item_key).hash;
-#ifdef DD4HEP_CONDITIONKEY_HAVE_NAME
+#ifdef DD4HEP_CONDITIONS_HAVE_NAME
   char text[32];
   ::snprintf(text,sizeof(text),"#%08X",item_key);
   name = detector.path()+text;
@@ -256,7 +248,7 @@ string ConditionKey::toString()  const    {
   dd4hep::ConditionKey::KeyMaker key(hash);
   char text[64];
   ::snprintf(text,sizeof(text),"%08X-%08X",key.values.det_key, key.values.item_key);
-#if defined(DD4HEP_CONDITIONS_DEBUG) || defined(DD4HEP_CONDITIONKEY_HAVE_NAME)
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
   if ( !name.empty() )   {
     stringstream str;
     str << "(" << name << ") " << text;

--- a/DDCore/src/ConditionsInterna.cpp
+++ b/DDCore/src/ConditionsInterna.cpp
@@ -20,10 +20,10 @@
 using namespace std;
 using namespace dd4hep;
 
-#if !defined(DD4HEP_CONDITIONS_DEBUG) && defined(DD4HEP_MINIMAL_CONDITIONS)
-DD4HEP_INSTANTIATE_HANDLE_UNNAMED(detail::ConditionObject);
-#else
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
 DD4HEP_INSTANTIATE_HANDLE_NAMED(detail::ConditionObject);
+#else
+DD4HEP_INSTANTIATE_HANDLE_UNNAMED(detail::ConditionObject);
 #endif
 
 namespace {
@@ -44,12 +44,12 @@ detail::ConditionObject::ConditionObject()
 }
 
 /// Standard constructor
-#if !defined(DD4HEP_CONDITIONS_DEBUG) && defined(DD4HEP_MINIMAL_CONDITIONS)
-detail::ConditionObject::ConditionObject(const string& ,const string& )
-  : data()
-#else
+#if defined(DD4HEP_CONDITIONS_HAVE_NAME)
 detail::ConditionObject::ConditionObject(const string& nam,const string& tit)
   : NamedObject(nam, tit), data()
+#else
+detail::ConditionObject::ConditionObject(const string& ,const string& )
+  : data()
 #endif
 {
   InstanceCount::increment(this);

--- a/DDCore/src/ShapeUtilities.cpp
+++ b/DDCore/src/ShapeUtilities.cpp
@@ -858,7 +858,7 @@ namespace dd4hep {
     TGeoShape*  right_solid   = boolean->GetRightShape();
     TGeoTubeSeg* tubs = (TGeoTubeSeg*)left_solid;
     TGeoBBox*    box  = (TGeoBBox*)right_solid;
-    double zhalf = params[0];
+    double dz    = params[0];
     double rmin  = params[1];
     double rmax  = params[2];
     double startPhi = params[3]/units::deg;
@@ -893,7 +893,7 @@ namespace dd4hep {
     double boxX      = 1.1*rmax + rmax/sin_alpha; // Need to adjust for move!
     double boxY      = rmax;
     // width of the box > width of the tubs
-    double boxZ      = 1.1 * zhalf;
+    double boxZ      = 1.1 * dz;
     double xBox;      // center point of the box
     if( cutInside )
       xBox = r - boxY / sin_alpha;
@@ -904,7 +904,7 @@ namespace dd4hep {
     TGeoRotation rot;
     rot.RotateZ( -alpha/units::deg );
     double box_dim[] = {boxX, boxY, boxZ};
-    double tub_dim[] = {rmin, rmax, zhalf, startPhi, deltaPhi};
+    double tub_dim[] = {rmin, rmax, dz, startPhi, deltaPhi};
     box->SetDimensions(box_dim);
     tubs->SetDimensions(tub_dim);
     TGeoCombiTrans* combi = (TGeoCombiTrans*)right_matrix;

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -328,19 +328,19 @@ void CutTube::make(const string& nam, double rmin, double rmax, double dz, doubl
 }
 
 /// Constructor to create a truncated tube object with attribute initialization
-TruncatedTube::TruncatedTube(double dZ, double rmin, double rmax, double startPhi, double deltaPhi,
+TruncatedTube::TruncatedTube(double dz, double rmin, double rmax, double startPhi, double deltaPhi,
                              double cutAtStart, double cutAtDelta, bool cutInside)
-{  make("", dZ, rmin, rmax, startPhi/units::deg, deltaPhi/units::deg, cutAtStart, cutAtDelta, cutInside);    }
+{  make("", dz, rmin, rmax, startPhi/units::deg, deltaPhi/units::deg, cutAtStart, cutAtDelta, cutInside);    }
 
 /// Constructor to create a truncated tube object with attribute initialization
 TruncatedTube::TruncatedTube(const string& nam,
-                             double dZ, double rmin, double rmax, double startPhi, double deltaPhi,
+                             double dz, double rmin, double rmax, double startPhi, double deltaPhi,
                              double cutAtStart, double cutAtDelta, bool cutInside)
-{  make(nam, dZ, rmin, rmax, startPhi/units::deg, deltaPhi/units::deg, cutAtStart, cutAtDelta, cutInside);    }
+{  make(nam, dz, rmin, rmax, startPhi/units::deg, deltaPhi/units::deg, cutAtStart, cutAtDelta, cutInside);    }
 
 /// Internal helper method to support object construction
 void TruncatedTube::make(const string& nam,
-                         double dZ, double rmin, double rmax, double startPhi, double deltaPhi,
+                         double dz, double rmin, double rmax, double startPhi, double deltaPhi,
                          double cutAtStart, double cutAtDelta, bool cutInside)   {
   // check the parameters
   if( rmin <= 0 || rmax <= 0 || cutAtStart <= 0 || cutAtDelta <= 0 )
@@ -365,7 +365,7 @@ void TruncatedTube::make(const string& nam,
   double boxX      = 1.1*rmax + rmax/sin_alpha; // Need to adjust for move!
   double boxY      = rmax;
   // width of the box > width of the tubs
-  double boxZ      = 1.1 * dZ;
+  double boxZ      = 1.1 * dz;
   double xBox;      // center point of the box
   if( cutInside )
     xBox = r - boxY / sin_alpha;
@@ -377,12 +377,12 @@ void TruncatedTube::make(const string& nam,
   rot.RotateZ( -alpha/dd4hep::deg );
   TGeoTranslation trans(xBox, 0., 0.);  
   TGeoBBox* box  = new TGeoBBox((nam+"Box").c_str(), boxX, boxY, boxZ);
-  TGeoTubeSeg* tubs = new TGeoTubeSeg((nam+"Tubs").c_str(), rmin, rmax, dZ, startPhi, deltaPhi);
+  TGeoTubeSeg* tubs = new TGeoTubeSeg((nam+"Tubs").c_str(), rmin, rmax, dz, startPhi, deltaPhi);
   TGeoCombiTrans* combi = new TGeoCombiTrans(trans, rot);
   TGeoSubtraction* sub  = new TGeoSubtraction(tubs, box, nullptr, combi);
   _assign(new TGeoCompositeShape(nam.c_str(), sub),"",TRUNCATEDTUBE_TAG,true);
   stringstream params;
-  params << dZ               << " " << endl
+  params << dz                  << " " << endl
          << rmin                << " " << endl
          << rmax                << " " << endl
          << startPhi*units::deg << " " << endl
@@ -394,7 +394,7 @@ void TruncatedTube::make(const string& nam,
   //cout << "Params: " << params.str() << endl;
 #if 0
   params << TRUNCATEDTUBE_TAG << ":" << endl
-         << "\t dZ:       " << dZ << " " << endl
+         << "\t dz:          " << dz << " " << endl
          << "\t rmin:        " << rmin << " " << endl
          << "\t rmax:        " << rmax << " " << endl
          << "\t startPhi:    " << startPhi << " " << endl
@@ -410,7 +410,7 @@ void TruncatedTube::make(const string& nam,
 #if 0
   cout << "Trans:";  trans.Print(); cout << endl;
   cout << "Rot:  ";  rot.Print();   cout << endl;
-  cout << " dZ:           " << dZ
+  cout << " Dz:           " << dz
        << " rmin:         " << rmin
        << " rmax:         " << rmax
        << " r/cutAtStart: " << r

--- a/DDCore/src/plugins/ShapePlugins.cpp
+++ b/DDCore/src/plugins/ShapePlugins.cpp
@@ -151,7 +151,7 @@ DECLARE_XML_SHAPE(EllipticalTube__shape_constructor,create_EllipticalTube)
 static Handle<TObject> create_TruncatedTube(Detector&, xml_h element)   {
   xml_dim_t e(element);
   double sp = e.startphi(0.0), dp = e.deltaphi(2*M_PI);
-  Solid solid = TruncatedTube(e.zhalf(), e.rmin(0.0), e.rmax(), sp, dp,
+  Solid solid = TruncatedTube(e.dz(), e.rmin(0.0), e.rmax(), sp, dp,
                               e.attr<double>(xml_tag_t("cutAtStart")),
                               e.attr<double>(xml_tag_t("cutAtDelta")),
                               e.attr<bool>(xml_tag_t("cutInside")));

--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -115,7 +115,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_readback_xml
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml
   -input  file:${AlignDet_INSTALL}/compact/Telescope.xml
   -deltas file:./new_cond.xml
-  REGEX_PASS "52 conditions in slice. \\(T:33,S:33,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
+  REGEX_PASS "40 conditions in slice. \\(T:21,S:21,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #

--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -115,7 +115,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_readback_xml
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml
   -input  file:${AlignDet_INSTALL}/compact/Telescope.xml
   -deltas file:./new_cond.xml
-  REGEX_PASS "40 conditions in slice. \\(T:21,S:21,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
+  REGEX_PASS "52 conditions in slice. \\(T:33,S:33,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #

--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -55,7 +55,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_read_xml
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml 
      -input  file:${AlignDet_INSTALL}/compact/Telescope.xml 
      -deltas file:${CMAKE_INSTALL_PREFIX}/examples/Conditions/data/repository.xml 
-  REGEX_PASS "20 conditions in slice. \\(T:20,S:20,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
+  REGEX_PASS "39 conditions in slice. \\(T:20,S:20,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -115,7 +115,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_readback_xml
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml
   -input  file:${AlignDet_INSTALL}/compact/Telescope.xml
   -deltas file:./new_cond.xml
-  REGEX_PASS "33 conditions in slice. \\(T:33,S:33,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
+  REGEX_PASS "52 conditions in slice. \\(T:33,S:33,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #

--- a/examples/AlignDet/src/AlignmentExample_read_xml.cpp
+++ b/examples/AlignDet/src/AlignmentExample_read_xml.cpp
@@ -99,7 +99,7 @@ static int alignment_example (Detector& description, int argc, char** argv)  {
   printout(INFO,"Example",
            "%ld conditions in slice. (T:%ld,S:%ld,L:%ld,C:%ld,M:%ld) "
            "Alignments accessed: %ld (A:%ld,M:%ld) for IOV:%-12s",
-           slice->conditions().size(),
+           slice->pool->size(),
            cres.total(), cres.selected, cres.loaded, cres.computed, cres.missing, 
            total_accessed, ares.computed, ares.missing, iov_typ->str().c_str());
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,9 +41,14 @@ dd4hep_configure_output()
 
 #==========================================================================
 
-SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDB DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency DDCAD SimpleDetector"
+SET(DD4HEP_EXAMPLES "AlignDet CLICSiD ClientTests Conditions DDCMS DDCodex DDDigi DDG4 DDG4_MySensDet LHeD OpticalSurfaces Persistency DDCAD SimpleDetector"
   CACHE STRING "List of DD4hep Examples to build")
 SEPARATE_ARGUMENTS(DD4HEP_EXAMPLES)
+
+IF(DD4HEP_BUILD_DEBUG)
+  SET(DD4HEP_EXAMPLES "${DD4HEP_EXAMPLES} DDDB"
+  CACHE STRING "List of DD4hep Examples to build")
+ENDIF()
 
 FOREACH(DDExample IN LISTS DD4HEP_EXAMPLES)
   dd4hep_print("|> Building ${DDExample}")

--- a/examples/ClientTests/compact/Check_Shape_TruncatedTube.xml
+++ b/examples/ClientTests/compact/Check_Shape_TruncatedTube.xml
@@ -6,19 +6,19 @@
   <detectors>
     <detector id="1" name="Shape_TruncatedTube" type="DD4hep_TestShape_Creator">
       <check vis="Shape1_vis">
-        <shape type="TruncatedTube" zhalf="50*cm" rmin="20*cm" rmax="40*cm" 
+        <shape type="TruncatedTube" dz="50*cm" rmin="20*cm" rmax="40*cm" 
                startphi="0*deg" deltaphi="90*deg" 
                cutAtStart="25*cm" cutAtDelta="35*cm" cutInside="true"/>
         <position x="0*cm"  y="0*cm"   z="100*cm"/>
       </check>
       <check vis="Shape1_vis">
-        <shape type="TruncatedTube" zhalf="50*cm" rmin="20*cm" rmax="40*cm" 
+        <shape type="TruncatedTube" dz="50*cm" rmin="20*cm" rmax="40*cm" 
                startphi="0*deg" deltaphi="90*deg" 
                cutAtStart="25*cm" cutAtDelta="35*cm" cutInside="false"/>
         <position x="0*cm"  y="0*cm"   z="-100*cm"/>
       </check>
       <check vis="Shape2_vis">
-        <shape type="TruncatedTube" zhalf="50*cm" rmin="20*cm" rmax="40*cm" 
+        <shape type="TruncatedTube" dz="50*cm" rmin="20*cm" rmax="40*cm" 
                startphi="0*deg" deltaphi="45*deg" 
                cutAtStart="20*cm" cutAtDelta="30*cm" cutInside="true"/>
         <position x="0*cm"  y="150*cm"   z="-100*cm"/>
@@ -26,27 +26,27 @@
 <!--  This one for one reason or another creates a slightly different mesh on MAC than on linux
       (two mesh points more, the others identical). Lets remove this test.
       <check vis="Shape3_vis">
-        <shape type="TruncatedTube" zhalf="50*cm" rmin="20*cm" rmax="40*cm" 
+        <shape type="TruncatedTube" dz="50*cm" rmin="20*cm" rmax="40*cm" 
                startphi="0*deg" deltaphi="150*deg" 
                cutAtStart="20*cm" cutAtDelta="35*cm" cutInside="true"/>
         <position x="90*cm"  y="150*cm"   z="100*cm"/>
       </check>
 -->
 <!--
-      <TruncTubs name="trunctubs2" rMin="6.9551*m" rMax="9*m" cutAtStart="6.9551*m" cutAtDelta="7.20045*m" cutInside="true" startPhi="0*deg" deltaPhi="15*deg" zHalf="6.57005*m"/>
+      <TruncTubs name="trunctubs2" rMin="6.9551*m" rMax="9*m" cutAtStart="6.9551*m" cutAtDelta="7.20045*m" cutInside="true" startPhi="0*deg" deltaPhi="15*deg" dz="6.57005*m"/>
 
         <position z="-28.9*m" y="5.9*m" x="0."/>
 -->
 <!--
       <check vis="Shape1_vis">
-        <shape type="TruncatedTube" zhalf="6.57005*m" rmin="6.9551*m" rmax="9*m" 
+        <shape type="TruncatedTube" dz="6.57005*m" rmin="6.9551*m" rmax="9*m" 
                startphi="0*deg" deltaphi="15*deg" 
                cutAtStart="6.9551*m" cutAtDelta="7.20045*m" cutInside="true"/>
       </check>
 -->
 <!--
       <check vis="Shape2_vis">
-        <shape type="TruncatedTube" zhalf="50*cm" rmin="20*cm" rmax="40*cm" 
+        <shape type="TruncatedTube" dz="50*cm" rmin="20*cm" rmax="40*cm" 
                startphi="0*rad" deltaphi="pi/2*rad" 
                cutAtStart="25*cm" cutAtDelta="35*cm" cutInside="0"/>
         <position x="0*cm"  y="90*cm"   z="0*cm"/>

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -54,7 +54,7 @@ dd4hep_add_test_reg( Conditions_Telescope_cond_dump_by_detelement
   -compact file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
   -plugin DD4hep_ConditionsXMLRepositoryParser file:${CMAKE_INSTALL_PREFIX}/examples/Conditions/data/repository.xml 
   -plugin DD4hep_DetElementConditionsDump
-  REGEX_PASS "Key\\:FA708B8A8CDE3019 Type\\:dd4hep\\:\\:Delta"
+  REGEX_PASS "Key\\:FA708B8A6E87AB8E Type\\:dd4hep\\:\\:Delta"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -54,7 +54,7 @@ dd4hep_add_test_reg( Conditions_Telescope_cond_dump_by_detelement
   -compact file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml 
   -plugin DD4hep_ConditionsXMLRepositoryParser file:${CMAKE_INSTALL_PREFIX}/examples/Conditions/data/repository.xml 
   -plugin DD4hep_DetElementConditionsDump
-  REGEX_PASS "Path\\:/world/Telescope/module_9#alignment"
+  REGEX_PASS "Key\\:FA708B8A8CDE3019 Type\\:dd4hep\\:\\:Delta"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #

--- a/examples/Conditions/data/Modules_run-1000...2000.xml
+++ b/examples/Conditions/data/Modules_run-1000...2000.xml
@@ -4,10 +4,10 @@
 <conditions>
 
   <detelement path="/world/Telescope">
-    <alignment>
+    <alignment_delta>
       <position x="0" y="0" z="5*cm"/>
       <rotation x="0" y="0" z="0"/>     
-    </alignment>
+    </alignment_delta>
   </detelement>
 
   <detelement path="/world/Telescope/module_1">
@@ -26,35 +26,35 @@
   </detelement>
 
   <detelement path="/world/Telescope/module_6">
-    <alignment>
+    <alignment_delta>
       <position x="0" y="0"    z="290.0*mm"/>
       <rotation x="0" y="pi/2" z="0"/>     
-    </alignment>
+    </alignment_delta>
   </detelement>
 
   <detelement path="/world/Telescope/module_7">
-    <alignment>
+    <alignment_delta>
       <position x="0" y="0"    z="290.0*mm"/>
       <rotation x="0" y="pi/2" z="0"/>     
-    </alignment>
+    </alignment_delta>
   </detelement>
 
   <detelement path="/world/Telescope/module_8">
-    <alignment>
+    <alignment_delta>
       <position x="0" y="0"    z="290.0*mm"/>
       <rotation x="0" y="pi/2" z="0"/>     
-    </alignment>
+    </alignment_delta>
   </detelement>
 <!--
 -->
   <detelement path="/world/Telescope/module_9" ref="default_module.xml">
-    <alignment>
+    <alignment_delta>
       <position x="0" y="0" z="10.0*mm"/>
       <rotation x="0" y="0" z="0"/>     
       <pivot    x="0" y="0" z="0"/>     
-    </alignment>
+    </alignment_delta>
     <detelement path="/world/Telescope/module_9/sensor">
-      <alignment>
+      <alignment_delta>
         <position x="0" y="0" z="10.0*mm"/>
         <!-- This is a point symmetry of 180 degree. 
              Can be checked with the printer. 
@@ -62,7 +62,7 @@
          -->
         <rotation x="0" y="0" z="pi"/>     
         <pivot    x="0" y="0" z="0"/>     
-      </alignment>
+      </alignment_delta>
     </detelement>
 <!--
 -->

--- a/examples/DDDB/src/plugins/DDDBConditionsLoader.cpp
+++ b/examples/DDDB/src/plugins/DDDBConditionsLoader.cpp
@@ -82,12 +82,12 @@ namespace {
           if ( i != rc.end() ) {
             (*i) = cond;
             printout(DEBUG,"DDDB","++ Got  MATCH: %-40s [%16llX] --> %s.",
-                     c->name.c_str(), c->hash, c->address.c_str());
+                     cond.name(), cond.key(), c->address.c_str());
             iov.iov_intersection(*c->iov);
             return;
           }
           printout(INFO,"DDDB","++ Got update: %-40s [%16llX] --> %s.",
-                   c->name.c_str(), c->hash, c->address.c_str());
+                   cond.name(), cond.key(), c->address.c_str());
         }
         else if (  cmd == INSERT )  {
           iov.iov_intersection(*c->iov);

--- a/examples/DDDB/src/plugins/DDDBDetectorDumps.cpp
+++ b/examples/DDDB/src/plugins/DDDBDetectorDumps.cpp
@@ -268,7 +268,7 @@ namespace {
           ::sprintf(fmt,"%03d %%-%ds Key: %%16llX -> %%s # %%s",level+1,2*level+3);
           for(const auto cond : conditions )  {
             if ( with_keys )   {
-              printout(s_PrintLevel,m_detElementPrinter.name,fmt,"",cond->hash, de.path().c_str(), cond->name.c_str());
+              printout(s_PrintLevel,m_detElementPrinter.name,fmt,"",cond.key(), de.path().c_str(), cond.name());
             }
             if ( with_values )   {
               m_detElementPrinter(cond);


### PR DESCRIPTION
BEGINRELEASENOTES
- Propagate condition names for printouts. Names are enabled by default. The feature can be disabled
  to minimize conditions memory footprint. Comment `DD4HEP_CONDITIONS_HAVE_NAME` in `DD4hep/config.h`

- If the debug flag `DD4HEP_CONDITIONS_DEBUG` is set (enabled by the compile definition `DD4HEP_DEBUG`, which in turn is enabled by the cmake flag `DD4HEP_BUILD_DEBUG`, which is turned on in debug builds automatically), then condition objects offer optional storage e.g. to store the object address or an xml-string etc.

- Update and fix some tests, which were assuming names
ENDRELEASENOTES