### PR TITLE
Fix to keep DetElement reference in the conditions dependency 

### DIFF
--- a/DDCond/src/plugins/ConditionsUserPool.cpp
+++ b/DDCond/src/plugins/ConditionsUserPool.cpp
@@ -244,12 +244,12 @@ template<typename MAPPING> inline bool
 ConditionsMappedUserPool<MAPPING>::i_insert(Condition::Object* o)   {
   int ret = m_conditions.emplace(o->hash,o).second;
   if ( flags&PRINT_INSERT )  {
-    printout(INFO,"UserPool","++ %s condition [%016llX]: %s [%s].",
-             ret ? "Successfully inserted" : "FAILED to insert", o->hash,
+    printout(INFO,"UserPool","++ %s condition [%016llX]"
 #if defined(DD4HEP_CONDITIONS_HAVE_NAME)
-             o->GetName(), o->GetTitle());
+             ": %s [%s].", ret ? "Successfully inserted" : "FAILED to insert",
+             o->hash, o->GetName(), o->GetTitle());
 #else
-    "", "");
+    , ret ? "Successfully inserted" : "FAILED to insert", o->hash);
 #endif
   }
   return ret;

--- a/DDCore/include/DD4hep/ConditionDerived.h
+++ b/DDCore/include/DD4hep/ConditionDerived.h
@@ -316,10 +316,8 @@ namespace dd4hep {
       int                                  m_refCount {0};
 
     public:
-#ifdef DD4HEP_CONDITIONS_DEBUG
       /// Reference to the target's detector element
       DetElement                           detector;
-#endif
       /// Key to the condition to be updated
       ConditionKey                         target {0};
       /// Dependency keys this condition depends on
@@ -337,13 +335,9 @@ namespace dd4hep {
 
     public:
       /// Initializing constructor used by builder
-      ConditionDependency(Condition::key_type key, std::shared_ptr<ConditionUpdateCall> call);
-      /// Initializing constructor used by builder
       ConditionDependency(DetElement de, const std::string& item, std::shared_ptr<ConditionUpdateCall> call);
       /// Initializing constructor used by builder
       ConditionDependency(DetElement de, Condition::itemkey_type item_key, std::shared_ptr<ConditionUpdateCall> call);
-      /// Initializing constructor used by builder
-      ConditionDependency(Condition::detkey_type det_key, Condition::itemkey_type item_key, std::shared_ptr<ConditionUpdateCall> call);
       /// Default constructor
       ConditionDependency();
       /// Access the dependency key

--- a/DDCore/include/DD4hep/config.h
+++ b/DDCore/include/DD4hep/config.h
@@ -23,13 +23,13 @@
 #define DD4HEP_CONDITIONS_DEBUG     1
 #endif
 
-#if !defined(DD4HEP_CONDITIONS_DEBUG)
+#if defined(DD4HEP_CONDITIONS_DEBUG)
+/// Enable flag to store conditions names to keys (needs some support from user code!)
+#define DD4HEP_CONDITIONS_HAVE_NAME 1
+#else
 /// Enable this if you want to minimize the footprint of conditions
 #define DD4HEP_MINIMAL_CONDITIONS   1
 #endif
-
-/// Enable flag to store conditions names to keys (needs some support from user code!)
-#define DD4HEP_CONDITIONS_HAVE_NAME 1
 
 /// Valid implementations of the Gaudi plugin service are 1 and 2
 #define DD4HEP_PLUGINSVC_VERSION    2

--- a/DDCore/src/ConditionDerived.cpp
+++ b/DDCore/src/ConditionDerived.cpp
@@ -132,31 +132,10 @@ void ConditionUpdateContext::accessFailure(const ConditionKey& key_value)  const
 }
 
 /// Initializing constructor
-ConditionDependency::ConditionDependency(Condition::key_type  key,
-                                         std::shared_ptr<ConditionUpdateCall> call)
-  : m_refCount(0), target(key), callback(std::move(call))
-{
-  InstanceCount::increment(this);
-}
-
-/// Initializing constructor
-ConditionDependency::ConditionDependency(Condition::detkey_type det_key,
-                                         Condition::itemkey_type item_key,
-                                         std::shared_ptr<ConditionUpdateCall> call)
-  : m_refCount(0), target(det_key, item_key), callback(std::move(call))
-{
-  InstanceCount::increment(this);
-}
-
-/// Initializing constructor
 ConditionDependency::ConditionDependency(DetElement              de,
                                          Condition::itemkey_type item_key,
                                          std::shared_ptr<ConditionUpdateCall> call)
-  : m_refCount(0), 
-#ifdef DD4HEP_CONDITIONS_DEBUG
-  detector(de),
-#endif
-  target(de, item_key), callback(std::move(call))
+  : m_refCount(0), detector(de), target(de, item_key), callback(std::move(call))
 {
   InstanceCount::increment(this);
 }
@@ -166,10 +145,7 @@ ConditionDependency::ConditionDependency(DetElement de,
                                          const std::string&   item, 
                                          std::shared_ptr<ConditionUpdateCall> call)
   : 
-#ifdef DD4HEP_CONDITIONS_DEBUG
-  detector(de),
-#endif
-  target(de, item), callback(std::move(call))
+  detector(de), target(de, item), callback(std::move(call))
 {
   InstanceCount::increment(this);
 }

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -1517,11 +1517,13 @@ template <> void Converter<Compact>::operator()(xml_h element) const {
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   /// These two must be parsed early, because they are needed by the detector constructors
   xml_coll_t(compact, _U(properties)).for_each(_U(constant), Converter<PropertyConstant>(description));
-  xml_coll_t(compact, _U(properties)).for_each(_U(matrix), Converter<PropertyTable>(description));
+  xml_coll_t(compact, _U(properties)).for_each(_U(matrix),   Converter<PropertyTable>(description));
+  xml_coll_t(compact, _U(properties)).for_each(_U(plugin),   Converter<Plugin> (description));
   xml_coll_t(compact, _U(surfaces)).for_each(_U(opticalsurface), Converter<OpticalSurface>(description));
 #endif
-  xml_coll_t(compact, _U(materials)).for_each(_U(element), Converter<Atom>(description));
+  xml_coll_t(compact, _U(materials)).for_each(_U(element),  Converter<Atom>(description));
   xml_coll_t(compact, _U(materials)).for_each(_U(material), Converter<Material>(description));
+  xml_coll_t(compact, _U(materials)).for_each(_U(plugin),   Converter<Plugin> (description));
   
   xml_coll_t(compact, _U(display)).for_each(_U(include), Converter<DetElementInclude>(description));
   xml_coll_t(compact, _U(display)).for_each(_U(vis), Converter<VisAttr>(description));

--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -115,7 +115,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_readback_xml
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml
   -input  file:${AlignDet_INSTALL}/compact/Telescope.xml
   -deltas file:./new_cond.xml
-  REGEX_PASS "52 conditions in slice. \\(T:33,S:33,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
+  REGEX_PASS "40 conditions in slice. \\(T:21,S:21,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #

--- a/examples/Conditions/src/ConditionExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionExampleObjects.cpp
@@ -155,9 +155,6 @@ int ConditionsDependencyCreator::operator()(DetElement de, int)  const  {
   DependencyBuilder build_1(de, target1.item_key(), call1);
   DependencyBuilder build_2(de, target2.item_key(), call2);
   DependencyBuilder build_3(de, target3.item_key(), call3);
-  //DependencyBuilder build_1(de, "derived_data/derived_1", call1);
-  //DependencyBuilder build_2(de, "derived_data/derived_2", call2);
-  //DependencyBuilder build_3(de, "derived_data/derived_3", call3);
 
   // Compute the derived stuff
   sbuild_1.add(key);


### PR DESCRIPTION

BEGINRELEASENOTES
- The ability to access the DetElement in a derived condition is very useful. Access to it is enabled now for all
compilations (Debug + Release).
- When parsing compact, it is possible to inject plugins to create tables with tabulated properties in C++
- When parsing compact, it is possible to inject plugins to assign property tables to materials.
ENDRELEASENOTES