### PR TITLE
Replace tbb with std containers

### DIFF
--- a/DDCore/CMakeLists.txt
+++ b/DDCore/CMakeLists.txt
@@ -15,7 +15,7 @@ dd4hep_print("|++> Will be Building DDCore")
 
 file(GLOB DDCore_SOURCES src/*.cpp src/segmentations/*.cpp src/XML/*.cpp)
 
-if(NOT DD4HEP_USE_TBB OR ${CMAKE_CXX_STANDARD} LESS 17)
+if(${CMAKE_CXX_STANDARD} LESS 17)
   list(APPEND EXCLUDE_HEADER include/DD4hep/SpecParRegistry.h)
   list(APPEND EXCLUDE_HEADER include/DD4hep/Filter.h)
   list(FILTER DDCore_SOURCES EXCLUDE REGEX Filter\.cpp|SpecParRegistry\.cpp )

--- a/DDCore/include/DD4hep/Filter.h
+++ b/DDCore/include/DD4hep/Filter.h
@@ -29,39 +29,18 @@
 //         Created:  Tue, 12 Mar 2019 09:51:33 CET
 //
 //
-
 #include <memory>
 #include <vector>
 #include <regex>
+#include <unordered_map>
 
 namespace dd4hep {
   struct SpecPar;
 
   struct Filter {
-    void print() const {
-      /* edm::LogVerbatim("Geometry").log([&](auto& log) { */
-      /*   for (const auto& it : skeys) { */
-      /*     log << it << ", "; */
-      /*   } */
-      /*   if (next) { */
-      /*     log << "Next:\n"; */
-      /*     print(next); */
-      /*   } */
-      /*   if (up) { */
-      /*     log << "Up:\n"; */
-      /*     up->print(); */
-      /*   } */
-      /* }); */
-    }
-
-    //    void print(const std::unique_ptr<Filter>& filter) const {
-      /* edm::LogVerbatim("Geometry").log([&](auto& log) { */
-      /*   for (const auto& it : filter->skeys) { */
-      /*     log << it << ", "; */
-      /*   } */
-      /* }); */
-    //}
-
+    std::vector<bool> isRegex;
+    std::vector<bool> hasNamaspace;
+    std::vector<int> index;
     std::vector<std::string_view> skeys;
     std::vector<std::regex> keys;
     std::unique_ptr<Filter> next;
@@ -72,6 +51,7 @@ namespace dd4hep {
   namespace dd {
     bool accepted(std::vector<std::regex> const&, std::string_view);
     bool isRegex(std::string_view);
+    bool hasNamespace(std::string_view);
     bool isMatch(std::string_view, std::string_view);
     bool compareEqual(std::string_view, std::string_view);
     bool compareEqual(std::string_view, std::regex);

--- a/DDCore/include/DD4hep/Filter.h
+++ b/DDCore/include/DD4hep/Filter.h
@@ -39,7 +39,7 @@ namespace dd4hep {
 
   struct Filter {
     std::vector<bool> isRegex;
-    std::vector<bool> hasNamaspace;
+    std::vector<bool> hasNamespace;
     std::vector<int> index;
     std::vector<std::string_view> skeys;
     std::vector<std::regex> keys;
@@ -50,11 +50,14 @@ namespace dd4hep {
 
   namespace dd {
     bool accepted(std::vector<std::regex> const&, std::string_view);
+    bool accepted(const Filter*, std::string_view);
     bool isRegex(std::string_view);
     bool hasNamespace(std::string_view);
     bool isMatch(std::string_view, std::string_view);
     bool compareEqual(std::string_view, std::string_view);
     bool compareEqual(std::string_view, std::regex);
+    bool compareEqualName(std::string_view, std::string_view);
+    bool compareEqualCopyNumber(std::string_view, int);
     std::string_view realTopName(std::string_view);
     std::vector<std::string_view> split(std::string_view, const char*);
     std::string_view noNamespace(std::string_view);

--- a/DDCore/include/DD4hep/SpecParRegistry.h
+++ b/DDCore/include/DD4hep/SpecParRegistry.h
@@ -38,10 +38,11 @@ namespace dd4hep {
   };
 
   using SpecParMap = std::unordered_map<std::string, SpecPar>;
-  using SpecParRefs = std::vector<std::pair<std::string_view, const SpecPar*>>;
+  using SpecParRefs = std::vector<std::pair<std::string, const SpecPar*>>;
 
   struct SpecParRegistry {
-    void filter(SpecParRefs&, const std::string&, const std::string& = "") const;
+    void filter(SpecParRefs&, const std::string&, const std::string&) const;
+    void filter(SpecParRefs&, const std::string&) const;
     std::vector<std::string_view> names() const;
     std::vector<std::string_view> names(const std::string& path) const;
     bool hasSpecPar(std::string_view) const;

--- a/DDCore/include/DD4hep/SpecParRegistry.h
+++ b/DDCore/include/DD4hep/SpecParRegistry.h
@@ -15,18 +15,18 @@
 
 #include <string>
 #include <string_view>
-#include "tbb/concurrent_unordered_map.h"
-#include "tbb/concurrent_vector.h"
+#include <unordered_map>
+#include <vector>
 
 namespace dd4hep {
-  using Paths = tbb::concurrent_vector<std::string>;
-  using PartSelectionMap = tbb::concurrent_unordered_map<std::string, tbb::concurrent_vector<std::string>>;
-  using VectorsMap = tbb::concurrent_unordered_map<std::string, tbb::concurrent_vector<double>>;
+  using Paths = std::vector<std::string>;
+  using PartSelectionMap = std::unordered_map<std::string, std::vector<std::string>>;
+  using VectorsMap = std::unordered_map<std::string, std::vector<double>>;
 
   struct SpecPar {
     std::string_view strValue(const std::string&) const;
-    bool hasValue(const std::string& key) const;
-    bool hasPath(const std::string& path) const;
+    bool hasValue(const std::string&) const;
+    bool hasPath(const std::string&) const;
     double dblValue(const std::string&) const;
 
     template <typename T>
@@ -35,11 +35,10 @@ namespace dd4hep {
     Paths paths;
     PartSelectionMap spars;
     VectorsMap numpars;
-    std::string_view name;
   };
 
-  using SpecParMap = tbb::concurrent_unordered_map<std::string, SpecPar>;
-  using SpecParRefs = std::vector<const SpecPar*>;
+  using SpecParMap = std::unordered_map<std::string, SpecPar>;
+  using SpecParRefs = std::vector<std::pair<std::string_view, const SpecPar*>>;
 
   struct SpecParRegistry {
     void filter(SpecParRefs&, const std::string&, const std::string& = "") const;

--- a/DDCore/src/Filter.cpp
+++ b/DDCore/src/Filter.cpp
@@ -32,6 +32,10 @@ namespace dd4hep {
       return (input.find(".") != std::string_view::npos) || (input.find("*") != std::string_view::npos);
     }
 
+    bool hasNamespace(std::string_view input) {
+      return (input.find(":") != std::string_view::npos);
+    }
+    
     string_view realTopName(string_view input) {
       string_view v = input;
       auto first = v.find_first_of("//");

--- a/DDCore/src/Filter.cpp
+++ b/DDCore/src/Filter.cpp
@@ -23,9 +23,40 @@ namespace dd4hep {
       return regex_match(std::string(node.data(), node.size()), pattern);
     }
 
+    bool compareEqualName(const std::string_view selection, const std::string_view name) {
+      return (!(dd4hep::dd::isRegex(selection)) ? dd4hep::dd::compareEqual(name, selection)
+	      : regex_match(name.begin(), name.end(), regex(std::string(selection))));
+    }
+
+    bool compareEqualCopyNumber(std::string_view name, int copy) {
+      auto pos = name.rfind('[');
+      if (pos != name.npos) {
+	if (std::stoi(std::string(name.substr(pos + 1, name.rfind(']')))) == copy) {
+	  return true;
+	}
+      }
+      
+      return false;
+    }
+
     bool accepted(vector<std::regex> const& keys, string_view node) {
       return (find_if(begin(keys), end(keys), [&](const auto& n) -> bool { return compareEqual(node, n); }) !=
               end(keys));
+    }
+
+    bool accepted(const Filter* filter, std::string_view name) {
+      for(unsigned int i = 0; i < filter->isRegex.size(); i++ ) {
+	if(!filter->isRegex[i]) {
+	  if(compareEqual(filter->skeys[i], name)) {
+	    return true;
+	  }
+	} else {
+	  if(compareEqual(name, filter->keys[filter->index[i]])) {
+	    return true;
+	  }
+	}
+      }
+      return false;
     }
 
     bool isRegex(string_view input) {

--- a/DDCore/src/SpecParRegistry.cpp
+++ b/DDCore/src/SpecParRegistry.cpp
@@ -110,10 +110,19 @@ void SpecParRegistry::filter(SpecParRefs& refs, const std::string& attribute, co
       }
     });
     if (found) {
-      refs.emplace_back(std::make_pair(k.first, &k.second));
+      refs.emplace_back(std::string(k.first.data(), k.first.size()), &k.second);
     }
   });
 }
+
+void SpecParRegistry::filter(SpecParRefs& refs, const std::string& key) const {
+  for (auto const& it : specpars) {
+    if (it.second.hasValue(key) || (it.second.spars.find(key) != end(it.second.spars))) {
+      refs.emplace_back(it.first, &it.second);
+    }
+  }
+}
+
 
 std::vector<std::string_view> SpecParRegistry::names(const std::string& path) const {
   std::vector<std::string_view> result;

--- a/DDCore/src/SpecParRegistry.cpp
+++ b/DDCore/src/SpecParRegistry.cpp
@@ -110,8 +110,7 @@ void SpecParRegistry::filter(SpecParRefs& refs, const std::string& attribute, co
       }
     });
     if (found) {
-      k.second.name = k.first;
-      refs.emplace_back(&k.second);
+      refs.emplace_back(std::make_pair(k.first, &k.second));
     }
   });
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- SpecParRegistry: remove need for TBB
  - TBB has a slight overhead compare to std containers
  - Using std containers allows to return references to the containers in the registry

- Reverse the plan to process XML files in parallel

ENDRELEASENOTES