### PR TITLE
Examples.DDG4: fix userdict for root <= 6.18

### DIFF
--- a/examples/DDG4/CMakeLists.txt
+++ b/examples/DDG4/CMakeLists.txt
@@ -30,7 +30,7 @@ if (DD4HEP_USE_GEANT4)
   SOURCES ${DD4hep_DIR}/include/ROOT/Warnings.h src/Dictionary.h
   LINKDEF ${DD4hep_DIR}/include/ROOT/LinkDef.h
   DEFINITIONS DD4HEP_DICTIONARY_MODE
-  OPTIONS -rmf=${LIBRARY_OUTPUT_PATH}/G__DDG4UserDict.rootmap -rml=libDDG4UserLib.so
+  OPTIONS -rmf ${LIBRARY_OUTPUT_PATH}/G__DDG4UserDict.rootmap -rml libDDG4UserLib.so
   OUTPUT ${LIBRARY_OUTPUT_PATH}
   )
   #----  Example of a client library with user defined plugins  --------------------


### PR DESCRIPTION

@gaede This should fix #737 down to at least root 6.08.

Follow up for #728, no need for release notes