### PR TITLE
Make example tests work when compiled together with main project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 SET(DD4hep_DIR ${CMAKE_SOURCE_DIR} CACHE STRING "DD4hep directory")
+SET(DD4hep_ROOT ${CMAKE_INSTALL_PREFIX})
 
 IF(${CMAKE_CXX_STANDARD} LESS 14)
   MESSAGE(FATAL_ERROR "DD4hep requires at least CXX Standard 14 to compile")
@@ -214,7 +215,6 @@ ELSE()
   endif()
 
   if(DD4HEP_BUILD_EXAMPLES)
-    set(DD4hep_DIR ${CMAKE_INSTALL_PREFIX})
     add_subdirectory(examples)
   endif()
 

--- a/cmake/thisdd4hep_package.sh.in
+++ b/cmake/thisdd4hep_package.sh.in
@@ -9,7 +9,7 @@
 #################################################################################
 # Default of DD4hep is the primary installation directory
 if [ ! ${DD4hep_DIR} ]; then
-    export DD4hep_DIR=@DD4hep_DIR@;
+    export DD4hep_DIR=@DD4hep_ROOT@;
 fi;
 if [ @CLHEP_DIR@ ]; then
     export CLHEP_DIR=@CLHEP_DIR@;

--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -123,7 +123,7 @@ dd4hep_add_test_reg( AlignDet_Telescope_readback_xml
 dd4hep_add_test_reg( AlignDet_CLICSiD_stress_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun  -volmgr -destroy -plugin DD4hep_AlignmentExample_stress 
-      -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 10 -runs 100
+      -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 10 -runs 100
   REGEX_PASS "Summary: Total 7372260 conditions used \\(S:7372260,L:0,C:0,M:0\\) \\(A:351060,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -132,7 +132,7 @@ dd4hep_add_test_reg( AlignDet_CLICSiD_stress_LONGTEST
 dd4hep_add_test_reg( AlignDet_CLICSiD_align_nominal_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy -plugin DD4hep_AlignmentExample_nominal
-     -input  file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+     -input  file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
   REGEX_PASS "Printed 35107, scanned 35107 and computed a total of 35107 alignments \\(C:35107,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )

--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -61,14 +61,14 @@ endforeach()
 # ROOT Geometry overlap checks
 dd4hep_add_test_reg( CLICSiD_check_geometry_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  python ${DD4hep_DIR}/bin/checkGeometry --compact=file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+  EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkGeometry --compact=file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
   # This takes too long                  --full=true --ntracks=10 --option=o --vx=0 --vy=0 --vz=0
   REGEX_PASS " Execution finished..." )
 #
 # ROOT Geometry overlap checks
 dd4hep_add_test_reg( CLICSiD_check_overlaps_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  python ${DD4hep_DIR}/bin/checkOverlaps --compact=file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+  EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkOverlaps --compact=file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
                     --tolerance=0.1
   REGEX_PASS " Execution finished..." )
 #
@@ -151,14 +151,14 @@ if (DD4HEP_USE_GEANT4)
   # Material scan
   dd4hep_add_test_reg( CLICSiD_DDG4_g4material_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/bin/g4MaterialScan --compact=$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4MaterialScan --compact=$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
                       "--position=0,0,0" "--direction=0,1,0"
     REGEX_PASS " Terminate Geant4 and delete associated actions." )
   #
   # Geometry scan
   dd4hep_add_test_reg( CLICSiD_DDG4_g4geometry_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/bin/g4GeometryScan --compact=$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4GeometryScan --compact=$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
                       "--position=0,0,0" "--direction=0,1,0"
     REGEX_PASS "|   856     2374.8789   3000.000     (   0.00,3000.00,   0.00)  Path:\"/world\" Shape:G4Box  Mat:Air" )
   #
@@ -168,7 +168,7 @@ if (DD4HEP_USE_GEANT4)
     # Build AClick from the source file
     dd4hep_add_test_reg( CLICSiD_DDG4_${script}_as_AClick_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-      EXEC_ARGS  root.exe -b -x -n -q -l "${DD4hep_DIR}/examples/DDG4/examples/run.C(\"${CLICSiDEx_INSTALL}/scripts/${script}\")"
+      EXEC_ARGS  root.exe -b -x -n -q -l "${DD4hep_ROOT}/examples/DDG4/examples/run.C(\"${CLICSiDEx_INSTALL}/scripts/${script}\")"
       REGEX_PASS "UserEvent_1      INFO  Geant4TestEventAction> calling end.event_id=9"
       REGEX_FAIL "EXCEPTION;ERROR;Error" )
     #

--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -46,14 +46,14 @@ include(CTest)
 ##dd4hep_add_test_reg ( "CLICSiD_converter_gdml_LONGTEST" 
 ##  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
 ##  EXEC_ARGS  geoConverter -compact2gdml 
-##                          -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+##                          -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
 ##                          -output file:CLICSiD.gdml
 ##  REGEX_PASS " Successfully extracted GDML to" )
 foreach ( typ description vis )
   dd4hep_add_test_reg ( "CLICSiD_converter_${typ}_LONGTEST" 
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
     EXEC_ARGS  geoConverter -compact2${typ} 
-                            -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+                            -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
                             -output file:CLICSiD.${typ}
     REGEX_PASS " Handled [1-9][0-9][0-9]+ volumes" )
 endforeach()
@@ -61,14 +61,14 @@ endforeach()
 # ROOT Geometry overlap checks
 dd4hep_add_test_reg( CLICSiD_check_geometry_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkGeometry --compact=file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+  EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkGeometry --compact=file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
   # This takes too long                  --full=true --ntracks=10 --option=o --vx=0 --vy=0 --vz=0
   REGEX_PASS " Execution finished..." )
 #
 # ROOT Geometry overlap checks
 dd4hep_add_test_reg( CLICSiD_check_overlaps_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkOverlaps --compact=file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+  EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkOverlaps --compact=file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
                     --tolerance=0.1
   REGEX_PASS " Execution finished..." )
 #
@@ -90,7 +90,7 @@ if( "${ROOT_FIND_VERSION}" VERSION_GREATER "6.13.0" )
 # ROOT Geometry export to GDML
 dd4hep_add_test_reg( CLICSiD_GDML_export_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  geoPluginRun -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -print WARNING -destroy -volmgr
+  EXEC_ARGS  geoPluginRun -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -print WARNING -destroy -volmgr
              -plugin DD4hep_ROOTGDMLExtract -output EcalBarrel.gdml            -path /world/EcalBarrel
              -plugin DD4hep_ROOTGDMLExtract -output EcalEndcap.gdml            -path /world/EcalEndcap
              -plugin DD4hep_ROOTGDMLExtract -output HcalBarrel.gdml            -path /world/HcalBarrel 
@@ -109,7 +109,7 @@ dd4hep_add_test_reg( CLICSiD_GDML_export_LONGTEST
 # ROOT Geometry export to GDML
 dd4hep_add_test_reg( CLICSiD_GDML_import_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  geoPluginRun -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -print WARNING -destroy -volmgr
+  EXEC_ARGS  geoPluginRun -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -print WARNING -destroy -volmgr
              -plugin DD4hep_ROOTGDMLParse    -input EcalBarrel.gdml            -path /world/EcalBarrel
              -plugin DD4hep_ROOTGDMLParse    -input EcalEndcap.gdml            -path /world/EcalEndcap
              -plugin DD4hep_ROOTGDMLParse    -input HcalBarrel.gdml            -path /world/HcalBarrel
@@ -151,14 +151,14 @@ if (DD4HEP_USE_GEANT4)
   # Material scan
   dd4hep_add_test_reg( CLICSiD_DDG4_g4material_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4MaterialScan --compact=$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4MaterialScan --compact=${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
                       "--position=0,0,0" "--direction=0,1,0"
     REGEX_PASS " Terminate Geant4 and delete associated actions." )
   #
   # Geometry scan
   dd4hep_add_test_reg( CLICSiD_DDG4_g4geometry_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4GeometryScan --compact=$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4GeometryScan --compact=${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
                       "--position=0,0,0" "--direction=0,1,0"
     REGEX_PASS "|   856     2374.8789   3000.000     (   0.00,3000.00,   0.00)  Path:\"/world\" Shape:G4Box  Mat:Air" )
   #

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,6 +35,16 @@ IF(NOT TARGET DD4hep::DDCore)
 ENDIF()
 include(DD4hepMacros) 
 
+IF( "$ENV{DD4hepINSTALL}" STREQUAL "" )
+  IF( DD4hep_FOUND )
+    MESSAGE( FATAL_ERROR "Must source <DD4hep-install-dir>/bin/thisdd4hep.sh first" )
+    EXIT(1)
+  ENDIF()
+  # When building the examples together with DD4hep (-DDD4HEP_BUILD_EXAMPLES=ON),
+  # thisdd4hep.sh hasn't run. Manually set up the required variables for the tests.
+  SET( ENV{DD4hepINSTALL} ${CMAKE_INSTALL_PREFIX} )
+ENDIF()
+
 dd4hep_set_compiler_flags()
 dd4hep_configure_output()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,16 +35,6 @@ IF(NOT TARGET DD4hep::DDCore)
 ENDIF()
 include(DD4hepMacros) 
 
-IF( "$ENV{DD4hepINSTALL}" STREQUAL "" )
-  IF( DD4hep_FOUND )
-    MESSAGE( FATAL_ERROR "Must source <DD4hep-install-dir>/bin/thisdd4hep.sh first" )
-    EXIT(1)
-  ENDIF()
-  # When building the examples together with DD4hep (-DDD4HEP_BUILD_EXAMPLES=ON),
-  # thisdd4hep.sh hasn't run. Manually set up the required variables for the tests.
-  SET( ENV{DD4hepINSTALL} ${CMAKE_INSTALL_PREFIX} )
-ENDIF()
-
 dd4hep_set_compiler_flags()
 dd4hep_configure_output()
 

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -300,7 +300,7 @@ foreach (test Assemblies BoxTrafos CaloEndcapReflection LheD_tracker MagnetField
   if (DD4HEP_USE_GEANT4)
     dd4hep_add_test_reg( ClientTests_g4material_scan_${test}_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-      EXEC_ARGS  python ${DD4hep_DIR}/bin/g4MaterialScan --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
+      EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4MaterialScan --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
                         "--position=0,0,0" "--direction=0,1,0"
       REGEX_PASS " Terminate Geant4 and delete associated actions." )
   endif(DD4HEP_USE_GEANT4)
@@ -321,14 +321,14 @@ foreach (test BoxTrafos CaloEndcapReflection IronCylinder MiniTel SiliconBlock N
   # ROOT Geometry checks
   dd4hep_add_test_reg( ClientTests_check_geometry_${test}_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/bin/checkGeometry --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkGeometry --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
                       --full=true --ntracks=10
     REGEX_PASS " Execution finished..." )
   #
   # ROOT Geometry overlap checks
   dd4hep_add_test_reg( ClientTests_check_overlaps_${test}_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/bin/checkOverlaps --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkOverlaps --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
                       --tolerance=0.1
     REGEX_PASS " Execution finished..." )
 endforeach()
@@ -342,13 +342,14 @@ if (DD4HEP_USE_GEANT4)
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/Check_Air.py
     -geometry  ${ClientTestsEx_INSTALL}/compact/Check_Air.xml batch
+    REQUIRES   DDG4 Geant4
     REGEX_PASS "Imean:  85.538 eV   temperature: 333.33 K  pressure:   2.22 atm"
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
   #
   # Geant4 test with gdml input file (LHCb:FT)
   dd4hep_add_test_reg( ClientTests_g4_gdml_detector
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/bin/g4GeometryScan --compact=${ClientTestsEx_INSTALL}/compact/GdmlDetector.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4GeometryScan --compact=${ClientTestsEx_INSTALL}/compact/GdmlDetector.xml
                       --position=200,200,-2000 --direction=0,0,1
     REGEX_PASS "   122   2777.0000  5200.000  "
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
@@ -356,7 +357,7 @@ if (DD4HEP_USE_GEANT4)
   # Geant4 test with gdml input file (LHCb:MT)
   dd4hep_add_test_reg( ClientTests_g4_gdml_MT
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/bin/g4GeometryScan --compact=${ClientTestsEx_INSTALL}/compact/MT.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4GeometryScan --compact=${ClientTestsEx_INSTALL}/compact/MT.xml
                       --position=200,200,7900 --direction=0,0,1
     REGEX_PASS "    15   2777.0000  4210.000   "
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -110,7 +110,7 @@ dd4hep_add_test_reg( ClientTests_DumpMaterials
 dd4hep_add_test_reg( ClientTests_MultipleGeometries
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS   multipleGeo
-  -compact file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+  -compact file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
   -compact file:${ClientTestsEx_INSTALL}/compact/MiniTel.xml
   -compact file:${ClientTestsEx_INSTALL}/compact/NestedDetectors.xml
   -no-interp
@@ -342,7 +342,6 @@ if (DD4HEP_USE_GEANT4)
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  python ${ClientTestsEx_INSTALL}/scripts/Check_Air.py
     -geometry  ${ClientTestsEx_INSTALL}/compact/Check_Air.xml batch
-    REQUIRES   DDG4 Geant4
     REGEX_PASS "Imean:  85.538 eV   temperature: 333.33 K  pressure:   2.22 atm"
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
   #

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -141,7 +141,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_pool
 dd4hep_add_test_reg( Conditions_CLICSiD_stress_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress 
-    -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 10 -runs 100
+    -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 10 -runs 100
   REGEX_PASS "\\+  Accessed a total of 31596300 conditions \\(S:30192020,L:     0,C:1404280,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -150,7 +150,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_stress2_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress2 
-    -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 20
+    -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 20
   REGEX_PASS "\\+  Accessed a total of 6319260 conditions \\(S:3510700,L:     0,C:2808560,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -159,7 +159,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress2_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_MT_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_MT 
-    -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 3 -runs 2 -threads 1
+    -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3 -runs 2 -threads 1
   REGEX_PASS "\\+  Accessed a total of 10742742 conditions \\(S:9900174,L:     0,C:842568,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
@@ -168,7 +168,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_MT_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_root_save_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_save
-    -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 3
+    -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3
     -conditions CLICSiDConditions.root
   REGEX_PASS "\\+ Successfully saved 2527704 condition to file."
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
@@ -178,7 +178,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_save_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_root_load_iov_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_load
-    -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 3 -restore iovpool
+    -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3 -restore iovpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
   REGEX_PASS "\\+  Accessed a total of 947889 conditions \\(S:842568,L:     0,C:105321,M:0\\)"
@@ -189,7 +189,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_iov_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_root_load_usr_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_load
-    -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 3 -restore userpool
+    -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3 -restore userpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
   REGEX_PASS "\\+  Accessed a total of 947889 conditions \\(S:842568,L:     0,C:105321,M:0\\)"
@@ -200,7 +200,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_usr_LONGTEST
 dd4hep_add_test_reg( Conditions_CLICSiD_root_load_cond_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_load
-    -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml -iovs 3 -restore condpool
+    -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3 -restore condpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
   REGEX_PASS "\\+  Accessed a total of 947889 conditions \\(S:842568,L:     0,C:105321,M:0\\)"

--- a/examples/DDG4/CMakeLists.txt
+++ b/examples/DDG4/CMakeLists.txt
@@ -50,14 +50,14 @@ if (DD4HEP_USE_GEANT4)
   # Test HepMC input reader
   dd4hep_add_test_reg( DDG4_HepMC_reader
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/examples/DDG4/examples/readHEPMC.py
+    EXEC_ARGS  python ${DD4hep_ROOT}/examples/DDG4/examples/readHEPMC.py
                       ${DDG4examples_INSTALL}/data/hepmc_geant4.dat
     REGEX_PASS "Geant4InputAction\\[Input\\]: Event 10 Error when moving to event -  EOF")
   #
   # Test HepMC input reader with slightly non-standard HEPMC file
   dd4hep_add_test_reg( DDG4_HepMC_reader_minbias
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/examples/DDG4/examples/readHEPMC.py
+    EXEC_ARGS  python ${DD4hep_ROOT}/examples/DDG4/examples/readHEPMC.py
                       ${DDG4examples_INSTALL}/data/LHCb_MinBias_HepMC.txt
     REGEX_PASS "Geant4InputAction\\[Input\\]: Event 27 Error when moving to event -  EOF")
 endif()

--- a/examples/DDG4_MySensDet/CMakeLists.txt
+++ b/examples/DDG4_MySensDet/CMakeLists.txt
@@ -53,7 +53,7 @@ if (DD4HEP_USE_GEANT4)
   # Geant4 material scan. From position=0,0,0 to end-of-world 
   dd4hep_add_test_reg( DDG4_MySensDet_g4material_scan_SiliconBlock_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4_MySensDet.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/bin/g4MaterialScan --compact=file:${CMAKE_INSTALL_PREFIX}/examples/ClientTests/compact/SiliconBlock.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4MaterialScan --compact=file:${CMAKE_INSTALL_PREFIX}/examples/ClientTests/compact/SiliconBlock.xml
                "--position=0,0,0" "--direction=0,1,0"
     REGEX_PASS " Terminate Geant4 and delete associated actions."
   )

--- a/examples/LHeD/CMakeLists.txt
+++ b/examples/LHeD/CMakeLists.txt
@@ -68,14 +68,14 @@ endforeach()
 # ROOT Geometry overlap checks
 dd4hep_add_test_reg( LHeD_check_geometry_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
-  EXEC_ARGS  python ${DD4hep_DIR}/bin/checkGeometry --compact=file:${LHeDEx_INSTALL}/compact/compact.xml
+  EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkGeometry --compact=file:${LHeDEx_INSTALL}/compact/compact.xml
   # This takes too long                  --full=true --ntracks=10 --option=o --vx=0 --vy=0 --vz=0
   REGEX_PASS " Execution finished..." )
 #
 # ROOT Geometry overlap checks
 dd4hep_add_test_reg( LHeD_check_overlaps_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
-  EXEC_ARGS  python ${DD4hep_DIR}/bin/checkOverlaps --compact=file:${LHeDEx_INSTALL}/compact/compact.xml
+  EXEC_ARGS  python ${DD4hep_ROOT}/bin/checkOverlaps --compact=file:${LHeDEx_INSTALL}/compact/compact.xml
                     --tolerance=0.1
   REGEX_PASS " Execution finished..." )
 #
@@ -95,7 +95,7 @@ if (DD4HEP_USE_GEANT4)
   # Material scan
   dd4hep_add_test_reg( LHeD_DDG4_g4material_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
-    EXEC_ARGS  python ${DD4hep_DIR}/bin/g4MaterialScan --compact=file:${LHeDEx_INSTALL}/compact/compact.xml
+    EXEC_ARGS  python ${DD4hep_ROOT}/bin/g4MaterialScan --compact=file:${LHeDEx_INSTALL}/compact/compact.xml
                       "--position=0,0,0" "--direction=0,1,0"
     REGEX_PASS " Terminate Geant4 and delete associated actions." )
   #

--- a/examples/LHeD/scripts/LheSimu.py
+++ b/examples/LHeD/scripts/LheSimu.py
@@ -31,7 +31,7 @@ def run():
   lhed.setupField(quiet=False)
   DDG4.importConstants(kernel.detectorDescription(), debug=False)
 
-  dd4hep_dir = os.environ['DD4hep']
+  dd4hep_dir = os.environ['DD4hep_DIR']
   kernel.loadXML("file:" + dd4hep_dir + "/examples/LHeD/scripts/DDG4_field.xml")
 
   geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')

--- a/examples/Persistency/CMakeLists.txt
+++ b/examples/Persistency/CMakeLists.txt
@@ -129,7 +129,7 @@ dd4hep_add_test_reg( Persist_MiniTel_Restore_Readouts_LONGTEST
 dd4hep_add_test_reg( Persist_CLICSiD_Save_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Persistency.sh"
   EXEC_ARGS  geoPluginRun
-  -volmgr    -destroy -input file:$ENV{DD4hepINSTALL}/DDDetectors/compact/SiD.xml
+  -volmgr    -destroy -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
   -plugin    DD4hep_Geometry2ROOT -output CLICSiD_geometry.root
   REGEX_PASS "\\+\\+\\+ Successfully saved geometry data to file."
   REGEX_FAIL " ERROR ;EXCEPTION;Exception;FAILED;WriteObjectAny"


### PR DESCRIPTION
This allows the examples and example tests to be built and run together with the main project in one go. Usage example:
```
mkdir build && cd build
cmake -DCMAKE_INSTALL_PREFIX=<install-dir> \
      -DDD4HEP_USE_GEANT4=ON \
      -DDD4HEP_USE_XERCESC=ON \
      -DDD4HEP_USE_TBB=ON \
      -DBoost_NO_BOOST_CMAKE=ON \
      -DDD4HEP_BUILD_EXAMPLES=ON \
      -DBUILD_TESTING=ON \
      ..
cmake --build . -j8 --target install
ctest -j8 --output-on-failure
```
This reverts commit e2f826e9c91a070d3a60f02ea497ce24634901d6.

The build system outside of "examples" assumes that DD4hep_DIR points to the source tree. Switching this meaning on the fly makes things rather fragile. For instance, `dd4hep_configure_scripts()` is broken after the `if(DD4HEP_BUILD_EXAMPLES)` block if the test is true, otherwise not. This commit consistently points DD4hep_ROOT to the installation tree and DD4hep_DIR to the source tree.


BEGINRELEASENOTES
- CMake: Fix regression that examples and example tests can now be built and run together with the main project

ENDRELEASENOTES