### PR TITLE
Improve thisdd4hep.sh setup scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,12 @@ IF(${CMAKE_CXX_STANDARD} LESS 14)
   MESSAGE(FATAL_ERROR "DD4hep requires at least CXX Standard 14 to compile")
 ENDIF()
 
+# ----for APPLE scripts have to set the DYLD_LIBRARY_PATH
+if(APPLE)
+  set(USE_DYLD 1)
+  set(CMAKE_MACOSX_RPATH 1)
+endif()
+
 ###############################
 # Define DD4hep build options #
 ###############################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,12 +59,6 @@ IF(${CMAKE_CXX_STANDARD} LESS 14)
   MESSAGE(FATAL_ERROR "DD4hep requires at least CXX Standard 14 to compile")
 ENDIF()
 
-# ----for APPLE scripts have to set the DYLD_LIBRARY_PATH
-if(APPLE)
-  set(USE_DYLD 1)
-  set(CMAKE_MACOSX_RPATH 1)
-endif()
-
 ###############################
 # Define DD4hep build options #
 ###############################

--- a/DDParsersStandAlone/CMakeLists.txt
+++ b/DDParsersStandAlone/CMakeLists.txt
@@ -52,11 +52,6 @@ include(DD4hepMacros)
 add_subdirectory(DDParsers)
 #
 #---Configuration-------------------------------------------------------------------
-# ----for APPLE scripts have to set the DYLD_LIBRARY_PATH 
-if( APPLE ) 
-  set( USE_DYLD 1)
-  set(CMAKE_MACOSX_RPATH 1)
-endif()
 #-----------------------------------------------------------------------------------
 display_std_variables()
 

--- a/cmake/DD4hepConfig.cmake.in
+++ b/cmake/DD4hepConfig.cmake.in
@@ -97,11 +97,6 @@ ENDIF()
 #---- build with xercesc or tinyxml ?
 INCLUDE( ${@CMAKE_PROJECT_NAME@_DIR}/cmake/DD4hep_XML_setup.cmake )
 
-#----- APPLE ? -------
-
-set( USE_DYLD @USE_DYLD@ )
-MARK_AS_ADVANCED( USE_DYLD )
-
 # ---------- final checking ---------------------------------------------------
 INCLUDE( FindPackageHandleStandardArgs )
 # set DD4HEP_FOUND to TRUE if all listed variables are TRUE and not empty

--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -35,7 +35,7 @@ dd4hep_add_path()   {
     path_prefix=${2}
     eval path_value=\$$path_name
     # Prevent duplicates
-    path_value=`echo ${path_value} | tr : '\n' | grep -v ${path_prefix} | tr '\n' : | sed 's|:$||'`
+    path_value=`echo ${path_value} | tr : '\n' | grep -v "${path_prefix}" | tr '\n' : | sed 's|:$||'`
     path_value="${path_prefix}${path_value:+:${path_value}}"
     eval export ${path_name}='${path_value}'
     unset path_name path_prefix path_value

--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -112,7 +112,7 @@ dd4hep_add_path PYTHONPATH ${THIS}/@DD4HEP_PYTHON_INSTALL_DIR@;
 #----ROOT_INCLUDE_PATH--------------------------------------------------------
 dd4hep_add_path ROOT_INCLUDE_PATH ${THIS}/include;
 #-----------------------------------------------------------------------------
-if [ @USE_DYLD@ ];
+if [ @APPLE@ ];
 then
     export DD4HEP_LIBRARY_PATH=${DYLD_LIBRARY_PATH};
 else

--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -34,14 +34,9 @@ dd4hep_add_path()   {
     path_name=${1}
     path_prefix=${2}
     eval path_value=\$$path_name
-    if [ "${path_value}" ]; then
-        # Prevent duplicates
-        if ! echo ${path_value} | tr : '\n' | grep -q "^${path_prefix}$"; then
-            path_value="${path_prefix}:${path_value}"
-        fi
-    else
-	path_value="${path_prefix}"
-    fi; 
+    # Prevent duplicates
+    path_value=`echo ${path_value} | tr : '\n' | grep -v ${path_prefix} | tr '\n' : | sed 's|:$||'`
+    path_value="${path_prefix}${path_value:+:${path_value}}"
     eval export ${path_name}='${path_value}'
     unset path_name path_prefix path_value
 }

--- a/cmake/thisdd4hep_only.sh
+++ b/cmake/thisdd4hep_only.sh
@@ -36,14 +36,9 @@ dd4hep_add_path()   {
     path_name=${1}
     path_prefix=${2}
     eval path_value=\$$path_name
-    if [ "${path_value}" ]; then
-        # Prevent duplicates
-        if ! echo ${path_value} | tr : '\n' | grep -q "^${path_prefix}$"; then
-            path_value="${path_prefix}:${path_value}"
-        fi
-    else
-	path_value="${path_prefix}"
-    fi;
+    # Prevent duplicates
+    path_value=`echo ${path_value} | tr : '\n' | grep -v ${path_prefix} | tr '\n' : | sed 's|:$||'`
+    path_value="${path_prefix}${path_value:+:${path_value}}"
     eval export ${path_name}='${path_value}'
     unset path_name path_prefix path_value
 }

--- a/cmake/thisdd4hep_only.sh
+++ b/cmake/thisdd4hep_only.sh
@@ -37,7 +37,7 @@ dd4hep_add_path()   {
     path_prefix=${2}
     eval path_value=\$$path_name
     # Prevent duplicates
-    path_value=`echo ${path_value} | tr : '\n' | grep -v ${path_prefix} | tr '\n' : | sed 's|:$||'`
+    path_value=`echo ${path_value} | tr : '\n' | grep -v "${path_prefix}" | tr '\n' : | sed 's|:$||'`
     path_value="${path_prefix}${path_value:+:${path_value}}"
     eval export ${path_name}='${path_value}'
     unset path_name path_prefix path_value

--- a/cmake/thisdd4hep_only.sh
+++ b/cmake/thisdd4hep_only.sh
@@ -78,7 +78,7 @@ dd4hep_add_path PYTHONPATH ${THIS}/@DD4HEP_PYTHON_INSTALL_DIR@;
 #----ROOT_INCLUDE_PATH--------------------------------------------------------
 dd4hep_add_path ROOT_INCLUDE_PATH ${THIS}/include;
 #-----------------------------------------------------------------------------
-if [ @USE_DYLD@ ];
+if [ @APPLE@ ];
 then
     export DD4HEP_LIBRARY_PATH=${DYLD_LIBRARY_PATH};
 else


### PR DESCRIPTION
BEGINRELEASENOTES
- Improve path handling in setup scripts, by avoiding duplicates in paths. Also support whitespaces in paths and don't add system paths to library paths on macOS

ENDRELEASENOTES