### PR TITLE
Geant4InputHandling: create G4PrimaryParticle with 4 vector that cons…

### DIFF
--- a/DDG4/src/Geant4InputHandling.cpp
+++ b/DDG4/src/Geant4InputHandling.cpp
@@ -351,7 +351,9 @@ static G4PrimaryParticle* createG4Primary(const Geant4ParticleHandle p)  {
     g4 = new G4PrimaryParticle(def, p->psx, p->psy, p->psz, p.energy());
     g4->SetCharge(p.charge());
   }
-  g4->SetMass(p->mass);
+  // The particle is fully defined with the 4-vector set above, setting the mass isn't necessary, not
+  // using the 4-vector, means the PDG mass is used, and the momentum is scaled if the mass is set here
+  // g4->SetMass(p->mass);
   return g4;
 }
 

--- a/DDG4/src/Geant4InputHandling.cpp
+++ b/DDG4/src/Geant4InputHandling.cpp
@@ -344,11 +344,11 @@ int dd4hep::sim::smearInteraction(const Geant4Action* caller,
 static G4PrimaryParticle* createG4Primary(const Geant4ParticleHandle p)  {
   G4PrimaryParticle* g4 = 0;
   if ( 0 != p->pdgID )   {
-    g4 = new G4PrimaryParticle(p->pdgID, p->psx, p->psy, p->psz);
+    g4 = new G4PrimaryParticle(p->pdgID, p->psx, p->psy, p->psz, p.energy());
   }
   else   {
     const G4ParticleDefinition* def = p.definition();
-    g4 = new G4PrimaryParticle(def, p->psx, p->psy, p->psz);
+    g4 = new G4PrimaryParticle(def, p->psx, p->psy, p->psz, p.energy());
     g4->SetCharge(p.charge());
   }
   g4->SetMass(p->mass);


### PR DESCRIPTION
…trains also the mass, setting the mass after, affects the momentum

BEGINRELEASENOTES
- DDG4: Geant4InputHandling: create particle with 4 vector (vecP, E), solves issue where the dynamic mass differs from the PDG mass (e.g., via particle.tbl / extraParticles), #760 

ENDRELEASENOTES

I think in our input readers, we always have a consistency between momentum, mass and energy, so this shouldn't be a problem.
I Still need to check, but opening this for discussion at the meeting later today.

cf. https://github.com/AIDASoft/DD4hep/issues/760#issuecomment-737376619
https://github.com/AIDASoft/DD4hep/blob/b5307693a98868079619a835e7381c42f9b2414b/DDG4/src/Geant4InputHandling.cpp#L354
I added `g4->Print()` before and after this line, which gives:
```
==== PDGcode 9900012  Particle name nu_Re
 Assigned charge : 0
     Momentum ( -28.3765[GeV/c], 12.5034[GeV/c], -2.5186[GeV/c] )
     kinetic Energy : 31.0612 [GeV]
     Mass : 0.05 [GeV]
     Polarization ( 0, 0, 0 )
     Weight : 1
<<<< End of link
Massive
==== PDGcode 9900012  Particle name nu_Re
 Assigned charge : 0
     Momentum ( -58.1954[GeV/c], 25.6423[GeV/c], -5.16523[GeV/c] )
     kinetic Energy : 31.0612 [GeV]
     Mass : 50 [GeV]
     Polarization ( 0, 0, 0 )
     Weight : 1
<<<< End of link
```