### PR TITLE
Improve thread efficiency of Evaluator

### DIFF
--- a/DDParsers/include/Evaluator/Evaluator.h
+++ b/DDParsers/include/Evaluator/Evaluator.h
@@ -68,7 +68,13 @@ namespace dd4hep  {
       /**
        * Constructor.
        */
-      Evaluator();
+      Evaluator(double meter = 1.0, double kilogram = 1.0, double second = 1.0, double ampere = 1.0, double kelvin = 1.0
+                , double mole = 1.0, double candela = 1.0, double radians = 1.0);
+
+      /**
+       * MoveConstructor.
+       */
+      Evaluator(Evaluator&&);
 
       /**
        * Destructor.

--- a/DDParsers/include/Evaluator/Evaluator.h
+++ b/DDParsers/include/Evaluator/Evaluator.h
@@ -261,9 +261,9 @@ namespace dd4hep  {
       bool findFunction(const std::string& name, int npar)   const;
 
       class Object;
-      Object* object = 0;                                  // internal data
 
     private:
+      Object* object = 0;                                  // internal data
       Evaluator(const Evaluator &) = delete;               // copy constructor is not allowed
       Evaluator & operator=(const Evaluator &) = delete;   // assignment is not allowed
     };

--- a/DDParsers/include/Evaluator/detail/Evaluator.h
+++ b/DDParsers/include/Evaluator/detail/Evaluator.h
@@ -51,6 +51,36 @@ namespace dd4hep  {
        * @see error_position
        * @see print_error
        */
+      struct EvalStatus {
+        /**
+         * Returns status of the last operation with the evaluator.
+         */
+        int status() const;
+
+        /**
+         * Returns result of the last operation with the evaluator.
+         */
+        double result() const;
+        
+        /**
+         * Returns position in the input string where the problem occured.
+         */
+        int error_position(const char* expression) const;
+        
+        /**
+         * Prints error message if status() is an ERROR.
+         */
+        void print_error(std::ostream& os) const;
+        
+        /**
+         * Prints error message if status() is an ERROR using std::cerr.
+         */
+        void print_error() const;
+
+        char const* thePosition = 0;
+        int         theStatus = OK;
+        double      theResult = 0.0;
+      };
 
       /**
        * Constructor.
@@ -74,42 +104,23 @@ namespace dd4hep  {
        * @see error_position
        * @see print_error
        */
-      double evaluate(const char* expression);
-
-      /**
-       * Returns status of the last operation with the evaluator.
-       */
-      int status() const;
-
-      /**
-       * Returns position in the input string where the problem occured.
-       */
-      int error_position() const;
-
-      /**
-       * Prints error message if status() is an ERROR.
-       */
-      void print_error(std::ostream& os) const;
-
-      /**
-       * Prints error message if status() is an ERROR using std::cerr.
-       */
-      void print_error() const;
+      EvalStatus evaluate(const char* expression);
 
       /**
        * Adds to the dictionary a string constant
        *
        * @param name name of the variable.
        * @param value value assigned to the variable.
+       * @return returns status
        */
-      void setEnviron(const char* name, const char* value);
+      int setEnviron(const char* name, const char* value);
 
       /**
        * Lookup the dictionary for a string constant
        *
        * @param name name of the variable.
        */
-      const char* getEnviron(const char* name);
+      std::pair<const char*, int> getEnviron(const char* name);
 
       /**
        * Adds to the dictionary a variable with given value.
@@ -119,7 +130,7 @@ namespace dd4hep  {
        * @param name name of the variable.
        * @param value value assigned to the variable.
        */
-      void setVariable(const char* name, double value);
+      int setVariable(const char* name, double value);
 
       /**
        * Adds to the dictionary a variable with an arithmetic expression
@@ -130,7 +141,7 @@ namespace dd4hep  {
        * @param name name of the variable.
        * @param expression arithmetic expression.
        */
-      void setVariable(const char* name, const char* expression);
+      int setVariable(const char* name, const char* expression);
 
       /**
        * Adds to the dictionary a function without parameters.
@@ -140,7 +151,7 @@ namespace dd4hep  {
        * @param name function name.
        * @param fun pointer to the real function in the user code.
        */
-      void setFunction(const char* name, double (*fun)());
+      int setFunction(const char* name, double (*fun)());
 
       /**
        * Adds to the dictionary a function with one parameter.
@@ -150,7 +161,7 @@ namespace dd4hep  {
        * @param name function name.
        * @param fun pointer to the real function in the user code.
        */
-      void setFunction(const char* name, double (*fun)(double));
+      int setFunction(const char* name, double (*fun)(double));
 
       /**
        * Adds to the dictionary a function with two parameters.
@@ -160,7 +171,7 @@ namespace dd4hep  {
        * @param name function name.
        * @param fun pointer to the real function in the user code.
        */
-      void setFunction(const char* name, double (*fun)(double, double));
+      int setFunction(const char* name, double (*fun)(double, double));
 
       /**
        * Adds to the dictionary a function with three parameters.
@@ -170,7 +181,7 @@ namespace dd4hep  {
        * @param name function name.
        * @param fun pointer to the real function in the user code.
        */
-      void setFunction(const char* name, double (*fun)(double, double, double));
+      int setFunction(const char* name, double (*fun)(double, double, double));
 
       /**
        * Adds to the dictionary a function with four parameters.
@@ -180,7 +191,7 @@ namespace dd4hep  {
        * @param name function name.
        * @param fun pointer to the real function in the user code.
        */
-      void setFunction(const char* name, double (*fun)(double, double, double, double));
+      int setFunction(const char* name, double (*fun)(double, double, double, double));
 
       /**
        * Adds to the dictionary a function with five parameters.
@@ -190,7 +201,7 @@ namespace dd4hep  {
        * @param name function name.
        * @param fun pointer to the real function in the user code.
        */
-      void setFunction(const char* name, double (*fun)(double, double, double, double, double));
+      int setFunction(const char* name, double (*fun)(double, double, double, double, double));
 
       /**
        * Finds the variable in the dictionary.
@@ -263,9 +274,6 @@ namespace dd4hep  {
       void setSystemOfUnits(double meter = 1.0, double kilogram = 1.0, double second = 1.0, double ampere = 1.0, double kelvin =
                             1.0, double mole = 1.0, double candela = 1.0, double radians = 1.0 );
 
-
-      void lock();
-      void unlock();
 
       struct Struct;
       

--- a/DDParsers/include/Evaluator/detail/Evaluator.h
+++ b/DDParsers/include/Evaluator/detail/Evaluator.h
@@ -133,7 +133,7 @@ namespace dd4hep  {
        * @see error_position
        * @see print_error
        */
-      EvalStatus evaluate(const char* expression);
+      EvalStatus evaluate(const char* expression) const;
 
       /**
        * Adds to the dictionary a string constant
@@ -149,7 +149,7 @@ namespace dd4hep  {
        *
        * @param name name of the variable.
        */
-      std::pair<const char*, int> getEnviron(const char* name);
+      std::pair<const char*, int> getEnviron(const char* name) const;
 
       /**
        * Adds to the dictionary a variable with given value.
@@ -305,7 +305,6 @@ namespace dd4hep  {
        * Sets standard mathematical functions and constants.
        */
       void setStdMath();
-
 
       Struct* imp {0};                               // private data
       Object(const Object &) = delete;               // copy constructor is not allowed

--- a/DDParsers/include/Evaluator/detail/Evaluator.h
+++ b/DDParsers/include/Evaluator/detail/Evaluator.h
@@ -306,6 +306,14 @@ namespace dd4hep  {
        */
       void setStdMath();
 
+      /**
+       * Used only during construction
+       */
+      void setVariableNoLock(const char* name, double value);
+      void setFunctionNoLock(const char* name, double (*fun)(double));
+      void setFunctionNoLock(const char* name, double (*fun)(double, double));
+
+
       Struct* imp {0};                               // private data
       Object(const Object &) = delete;               // copy constructor is not allowed
       Object & operator=(const Object &) = delete;   // assignment is not allowed

--- a/DDParsers/include/Evaluator/detail/Evaluator.h
+++ b/DDParsers/include/Evaluator/detail/Evaluator.h
@@ -85,7 +85,36 @@ namespace dd4hep  {
       /**
        * Constructor.
        */
-      Object();
+
+      /**
+       * Sets system of units. Default is the SI system of units.
+       * To set the CGS (Centimeter-Gram-Second) system of units
+       * one should call:
+       *   Object o(100., 1000., 1.0, 1.0, 1.0, 1.0, 1.0);
+       *
+       * To set system of units accepted in the GEANT4 simulation toolkit
+       * one should call:
+       * @code
+       *   setSystemOfUnits(1.e+3, 1./1.60217733e-25, 1.e+9, 1./1.60217733e-10,
+       *                    1.0, 1.0, 1.0);
+       * @endcode
+       *
+       * The basic units in GEANT4 are:
+       * @code
+       *   millimeter              (millimeter = 1.)
+       *   nanosecond              (nanosecond = 1.)
+       *   Mega electron Volt      (MeV        = 1.)
+       *   positron charge         (eplus      = 1.)
+       *   degree Kelvin           (kelvin     = 1.)
+       *   the amount of substance (mole       = 1.)
+       *   luminous intensity      (candela    = 1.)
+       *   radian                  (radian     = 1.)
+       *   steradian               (steradian  = 1.)
+       * @endcode
+       */
+
+      Object(double meter = 1.0, double kilogram = 1.0, double second = 1.0, double ampere = 1.0, double kelvin =
+                            1.0, double mole = 1.0, double candela = 1.0, double radians = 1.0 );
 
       /**
        * Destructor.
@@ -240,11 +269,9 @@ namespace dd4hep  {
        */
       void clear();
 
-      /**
-       * Sets standard mathematical functions and constants.
-       */
-      void setStdMath();
-
+      struct Struct;
+      
+    private:
       /**
        * Sets system of units. Default is the SI system of units.
        * To set the CGS (Centimeter-Gram-Second) system of units
@@ -271,16 +298,18 @@ namespace dd4hep  {
        *   steradian               (steradian  = 1.)
        * @endcode
        */
-      void setSystemOfUnits(double meter = 1.0, double kilogram = 1.0, double second = 1.0, double ampere = 1.0, double kelvin =
-                            1.0, double mole = 1.0, double candela = 1.0, double radians = 1.0 );
+      void setSystemOfUnits(double meter, double kilogram, double second, double ampere, double kelvin
+                          , double mole, double candela, double radians );
+
+      /**
+       * Sets standard mathematical functions and constants.
+       */
+      void setStdMath();
 
 
-      struct Struct;
-      
-    private:
-      Struct* imp {0};                      // private data
-      Object(const Object &);               // copy constructor is not allowed
-      Object & operator=(const Object &);   // assignment is not allowed
+      Struct* imp {0};                               // private data
+      Object(const Object &) = delete;               // copy constructor is not allowed
+      Object & operator=(const Object &) = delete;   // assignment is not allowed
     };
 
   }   // namespace tools

--- a/DDParsers/src/Evaluator/Evaluator.cpp
+++ b/DDParsers/src/Evaluator/Evaluator.cpp
@@ -791,6 +791,12 @@ int Evaluator::Object::setVariable(const char * name, const char * expression)  
   return setItem("", name, Item(expression), imp);
 }
 
+void Evaluator::Object::setVariableNoLock(const char * name, double value)  {
+  string item_name = name;
+  Item item(value);
+  imp->theDictionary[item_name] = item;
+}
+
 int Evaluator::Object::setFunction(const char * name,double (*fun)())   {
   return setItem("0", name, Item(FCN(fun).ptr), imp);
 }
@@ -814,6 +820,19 @@ int Evaluator::Object::setFunction(const char * name, double (*fun)(double,doubl
 int Evaluator::Object::setFunction(const char * name, double (*fun)(double,double,double,double,double))  {
   return setItem("5", name, Item(FCN(fun).ptr), imp);
 }
+
+void Evaluator::Object::setFunctionNoLock(const char * name,double (*fun)(double))   {
+  string item_name = "1"+string(name);
+  Item item(FCN(fun).ptr);
+  imp->theDictionary[item_name] = item;
+}
+
+void Evaluator::Object::setFunctionNoLock(const char * name, double (*fun)(double,double))  {
+  string item_name = "2"+string(name);
+  Item item(FCN(fun).ptr);
+  imp->theDictionary[item_name] = item;
+}
+
 
 //---------------------------------------------------------------------------
 bool Evaluator::Object::findVariable(const char * name) const {

--- a/DDParsers/src/Evaluator/Evaluator.cpp
+++ b/DDParsers/src/Evaluator/Evaluator.cpp
@@ -61,6 +61,7 @@ typedef hash_map<string,Item> dic_type;
 
 /// Internal expression evaluator helper class
 struct EVAL::Object::Struct {
+  // based on https://stackoverflow.com/a/58018604
   struct ReadLock {
     ReadLock(Struct* s): theStruct(s), theLg(s->theLock) { 
       while(theStruct->theWriterWaiting)

--- a/DDParsers/src/Evaluator/Evaluator.cpp
+++ b/DDParsers/src/Evaluator/Evaluator.cpp
@@ -646,8 +646,11 @@ static int setItem(const char * prefix, const char * name,
 using namespace dd4hep::tools;
 
 //---------------------------------------------------------------------------
-Evaluator::Object::Object() {
-  imp = new Struct();
+Evaluator::Object::Object(double meter, double kilogram, double second, double ampere, double kelvin
+                          , double mole, double candela, double radians) : imp( new Struct()) {
+  setStdMath();
+  setSystemOfUnits(meter, kilogram, second, ampere, kelvin
+                   , mole, candela, radians );
 }
 
 //---------------------------------------------------------------------------
@@ -815,8 +818,14 @@ void Evaluator::Object::removeFunction(const char * name, int npar) {
 }
 
 //---------------------------------------------------------------------------
-Evaluator::Evaluator()   {
-  object = new Object();
+Evaluator::Evaluator(double meter, double kilogram, double second, double ampere, double kelvin
+                          , double mole, double candela, double radians)   {
+  object = new Object(meter, kilogram, second, ampere, kelvin, mole, candela, radians);
+}
+
+//---------------------------------------------------------------------------
+Evaluator::Evaluator(Evaluator&& other):object(other.object) {
+  other.object=nullptr;
 }
 
 //---------------------------------------------------------------------------

--- a/DDParsers/src/Evaluator/ExpressionEvaluator.cpp
+++ b/DDParsers/src/Evaluator/ExpressionEvaluator.cpp
@@ -33,17 +33,13 @@ namespace {
   void _init(dd4hep::tools::Evaluator& e) {
     // Initialize numerical expressions parser with the standard math functions
     // and the system of units used by Gaudi (Geant4)
-    e.object->lock();
     e.object->setStdMath();
-    e.object->unlock();
   }
 
   void _cgsUnits(dd4hep::tools::Evaluator& e) {
     // ===================================================================================
     // CGS units
-    e.object->lock();
     e.object->setSystemOfUnits(100., 1000., 1.0, 1.0, 1.0, 1.0, 1.0);
-    e.object->unlock();
   }
   
   void _tgeoUnits(dd4hep::tools::Evaluator& e) {
@@ -55,7 +51,6 @@ namespace {
 
     //    e.setSystemOfUnits(1.e+2, 1./1.60217733e-6, 1.0, 1./1.60217733e-19, 1.0, 1.0, 1.0);
     // use the units as defined in DD4hepUnits.h:
-    e.object->lock();
     e.object->setSystemOfUnits( units::meter,
 				units::kilogram,
 				units::second,
@@ -64,16 +59,13 @@ namespace {
 				units::mole,
 				units::candela,
 				units::rad );
-    e.object->unlock();
   }
   
   void _g4Units(dd4hep::tools::Evaluator& e) {
     // ===================================================================================
     // Geant4 units
     // Geant4:  kilogram = joule*s*s/(m*m) 1/e_SI * 1e-6 * 1e9 1e9 / 1e3 / 1e3 = 1. / 1.60217733e-25
-    e.object->lock();
     e.object->setSystemOfUnits(1.e+3, 1./1.60217733e-25, 1.e+9, 1./1.60217733e-10, 1.0, 1.0, 1.0);
-    e.object->unlock();
   }
 }
 

--- a/DDParsers/src/Evaluator/hash_map.src
+++ b/DDParsers/src/Evaluator/hash_map.src
@@ -55,8 +55,8 @@ public:
   public: 
     hash_map_iterator() : entry(0) {}
     hash_map_iterator(Entry & e) : entry(&e) {} 
-    std::pair<const K,T> & operator * () const { return entry->data; }
-    std::pair<const K,T> * operator ->() const { return &(operator*()); }
+    std::pair<const K,T>& operator * () const { return entry->data; }
+    std::pair<const K,T>* operator ->() const { return &(operator*()); }
     bool operator==(hash_map_iterator i) const {
       return (entry == i.entry);
     }
@@ -65,11 +65,26 @@ public:
     }
   };
 
+  class hash_map_const_iterator { // Hash_map iterator
+    Entry const* entry;
+  public: 
+    hash_map_const_iterator() : entry(0) {}
+    hash_map_const_iterator(Entry & e) : entry(&e) {} 
+    std::pair<const K,T> const& operator * () const { return entry->data; }
+    std::pair<const K,T> const* operator ->() const { return &(operator*()); }
+    bool operator==(hash_map_const_iterator i) const {
+      return (entry == i.entry);
+    }
+    bool operator!=(hash_map_const_iterator i) const {
+      return (entry != i.entry);
+    }
+  };
+
 public:
   typedef unsigned int            size_type;
   typedef std::pair<const K,T> value_type;
   typedef hash_map_iterator       iterator;
-  typedef hash_map_iterator       const_iterator;
+  typedef hash_map_const_iterator const_iterator;
 
 private:
   Entry**   table;          // Hash table: pointers to entries
@@ -96,6 +111,11 @@ private:
   bool eq(const string & a, const string & b) const {
     return (a == b);
   }
+
+  bool eq(const char * a, const string& b) const {
+    return (b == a);
+  }
+
 
 public:
 
@@ -160,10 +180,28 @@ public:
   }
 
   // Finds element with given key.  
-  iterator find(const K & key) const {
+  const_iterator find(const K & key) const {
+    size_type i = hash(key) % max_size;
+    for (Entry* p=table[i]; p; p=p->next) {
+      if (eq(key,p->data.first)) return const_iterator(*p);
+    }
+    return end();
+  }
+
+  iterator find(const K & key) {
     size_type i = hash(key) % max_size;
     for (Entry* p=table[i]; p; p=p->next) {
       if (eq(key,p->data.first)) return iterator(*p);
+    }
+    return end();
+  }
+
+  // Finds element with a key equivalent.  
+  template<typename K2>
+  const_iterator find(const K2 & key) const {
+    size_type i = hash(key) % max_size;
+    for (Entry* p=table[i]; p; p=p->next) {
+      if (eq(key,p->data.first)) return const_iterator(*p);
     }
     return end();
   }
@@ -199,7 +237,8 @@ public:
   }
 
   // Returns end iterator.
-  iterator end() const { return iterator(); }
+  const_iterator end() const { return const_iterator(); }
+  iterator end() { return iterator(); }
 
 #ifdef DEBUG_MODE
   // Prints content of the hash table.

--- a/DDParsers/src/Evaluator/setStdMath.cpp
+++ b/DDParsers/src/Evaluator/setStdMath.cpp
@@ -73,65 +73,65 @@ namespace dd4hep  {
 
       //   S E T   S T A N D A R D   C O N S T A N T S
 
-      setVariable("pi",     3.14159265358979323846);
-      setVariable("e",      2.7182818284590452354);
-      setVariable("gamma",  0.577215664901532861);
+      setVariableNoLock("pi",     3.14159265358979323846);
+      setVariableNoLock("e",      2.7182818284590452354);
+      setVariableNoLock("gamma",  0.577215664901532861);
 
 
-      // setVariable("radian", 1.0);
-      // setVariable("rad",    1.0);
-      // setVariable("degree", 3.14159265358979323846/180.);
-      // setVariable("deg",    3.14159265358979323846/180.);
-      setVariable("radian", units::radian );
-      setVariable("rad",    units::radian );
-      setVariable("degree", units::degree );
-      setVariable("deg",    units::degree );
-      setVariable("int:epsilon",    std::numeric_limits<int>::epsilon());
-      setVariable("long:epsilon",   std::numeric_limits<long>::epsilon());
-      setVariable("float:epsilon",  std::numeric_limits<float>::epsilon());
-      setVariable("double:epsilon", std::numeric_limits<double>::epsilon());
+      // setVariableNoLock("radian", 1.0);
+      // setVariableNoLock("rad",    1.0);
+      // setVariableNoLock("degree", 3.14159265358979323846/180.);
+      // setVariableNoLock("deg",    3.14159265358979323846/180.);
+      setVariableNoLock("radian", units::radian );
+      setVariableNoLock("rad",    units::radian );
+      setVariableNoLock("degree", units::degree );
+      setVariableNoLock("deg",    units::degree );
+      setVariableNoLock("int:epsilon",    std::numeric_limits<int>::epsilon());
+      setVariableNoLock("long:epsilon",   std::numeric_limits<long>::epsilon());
+      setVariableNoLock("float:epsilon",  std::numeric_limits<float>::epsilon());
+      setVariableNoLock("double:epsilon", std::numeric_limits<double>::epsilon());
 
       //   S E T   S T A N D A R D   F U N C T I O N S
 
-      setFunction("abs",        eval_abs);
-      setFunction("fabs",       eval_fabs);
-      setFunction("fmod",       eval_fmod);
-      setFunction("min",        eval_min);
-      setFunction("max",        eval_max);
-      setFunction("sqrt",       eval_sqrt);
-      setFunction("cbrt",       eval_cbrt);
-      setFunction("pow",        eval_pow);
-      setFunction("sin",        eval_sin);
-      setFunction("cos",        eval_cos);
-      setFunction("tan",        eval_tan);
-      setFunction("asin",       eval_asin);
-      setFunction("acos",       eval_acos);
-      setFunction("atan",       eval_atan);
-      setFunction("atan2",      eval_atan2);
-      setFunction("sinh",       eval_sinh);
-      setFunction("cosh",       eval_cosh);
-      setFunction("tanh",       eval_tanh);
-      setFunction("exp",        eval_exp);
-      setFunction("exp2",       eval_exp2);
-      setFunction("exp10",      eval_exp10);
-      setFunction("expm1",      eval_expm1);
-      setFunction("log",        eval_log);
-      setFunction("logb",       eval_logb);
-      setFunction("log10",      eval_log10);
-      setFunction("log1p",      eval_log1p);
-      setFunction("hypot",      eval_hypot);
-      setFunction("erf",        eval_erf);
-      setFunction("erfc",       eval_erfc);
-      setFunction("gamma",      eval_gamma);
-      setFunction("double",     eval_double);
-      setFunction("int",        eval_int);
-      setFunction("nint",       eval_nint);
-      setFunction("floor",      eval_floor);
-      setFunction("round",      eval_round);
-      setFunction("ceil",       eval_ceil);
-      setFunction("isnan",      eval_isnan);
-      setFunction("isinf",      eval_isinf);
-      setFunction("nearbyint",  eval_nearbyint);
+      setFunctionNoLock("abs",        eval_abs);
+      setFunctionNoLock("fabs",       eval_fabs);
+      setFunctionNoLock("fmod",       eval_fmod);
+      setFunctionNoLock("min",        eval_min);
+      setFunctionNoLock("max",        eval_max);
+      setFunctionNoLock("sqrt",       eval_sqrt);
+      setFunctionNoLock("cbrt",       eval_cbrt);
+      setFunctionNoLock("pow",        eval_pow);
+      setFunctionNoLock("sin",        eval_sin);
+      setFunctionNoLock("cos",        eval_cos);
+      setFunctionNoLock("tan",        eval_tan);
+      setFunctionNoLock("asin",       eval_asin);
+      setFunctionNoLock("acos",       eval_acos);
+      setFunctionNoLock("atan",       eval_atan);
+      setFunctionNoLock("atan2",      eval_atan2);
+      setFunctionNoLock("sinh",       eval_sinh);
+      setFunctionNoLock("cosh",       eval_cosh);
+      setFunctionNoLock("tanh",       eval_tanh);
+      setFunctionNoLock("exp",        eval_exp);
+      setFunctionNoLock("exp2",       eval_exp2);
+      setFunctionNoLock("exp10",      eval_exp10);
+      setFunctionNoLock("expm1",      eval_expm1);
+      setFunctionNoLock("log",        eval_log);
+      setFunctionNoLock("logb",       eval_logb);
+      setFunctionNoLock("log10",      eval_log10);
+      setFunctionNoLock("log1p",      eval_log1p);
+      setFunctionNoLock("hypot",      eval_hypot);
+      setFunctionNoLock("erf",        eval_erf);
+      setFunctionNoLock("erfc",       eval_erfc);
+      setFunctionNoLock("gamma",      eval_gamma);
+      setFunctionNoLock("double",     eval_double);
+      setFunctionNoLock("int",        eval_int);
+      setFunctionNoLock("nint",       eval_nint);
+      setFunctionNoLock("floor",      eval_floor);
+      setFunctionNoLock("round",      eval_round);
+      setFunctionNoLock("ceil",       eval_ceil);
+      setFunctionNoLock("isnan",      eval_isnan);
+      setFunctionNoLock("isinf",      eval_isinf);
+      setFunctionNoLock("nearbyint",  eval_nearbyint);
     }
 
   } // namespace tools

--- a/DDParsers/src/Evaluator/setSystemOfUnits.cpp
+++ b/DDParsers/src/Evaluator/setSystemOfUnits.cpp
@@ -42,43 +42,43 @@ namespace dd4hep  {
       // Length
       // metrum (Latin) and metron (Greek) "measure"
       const double m = meter;
-      setVariable("meter", m);
-      setVariable("metre", m);
-      setVariable("m",     m);
+      setVariableNoLock("meter", m);
+      setVariableNoLock("metre", m);
+      setVariableNoLock("m",     m);
 
       // Mass
       const double kg = kilogram;
-      setVariable("kilogram", kg);
-      setVariable("kg",       kg);
+      setVariableNoLock("kilogram", kg);
+      setVariableNoLock("kg",       kg);
 
       // Time
       // minuta secundam (Latin) "second small one"
       const double s = second;
-      setVariable("second", s);
-      setVariable("s",      s);
+      setVariableNoLock("second", s);
+      setVariableNoLock("s",      s);
 
       // Current
       // ---  honors Andre-Marie Ampere (1775-1836) of France
       const double A = ampere;
-      setVariable("ampere", A);
-      setVariable("amp",    A);
-      setVariable("A",      A);
+      setVariableNoLock("ampere", A);
+      setVariableNoLock("amp",    A);
+      setVariableNoLock("A",      A);
 
       // Temperature
       // ---  honors William Thomson, 1st Baron Lord Kelvin (1824-1907) of England
       const double K = kelvin;
-      setVariable("kelvin", K);
-      setVariable("K",      K);
+      setVariableNoLock("kelvin", K);
+      setVariableNoLock("K",      K);
 
       // Amount of substance
       const double mol = mole;
-      setVariable("mole", mol);
-      setVariable("mol",  mol);
+      setVariableNoLock("mole", mol);
+      setVariableNoLock("mol",  mol);
 
       // Luminous intensity
       const double cd  = candela;
-      setVariable("candela", cd);
-      setVariable("cd",      cd);
+      setVariableNoLock("candela", cd);
+      setVariableNoLock("cd",      cd);
 
       // ======================================================================
       //
@@ -93,20 +93,20 @@ namespace dd4hep  {
 
       const double rad = radians ;
 
-      setVariable("radian", rad);
-      setVariable("rad",    rad);
-      setVariable("milliradian", milli_ * rad);
-      setVariable("mrad",        milli_ * rad);
+      setVariableNoLock("radian", rad);
+      setVariableNoLock("rad",    rad);
+      setVariableNoLock("milliradian", milli_ * rad);
+      setVariableNoLock("mrad",        milli_ * rad);
 
       const double deg = rad*pi/180.;
 
-      setVariable("degree", deg);
-      setVariable("deg",    deg);
+      setVariableNoLock("degree", deg);
+      setVariableNoLock("deg",    deg);
 
       // Solid angle
       const double sr  = 1.;
-      setVariable("steradian", sr);
-      setVariable("sr",        sr);
+      setVariableNoLock("steradian", sr);
+      setVariableNoLock("sr",        sr);
 
       // ======================================================================
       //
@@ -117,126 +117,126 @@ namespace dd4hep  {
       // Frequency
       // ---  honors Heinrich Rudolf Hertz (1857-1894) of Germany
       const double Hz = 1./s;
-      setVariable("hertz", Hz);
-      setVariable("Hz",    Hz);
+      setVariableNoLock("hertz", Hz);
+      setVariableNoLock("Hz",    Hz);
 
       // Force
       // ---  honors Sir Isaac Newton (1642-1727) of England
       const double N = m * kg / (s*s);
-      setVariable("newton", N);
-      setVariable("N",      N);
+      setVariableNoLock("newton", N);
+      setVariableNoLock("N",      N);
 
       // Pressure
       // ---  honors Blaise Pascal (1623-1662) of France
       const double Pa = N / (m*m);
-      setVariable("pascal",    Pa);
-      setVariable("Pa",        Pa);
-      setVariable("hPa", 100.0*Pa);
+      setVariableNoLock("pascal",    Pa);
+      setVariableNoLock("Pa",        Pa);
+      setVariableNoLock("hPa", 100.0*Pa);
 
       const double atm = 101325. * Pa;
-      setVariable("atmosphere", atm);
-      setVariable("atm",        atm);
+      setVariableNoLock("atmosphere", atm);
+      setVariableNoLock("atm",        atm);
 
       const double bar = 100000*Pa;
-      setVariable("bar", bar);
+      setVariableNoLock("bar", bar);
 
       // Energy
       // ---  honors James Prescott Joule (1818-1889) of England
       const double J = N * m;
-      setVariable("joule", J);
-      setVariable("J",     J);
+      setVariableNoLock("joule", J);
+      setVariableNoLock("J",     J);
 
       // Power
       // ---  honors James Watt (1736-1819) of Scotland
       const double W = J / s;
-      setVariable("watt", W);
-      setVariable("W",    W);
+      setVariableNoLock("watt", W);
+      setVariableNoLock("W",    W);
 
       // Electric charge
       // ---  honors Charles-Augustin de Coulomb (1736-1806) of France
       const double C = A * s;
-      setVariable("coulomb", C);
-      setVariable("C",       C);
+      setVariableNoLock("coulomb", C);
+      setVariableNoLock("C",       C);
 
       // Electric potential
       // ---  honors Count Alessandro Volta (1745-1827) of Italy
       const double V = J / C;
-      setVariable("volt", V);
-      setVariable("V",    V);
+      setVariableNoLock("volt", V);
+      setVariableNoLock("V",    V);
 
       // Electric resistance
       // ---  honors Georg Simon Ohm (1787-1854) of Germany
       const double ohm = V / A;
-      setVariable("ohm", ohm);
+      setVariableNoLock("ohm", ohm);
 
       // Electric conductance
       // ---  honors Ernst Werner von Siemens (1816-1892) or
       //      his brother Sir William (Karl Wilhelm von) Siemens (1823-1883)
       //      of Germany (England)
       const double S = 1./ ohm;
-      setVariable("siemens", S);
-      setVariable("S",       S);
+      setVariableNoLock("siemens", S);
+      setVariableNoLock("S",       S);
 
       // Electric capacitance
       // ---  honors Michael Faraday (1791-1867) of England
       const double F = C / V;
-      setVariable("farad", F);
-      setVariable("F",     F);
+      setVariableNoLock("farad", F);
+      setVariableNoLock("F",     F);
 
       // Magnetic flux density
       // ---  honors Nikola Tesla (1856-1943) of Croatia (United States)
       const double T = V * s / (m*m);
-      setVariable("tesla", T);
-      setVariable("T",     T);
+      setVariableNoLock("tesla", T);
+      setVariableNoLock("T",     T);
 
       // ---  honors Karl Friedrich Gauss (1777-1855) of Germany
       const double Gs = 1.e-4*T;
-      setVariable("gauss", Gs);
-      setVariable("Gs",    Gs);
+      setVariableNoLock("gauss", Gs);
+      setVariableNoLock("Gs",    Gs);
 
       // Magnetic flux
       // ---  honors Wilhelm Eduard Weber (1804-1891) of Germany
       const double Wb = V * s;
-      setVariable("weber", Wb);
-      setVariable("Wb",    Wb);
+      setVariableNoLock("weber", Wb);
+      setVariableNoLock("Wb",    Wb);
 
       // Inductance
       // ---  honors Joseph Henry (1797-1878) of the United States
       const double H = Wb / A;
-      setVariable("henry", H);
-      setVariable("H",     H);
+      setVariableNoLock("henry", H);
+      setVariableNoLock("H",     H);
 
       // Luminous flux
       const double lm = cd * sr;
-      setVariable("lumen", lm);
-      setVariable("lm",    lm);
+      setVariableNoLock("lumen", lm);
+      setVariableNoLock("lm",    lm);
 
       // Illuminace
       const double lx = lm / (m*m);
-      setVariable("lux", lx);
-      setVariable("lx",  lx);
+      setVariableNoLock("lux", lx);
+      setVariableNoLock("lx",  lx);
 
       // Radioactivity
       // ---  honors Antoine-Henri Becquerel (1852-1908) of France
       const double Bq = 1./s;
-      setVariable("becquerel", Bq);
-      setVariable("Bq",        Bq);
+      setVariableNoLock("becquerel", Bq);
+      setVariableNoLock("Bq",        Bq);
 
       // ---  honors Pierre Curie (1859-1906) of France
       //      and Marie Sklodowska Curie (1867-1934) of Poland
-      setVariable("curie", 3.7e+10 * Bq);
-      setVariable("Ci",    3.7e+10 * Bq);
+      setVariableNoLock("curie", 3.7e+10 * Bq);
+      setVariableNoLock("Ci",    3.7e+10 * Bq);
 
       // Specific energy
       // ---  honors Louis Harold Gray, F.R.S. (1905-1965) of England
       const double Gy = J / kg;
-      setVariable("gray", Gy);
-      setVariable("Gy",   Gy);
+      setVariableNoLock("gray", Gy);
+      setVariableNoLock("Gy",   Gy);
 
       // Dose equivalent
       const double Sv = J / kg;
-      setVariable("sievert", Sv);
-      setVariable("Sv",      Sv);
+      setVariableNoLock("sievert", Sv);
+      setVariableNoLock("Sv",      Sv);
 
       // ======================================================================
       //
@@ -247,165 +247,165 @@ namespace dd4hep  {
       // Length
 
       const double mm = milli_ * m;
-      setVariable("millimeter", mm);
-      setVariable("mm",         mm);
+      setVariableNoLock("millimeter", mm);
+      setVariableNoLock("mm",         mm);
 
       const double cm = centi_ * m;
-      setVariable("centimeter", cm);
-      setVariable("cm",         cm);
+      setVariableNoLock("centimeter", cm);
+      setVariableNoLock("cm",         cm);
 
-      setVariable("decimeter",  deci_ * m);
+      setVariableNoLock("decimeter",  deci_ * m);
 
       const double km = kilo_ * m;
-      setVariable("kilometer",  km);
-      setVariable("km",         km);
+      setVariableNoLock("kilometer",  km);
+      setVariableNoLock("km",         km);
 
-      setVariable("micrometer", micro_ * m);
-      setVariable("micron",     micro_ * m);
-      setVariable("mum",        micro_ * m);
-      setVariable("um",         micro_ * m);
-      setVariable("nanometer",  nano_  * m);
-      setVariable("nm",         nano_  * m);
+      setVariableNoLock("micrometer", micro_ * m);
+      setVariableNoLock("micron",     micro_ * m);
+      setVariableNoLock("mum",        micro_ * m);
+      setVariableNoLock("um",         micro_ * m);
+      setVariableNoLock("nanometer",  nano_  * m);
+      setVariableNoLock("nm",         nano_  * m);
 
       // ---  honors Anders Jonas Angstrom (1814-1874) of Sweden
-      setVariable("angstrom",   1.e-10 * m);
+      setVariableNoLock("angstrom",   1.e-10 * m);
 
       // ---  honors Enrico Fermi (1901-1954) of Italy
-      setVariable("fermi",      1.e-15 * m);
-      setVariable("femtometer", femto_ * m);
-      setVariable("fm",         femto_ * m);
+      setVariableNoLock("fermi",      1.e-15 * m);
+      setVariableNoLock("femtometer", femto_ * m);
+      setVariableNoLock("fm",         femto_ * m);
 
       // Length^2
 
-      setVariable("m2",  m*m);
-      setVariable("mm2", mm*mm);
-      setVariable("cm2", cm*cm);
-      setVariable("km2", km*km);
+      setVariableNoLock("m2",  m*m);
+      setVariableNoLock("mm2", mm*mm);
+      setVariableNoLock("cm2", cm*cm);
+      setVariableNoLock("km2", km*km);
 
       const double barn = 1.e-28 * m*m;
-      setVariable("barn",      barn);
-      setVariable("millibarn", milli_ * barn);
-      setVariable("mbarn",     milli_ * barn);
-      setVariable("microbarn", micro_ * barn);
-      setVariable("nanobarn",  nano_  * barn);
-      setVariable("picobarn",  pico_  * barn);
+      setVariableNoLock("barn",      barn);
+      setVariableNoLock("millibarn", milli_ * barn);
+      setVariableNoLock("mbarn",     milli_ * barn);
+      setVariableNoLock("microbarn", micro_ * barn);
+      setVariableNoLock("nanobarn",  nano_  * barn);
+      setVariableNoLock("picobarn",  pico_  * barn);
 
       // LengthL^3
 
-      setVariable("m3",  m*m*m);
-      setVariable("mm3", mm*mm*mm);
-      setVariable("cm3", cm*cm*cm);
-      setVariable("cc",  cm*cm*cm);
-      setVariable("km3", km*km*km);
+      setVariableNoLock("m3",  m*m*m);
+      setVariableNoLock("mm3", mm*mm*mm);
+      setVariableNoLock("cm3", cm*cm*cm);
+      setVariableNoLock("cc",  cm*cm*cm);
+      setVariableNoLock("km3", km*km*km);
 
       const double L = 1.e-3*m*m*m;
-      setVariable("liter", L);
-      setVariable("litre", L);
-      setVariable("L",     L);
-      setVariable("centiliter",  centi_ * L);
-      setVariable("cL",          centi_ * L);
-      setVariable("milliliter",  milli_ * L);
-      setVariable("mL",          milli_ * L);
+      setVariableNoLock("liter", L);
+      setVariableNoLock("litre", L);
+      setVariableNoLock("L",     L);
+      setVariableNoLock("centiliter",  centi_ * L);
+      setVariableNoLock("cL",          centi_ * L);
+      setVariableNoLock("milliliter",  milli_ * L);
+      setVariableNoLock("mL",          milli_ * L);
 
       // Length^-1
 
       const double dpt = 1./m;
-      setVariable("diopter", dpt);
-      setVariable("dioptre", dpt);
-      setVariable("dpt",     dpt);
+      setVariableNoLock("diopter", dpt);
+      setVariableNoLock("dioptre", dpt);
+      setVariableNoLock("dpt",     dpt);
 
       // Mass
 
       const double g = 0.001*kg;
-      setVariable("gram", g);
-      setVariable("g",    g);
-      setVariable("milligram",   milli_ * g);
-      setVariable("mg",          milli_ * g);
+      setVariableNoLock("gram", g);
+      setVariableNoLock("g",    g);
+      setVariableNoLock("milligram",   milli_ * g);
+      setVariableNoLock("mg",          milli_ * g);
 
       // Time
 
-      setVariable("millisecond", milli_ * s);
-      setVariable("ms",          milli_ * s);
-      setVariable("microsecond", micro_ * s);
-      setVariable("nanosecond",  nano_  * s);
-      setVariable("ns",          nano_  * s);
-      setVariable("picosecond",  pico_  * s);
+      setVariableNoLock("millisecond", milli_ * s);
+      setVariableNoLock("ms",          milli_ * s);
+      setVariableNoLock("microsecond", micro_ * s);
+      setVariableNoLock("nanosecond",  nano_  * s);
+      setVariableNoLock("ns",          nano_  * s);
+      setVariableNoLock("picosecond",  pico_  * s);
 
       // Current
 
-      setVariable("milliampere", milli_ * A);
-      setVariable("mA",          milli_ * A);
-      setVariable("microampere", micro_ * A);
-      setVariable("nanoampere",  nano_  * A);
+      setVariableNoLock("milliampere", milli_ * A);
+      setVariableNoLock("mA",          milli_ * A);
+      setVariableNoLock("microampere", micro_ * A);
+      setVariableNoLock("nanoampere",  nano_  * A);
 
       // Frequency
 
-      setVariable("kilohertz",   kilo_ * Hz);
-      setVariable("kHz",         kilo_ * Hz);
-      setVariable("megahertz",   mega_ * Hz);
-      setVariable("MHz",         mega_ * Hz);
+      setVariableNoLock("kilohertz",   kilo_ * Hz);
+      setVariableNoLock("kHz",         kilo_ * Hz);
+      setVariableNoLock("megahertz",   mega_ * Hz);
+      setVariableNoLock("MHz",         mega_ * Hz);
 
       // Force
-      setVariable("kilonewton",  kilo_ * N);
-      setVariable("kN",          kilo_ * N);
+      setVariableNoLock("kilonewton",  kilo_ * N);
+      setVariableNoLock("kN",          kilo_ * N);
 
       // Pressure
-      setVariable("kilobar",     kilo_ * bar);
-      setVariable("kbar",        kilo_ * bar);
-      setVariable("millibar",    milli_ * bar);
-      setVariable("mbar",        milli_ * bar);
+      setVariableNoLock("kilobar",     kilo_ * bar);
+      setVariableNoLock("kbar",        kilo_ * bar);
+      setVariableNoLock("millibar",    milli_ * bar);
+      setVariableNoLock("mbar",        milli_ * bar);
 
       // Energy
-      setVariable("kilojoule",   kilo_ * J);
-      setVariable("kJ",          kilo_ * J);
-      setVariable("megajoule",   mega_ * J);
-      setVariable("MJ",          mega_ * J);
-      setVariable("gigajoule",   giga_ * J);
-      setVariable("GJ",          giga_ * J);
+      setVariableNoLock("kilojoule",   kilo_ * J);
+      setVariableNoLock("kJ",          kilo_ * J);
+      setVariableNoLock("megajoule",   mega_ * J);
+      setVariableNoLock("MJ",          mega_ * J);
+      setVariableNoLock("gigajoule",   giga_ * J);
+      setVariableNoLock("GJ",          giga_ * J);
 
       const double e_SI  = 1.60217733e-19;  // positron charge in coulomb
       const double ePlus = e_SI * C;        // positron charge
       const double eV    = ePlus * V;
-      setVariable("electronvolt", eV);
-      setVariable("eV",           eV);
-      setVariable("kiloelectronvolt", kilo_ * eV);
-      setVariable("keV",              kilo_ * eV);
-      setVariable("megaelectronvolt", mega_ * eV);
-      setVariable("MeV",              mega_ * eV);
-      setVariable("gigaelectronvolt", giga_ * eV);
-      setVariable("GeV",              giga_ * eV);
-      setVariable("teraelectronvolt", tera_ * eV);
-      setVariable("TeV",              tera_ * eV);
-      setVariable("petaelectronvolt", peta_ * eV);
-      setVariable("PeV",              peta_ * eV);
+      setVariableNoLock("electronvolt", eV);
+      setVariableNoLock("eV",           eV);
+      setVariableNoLock("kiloelectronvolt", kilo_ * eV);
+      setVariableNoLock("keV",              kilo_ * eV);
+      setVariableNoLock("megaelectronvolt", mega_ * eV);
+      setVariableNoLock("MeV",              mega_ * eV);
+      setVariableNoLock("gigaelectronvolt", giga_ * eV);
+      setVariableNoLock("GeV",              giga_ * eV);
+      setVariableNoLock("teraelectronvolt", tera_ * eV);
+      setVariableNoLock("TeV",              tera_ * eV);
+      setVariableNoLock("petaelectronvolt", peta_ * eV);
+      setVariableNoLock("PeV",              peta_ * eV);
 
       // Power
-      setVariable("kilowatt",    kilo_ * W);
-      setVariable("kW",          kilo_ * W);
-      setVariable("megawatt",    mega_ * W);
-      setVariable("MW",          mega_ * W);
-      setVariable("gigawatt",    giga_ * W);
-      setVariable("GW",          giga_ * W);
+      setVariableNoLock("kilowatt",    kilo_ * W);
+      setVariableNoLock("kW",          kilo_ * W);
+      setVariableNoLock("megawatt",    mega_ * W);
+      setVariableNoLock("MW",          mega_ * W);
+      setVariableNoLock("gigawatt",    giga_ * W);
+      setVariableNoLock("GW",          giga_ * W);
 
       // Electric potential
-      setVariable("kilovolt",    kilo_ * V);
-      setVariable("kV",          kilo_ * V);
-      setVariable("megavolt",    mega_ * V);
-      setVariable("MV",          mega_ * V);
+      setVariableNoLock("kilovolt",    kilo_ * V);
+      setVariableNoLock("kV",          kilo_ * V);
+      setVariableNoLock("megavolt",    mega_ * V);
+      setVariableNoLock("MV",          mega_ * V);
 
       // Electric capacitance
-      setVariable("millifarad",  milli_ * F);
-      setVariable("mF",          milli_ * F);
-      setVariable("microfarad",  micro_ * F);
-      setVariable("uF",          micro_ * F);
-      setVariable("nanofarad",   nano_  * F);
-      setVariable("nF",          nano_  * F);
-      setVariable("picofarad",   pico_  * F);
-      setVariable("pF",          pico_  * F);
+      setVariableNoLock("millifarad",  milli_ * F);
+      setVariableNoLock("mF",          milli_ * F);
+      setVariableNoLock("microfarad",  micro_ * F);
+      setVariableNoLock("uF",          micro_ * F);
+      setVariableNoLock("nanofarad",   nano_  * F);
+      setVariableNoLock("nF",          nano_  * F);
+      setVariableNoLock("picofarad",   pico_  * F);
+      setVariableNoLock("pF",          pico_  * F);
 
       // Magnetic flux density
-      setVariable("kilogauss",   kilo_ * Gs);
-      setVariable("kGs",         kilo_ * Gs);
+      setVariableNoLock("kilogauss",   kilo_ * Gs);
+      setVariableNoLock("kGs",         kilo_ * Gs);
     }
 
   } // namespace tools

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -23,6 +23,7 @@ foreach(TEST_NAME
     test_cellDimensions
     test_cellDimensionsRPhi2
     test_segmentationHandles
+    test_Evaluator
     )
   add_executable(${TEST_NAME} src/${TEST_NAME}.cc)
   target_link_libraries(${TEST_NAME} DD4hep::DDCore DD4hep::DDRec DD4hep::DDTest)

--- a/DDTest/src/test_Evaluator.cc
+++ b/DDTest/src/test_Evaluator.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <assert.h>
 #include <cmath>
+#include <array>
 
 #include <atomic>
 #include <thread>

--- a/DDTest/src/test_Evaluator.cc
+++ b/DDTest/src/test_Evaluator.cc
@@ -1,0 +1,193 @@
+#include "DD4hep/DDTest.h"
+#include <exception>
+#include <iostream>
+#include <assert.h>
+#include <cmath>
+
+#include <atomic>
+#include <thread>
+
+#include "Evaluator/Evaluator.h"
+
+
+using namespace std ;
+using namespace dd4hep ;
+
+// this should be the first line in your test
+static DDTest test( "Evaluator" ) ; 
+
+namespace {
+  double foo() { return 8.0;}
+}
+
+//=============================================================================
+
+int main(int /* argc */, char** /* argv */ ){
+    
+  try{
+    
+    // ----- write your tests in here -------------------------------------
+
+    test.log( "test Evaluator" );
+    using namespace dd4hep::tools;
+    Evaluator e;
+    {
+      auto r = e.evaluate("5.2");
+      test( r.second , 5.2, " double value");
+      test( r.first, Evaluator::OK, " status OK");
+    }
+
+    {
+      auto r = e.evaluate("4*m");
+      test( r.second , 4, " double value in meters");
+      test( r.first, Evaluator::OK, " status OK");
+    }
+
+    {
+      auto r = e.evaluate("4*cm");
+      test( r.second , 0.04, " double value in cm");
+      test( r.first, Evaluator::OK, " status OK");
+    }
+
+    {
+      auto r = e.evaluate("abs(-4)");
+      test( r.second , 4., " call abs");
+      test( r.first, Evaluator::OK, " status OK");
+    }
+
+    {
+      auto r = e.evaluate("min(7, 2)");
+      test( r.second , 2., " call min");
+      test( r.first, Evaluator::OK, " status OK");
+    }
+
+    {
+      auto r = e.evaluate("7_");
+      test( r.first, Evaluator::ERROR_UNEXPECTED_SYMBOL, " status UNEXPECTED SYMBOL");
+    }
+
+    {
+      e.setVariable("myVar", 12);
+      auto r = e.evaluate("myVar");
+      test( r.second , 12., " use myVar variable");
+      test( r.first, Evaluator::OK, " status OK");
+    }
+
+    {
+      e.setFunction("foo", foo);
+      auto r = e.evaluate("foo()");
+      test( r.second , foo(), " call new function foo");
+      test( r.first, Evaluator::OK, " status OK");
+    }
+    
+    {
+      //use cm as length
+      Evaluator e_cm(100.);
+
+      {
+        auto r = e_cm.evaluate("4*m");
+        test( r.second , 400, " double value in meters with cm as unit");
+        test( r.first, Evaluator::OK, " status OK");
+      }
+      
+      {
+        auto r = e_cm.evaluate("4*cm");
+        test( r.second , 4, " double value in cm with cm as unit");
+        test( r.first, Evaluator::OK, " status OK");
+      }
+    }
+
+    {
+      //do modifications while running multple threads
+      std::atomic<int> countDownToStart{2};
+
+      std::atomic<bool> success{true};
+
+      Evaluator e_threads;
+
+      std::array<std::string,100> nameExtensions;
+      char extension[3];
+      extension[2] = 0;
+      for(char i = 0; i< 4;++i) {
+        extension[1] = 97+i;
+        for(char j = 0; j<25;++j) {
+          extension[0]=97+j;
+          nameExtensions[i*25+j] = std::string(extension,2);
+        }
+      }
+      
+      
+        std::thread t1([&countDownToStart, &success, &e_threads, &nameExtensions]() { 
+          const std::string name("ta");
+          --countDownToStart;
+          while(countDownToStart != 0);
+      
+          for(int i=0; i< 100; ++i) {
+            std::string newName = name+nameExtensions[i];
+             auto status = e_threads.setVariable(newName, i);
+            if(status != Evaluator::OK) {
+              success = false;
+              std::cout <<"Failed to add variable "<<newName<<" "<<status<<std::endl;
+              break;
+            };
+            auto r = e_threads.evaluate( newName+"*m");
+            if(r.first != Evaluator::OK) {
+              success = false;
+              std::cout <<"Parser failure "<<r.first<<" for variable "<<newName<<std::endl;
+              break;
+            }
+            if(r.second != i) {
+              success = false;
+              std::cout <<"Failed evaluation "<<i <<" != "<<r.second<<" for variable "<<newName<<std::endl;
+              break;
+            }
+          }
+          
+        }
+        ); 
+
+      std::thread t2([&countDownToStart, &success, &e_threads,&nameExtensions]() {
+          const std::string name("tb");
+          --countDownToStart;
+          while(countDownToStart != 0);
+          return;
+
+          for(int i=0; i< 100; ++i) {
+            std::string newName = name+nameExtensions[i];
+            e_threads.setVariable(newName, i);
+            auto r = e_threads.evaluate( newName+"*m");
+            if(r.first != Evaluator::OK) {
+              success = false;
+              std::cout <<"Parser failure "<<r.first<<" for variable "<<newName<<std::endl;
+              break;
+            }
+            if(r.second != i) {
+              success = false;
+              std::cout <<"Failed evaluation "<<i <<" != "<<r.second<<" for variable "<<newName<<std::endl;
+              break;
+            }
+          }
+        }
+      );
+      
+      t1.join();
+      t2.join();
+
+      test(success.load(), " multi-thread test");
+
+    }
+
+    // --------------------------------------------------------------------
+
+
+  } catch( exception &e ){
+    //} catch( ... ){
+
+    test.log( e.what() );
+    test.error( "exception occurred" );
+  }
+
+  return 0;
+}
+
+//=============================================================================


### PR DESCRIPTION

BEGINRELEASENOTES
- Made internal classes used by Evaluator to be less stateful
- Switch to using a read/write lock as modifications to the Evaluator are much less frequent than reads.
- Added unit test for Evaluator

ENDRELEASENOTES