### PR TITLE
AlignDet Test: number conditions depends on DEBUG or not

### DIFF
--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -111,14 +111,22 @@ dd4hep_add_test_reg( AlignDet_Telescope_align_nominal
   )
 #
 #---Testing: Load Telescope geometry and read and print alignments --------
+IF(DD4HEP_BUILD_DEBUG STREQUAL "ON")
+  SET(EXPECTED_CONDITIONS 52)
+  SET(EXPECTED_TS 33)
+ELSE()
+  SET(EXPECTED_CONDITIONS 40)
+  SET(EXPECTED_TS 21)
+ENDIF()
 dd4hep_add_test_reg( AlignDet_Telescope_readback_xml
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_AlignDet.sh"
   EXEC_ARGS  geoPluginRun -volmgr -destroy -plugin DD4hep_AlignmentExample_read_xml
   -input  file:${AlignDet_INSTALL}/compact/Telescope.xml
   -deltas file:./new_cond.xml
-  REGEX_PASS "40 conditions in slice. \\(T:21,S:21,L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
+  REGEX_PASS "${EXPECTED_CONDITIONS} conditions in slice. \\(T:${EXPECTED_TS},S:${EXPECTED_TS},L:0,C:0,M:0\\) Alignments accessed: 20 \\(A:19,M:0\\) for IOV:run\\(1\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
+set_property(TEST t_AlignDet_Telescope_readback_xml APPEND PROPERTY DEPENDS t_AlignDet_Telescope_write_xml)
 #
 #---Testing: Extended stress: Load CLICSiD geometry and have multiple runs on IOVs
 dd4hep_add_test_reg( AlignDet_CLICSiD_stress_LONGTEST


### PR DESCRIPTION
Fix the failing test because of different number of conditions with DEBUG and without.
@MarkusFrankATcernch does that make sense to you? I am not sure what this is counting in the test

https://github.com/AIDASoft/DD4hep/blob/12caacb209af70835dbdd48efa7ef8d0b77b3dcd/examples/AlignDet/src/AlignmentExample_read_xml.cpp#L102