### PR TITLE
Adapt to new ROOT mechanism for switching the unit system

### DIFF
--- a/DDCond/include/DDCond/ConditionsDependencyHandler.h
+++ b/DDCond/include/DDCond/ConditionsDependencyHandler.h
@@ -133,18 +133,18 @@ namespace dd4hep {
       /// Access to the detector description instance
       virtual Detector& detectorDescription() const  override;
       /// Access to the conditions manager
-      virtual Ref_t manager() const  override                    { return m_manager;         }
+      virtual Ref_t manager() const  override                 { return m_manager;           }
       /// Access to pool IOV
-      virtual const IOV& requiredValidity()  const  override     { return m_pool.validity(); }
+      virtual const IOV& requiredValidity()  const  override  { return m_pool.validity();   }
       /// Accessor for the current conditons mapping
-      virtual ConditionsMap& conditionsMap() const override      { return m_pool;            }
+      virtual ConditionsMap& conditionsMap() const override   { return m_pool;              }
       /// ConditionResolver implementation: Interface to access conditions.
-      virtual Condition get(const ConditionKey& key) override    { return get(key.hash);     }
+      virtual Condition get(const ConditionKey& key) override { return get(key.hash, true); }
       /// Interface to access conditions by conditions key
       virtual Condition get(const ConditionKey& key, bool throw_if_not)  override
-      {  return get(key.hash, throw_if_not);                                                 }
+      {  return get(key.hash, throw_if_not);                                                }
       /// ConditionResolver implementation: Interface to access conditions
-      virtual Condition get(Condition::key_type key) override    { return get(key, true);    }
+      virtual Condition get(Condition::key_type key) override { return get(key, true);      }
       /// Interface to access conditions by hash value
       virtual Condition get(Condition::key_type key, bool throw_if_not)  override;
       /// Interface to access conditions by hash value of the DetElement (only valid at resolve!)

--- a/DDCond/src/ConditionsDependencyHandler.cpp
+++ b/DDCond/src/ConditionsDependencyHandler.cpp
@@ -50,6 +50,9 @@ Condition ConditionsDependencyHandler::Work::resolve(Work*& current)   {
   Work* previous = current;
   current = this;
   state = RESOLVED;
+  if ( !condition )   {
+    printout(ERROR,"ConditionsDependency","ERROR: Cannot resolve not existing conditions.");
+  }
   context.dependency->callback->resolve(condition, context);
   previous->do_intersection(iov);
   current = previous;
@@ -57,8 +60,8 @@ Condition ConditionsDependencyHandler::Work::resolve(Work*& current)   {
 }
 
 /// Default constructor
-ConditionsDependencyHandler::ConditionsDependencyHandler(ConditionsManager mgr,
-                                                         UserPool& pool,
+ConditionsDependencyHandler::ConditionsDependencyHandler(ConditionsManager   mgr,
+                                                         UserPool&           pool,
                                                          const Dependencies& dependencies,
                                                          ConditionUpdateUserContext* user_param)
   : m_manager(mgr.access()), m_pool(pool), m_dependencies(dependencies),
@@ -93,10 +96,12 @@ void ConditionsDependencyHandler::compute()   {
   for( const auto& i : m_todo )   {
     if ( !i.second->condition )  {
       do_callback(i.second);
-      continue;
+      if ( !i.second->condition )  {
+	except("ConditionsDependencyHandler",
+	       "Derived condition was not created after calling the creation callback!");
+      }
     }
     // printout(INFO,"UserPool","Already calcluated: %s",d->name());
-    continue;
   }
 }
 

--- a/DDCond/src/ConditionsDependencyHandler.cpp
+++ b/DDCond/src/ConditionsDependencyHandler.cpp
@@ -280,6 +280,18 @@ void ConditionsDependencyHandler::do_callback(Work* work)   {
       work->state = CREATED;
       ++num_callback;
     }
+    else   {
+      printout(ERROR,"ConditionDependency",
+	       "+++ Callback handler returned invalid condition.  Key:%s %c%s%c",
+	       work->context.dependency->target.toString().c_str(),
+#if defined(DD4HEP_CONDITIONS_DEBUG)
+	       '[',work->context.dependency->detector.path().c_str(),']'
+#else
+	       ' ',"",' '
+#endif
+	       );
+      throw std::runtime_error("Invalid derived condition callback");
+    }
     return;
   }
   catch(const std::exception& e)   {

--- a/DDCore/src/ConditionsInterna.cpp
+++ b/DDCore/src/ConditionsInterna.cpp
@@ -95,3 +95,7 @@ const dd4hep::IOVType* detail::ConditionObject::iovType() const    {
   invalidHandleError<IOVType>();
   return 0;
 }
+
+
+#include "DD4hep/GrammarUnparsed.h"
+static auto s_registry = GrammarRegistry::pre_note<vector<Condition> >(1);

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -164,7 +164,7 @@ DetectorImp::DetectorImp()
 DetectorImp::DetectorImp(const string& name)
   : TNamed(), DetectorData(), DetectorLoad(this), m_buildType(BUILD_NONE)
 {
-#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE > ROOT_VERSION(6,22,7)
+#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,22,7)
     printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
     if ( TGeoManager::GetDefaultUnits() != TGeoManager::kG4Units )  {
       TGeoManager::LockDefaultUnits(kFALSE);

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -167,10 +167,10 @@ DetectorImp::DetectorImp(const string& name)
   static bool first = true;
   if ( first )    {
     first = false;
-#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,23,0)
+#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,22,7)
     printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
     TGeoManager::SetDefaultUnits(TGeoManager::kG4Units);
-#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,23,0)
+#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,22,7)
     TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
 #elif defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
     printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -167,7 +167,12 @@ DetectorImp::DetectorImp(const string& name)
   static bool first = true;
   if ( first )    {
     first = false;
-#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
+#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,23,0)
+    printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
+    TGeoManager::SetDefaultUnits(TGeoManager::kG4Units);
+#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,23,0)
+    TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+#elif defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
     printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
     TGeoManager::SetDefaultG4Units();
     TGeoUnit::setUnitType(TGeoUnit::kTGeant4Units);

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -197,7 +197,6 @@ DetectorImp::DetectorImp(const string& name)
     new(table) TGeoElementTable();
     // This will initialize the table without filling:
     table->AddElement("VACUUM","VACUUM", 1, 1, 1e-15);
-    // table->Print();
 #endif
   }
   if ( 0 == gGeoIdentity )

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -164,15 +164,24 @@ DetectorImp::DetectorImp()
 DetectorImp::DetectorImp(const string& name)
   : TNamed(), DetectorData(), DetectorLoad(this), m_buildType(BUILD_NONE)
 {
+#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE > ROOT_VERSION(6,22,7)
+    printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
+    if ( TGeoManager::GetDefaultUnits() != TGeoManager::kG4Units )  {
+      TGeoManager::LockDefaultUnits(kFALSE);
+      TGeoManager::SetDefaultUnits(TGeoManager::kG4Units);
+      TGeoManager::LockDefaultUnits(kTRUE);
+    }
+#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,22,7)
+    if ( TGeoManager::GetDefaultUnits() != TGeoManager::kRootUnits )  {
+      TGeoManager::LockDefaultUnits(kFALSE);
+      TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+      TGeoManager::LockDefaultUnits(kTRUE);
+    }
+#else
   static bool first = true;
   if ( first )    {
     first = false;
-#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,22,7)
-    printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
-    TGeoManager::SetDefaultUnits(TGeoManager::kG4Units);
-#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,22,7)
-    TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
-#elif defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
+#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
     printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
     TGeoManager::SetDefaultG4Units();
     TGeoUnit::setUnitType(TGeoUnit::kTGeant4Units);
@@ -181,6 +190,7 @@ DetectorImp::DetectorImp(const string& name)
     TGeoUnit::setUnitType(TGeoUnit::kTGeoUnits);
 #endif
   }
+#endif
   SetName(name.c_str());
   SetTitle("DD4hep detector description object");
   set_terminate( description_unexpected );

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -71,7 +71,7 @@ dd4hep_add_test_reg( Conditions_Telescope_populate
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_populate
       -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 5
-  REGEX_PASS "Accessed a total of 900 conditions \\(S:   500,L:     0,C:   400,M:0\\)"
+  REGEX_PASS "Accessed a total of 1000 conditions \\(S:   500,L:     0,C:   500,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -80,7 +80,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress 
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 10 -runs 20
-  REGEX_PASS "\\+  Accessed a total of 3600 conditions \\(S:  2880,L:     0,C:   720,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 4000 conditions \\(S:  3100,L:     0,C:   900,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -89,7 +89,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress2
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress2 
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 10
-  REGEX_PASS "\\+  Accessed a total of 1800 conditions \\(S:  1000,L:     0,C:   800,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 2000 conditions \\(S:  1000,L:     0,C:  1000,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -98,7 +98,7 @@ dd4hep_add_test_reg( Conditions_Telescope_MT_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_MT 
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 30 -runs 10 -threads 1
-  REGEX_PASS "\\+  Accessed a total of 322200 conditions \\(S:298200,L:     0,C: 24000,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 358000 conditions \\(S:328000,L:     0,C: 30000,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -108,7 +108,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_save
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_save
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 30
     -conditions TelescopeConditions.root
-  REGEX_PASS "\\+ Successfully saved 14400 condition to file."
+  REGEX_PASS "\\+ Successfully saved 16200 condition to file."
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -119,7 +119,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_iov
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore iovpool
   DEPENDS Conditions_Telescope_root_save
-  REGEX_PASS "\\+  Accessed a total of 5400 conditions \\(S:  4800,L:     0,C:   600,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 6000 conditions \\(S:  5400,L:     0,C:   600,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -130,7 +130,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_usr
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore userpool
   DEPENDS Conditions_Telescope_root_save
-  REGEX_PASS "\\+  Accessed a total of 5400 conditions \\(S:  4800,L:     0,C:   600,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 6000 conditions \\(S:  5400,L:     0,C:   600,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -141,7 +141,7 @@ dd4hep_add_test_reg( Conditions_Telescope_root_load_pool
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml
     -conditions TelescopeConditions.root -iovs 30 -restore condpool
   DEPENDS Conditions_Telescope_root_save
-  REGEX_PASS "\\+  Accessed a total of 5400 conditions \\(S:  4800,L:     0,C:   600,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 6000 conditions \\(S:  5400,L:     0,C:   600,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -150,7 +150,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress 
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 10 -runs 100
-  REGEX_PASS "\\+  Accessed a total of 31596300 conditions \\(S:30192020,L:     0,C:1404280,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 35107000 conditions \\(S:33351650,L:     0,C:1755350,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -159,7 +159,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress2_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress2 
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 20
-  REGEX_PASS "\\+  Accessed a total of 6319260 conditions \\(S:3510700,L:     0,C:2808560,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 7021400 conditions \\(S:3510700,L:     0,C:3510700,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -168,7 +168,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_MT_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_MT 
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3 -runs 2 -threads 1
-  REGEX_PASS "\\+  Accessed a total of 10742742 conditions \\(S:9900174,L:     0,C:842568,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 11936380 conditions \\(S:10883170,L:     0,C:1053210,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -178,7 +178,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_save_LONGTEST
   EXEC_ARGS  geoPluginRun -print WARNING -destroy -plugin DD4hep_ConditionExample_save
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3
     -conditions CLICSiDConditions.root
-  REGEX_PASS "\\+ Successfully saved 2527704 condition to file."
+  REGEX_PASS "\\+ Successfully saved 2843667 condition to file."
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -189,7 +189,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_iov_LONGTEST
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3 -restore iovpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
-  REGEX_PASS "\\+  Accessed a total of 947889 conditions \\(S:842568,L:     0,C:105321,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 1053210 conditions \\(S:947889,L:     0,C:105321,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -200,7 +200,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_usr_LONGTEST
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3 -restore userpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
-  REGEX_PASS "\\+  Accessed a total of 947889 conditions \\(S:842568,L:     0,C:105321,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 1053210 conditions \\(S:947889,L:     0,C:105321,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -211,6 +211,6 @@ dd4hep_add_test_reg( Conditions_CLICSiD_root_load_cond_LONGTEST
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3 -restore condpool
     -conditions CLICSiDConditions.root
   DEPENDS Conditions_CLICSiD_root_save_LONGTEST
-  REGEX_PASS "\\+  Accessed a total of 947889 conditions \\(S:842568,L:     0,C:105321,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 1053210 conditions \\(S:947889,L:     0,C:105321,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )

--- a/examples/Conditions/CMakeLists.txt
+++ b/examples/Conditions/CMakeLists.txt
@@ -71,7 +71,7 @@ dd4hep_add_test_reg( Conditions_Telescope_populate
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_populate
       -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 5
-  REGEX_PASS "Accessed a total of 1000 conditions \\(S:   500,L:     0,C:   500,M:0\\)"
+  REGEX_PASS "Accessed a total of 1000 conditions \\(S:   600,L:     0,C:   400,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -80,7 +80,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress 
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 10 -runs 20
-  REGEX_PASS "\\+  Accessed a total of 4000 conditions \\(S:  3100,L:     0,C:   900,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 4000 conditions \\(S:  3280,L:     0,C:   720,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -89,7 +89,7 @@ dd4hep_add_test_reg( Conditions_Telescope_stress2
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress2 
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 10
-  REGEX_PASS "\\+  Accessed a total of 2000 conditions \\(S:  1000,L:     0,C:  1000,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 2000 conditions \\(S:  1200,L:     0,C:   800,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -98,7 +98,7 @@ dd4hep_add_test_reg( Conditions_Telescope_MT_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_MT 
     -input file:${CMAKE_INSTALL_PREFIX}/examples/AlignDet/compact/Telescope.xml -iovs 30 -runs 10 -threads 1
-  REGEX_PASS "\\+  Accessed a total of 358000 conditions \\(S:328000,L:     0,C: 30000,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 358000 conditions \\(S:334000,L:     0,C: 24000,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -150,7 +150,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress 
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 10 -runs 100
-  REGEX_PASS "\\+  Accessed a total of 35107000 conditions \\(S:33351650,L:     0,C:1755350,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 35107000 conditions \\(S:33702720,L:     0,C:1404280,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -159,7 +159,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_stress2_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_stress2 
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 20
-  REGEX_PASS "\\+  Accessed a total of 7021400 conditions \\(S:3510700,L:     0,C:3510700,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 7021400 conditions \\(S:4212840,L:     0,C:2808560,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #
@@ -168,7 +168,7 @@ dd4hep_add_test_reg( Conditions_CLICSiD_MT_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Conditions.sh"
   EXEC_ARGS  geoPluginRun  -destroy -plugin DD4hep_ConditionExample_MT 
     -input file:${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -iovs 3 -runs 2 -threads 1
-  REGEX_PASS "\\+  Accessed a total of 11936380 conditions \\(S:10883170,L:     0,C:1053210,M:0\\)"
+  REGEX_PASS "\\+  Accessed a total of 11936380 conditions \\(S:11093812,L:     0,C:842568,M:0\\)"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #

--- a/examples/Conditions/src/ConditionExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionExampleObjects.cpp
@@ -131,31 +131,19 @@ void ConditionUpdate3::resolve(Condition target, ConditionUpdateContext& context
 }
 
 /// Interface to client Callback in order to update the condition
-Condition ConditionUpdate4::operator()(const ConditionKey& key, ConditionUpdateContext&)  {
+Condition ConditionUpdate4::operator()(const ConditionKey& key, ConditionUpdateContext& context)  {
 #ifdef DD4HEP_CONDITIONS_DEBUG
-  printout(printLevel,"ConditionUpdate3","++ Building dependent condition: %016llX  [%s]",key.hash, key.name.c_str());
+  printout(printLevel,"ConditionUpdate4","++ Building dependent condition: %016llX  [%s]",key.hash, key.name.c_str());
   Condition    target(key.name,"derived");
 #else
-  printout(printLevel,"ConditionUpdate3","++ Building dependent condition: %016llX",key.hash);
+  printout(printLevel,"ConditionUpdate4","++ Building dependent condition: %016llX",key.hash);
   Condition    target(key.hash);
 #endif
-  target.bind<vector<int> >();
-  return target;
-}
-
-/// Interface to client Callback in order to update the condition
-void ConditionUpdate4::resolve(Condition target, ConditionUpdateContext& context)  {
-  vector<int>& data  = target.get<vector<int> >();
+  vector<int>& data  = target.bind<vector<int> >();
   Condition    cond3 = context.condition(context.key(0));
   Condition    cond2 = context.condition(context.key(1));
   Condition    cond0 = context.condition(context.key(2));
   Condition    cond1 = context.condition(context.key(3));
-
-  // Ensure the data are really accessible
-  if ( typeid(*cond0.ptr()) == typeid(detail::ConditionObject) )   {  }
-  if ( typeid(*cond1.ptr()) == typeid(detail::ConditionObject) )   {  }
-  if ( typeid(*cond2.ptr()) == typeid(detail::ConditionObject) )   {  }
-  if ( typeid(*cond3.ptr()) == typeid(detail::ConditionObject) )   {  }
 
   data.push_back(cond0.get<int>());
   data.push_back(cond0.get<int>()*2);
@@ -164,17 +152,92 @@ void ConditionUpdate4::resolve(Condition target, ConditionUpdateContext& context
 
   vector<int>& c2 = cond2.get<vector<int> >();
   data.insert(data.end(), c2.begin(), c2.end());
+
+  vector<int>& c3 = cond3.get<vector<int> >();
+  data.insert(data.end(), c3.begin(), c3.end());
+  return target;
+}
+
+/// Interface to client Callback in order to update the condition
+Condition ConditionUpdate5::operator()(const ConditionKey& key, ConditionUpdateContext& context)  {
+#ifdef DD4HEP_CONDITIONS_DEBUG
+  printout(printLevel,"ConditionUpdate5","++ Building dependent condition: %016llX  [%s]",key.hash, key.name.c_str());
+  Condition    target(key.name,"derived");
+#else
+  printout(printLevel,"ConditionUpdate5","++ Building dependent condition: %016llX",key.hash);
+  Condition    target(key.hash);
+#endif
+  vector<int>& data  = target.bind<vector<int> >();
+  Condition    cond3 = context.condition(context.key(0));
+  Condition    cond2 = context.condition(context.key(1));
+  Condition    cond0 = context.condition(context.key(2));
+  Condition    cond1 = context.condition(context.key(3));
+  Condition    cond4 = context.condition(context.key(4));
+
+  data.push_back(cond0.get<int>());
+  data.push_back(cond0.get<int>()*2);
+  vector<int>& c1 = cond1.get<vector<int> >();
+  data.insert(data.end(), c1.begin(), c1.end());
+
+  vector<int>& c2 = cond2.get<vector<int> >();
+  data.insert(data.end(), c2.begin(), c2.end());
+
+  vector<int>& c3 = cond3.get<vector<int> >();
+  data.insert(data.end(), c3.begin(), c3.end());
+
+  vector<int>& c4 = cond4.get<vector<int> >();
+  data.insert(data.end(), c4.begin(), c4.end());
+  return target;
+}
+
+/// Interface to client Callback in order to update the condition
+Condition ConditionUpdate6::operator()(const ConditionKey& key, ConditionUpdateContext& context)  {
+#ifdef DD4HEP_CONDITIONS_DEBUG
+  printout(printLevel,"ConditionUpdate6","++ Building dependent condition: %016llX  [%s]",key.hash, key.name.c_str());
+  Condition    target(key.name,"derived");
+#else
+  printout(printLevel,"ConditionUpdate6","++ Building dependent condition: %016llX",key.hash);
+  Condition    target(key.hash);
+#endif
+  auto* dep = context.dependency;
+  vector<Condition>& data = target.bind<vector<Condition> >();
+  data.reserve(dep->dependencies.size());
+  for ( size_t i=0; i<dep->dependencies.size(); ++i )   {
+    Condition c = context.condition(context.key(i));
+    if ( c.get<string>().empty() )  {
+      printout(printLevel,"ConditionUpdate6","++ Invalid dependent condition in: %016llX",key.hash);      
+    }
+    data.emplace_back(c);
+  }
+  max_deps = std::max(data.size(), max_deps);
+  min_deps = std::min(data.size(), min_deps);
+  num_deps += data.size();
+  ++call_count;
+  return target;
+}
+namespace {
+  size_t num_depath_checks = 0;
+  size_t num_depath_entries = 0;
+}
+/// Default destructor
+ConditionUpdate6::~ConditionUpdate6()   {
+  printout(ALWAYS,"Statistics","+++ Variable dependencies:  MIN: %ld MAX: %ld MEAN:%.3f COUNT:%d",
+	   min_deps, max_deps, double(num_deps)/double(std::max(call_count,1UL)), call_count);
+      /// Statistics
+  printout(ALWAYS,"Statistics","+++ DePath: Entries: %ld  Checks:%ld",num_depath_entries,num_depath_checks);
 }
 
 /// Initializing constructor
-ConditionsDependencyCreator::ConditionsDependencyCreator(ConditionsContent& c, PrintLevel p, bool persist)
-  : OutputLevel(p), content(c), persist_conditions(persist)
+ConditionsDependencyCreator::ConditionsDependencyCreator(ConditionsContent& c, PrintLevel p, bool persist, int ex)
+  : OutputLevel(p), content(c), persist_conditions(persist), extended(ex)
 {
   scall1 = std::shared_ptr<ConditionUpdateCall>(new ConditionNonDefaultCtorUpdate1(printLevel));
   call1  = std::shared_ptr<ConditionUpdateCall>(new ConditionUpdate1(printLevel));
   call2  = std::shared_ptr<ConditionUpdateCall>(new ConditionUpdate2(printLevel));
   call3  = std::shared_ptr<ConditionUpdateCall>(new ConditionUpdate3(printLevel));
   call4  = std::shared_ptr<ConditionUpdateCall>(new ConditionUpdate4(printLevel));
+  call5  = std::shared_ptr<ConditionUpdateCall>(new ConditionUpdate5(printLevel));
+  call6  = std::shared_ptr<ConditionUpdateCall>(new ConditionUpdate6(printLevel));
 }
 
 /// Destructor
@@ -183,17 +246,18 @@ ConditionsDependencyCreator::~ConditionsDependencyCreator()  {
 
 /// Callback to process a single detector element
 int ConditionsDependencyCreator::operator()(DetElement de, int)  const  {
-  ConditionKey      key(de,"derived_data");
+  ConditionKey      key     (de,"derived_data");
+  ConditionKey      key_path(de,"derived_data/de_path");
   ConditionKey      starget1(de,"derived_data/NonDefaultCtor_1");
   ConditionKey      target1(de,"derived_data/derived_1");
   ConditionKey      target2(de,"derived_data/derived_2");
   ConditionKey      target3(de,"derived_data/derived_3");
   ConditionKey      target4(de,"derived_data/derived_4");
+  ConditionKey      target5(de,"derived_data/derived_5");
   DependencyBuilder sbuild_1(de, starget1.item_key(), scall1);
   DependencyBuilder build_1(de, target1.item_key(), call1);
   DependencyBuilder build_2(de, target2.item_key(), call2);
   DependencyBuilder build_3(de, target3.item_key(), call3);
-  DependencyBuilder build_4(de, target4.item_key(), call4);
 
   // Compute the derived stuff
   sbuild_1.add(key);
@@ -206,19 +270,38 @@ int ConditionsDependencyCreator::operator()(DetElement de, int)  const  {
   build_3.add(target1);
   build_3.add(target2);
 
-  /// Make here some random dependencies
-  build_4.add(target3);
-  build_4.add(target2);
-  build_4.add(key);
-  build_4.add(target1);
-
+  if ( extended >= 1 )   {
+    DependencyBuilder build_4(de, target4.item_key(), call4);
+    build_4.add(target3);
+    build_4.add(target2);
+    build_4.add(key);
+    build_4.add(target1);
+    content.addDependency(build_4.release());
+  }
+  if ( extended >= 2 )   {
+    DependencyBuilder build_5(de, target5.item_key(), call5);
+    build_5.add(target3);
+    build_5.add(target2);
+    build_5.add(key);
+    build_5.add(target1);
+    build_5.add(target4);
+    content.addDependency(build_5.release());
+  }
+  if ( extended >= 3 )   {
+    DependencyBuilder build(de, key_path.item_key(), call6);
+    if ( de.parent().isValid() )
+      build.add(ConditionKey(de.parent(),"de_path"));
+    for(const auto& c : de.children())   {
+      build.add(ConditionKey(c.second,"de_path"));
+    }
+    content.addDependency(build.release());
+  }
   if ( !persist_conditions )  {
     content.addDependency(sbuild_1.release());
   }
   content.addDependency(build_1.release());
   content.addDependency(build_2.release());
   content.addDependency(build_3.release());
-  content.addDependency(build_4.release());
   printout(printLevel,"Example","++ Added derived conditions dependencies for %s",de.path().c_str());
   return 1;
 }
@@ -232,16 +315,19 @@ int ConditionsDataAccess::operator()(DetElement de, int level)  const  {
 
 /// Common call to access selected conditions
 int ConditionsDataAccess::accessConditions(DetElement de, const std::vector<Condition>& conditions)  const  {
+  ConditionKey key_path        (de,"de_path");
   ConditionKey key_temperature (de,"temperature");
   ConditionKey key_pressure    (de,"pressure");
   ConditionKey key_double_table(de,"double_table");
   ConditionKey key_int_table   (de,"int_table");
   ConditionKey key_derived_data(de,"derived_data");
+  ConditionKey key_depath      (de,"derived_data/de_path");
   ConditionKey key_noctor_1    (de,"derived_data/NonDefaultCtor_1");
   ConditionKey key_derived1    (de,"derived_data/derived_1");
   ConditionKey key_derived2    (de,"derived_data/derived_2");
   ConditionKey key_derived3    (de,"derived_data/derived_3");
   ConditionKey key_derived4    (de,"derived_data/derived_4");
+  ConditionKey key_derived5    (de,"derived_data/derived_5");
   int result = 0, count = 0;
 
   // Let's go for the deltas....
@@ -254,7 +340,34 @@ int ConditionsDataAccess::accessConditions(DetElement de, const std::vector<Cond
       printout(ERROR,"accessConditions","Condition with bad base class!");
     }
     
-    if ( cond.item_key() == key_temperature.item_key() )  {
+    if ( cond.item_key() == key_path.item_key() )  {
+      ++result;
+      if ( cond.get<string>() != de.path() )
+	printout(ERROR,"CondAccess","++ string:%s <> %s",de.path().c_str(), cond.get<string>().c_str());
+    }
+    else if ( cond.item_key() == key_depath.item_key() )  {
+      vector<Condition>& data = cond.get<vector<Condition> >();
+      size_t cnt = 0;
+      ++num_depath_entries;
+      if ( de.parent().isValid() )  {
+	++num_depath_checks;
+	if ( data[0].get<string>() != de.parent().path() )  {
+	  printout(ERROR,"CondAccess","++ string:%s <> %s",
+		   de.parent().path().c_str(), data[0].get<string>().c_str());
+	}
+	++cnt;
+      }
+      for(const auto& child : de.children())   {
+	const Condition& c = data[cnt];
+	++num_depath_checks;
+	if ( c.get<string>() != child.second.path() )  {
+	  printout(ERROR,"CondAccess","++ string:%s <> %s",
+		   child.second.path().c_str(), c.get<string>().c_str());
+	}
+	++cnt;
+      }
+    }
+    else if ( cond.item_key() == key_temperature.item_key() )  {
       result += int(cond.get<double>());
     }
     else if ( cond.item_key() == key_pressure.item_key() )  {
@@ -281,6 +394,9 @@ int ConditionsDataAccess::accessConditions(DetElement de, const std::vector<Cond
     else if ( cond.item_key() == key_derived4.item_key() )  {
       result += int(cond.get<vector<int> >().size());
     }
+    else if ( cond.item_key() == key_derived5.item_key() )  {
+      result += int(cond.get<vector<int> >().size());
+    }
     else if ( cond.item_key() == key_noctor_1.item_key() )  {
       const NonDefaultCtorCond& c = cond.get<NonDefaultCtorCond>(); 
       result += c.a + c.b + c.b + c.d;
@@ -302,6 +418,7 @@ int ConditionsKeys::operator()(DetElement de, int)  const   {
   content.insertKey(ConditionKey(de,"double_table").hash);
   content.insertKey(ConditionKey(de,"int_table").hash);
   content.insertKey(ConditionKey(de,"derived_data").hash);
+  content.insertKey(ConditionKey(de,"de_path").hash);
   return 1;
 }
 
@@ -329,12 +446,14 @@ int ConditionsCreator::operator()(DetElement de, int)  const  {
   Condition derived     = make_condition<int>   (de,"derived_data",100);
   Condition dbl_table   = make_condition<vector<double> >(de,"double_table",{1.,2.,3.,4.,5.,6.,7.,8.,9.});
   Condition int_table   = make_condition<vector<int> >   (de,"int_table",{10,20,30,40,50,60,70,80,90});
+  Condition path        = make_condition<std::string>    (de,"de_path",de.path());
 
   slice.manager.registerUnlocked(pool, temperature);
   slice.manager.registerUnlocked(pool, pressure);
   slice.manager.registerUnlocked(pool, derived);
   slice.manager.registerUnlocked(pool, dbl_table);
   slice.manager.registerUnlocked(pool, int_table);
+  slice.manager.registerUnlocked(pool, path);
   printout(printLevel,"Creator","++ Adding manually conditions for %s",de.path().c_str());
   return 5;
 }

--- a/examples/Conditions/src/ConditionExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionExampleObjects.cpp
@@ -332,7 +332,7 @@ int ConditionsDataAccess::accessConditions(DetElement de, const std::vector<Cond
 
   // Let's go for the deltas....
   for( auto cond : conditions )  {
-    const auto& info = typeid(*cond.ptr());
+    const auto& info = cond.descriptor().type();
     if ( info != typeid(detail::ConditionObject) )  {
       printout(ERROR,"accessConditions","Condition with bad base class!");
     }

--- a/examples/Conditions/src/ConditionExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionExampleObjects.cpp
@@ -333,13 +333,10 @@ int ConditionsDataAccess::accessConditions(DetElement de, const std::vector<Cond
   // Let's go for the deltas....
   for( auto cond : conditions )  {
     const auto& info = cond.descriptor().type();
-    if ( info != typeid(detail::ConditionObject) )  {
-      printout(ERROR,"accessConditions","Condition with bad base class!");
-    }
     if ( 0 == dynamic_cast<detail::ConditionObject*>(cond.ptr()) )  {
       printout(ERROR,"accessConditions","Condition with bad base class!");
     }
-    
+   
     if ( cond.item_key() == key_path.item_key() )  {
       ++result;
       if ( cond.get<string>() != de.path() )

--- a/examples/Conditions/src/ConditionExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionExampleObjects.cpp
@@ -332,7 +332,7 @@ int ConditionsDataAccess::accessConditions(DetElement de, const std::vector<Cond
 
   // Let's go for the deltas....
   for( auto cond : conditions )  {
-    const auto& info = cond.descriptor().type();
+    // const auto& info = cond.descriptor().type();
     if ( 0 == dynamic_cast<detail::ConditionObject*>(cond.ptr()) )  {
       printout(ERROR,"accessConditions","Condition with bad base class!");
     }

--- a/examples/Conditions/src/ConditionExampleObjects.h
+++ b/examples/Conditions/src/ConditionExampleObjects.h
@@ -184,8 +184,46 @@ namespace dd4hep {
       virtual ~ConditionUpdate4() = default;
       /// Interface to client Callback in order to update the condition
       virtual Condition operator()(const ConditionKey& key, ConditionUpdateContext& context) override  final;
+    };
+    
+    /// Specialized conditions update callback 
+    /**
+     *  Used by clients to update a condition.
+     *
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_CONDITIONS
+     */
+    class ConditionUpdate5 : public ConditionUpdateCall, public OutputLevel  {
+    public:
+      /// Initializing constructor
+      ConditionUpdate5(PrintLevel p) : OutputLevel(p) {    }
+      /// Default destructor
+      virtual ~ConditionUpdate5() = default;
       /// Interface to client Callback in order to update the condition
-      virtual void resolve(Condition condition, ConditionUpdateContext& context) override  final;
+      virtual Condition operator()(const ConditionKey& key, ConditionUpdateContext& context) override  final;
+    };
+    
+    /// Specialized conditions update callback 
+    /**
+     *  Used by clients to update a condition.
+     *
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_CONDITIONS
+     */
+    class ConditionUpdate6 : public ConditionUpdateCall, public OutputLevel  {
+    public:
+      size_t max_deps = 0;
+      size_t min_deps = 999999999999UL;
+      size_t num_deps = 0;
+      size_t call_count = 0;
+      /// Initializing constructor
+      ConditionUpdate6(PrintLevel p) : OutputLevel(p) {    }
+      /// Default destructor
+      virtual ~ConditionUpdate6();
+      /// Interface to client Callback in order to update the condition
+      virtual Condition operator()(const ConditionKey& key, ConditionUpdateContext& context) override  final;
     };
     
     /// This is important, otherwise the register and forward calls won't find them!
@@ -216,11 +254,13 @@ namespace dd4hep {
       /// Content object to be filled
       ConditionsContent&   content;
       /// Three different update call types
-      std::shared_ptr<ConditionUpdateCall> scall1, call1, call2, call3, call4;
+      std::shared_ptr<ConditionUpdateCall> scall1, call1, call2, call3, call4, call5, call6;
       /// Flag for special setup for ROOT persistency
       bool persist_conditions;
+      /// Flag to indicate increased complexity
+      int  extended;
       /// Constructor
-      ConditionsDependencyCreator(ConditionsContent& c, PrintLevel p, bool persist=false);
+      ConditionsDependencyCreator(ConditionsContent& c, PrintLevel p, bool persist=false, int extended=0);
       /// Destructor
       virtual ~ConditionsDependencyCreator();
       /// Callback to process a single detector element
@@ -268,6 +308,7 @@ namespace dd4hep {
       const IOV&     iov;
       /// Reference to the conditions map to access conditions
       ConditionsMap& map;
+
       /// Constructor
       ConditionsDataAccess(const IOV& i, ConditionsMap& m, PrintLevel l=DEBUG)
         : OutputLevel(l), iov(i), map(m) {}

--- a/examples/Conditions/src/ConditionExampleObjects.h
+++ b/examples/Conditions/src/ConditionExampleObjects.h
@@ -168,6 +168,26 @@ namespace dd4hep {
       virtual void resolve(Condition condition, ConditionUpdateContext& context) override  final;
     };
     
+    /// Specialized conditions update callback 
+    /**
+     *  Used by clients to update a condition.
+     *
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_CONDITIONS
+     */
+    class ConditionUpdate4 : public ConditionUpdateCall, public OutputLevel  {
+    public:
+      /// Initializing constructor
+      ConditionUpdate4(PrintLevel p) : OutputLevel(p) {    }
+      /// Default destructor
+      virtual ~ConditionUpdate4() = default;
+      /// Interface to client Callback in order to update the condition
+      virtual Condition operator()(const ConditionKey& key, ConditionUpdateContext& context) override  final;
+      /// Interface to client Callback in order to update the condition
+      virtual void resolve(Condition condition, ConditionUpdateContext& context) override  final;
+    };
+    
     /// This is important, otherwise the register and forward calls won't find them!
     /**
      *  \author  M.Frank
@@ -196,7 +216,7 @@ namespace dd4hep {
       /// Content object to be filled
       ConditionsContent&   content;
       /// Three different update call types
-      std::shared_ptr<ConditionUpdateCall> scall1, call1, call2, call3;
+      std::shared_ptr<ConditionUpdateCall> scall1, call1, call2, call3, call4;
       /// Flag for special setup for ROOT persistency
       bool persist_conditions;
       /// Constructor


### PR DESCRIPTION
BEGINRELEASENOTES
- Adapt to new ROOT mechanism for switching the unit system.
  Units can be switched now multiple times provided the units are unlocked in the TGeoManager.
  See TGeoManager::LockDefaultUnits(Bool_t new_value).
  This is only available for ROOT versions >= 6.22.08
- Improve examples/Conditions. Allow for more complex dependencies. Not enabled by default.
ENDRELEASENOTES

Needs: https://github.com/root-project/root/pull/7165