### PR TITLE
RootDictionary: qualify std::pair, using namespace std was dropped fr…

### DIFF
--- a/DDCore/src/RootDictionary.h
+++ b/DDCore/src/RootDictionary.h
@@ -50,7 +50,7 @@ namespace dd4hep {
   namespace align {}
   namespace detail {}
   void run_interpreter(const std::string& name)  {
-    pair<int, char**> a(0,0);
+    std::pair<int, char**> a(0,0);
     TRint app(name.c_str(), &a.first, a.second);
     app.Run();
   }
@@ -65,7 +65,7 @@ namespace dd4hep {
       interp() = default;
       virtual ~interp() = default;
       static void run(const std::string& name)  {
-	pair<int, char**> a(0,0);
+	std::pair<int, char**> a(0,0);
 	TRint app(name.c_str(), &a.first, a.second);
 	app.Run();
       }


### PR DESCRIPTION
…om RootDict boilerplate

Probably following this change in ROOT https://github.com/root-project/root/pull/6852 the LCG dev3 started failing.
http://cdash.cern.ch/upload/4d8472ff9299443a566857aab7e7fe482a42e2dc/DD4hep-master-build.log
(We can't see that in our test now, because there won't be an update of the root master until this is fixed.)

I compiled a test just including the RootDictionary.h to test if nothing else is missing, but I am not totally sure it is compatible with the changes in ROOT

BEGINRELEASENOTES
- RootDictionary: fix incompatibility with Root 6.24

ENDRELEASENOTES