### PR TITLE
DDG4Dict: qualify std::pair, using namespace std was dropped from Roo…

### DIFF
--- a/DDG4/python/DDG4Dict.C
+++ b/DDG4/python/DDG4Dict.C
@@ -194,12 +194,12 @@ namespace dd4hep {
     };
 
     /// Container definitions for Geant4Vertex
-    typedef vector<Geant4Vertex*>  Geant4VertexVector;
-    typedef map<int,Geant4Vertex*> Geant4VertexIntMap;
+    typedef std::vector<Geant4Vertex*>  Geant4VertexVector;
+    typedef std::map<int,Geant4Vertex*> Geant4VertexIntMap;
 
     /// Container definitions for Geant4Particle
-    typedef vector<Geant4Particle*>  Geant4ParticleVector;
-    typedef map<int,Geant4Particle*> Geant4ParticleIntMap;
+    typedef std::vector<Geant4Particle*>  Geant4ParticleVector;
+    typedef std::map<int,Geant4Particle*> Geant4ParticleIntMap;
   }
 }
 


### PR DESCRIPTION
…tDict boilerplate

Another Dictionary with this problem:
http://cdash.cern.ch/upload/d6f266b09ff37242d3ff2c4fbfd17eb2ca2f4f8f/DD4hep-master-build.log


BEGINRELEASENOTES
- DDG4Dict: Adapt to changes in Root 6.24

ENDRELEASENOTES