### PR TITLE
Geant4: flush the buffer to fix the problem with the garbage output a…

### DIFF
--- a/DDG4/src/Geant4Kernel.cpp
+++ b/DDG4/src/Geant4Kernel.cpp
@@ -300,7 +300,10 @@ int Geant4Kernel::initialize() {
 
 int Geant4Kernel::run() {
   try  {
-    return Geant4Exec::run(*this);
+    auto result = Geant4Exec::run(*this);
+    // flush the geant4 stream buffer
+    G4cout << G4endl;
+    return result;
   }
   catch(const exception& e)   {
     printout(FATAL,"Geant4Kernel","+++ Exception while simulating:%s",e.what());


### PR DESCRIPTION
…t the end

So https://gitlab.cern.ch/geant4/geant4/-/blob/geant4-10.7-release/source/processes/hadronic/models/de_excitation/management/src/G4DeexPrecoParameters.cc#L294
Never uses G4endl;.
And we never use G4endl ourselves. So the buffer never gets flushed until the end.
So we just add one call...

BEGINRELEASENOTES
- DDG4: flush the geant4 strstream buffer after run. fixes #798 

ENDRELEASENOTES