### PR TITLE
Adopt new naming convention for Geant4 assembly imprints

### DIFF
--- a/DDCore/include/DD4hep/VolumeProcessor.h
+++ b/DDCore/include/DD4hep/VolumeProcessor.h
@@ -43,7 +43,7 @@ namespace dd4hep {
     /// Default copy constructor
     PlacedVolumeProcessor(const PlacedVolumeProcessor& copy) = default;
     /// Default destructor
-    virtual ~PlacedVolumeProcessor();
+    virtual ~PlacedVolumeProcessor() noexcept(false);
     /// Default assignment
     PlacedVolumeProcessor& operator=(const PlacedVolumeProcessor& copy) = default;
     /// Callback to output PlacedVolume information of an single Placement

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -105,8 +105,8 @@ namespace {
   
   class DetectorGuard  final  {
   protected:
-    static pair<mutex, map<DetectorImp*, TGeoManager*> >& detector_lock()   {
-      static pair<mutex, map<DetectorImp*, TGeoManager*> > s_inst;
+    static pair<recursive_mutex, map<DetectorImp*, TGeoManager*> >& detector_lock()   {
+      static pair<recursive_mutex, map<DetectorImp*, TGeoManager*> > s_inst;
       return s_inst;
     }
     DetectorImp* detector {nullptr};

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -766,7 +766,7 @@ void Polyhedra::make(const string& nam, int nsides, double start, double delta,
 }
 
 /// Helper function to create the polyhedron
-void ExtrudedPolygon::make(const string& nam,
+void ExtrudedPolygon::make(const string&         nam,
                            const vector<double>& pt_x,
                            const vector<double>& pt_y,
                            const vector<double>& sec_z,

--- a/DDCore/src/VolumeProcessor.cpp
+++ b/DDCore/src/VolumeProcessor.cpp
@@ -18,7 +18,7 @@
 using namespace dd4hep;
 
 /// Default destructor
-PlacedVolumeProcessor::~PlacedVolumeProcessor()   {
+PlacedVolumeProcessor::~PlacedVolumeProcessor()  noexcept(false)  {
 }
 
 /// Callback to output PlacedVolume information of an entire DetElement

--- a/DDCore/src/gdml/DetElementCreator.cpp
+++ b/DDCore/src/gdml/DetElementCreator.cpp
@@ -96,7 +96,7 @@ namespace dd4hep {
                       int sd_lvl,
                       PrintLevel p);
     /// Default destructor
-    virtual ~DetElementCreator();
+    virtual ~DetElementCreator() noexcept(false);
     /// Callback to output PlacedVolume information of an single Placement
     virtual int operator()(PlacedVolume pv, int level);
     /// Callback to output PlacedVolume information of an entire Placement
@@ -140,7 +140,7 @@ DetElementCreator::DetElementCreator(Detector& desc,
 }
 
 /// Default destructor
-DetElementCreator::~DetElementCreator()  {
+DetElementCreator::~DetElementCreator() noexcept(false)  {
   Count total;
   stringstream str, id_str;
   const char* pref = detector_volume_match.c_str();

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -135,12 +135,13 @@ static long display(Detector& description, int argc, char** argv) {
       detector = argv[++i];
     else  {
       cout <<
-        "Usage: -plugin <name> -arg [-arg]                                                   \n"
+        "Usage: -plugin DD4hep_GeometryDisplay  -arg [-arg]                                \n\n"
         "     -detector <string> Top level DetElement path. Default: '/world'                \n"
         "     -option   <string> ROOT Draw option.    Default: 'ogl'                         \n"
         "     -level    <number> Visualization level  [TGeoManager::SetVisLevel]  Default: 4 \n"
         "     -visopt   <number> Visualization option [TGeoManager::SetVisOption] Default: 1 \n"       
-        "\tArguments given: " << arguments(argc,argv) << endl << flush;
+        "     -help              Print this help output  \n"       
+        "     Arguments given: " << arguments(argc,argv) << endl << flush;
       ::exit(EINVAL);
     }
   }

--- a/DDG4/include/DDG4/DDG4Dict.h
+++ b/DDG4/include/DDG4/DDG4Dict.h
@@ -145,8 +145,8 @@ namespace dd4hep {
     inline Geant4Tracker::Hit::Hit(int, int, double, double)   {}
     /// Default destructor
     inline Geant4Tracker::Hit::~Hit()  {    }
-    /// Assignment operator
-    inline Geant4Tracker::Hit& Geant4Tracker::Hit::operator=(const Hit&)   { return *this; }
+    /// Explicit assignment operation
+    inline void Geant4Tracker::Hit::copyFrom(const Hit&)   {   }
     /// Clear hit content
     inline Geant4Tracker::Hit& Geant4Tracker::Hit::clear()    { return *this; }
     /// Store Geant4 point and step information into tracker hit structure.

--- a/DDG4/include/DDG4/Geant4AssemblyVolume.h
+++ b/DDG4/include/DDG4/Geant4AssemblyVolume.h
@@ -1,6 +1,3 @@
-#ifndef DDG4_GEANT4ASSEMBLYVOLUME_H
-#define DDG4_GEANT4ASSEMBLYVOLUME_H
-
 //==========================================================================
 //  AIDA Detector description implementation 
 //--------------------------------------------------------------------------
@@ -13,6 +10,8 @@
 // Author     : M.Frank
 //
 //==========================================================================
+#ifndef DDG4_GEANT4ASSEMBLYVOLUME_H
+#define DDG4_GEANT4ASSEMBLYVOLUME_H
 
 // Disable diagnostics for ROOT dictionaries
 #ifdef __clang__
@@ -28,12 +27,21 @@
 #pragma clang diagnostic pop
 #endif
 
+// ROOT includes
+#include "TGeoNode.h"
+
+/// C/C++ include files
+#include <vector>
+
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
 
   /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
   namespace sim {
 
+    /// Forward declarations
+    class Geant4GeometryInfo;
+    
     /// Hack! Wrapper around G4AssemblyVolume to access protected members.
     /**
      *  \author  M.Frank

--- a/DDG4/include/DDG4/Geant4AssemblyVolume.h
+++ b/DDG4/include/DDG4/Geant4AssemblyVolume.h
@@ -63,21 +63,10 @@ namespace dd4hep {
       ~Geant4AssemblyVolume()   {
       }
 
-      //std::vector<G4AssemblyTriplet>& triplets()  { return fTriplets; }
-      long placeVolume(const TGeoNode* n, G4LogicalVolume* pPlacedVolume, G4Transform3D& transformation) {
-        size_t id = fTriplets.size();
-        m_entries.push_back(n);
-        this->AddPlacedVolume(pPlacedVolume, transformation);
-        return (long)id;
-      }
-
-      long placeAssembly(const TGeoNode* n, Geant4AssemblyVolume* pPlacedVolume, G4Transform3D& transformation) {
-        size_t id = fTriplets.size();
-        m_entries.push_back(n);
-        this->AddPlacedAssembly(pPlacedVolume, transformation);
-        return (long)id;
-      }
-
+      long placeVolume(const TGeoNode* n, G4LogicalVolume* pPlacedVolume, G4Transform3D& transformation);
+      
+      long placeAssembly(const TGeoNode* n, Geant4AssemblyVolume* pPlacedVolume, G4Transform3D& transformation);
+      
       void imprint(Geant4GeometryInfo& info,
                    const TGeoNode* n,
                    Chain chain,

--- a/DDG4/include/DDG4/Geant4Data.h
+++ b/DDG4/include/DDG4/Geant4Data.h
@@ -238,12 +238,20 @@ namespace dd4hep {
       public:
         /// Default constructor
         Hit();
+        /// Move constructor
+        Hit(Hit&& c) = delete;
+        /// copy constructor
+        Hit(const Hit& c) = delete;
         /// Initializing constructor
         Hit(int track_id, int pdg_id, double deposit, double time_stamp);
         /// Default destructor
         virtual ~Hit();
-        /// Assignment operator
-        Hit& operator=(const Hit& c);
+        /// Move assignment operator
+        Hit& operator=(Hit&& c) = delete;
+        /// Copy assignment operator
+        Hit& operator=(const Hit& c) = delete;
+	/// Explicit assignment operation
+	void copyFrom(const Hit& c);
         /// Clear hit content
         Hit& clear();
         /// Store Geant4 point and step information into tracker hit structure.
@@ -280,10 +288,18 @@ namespace dd4hep {
       public:
         /// Default constructor (for ROOT)
         Hit();
+        /// Move constructor
+        Hit(Hit&& c) = delete;
+        /// copy constructor
+        Hit(const Hit& c) = delete;
         /// Standard constructor
         Hit(const Position& cell_pos);
         /// Default destructor
         virtual ~Hit();
+        /// Move assignment operator
+        Hit& operator=(Hit&& c) = delete;
+        /// Copy assignment operator
+        Hit& operator=(const Hit& c) = delete;
       };
     };
 

--- a/DDG4/plugins/Geant4Processes.cpp
+++ b/DDG4/plugins/Geant4Processes.cpp
@@ -38,6 +38,10 @@
 //
 // ======================================================================
 
+// Fast simulation
+#include "G4FastSimulationManagerProcess.hh"
+DECLARE_GEANT4_PROCESS(G4FastSimulationManagerProcess)
+
 // Photon Processes:
 #include "G4GammaConversion.hh"
 DECLARE_GEANT4_PROCESS(G4GammaConversion)

--- a/DDG4/plugins/Geant4SDActions.cpp
+++ b/DDG4/plugins/Geant4SDActions.cpp
@@ -353,7 +353,7 @@ namespace dd4hep {
         sensitive->mark(step->GetTrack());
         mean_pos.SetXYZ(0,0,0);
         mean_time = 0;
-        post = pre;
+        post.copyFrom(pre);
         combined = 0;
         cell = 0;
       }

--- a/DDG4/plugins/Geant4TrackerWeightedSD.cpp
+++ b/DDG4/plugins/Geant4TrackerWeightedSD.cpp
@@ -130,7 +130,7 @@ namespace dd4hep {
         post.truth.deposit = 0.0;
         current = pre.truth.trackID;
         sensitive->mark(step->GetTrack());
-        post = pre;
+        post.copyFrom(pre);
         parent = step->GetTrack()->GetParentID();
         g4ID = step->GetTrack()->GetTrackID();
 

--- a/DDG4/src/Geant4AssemblyVolume.cpp
+++ b/DDG4/src/Geant4AssemblyVolume.cpp
@@ -27,6 +27,26 @@
 
 using namespace dd4hep::sim;
 
+long Geant4AssemblyVolume::placeVolume(const TGeoNode* n,
+				       G4LogicalVolume* pPlacedVolume,
+				       G4Transform3D& transformation)
+{
+  size_t id = fTriplets.size();
+  m_entries.emplace_back(n);
+  this->AddPlacedVolume(pPlacedVolume, transformation);
+  return (long)id;
+}
+
+long Geant4AssemblyVolume::placeAssembly(const TGeoNode* n,
+					 Geant4AssemblyVolume* pPlacedVolume,
+					 G4Transform3D& transformation)
+{
+  size_t id = fTriplets.size();
+  m_entries.emplace_back(n);
+  this->AddPlacedAssembly(pPlacedVolume, transformation);
+  return (long)id;
+}
+
 void Geant4AssemblyVolume::imprint(Geant4GeometryInfo&   info,
                                    const TGeoNode*       parent,
                                    Chain                 chain,
@@ -51,8 +71,9 @@ void Geant4AssemblyVolume::imprint(Geant4GeometryInfo&   info,
   //cout << " Assembly:" << detail::tools::placementPath(chain) << endl;
 
   for( unsigned int i = 0; i < triplets.size(); i++ )  {
-    const TGeoNode* node = pParentAssembly->m_entries[i];
     Chain new_chain = chain;
+    const TGeoNode* node = pParentAssembly->m_entries[i];
+
     new_chain.emplace_back(node);
     //cout << " Assembly: Entry: " << detail::tools::placementPath(new_chain) << endl;
 
@@ -91,9 +112,9 @@ void Geant4AssemblyVolume::imprint(Geant4GeometryInfo&   info,
 	     << ':'
 	     << parent->GetNumber()
              << '#'
-             << m_entries[i]->GetName()
+             << node->GetName()
              << ':'
-             << m_entries[i]->GetNumber()
+             << node->GetNumber()
              << std::ends;
       // Generate a new physical volume instance inside a mother
       // (as we allow 3D transformation use G4ReflectionFactory to

--- a/DDG4/src/Geant4AssemblyVolume.cpp
+++ b/DDG4/src/Geant4AssemblyVolume.cpp
@@ -107,13 +107,13 @@ void Geant4AssemblyVolume::imprint(Geant4GeometryInfo&   info,
 #endif
       pvName << "AV_"
              << GetAssemblyID()
-             << '#'
+             << '!'
 	     << parent->GetName()
-	     << ':'
+	     << '#'
 	     << parent->GetNumber()
-             << '#'
+             << '!'
              << node->GetName()
-             << ':'
+             << '#'
              << node->GetNumber()
              << std::ends;
       // Generate a new physical volume instance inside a mother

--- a/DDG4/src/Geant4AssemblyVolume.cpp
+++ b/DDG4/src/Geant4AssemblyVolume.cpp
@@ -1,0 +1,146 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Geant4 include files
+#include "DD4hep/DetectorTools.h"
+#include "G4LogicalVolume.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4ReflectionFactory.hh"
+
+// C/C++ include files
+#include <sstream>
+#include <string>
+
+// Framework include files
+#include "DDG4/Geant4GeometryInfo.h"
+#include "DDG4/Geant4AssemblyVolume.h"
+
+using namespace dd4hep::sim;
+
+void Geant4AssemblyVolume::imprint(Geant4GeometryInfo&   info,
+                                   const TGeoNode*       parent,
+                                   Chain                 chain,
+                                   Geant4AssemblyVolume* pParentAssembly,
+                                   G4LogicalVolume*      pMotherLV,
+                                   G4Transform3D&        transformation,
+                                   G4int                 copyNumBase,
+                                   G4bool                surfCheck)
+{
+  static int level=0;
+  TGeoVolume* vol = parent->GetVolume();
+  unsigned int numberOfDaughters = (copyNumBase == 0) ? pMotherLV->GetNoDaughters() : copyNumBase;
+
+  ++level;
+
+  // We start from the first available index
+  //
+  numberOfDaughters++;
+  ImprintsCountPlus();
+
+  std::vector<G4AssemblyTriplet> triplets = pParentAssembly->fTriplets;
+  //cout << " Assembly:" << detail::tools::placementPath(chain) << endl;
+
+  for( unsigned int i = 0; i < triplets.size(); i++ )  {
+    const TGeoNode* node = pParentAssembly->m_entries[i];
+    Chain new_chain = chain;
+    new_chain.emplace_back(node);
+    //cout << " Assembly: Entry: " << detail::tools::placementPath(new_chain) << endl;
+
+    G4Transform3D Ta( *(triplets[i].GetRotation()), triplets[i].GetTranslation() );
+    if ( triplets[i].IsReflection() )  {
+      Ta = Ta * G4ReflectZ3D();
+    }
+    G4Transform3D Tfinal = transformation * Ta;
+    if ( triplets[i].GetVolume() )    {
+      // Generate the unique name for the next PV instance
+      // The name has format:
+      //
+      // av_WWW_impr_XXX_YYY_ZZZ
+      // where the fields mean:
+      // WWW - assembly volume instance number
+      // XXX - assembly volume imprint number
+      // YYY - the name of a log. volume we want to make a placement of
+      // ZZZ - the log. volume index inside the assembly volume
+      //
+      std::stringstream pvName;
+#if 0
+      pvName << "av_"
+             << GetAssemblyID()
+             << "_impr_"
+             << GetImprintsCount()
+             << "_"
+             << triplets[i].GetVolume()->GetName().c_str()
+             << "_pv_"
+             << i
+             << ends;
+#endif
+      pvName << "AV_"
+             << GetAssemblyID()
+             << '#'
+	     << parent->GetName()
+	     << ':'
+	     << parent->GetNumber()
+             << '#'
+             << m_entries[i]->GetName()
+             << ':'
+             << m_entries[i]->GetNumber()
+             << std::ends;
+      // Generate a new physical volume instance inside a mother
+      // (as we allow 3D transformation use G4ReflectionFactory to
+      //  take into account eventual reflection)
+      //
+#if 0
+      printout(INFO,"Geant4Converter","++ Place %svolume %s in assembly.",
+	       triplets[i].IsReflection() ? "REFLECTED " : "",
+	       detail::tools::placementPath(new_chain).c_str());
+#endif
+      G4PhysicalVolumesPair pvPlaced
+        = G4ReflectionFactory::Instance()->Place( Tfinal,
+                                                  pvName.str().c_str(),
+                                                  triplets[i].GetVolume(),
+                                                  pMotherLV,
+                                                  false,
+                                                  numberOfDaughters + i,
+                                                  surfCheck );
+
+      // Register the physical volume created by us so we can delete it later
+      //
+      //fPVStore.emplace_back( pvPlaced.first );
+      info.g4VolumeImprints[vol].emplace_back(new_chain,pvPlaced.first);
+#if 0
+      cout << " Assembly:Parent:" << parent->GetName() << " " << node->GetName()
+           << " " <<  (void*)node << " G4:" << pvName.str() << " Daughter:"
+           << detail::tools::placementPath(new_chain) << endl;
+      cout << endl;
+#endif
+
+      if ( pvPlaced.second )  {
+        G4Exception("Geant4AssemblyVolume::imprint(..)", "GeomVol0003", FatalException,
+                    "Fancy construct popping new mother from the stack!");
+        //fPVStore.emplace_back( pvPlaced.second );
+      }
+    }
+    else if ( triplets[i].GetAssembly() )  {
+      // Place volumes in this assembly with composed transformation
+      imprint(info, parent, new_chain, (Geant4AssemblyVolume*)triplets[i].GetAssembly(),
+              pMotherLV, Tfinal, i*100+copyNumBase, surfCheck );
+    }
+    else   {
+      --level;
+      G4Exception("Geant4AssemblyVolume::imprint(..)", "GeomVol0003", FatalException,
+                  "Triplet has no volume and no assembly");
+    }
+  }
+  //cout << "Imprinted assembly level:" << level << " in mother:" << pMotherLV->GetName() << endl;
+  --level;
+}

--- a/DDG4/src/Geant4Data.cpp
+++ b/DDG4/src/Geant4Data.cpp
@@ -92,7 +92,8 @@ Geant4HitData::Contribution Geant4HitData::extractContribution(const G4Step* ste
 
 /// Default constructor
 Geant4Tracker::Hit::Hit()
-: Geant4HitData(), position(), momentum(), length(0.0), truth(), energyDeposit(0.0) {
+: Geant4HitData(), position(), momentum(), length(0.0), truth(), energyDeposit(0.0)
+{
   InstanceCount::increment(this);
 }
 
@@ -107,15 +108,14 @@ Geant4Tracker::Hit::~Hit() {
   InstanceCount::decrement(this);
 }
 
-/// Assignment operator
-Geant4Tracker::Hit& Geant4Tracker::Hit::operator=(const Hit& c) {
+/// Explicit assignment operation
+void Geant4Tracker::Hit::copyFrom(const Hit& c) {
   if ( &c != this )  {
     position = c.position;
     momentum = c.momentum;
     length = c.length;
     truth = c.truth;
   }
-  return *this;
 }
 
 /// Clear hit content

--- a/DDG4/src/Geant4PhysicsList.cpp
+++ b/DDG4/src/Geant4PhysicsList.cpp
@@ -264,18 +264,17 @@ void Geant4PhysicsList::constructProcesses(G4VUserPhysicsList* physics_pointer) 
     if ( defs.empty() )  {
       except("Particle:%s Cannot find the corresponding entry in the particle table.", part_name.c_str());
     }
-    for ( G4ParticleDefinition* particle : defs )   {
-      G4ProcessManager* mgr = particle->GetProcessManager();
-      for ( const Process& p : procs )  {
-        if ( G4VProcess* g4 = PluginService::Create<G4VProcess*>(p.name) )   {
+    for ( const Process& p : procs )  {
+      if ( G4VProcess* g4 = PluginService::Create<G4VProcess*>(p.name) )   {
+	for ( G4ParticleDefinition* particle : defs )   {
+	  G4ProcessManager* mgr = particle->GetProcessManager();
 	  mgr->AddDiscreteProcess(g4);
 	  info("Particle:%s -> [%s] added discrete process %s", 
 	       part_name.c_str(), particle->GetParticleName().c_str(), p.name.c_str());
-	  continue;
 	}
-	except("Particle:%s -> [%s] Cannot create discrete physics process %s", 
-	       part_name.c_str(), particle->GetParticleName().c_str(), p.name.c_str());
+	continue;
       }
+      except("Cannot create discrete physics process %s", p.name.c_str());
     }
   }
   for ( const auto& [part_name, procs] : m_processes )   {
@@ -283,19 +282,18 @@ void Geant4PhysicsList::constructProcesses(G4VUserPhysicsList* physics_pointer) 
     if (defs.empty())  {
       except("Particle:%s Cannot find the corresponding entry in the particle table.", part_name.c_str());
     }
-    for ( G4ParticleDefinition* particle : defs )   {
-      G4ProcessManager* mgr = particle->GetProcessManager();
-      for ( const Process& p : procs )  {
-        if ( G4VProcess* g4 = PluginService::Create<G4VProcess*>(p.name) )   {
+    for ( const Process& p : procs )  {
+      if ( G4VProcess* g4 = PluginService::Create<G4VProcess*>(p.name) )   {
+	for ( G4ParticleDefinition* particle : defs )   {
+	  G4ProcessManager* mgr = particle->GetProcessManager();
 	  mgr->AddProcess(g4, p.ordAtRestDoIt, p.ordAlongSteptDoIt, p.ordPostStepDoIt);
 	  info("Particle:%s -> [%s] added process %s with flags (%d,%d,%d)", 
 	       part_name.c_str(), particle->GetParticleName().c_str(), p.name.c_str(),
 	       p.ordAtRestDoIt, p.ordAlongSteptDoIt, p.ordPostStepDoIt);
-	  continue;
 	}
-	except("Particle:%s -> [%s] Cannot create physics process %s", 
-	       part_name.c_str(), particle->GetParticleName().c_str(), p.name.c_str());
+	continue;
       }
+      except("Cannot create physics process %s", p.name.c_str());
     }
   }
 }

--- a/UtilityApps/src/display.cpp
+++ b/UtilityApps/src/display.cpp
@@ -18,11 +18,12 @@
 int main(int argc,char** argv)  {
   std::vector<const char*> av;
   std::string level, visopt, opt, detector;
-  bool dry = false;
+  bool dry = false, help = false;
   for(int i=0; i<argc; ++i)  {
     if ( i==1 && argv[i][0] != '-' ) av.emplace_back("-input");
-    if      ( strncmp(argv[i],"-load-only",4) == 0 ) dry = true, av.emplace_back(argv[i]);
-    else if ( strncmp(argv[i],"-dry-run",4)   == 0 ) dry = true, av.emplace_back(argv[i]);
+    if      ( strncmp(argv[i],"-load-only",4) == 0 ) dry  = true, av.emplace_back(argv[i]);
+    else if ( strncmp(argv[i],"-dry-run",4)   == 0 ) dry  = true, av.emplace_back(argv[i]);
+    else if ( strncmp(argv[i],"-help",4)      == 0 ) help = true, av.emplace_back(argv[i]);
     else if ( strncmp(argv[i],"-visopt",4)    == 0 ) visopt   = argv[++i];
     else if ( strncmp(argv[i],"-level", 4)    == 0 ) level    = argv[++i];
     else if ( strncmp(argv[i],"-option",4)    == 0 ) opt      = argv[++i];
@@ -33,6 +34,7 @@ int main(int argc,char** argv)  {
     av.emplace_back("-interactive");
     av.emplace_back("-plugin");
     av.emplace_back("DD4hep_GeometryDisplay");
+    if ( help              ) av.emplace_back("-help");
     if ( !opt.empty()      ) av.emplace_back("-opt"),      av.emplace_back(opt.c_str());
     if ( !level.empty()    ) av.emplace_back("-level"),    av.emplace_back(level.c_str());
     if ( !visopt.empty()   ) av.emplace_back("-visopt"),   av.emplace_back(visopt.c_str());

--- a/examples/DDG4_MySensDet/src/MyTrackerHit.cpp
+++ b/examples/DDG4_MySensDet/src/MyTrackerHit.cpp
@@ -18,12 +18,11 @@
 using namespace SomeExperiment;
 
 /// Assignment operator
-MyTrackerHit& MyTrackerHit::operator=(const MyTrackerHit& c)  {
+void MyTrackerHit::copyFrom(const MyTrackerHit& c)  {
   if ( &c != this )  {
-    this->dd4hep::sim::Geant4Tracker::Hit::operator=(c);
+    this->dd4hep::sim::Geant4Tracker::Hit::copyFrom(c);
     this->step_length = c.step_length;
     this->postPos = c.postPos;
     this->prePos = c.prePos;
   }
-  return *this;
 }

--- a/examples/DDG4_MySensDet/src/MyTrackerHit.h
+++ b/examples/DDG4_MySensDet/src/MyTrackerHit.h
@@ -52,7 +52,7 @@ namespace SomeExperiment {
     /// Default destructor
     virtual ~MyTrackerHit() = default;
     /// Assignment operator
-    MyTrackerHit& operator=(const MyTrackerHit& c);
+    void copyFrom(const MyTrackerHit& c);
   };
 
   /// Helper to dump data file


### PR DESCRIPTION
BEGINRELEASENOTES
- Disable copy and move construction/assignment in Geant4 data
  See issue https://github.com/AIDASoft/DD4hep/issues/807
- Adopt new naming convention for Geant4 assembly imprints
   See issue https://github.com/AIDASoft/DD4hep/issues/804
ENDRELEASENOTES