### PR TITLE
DDCore: move create_segmentation to header file so it can be used outside of DD4hep

### DIFF
--- a/DDCore/include/DD4hep/detail/SegmentationsInterna.h
+++ b/DDCore/include/DD4hep/detail/SegmentationsInterna.h
@@ -121,5 +121,13 @@ namespace dd4hep {
   /// Default destructor
   template <typename IMP> inline SegmentationWrapper<IMP>::~SegmentationWrapper()  {
   }
+
+  namespace {
+    template<typename T> SegmentationObject*
+    create_segmentation(const BitFieldCoder* decoder)  {
+      return new SegmentationWrapper<T>(decoder);
+    }
+  }
+
 }         /* End namespace dd4hep                       */
 #endif // DD4HEP_DETAIL_SEGMENTATIONSINTERNA_H

--- a/DDCore/src/plugins/ReadoutSegmentations.cpp
+++ b/DDCore/src/plugins/ReadoutSegmentations.cpp
@@ -18,13 +18,6 @@
 using namespace dd4hep;
 using namespace dd4hep::DDSegmentation;
 
-namespace {
-  template<typename T> dd4hep::SegmentationObject*
-  create_segmentation(const dd4hep::BitFieldCoder* decoder)  {
-    return new dd4hep::SegmentationWrapper<T>(decoder);
-  }
-}
-
 #include "DDSegmentation/NoSegmentation.h"
 DECLARE_SEGMENTATION(NoSegmentation,create_segmentation<dd4hep::DDSegmentation::NoSegmentation>)
 


### PR DESCRIPTION

@MarkusFrankATcernch as far as I can tell this is needed to be able to do

```c++
#include "DD4hep/detail/SegmentationsInterna.h"
//....
DECLARE_SEGMENTATION(GridDRcalo, create_segmentation<dd4hep::DDSegmentation::GridDRcalo>)
```

for #815 
So that the segmentation_constructor is created and part of the components file?


BEGINRELEASENOTES
- Move `create_segmentation` to DDCore/include/DD4hep/detail/SegmentationsInterna.h  to allow segmentation creation in other libraries

ENDRELEASENOTES