### PR TITLE
Propagate shape tags to shapes resulting from volume divisions. 

### DIFF
--- a/DDCAD/src/ASSIMPWriter.cpp
+++ b/DDCAD/src/ASSIMPWriter.cpp
@@ -65,11 +65,12 @@ namespace  {
     operator Tessellated::Vertex_t () const
     { return Tessellated::Vertex_t(x,y,z); }
   };
+#if 0
   vertex operator-(const vertex& v1, const vertex& v2)
   {  return vertex(v1.x-v2.x, v1.y-v2.y, v1.z-v2.z);   }
   vertex operator+(const vertex& v1, const vertex& v2)
   {  return vertex(v1.x+v2.x, v1.y+v2.y, v1.z+v2.z);   }
-
+#endif
 #if 0
       num_facet = tes->GetNfacets();
       int *nn = new int[num_facet];
@@ -214,7 +215,7 @@ int ASSIMPWriter::write(const std::string& file_name,
     if ( !tes.isValid() )   {
       typedef vertex vtx_t;
       unique_ptr<TBuffer3D> buf3D(v.solid()->MakeBuffer3D());
-      struct pol_t { int c, n; int segs[1]; } *pol;
+      struct pol_t { int c, n; int segs[1]; } *pol = nullptr;
       struct seg_t { int c, _1, _2;         };
       const  seg_t* segs = (seg_t*)buf3D->fSegs;
       const  vtx_t* vtcs = (vtx_t*)buf3D->fPnts;
@@ -230,7 +231,7 @@ int ASSIMPWriter::write(const std::string& file_name,
       tes = buf.get();
       q = buf3D->fPols;
       for( i=0, q=buf3D->fPols; i<buf3D->NbPols(); ++i)  {
-	pol_t* pol = (pol_t*)q;
+	pol = (pol_t*)q;
 	q += (2+pol->n);
 	for( int j=0; j < pol->n; j += 2 )   {
 	  /* ------------------------------------------------------------

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -65,6 +65,9 @@ namespace dd4hep {
   /// Output mesh vertices to string
   std::string toStringMesh(const TGeoShape* shape, int precision=2);
   
+  /// Retrieve tag name from shape type
+  std::string get_shape_tag(const TGeoShape* shape);
+  
   /// Access Shape dimension parameters (As in TGeo, but angles in radians rather than degrees)
   std::vector<double> get_shape_dimensions(TGeoShape* shape);
   

--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -493,7 +493,9 @@ namespace dd4hep {
    *   \ingroup DD4HEP_CORE
    */
   class VolumeMulti : public Volume   {
+    /// Import volume from pointer as a result of Solid->Divide()
     void verifyVolumeMulti();
+
   public:
     /// Default constructor
     VolumeMulti() = default;

--- a/DDCore/src/ShapeUtilities.cpp
+++ b/DDCore/src/ShapeUtilities.cpp
@@ -56,7 +56,7 @@ namespace dd4hep {
       return solid.isValid() && solid->IsA() == T::Class();
     }
   }
-  
+
   /// Type check of various shapes. Result like dynamic_cast. Compare with python's isinstance(obj,type)
   template <typename SOLID> bool isInstance(const Handle<TGeoShape>& solid)   {
     return check_shape_type<typename SOLID::Object>(solid);
@@ -185,6 +185,79 @@ namespace dd4hep {
     return sh && sh->IsA() == TGeoCompositeShape::Class()
       &&   sh->GetBoolNode()->GetBooleanOperator() == TGeoBoolNode::kGeoIntersection
       &&   ::strcmp(sh->GetTitle(), INTERSECTION_TAG) == 0;
+  }
+
+  /// Retrieve tag name from shape type
+  string get_shape_tag(const TGeoShape* sh)    {
+    if ( sh )    {
+      TClass* cl = sh->IsA();
+      if ( cl == TGeoShapeAssembly::Class() )
+        return SHAPELESS_TAG;
+      else if ( cl == TGeoBBox::Class() )
+        return BOX_TAG;
+      else if ( cl == TGeoHalfSpace::Class() )
+        return HALFSPACE_TAG;
+      else if ( cl == TGeoPgon::Class() )
+        return POLYHEDRA_TAG;
+      else if ( cl == TGeoPcon::Class() )
+        return POLYCONE_TAG;
+      else if ( cl == TGeoConeSeg::Class() )
+        return CONESEGMENT_TAG;
+      else if ( cl == TGeoCone::Class() )
+        return CONE_TAG;
+      else if ( cl == TGeoTube::Class() )
+        return TUBE_TAG;
+      else if ( cl == TGeoTubeSeg::Class() )
+        return TUBE_TAG;
+      else if ( cl == TGeoCtub::Class() )
+        return CUTTUBE_TAG;
+      else if ( cl == TGeoEltu::Class() )
+        return ELLIPTICALTUBE_TAG;
+      else if ( cl == TwistedTubeObject::Class() )
+        return TWISTEDTUBE_TAG;
+      else if ( cl == TGeoTrd1::Class() )
+        return TRD1_TAG;
+      else if ( cl == TGeoTrd2::Class() )
+        return TRD2_TAG;
+      else if ( cl == TGeoParaboloid::Class() )
+        return PARABOLOID_TAG;
+      else if ( cl == TGeoHype::Class() )
+        return HYPERBOLOID_TAG;
+      //else if ( cl == TGeoGtra::Class() )
+      //  return 
+      else if ( cl == TGeoTrap::Class() )
+        return TRAP_TAG;
+      else if ( cl == TGeoArb8::Class() )
+        return EIGHTPOINTSOLID_TAG;
+      else if ( cl == TGeoSphere::Class() )
+        return SPHERE_TAG;
+      else if ( cl == TGeoTorus::Class() )
+        return TORUS_TAG;
+      else if ( cl == TGeoXtru::Class() )
+        return EXTRUDEDPOLYGON_TAG;
+      else if ( cl == TGeoScaledShape::Class() )
+        return SCALE_TAG;
+#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
+      else if ( cl == TGeoTessellated::Class() )
+        return TESSELLATEDSOLID_TAG;
+#endif
+      else if (isA<TruncatedTube>(sh) )
+        return TRUNCATEDTUBE_TAG;
+      else if (isA<PseudoTrap>(sh) )
+        return PSEUDOTRAP_TAG;
+      else if ( isInstance<SubtractionSolid>(sh) )
+	return SUBTRACTION_TAG;
+      else if ( isInstance<UnionSolid>(sh) )
+	return UNION_TAG;
+      else if ( isInstance<IntersectionSolid>(sh) )
+	return INTERSECTION_TAG;
+      else
+        except("Solid","Failed to type of shape: %s [%s]",
+	       sh->GetName(), cl->GetName() );
+      return "";
+    }
+    except("Solid","Failed to access dimensions [Invalid handle].");
+    return "";
   }
 
   template <typename T> vector<double> dimensions(const TGeoShape* shape)    {
@@ -468,62 +541,62 @@ namespace dd4hep {
   template <> vector<double> dimensions<Solid>(const Handle<TGeoShape>& shape)   {
     if ( shape.ptr() )   {
       TClass* cl = shape->IsA();
-      if (cl == TGeoShapeAssembly::Class())
-        return dimensions<TGeoShapeAssembly>(shape.ptr());
-      else if (cl == TGeoBBox::Class())
-        return dimensions<TGeoBBox>(shape.ptr());
-      else if (cl == TGeoHalfSpace::Class())
-        return dimensions<TGeoHalfSpace>(shape.ptr());
-      else if (cl == TGeoPgon::Class())
-        return dimensions<TGeoPgon>(shape.ptr());
-      else if (cl == TGeoPcon::Class())
-        return dimensions<TGeoPcon>(shape.ptr());
-      else if (cl == TGeoConeSeg::Class())
-        return dimensions<TGeoConeSeg>(shape.ptr());
-      else if (cl == TGeoCone::Class())
-        return dimensions<TGeoCone>(shape.ptr());
-      else if (cl == TGeoTube::Class())
-        return dimensions<TGeoTube>(shape.ptr());
-      else if (cl == TGeoTubeSeg::Class())
-        return dimensions<TGeoTubeSeg>(shape.ptr());
-      else if (cl == TGeoCtub::Class())
-        return dimensions<TGeoCtub>(shape.ptr());
-      else if (cl == TGeoEltu::Class())
-        return dimensions<TGeoEltu>(shape.ptr());
-      else if (cl == TwistedTubeObject::Class())
-        return dimensions<TwistedTubeObject>(shape.ptr());
-      else if (cl == TGeoTrd1::Class())
-        return dimensions<TGeoTrd1>(shape.ptr());
-      else if (cl == TGeoTrd2::Class())
-        return dimensions<TGeoTrd2>(shape.ptr());
-      else if (cl == TGeoParaboloid::Class())
-        return dimensions<TGeoParaboloid>(shape.ptr());
-      else if (cl == TGeoHype::Class())
-        return dimensions<TGeoHype>(shape.ptr());
-      else if (cl == TGeoGtra::Class())
-        return dimensions<TGeoGtra>(shape.ptr());
-      else if (cl == TGeoTrap::Class())
-        return dimensions<TGeoTrap>(shape.ptr());
-      else if (cl == TGeoArb8::Class())
-        return dimensions<TGeoArb8>(shape.ptr());
-      else if (cl == TGeoSphere::Class())
-        return dimensions<TGeoSphere>(shape.ptr());
-      else if (cl == TGeoTorus::Class())
-        return dimensions<TGeoTorus>(shape.ptr());
-      else if (cl == TGeoXtru::Class())
-        return dimensions<TGeoXtru>(shape.ptr());
-      else if (cl == TGeoScaledShape::Class())
-        return dimensions<TGeoScaledShape>(shape.ptr());
+      if ( cl == TGeoShapeAssembly::Class() )
+        return dimensions<TGeoShapeAssembly>(shape.ptr() );
+      else if ( cl == TGeoBBox::Class() )
+        return dimensions<TGeoBBox>(shape.ptr() );
+      else if ( cl == TGeoHalfSpace::Class() )
+        return dimensions<TGeoHalfSpace>(shape.ptr() );
+      else if ( cl == TGeoPgon::Class() )
+        return dimensions<TGeoPgon>(shape.ptr() );
+      else if ( cl == TGeoPcon::Class() )
+        return dimensions<TGeoPcon>(shape.ptr() );
+      else if ( cl == TGeoConeSeg::Class() )
+        return dimensions<TGeoConeSeg>(shape.ptr() );
+      else if ( cl == TGeoCone::Class() )
+        return dimensions<TGeoCone>(shape.ptr() );
+      else if ( cl == TGeoTube::Class() )
+        return dimensions<TGeoTube>(shape.ptr() );
+      else if ( cl == TGeoTubeSeg::Class() )
+        return dimensions<TGeoTubeSeg>(shape.ptr() );
+      else if ( cl == TGeoCtub::Class() )
+        return dimensions<TGeoCtub>(shape.ptr() );
+      else if ( cl == TGeoEltu::Class() )
+        return dimensions<TGeoEltu>(shape.ptr() );
+      else if ( cl == TwistedTubeObject::Class() )
+        return dimensions<TwistedTubeObject>(shape.ptr() );
+      else if ( cl == TGeoTrd1::Class() )
+        return dimensions<TGeoTrd1>(shape.ptr() );
+      else if ( cl == TGeoTrd2::Class() )
+        return dimensions<TGeoTrd2>(shape.ptr() );
+      else if ( cl == TGeoParaboloid::Class() )
+        return dimensions<TGeoParaboloid>(shape.ptr() );
+      else if ( cl == TGeoHype::Class() )
+        return dimensions<TGeoHype>(shape.ptr() );
+      else if ( cl == TGeoGtra::Class() )
+        return dimensions<TGeoGtra>(shape.ptr() );
+      else if ( cl == TGeoTrap::Class() )
+        return dimensions<TGeoTrap>(shape.ptr() );
+      else if ( cl == TGeoArb8::Class() )
+        return dimensions<TGeoArb8>(shape.ptr() );
+      else if ( cl == TGeoSphere::Class() )
+        return dimensions<TGeoSphere>(shape.ptr() );
+      else if ( cl == TGeoTorus::Class() )
+        return dimensions<TGeoTorus>(shape.ptr() );
+      else if ( cl == TGeoXtru::Class() )
+        return dimensions<TGeoXtru>(shape.ptr() );
+      else if ( cl == TGeoScaledShape::Class() )
+        return dimensions<TGeoScaledShape>(shape.ptr() );
 #if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
-      else if (cl == TGeoTessellated::Class())
-        return dimensions<TGeoTessellated>(shape.ptr());
+      else if ( cl == TGeoTessellated::Class() )
+        return dimensions<TGeoTessellated>(shape.ptr() );
 #endif
-      else if (isA<TruncatedTube>(shape.ptr()))
+      else if (isA<TruncatedTube>(shape.ptr() ))
         return dimensions<TruncatedTube>(shape);
-      else if (isA<PseudoTrap>(shape.ptr()))
+      else if (isA<PseudoTrap>(shape.ptr() ))
         return dimensions<PseudoTrap>(shape);
-      else if (cl == TGeoCompositeShape::Class())
-        return dimensions<TGeoCompositeShape>(shape.ptr());
+      else if ( cl == TGeoCompositeShape::Class() )
+        return dimensions<TGeoCompositeShape>(shape.ptr() );
       else  {
         printout(ERROR,"Solid","Failed to access dimensions for shape of type:%s.",
                  cl->GetName());
@@ -1004,53 +1077,53 @@ namespace dd4hep {
     if ( shape.ptr() ) {
       TClass* cl = shape->IsA();
       Solid solid(shape);
-      if (cl == TGeoShapeAssembly::Class())
+      if ( cl == TGeoShapeAssembly::Class() )
         set_dimensions(ShapelessSolid(shape), params);
-      else if (cl == TGeoBBox::Class())
+      else if ( cl == TGeoBBox::Class() )
         set_dimensions(Box(shape), params);
-      else if (cl == TGeoHalfSpace::Class())
+      else if ( cl == TGeoHalfSpace::Class() )
         set_dimensions(HalfSpace(shape), params);
-      else if (cl == TGeoPcon::Class())
+      else if ( cl == TGeoPcon::Class() )
         set_dimensions(Polycone(shape), params);
-      else if (cl == TGeoConeSeg::Class())
+      else if ( cl == TGeoConeSeg::Class() )
         set_dimensions(ConeSegment(shape), params);
-      else if (cl == TGeoCone::Class())
+      else if ( cl == TGeoCone::Class() )
         set_dimensions(Cone(shape), params);
-      else if (cl == TGeoTube::Class())
+      else if ( cl == TGeoTube::Class() )
         set_dimensions(Tube(shape), params);
-      else if (cl == TGeoTubeSeg::Class())
+      else if ( cl == TGeoTubeSeg::Class() )
         set_dimensions(Tube(shape), params);
-      else if (cl == TGeoCtub::Class())
+      else if ( cl == TGeoCtub::Class() )
         set_dimensions(CutTube(shape), params);
-      else if (cl == TGeoEltu::Class())
+      else if ( cl == TGeoEltu::Class() )
         set_dimensions(EllipticalTube(shape), params);
-      else if (cl == TwistedTubeObject::Class())
+      else if ( cl == TwistedTubeObject::Class() )
         set_dimensions(TwistedTube(shape), params);
-      else if (cl == TGeoTrd1::Class())
+      else if ( cl == TGeoTrd1::Class() )
         set_dimensions(Trd1(shape), params);
-      else if (cl == TGeoTrd2::Class())
+      else if ( cl == TGeoTrd2::Class() )
         set_dimensions(Trd2(shape), params);
-      else if (cl == TGeoParaboloid::Class())
+      else if ( cl == TGeoParaboloid::Class() )
         set_dimensions(Paraboloid(shape), params);
-      else if (cl == TGeoHype::Class())
+      else if ( cl == TGeoHype::Class() )
         set_dimensions(Hyperboloid(shape), params);
-      else if (cl == TGeoSphere::Class())
+      else if ( cl == TGeoSphere::Class() )
         set_dimensions(Sphere(shape), params);
-      else if (cl == TGeoTorus::Class())
+      else if ( cl == TGeoTorus::Class() )
         set_dimensions(Torus(shape), params);
-      else if (cl == TGeoTrap::Class())
+      else if ( cl == TGeoTrap::Class() )
         set_dimensions(Trap(shape), params);
-      else if (cl == TGeoPgon::Class())
+      else if ( cl == TGeoPgon::Class() )
         set_dimensions(PolyhedraRegular(shape), params);
-      else if (cl == TGeoXtru::Class())
+      else if ( cl == TGeoXtru::Class() )
         set_dimensions(ExtrudedPolygon(shape), params);
-      else if (cl == TGeoArb8::Class())
+      else if ( cl == TGeoArb8::Class() )
         set_dimensions(EightPointSolid(shape), params);
 #if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
-      else if (cl == TGeoTessellated::Class())
+      else if ( cl == TGeoTessellated::Class() )
         set_dimensions(TessellatedSolid(shape), params);
 #endif
-      else if (cl == TGeoScaledShape::Class())  {
+      else if ( cl == TGeoScaledShape::Class() )  {
         TGeoScaledShape* sh = (TGeoScaledShape*) shape.ptr();
         set_dimensions(sh, params);
       }
@@ -1067,7 +1140,7 @@ namespace dd4hep {
       else if ( isA<BooleanSolid>(solid) )
         set_dimensions(BooleanSolid(shape), params);
       else
-        printout(ERROR,"Solid","Failed to set dimensions for shape of type:%s.",cl->GetName());
+        printout(ERROR,"Solid","Failed to set dimensions for shape of type:%s.",cl->GetName() );
       return;
     }
     except("Solid","set_shape_dimensions: Failed to set dimensions [Invalid handle].");
@@ -1103,21 +1176,21 @@ namespace dd4hep {
           << " y:" << sh->GetDY()
           << " z:" << sh->GetDZ();
     }
-    else if (cl == TGeoHalfSpace::Class()) {
+    else if ( cl == TGeoHalfSpace::Class() ) {
       TGeoHalfSpace* sh = (TGeoHalfSpace*)(const_cast<TGeoShape*>(shape));
       log << " Point:  (" << sh->GetPoint()[0] << ", " << sh->GetPoint()[1] << ", " << sh->GetPoint()[2] << ") " 
           << " Normal: (" << sh->GetNorm()[0]  << ", " << sh->GetNorm()[1]  << ", " << sh->GetNorm()[2]  << ") ";
     }
-    else if (cl == TGeoTube::Class()) {
+    else if ( cl == TGeoTube::Class() ) {
       const TGeoTube* sh = (const TGeoTube*) shape;
       log << " rmin:" << sh->GetRmin() << " rmax:" << sh->GetRmax() << " dz:" << sh->GetDz();
     }
-    else if (cl == TGeoTubeSeg::Class()) {
+    else if ( cl == TGeoTubeSeg::Class() ) {
       const TGeoTubeSeg* sh = (const TGeoTubeSeg*) shape;
       log << " rmin:" << sh->GetRmin() << " rmax:" << sh->GetRmax() << " dz:" << sh->GetDz()
           << " Phi1:" << sh->GetPhi1() << " Phi2:" << sh->GetPhi2();
     }
-    else if (cl == TGeoCtub::Class()) {
+    else if ( cl == TGeoCtub::Class() ) {
       const TGeoCtub* sh = (const TGeoCtub*) shape;
       const Double_t*	hi = sh->GetNhigh();
       const Double_t*	lo = sh->GetNlow();
@@ -1126,31 +1199,31 @@ namespace dd4hep {
           << " lx:" << lo[0] << " ly:" << lo[1] << " lz:" << lo[2]
           << " hx:" << hi[0] << " hy:" << hi[1] << " hz:" << hi[2];
     }
-    else if (cl == TGeoEltu::Class()) {
+    else if ( cl == TGeoEltu::Class() ) {
       const TGeoEltu* sh = (const TGeoEltu*) shape;
       log << " A:" << sh->GetA() << " B:" << sh->GetB() << " dz:" << sh->GetDz();
     }
-    else if (cl == TGeoTrd1::Class()) {
+    else if ( cl == TGeoTrd1::Class() ) {
       const TGeoTrd1* sh = (const TGeoTrd1*) shape;
       log << " x1:" << sh->GetDx1() << " x2:" << sh->GetDx2() << " y:" << sh->GetDy() << " z:" << sh->GetDz();
     }
-    else if (cl == TGeoTrd2::Class()) {
+    else if ( cl == TGeoTrd2::Class() ) {
       const TGeoTrd2* sh = (const TGeoTrd2*) shape;
       log << " x1:" << sh->GetDx1() << " x2:" << sh->GetDx2()
           << " y1:" << sh->GetDy1() << " y2:" << sh->GetDy2() << " z:" << sh->GetDz();
     }
-    else if (cl == TGeoTrap::Class()) {
+    else if ( cl == TGeoTrap::Class() )   {
       const TGeoTrap* sh = (const TGeoTrap*) shape;
       log << " dz:" << sh->GetDz() << " Theta:" << sh->GetTheta() << " Phi:" << sh->GetPhi()
           << " H1:" << sh->GetH1() << " Bl1:"   << sh->GetBl1()   << " Tl1:" << sh->GetTl1() << " Alpha1:" << sh->GetAlpha1()
           << " H2:" << sh->GetH2() << " Bl2:"   << sh->GetBl2()   << " Tl2:" << sh->GetTl2() << " Alpha2:" << sh->GetAlpha2();
     }
-    else if (cl == TGeoHype::Class()) {
+    else if ( cl == TGeoHype::Class() )   {
       const TGeoHype* sh = (const TGeoHype*) shape;
       log << " rmin:" << sh->GetRmin() << " rmax:"  << sh->GetRmax() << " dz:" << sh->GetDz()
           << " StIn:" << sh->GetStIn() << " StOut:" << sh->GetStOut();
     }
-    else if (cl == TGeoPgon::Class()) {
+    else if ( cl == TGeoPgon::Class() )   {
       const TGeoPgon* sh = (const TGeoPgon*) shape;
       log << " Phi1:"   << sh->GetPhi1()   << " dPhi:" << sh->GetDphi()
           << " NEdges:" << sh->GetNedges() << " Nz:" << sh->GetNz();
@@ -1159,7 +1232,7 @@ namespace dd4hep {
             << " r:[" << sh->GetRmin(i) << "," << sh->GetRmax(i) << "]";
       }
     }
-    else if (cl == TGeoPcon::Class()) {
+    else if ( cl == TGeoPcon::Class() )  {
       const TGeoPcon* sh = (const TGeoPcon*) shape;
       log << " Phi1:" << sh->GetPhi1() << " dPhi:" << sh->GetDphi() << " Nz:" << sh->GetNz();
       for(int i=0, n=sh->GetNz(); i<n; ++i)  {
@@ -1167,35 +1240,35 @@ namespace dd4hep {
             << " r:[" << sh->GetRmin(i) << "," << sh->GetRmax(i) << "]";
       }
     }
-    else if (cl == TGeoCone::Class()) {
+    else if ( cl == TGeoCone::Class() )  {
       const TGeoCone* sh = (const TGeoCone*) shape;
       log << " rmin1:" << sh->GetRmin1() << " rmax1:" << sh->GetRmax1()
           << " rmin2:" << sh->GetRmin2() << " rmax2:" << sh->GetRmax2()
           << " dz:"    << sh->GetDz();
     }
-    else if (cl == TGeoConeSeg::Class()) {
+    else if ( cl == TGeoConeSeg::Class() )  {
       const TGeoConeSeg* sh = (const TGeoConeSeg*) shape;
       log << " rmin1:" << sh->GetRmin1() << " rmax1:" << sh->GetRmax1()
           << " rmin2:" << sh->GetRmin2() << " rmax2:" << sh->GetRmax2()
           << " dz:"    << sh->GetDz()
           << " Phi1:"  << sh->GetPhi1() << " Phi2:" << sh->GetPhi2();
     }
-    else if (cl == TGeoParaboloid::Class()) {
+    else if ( cl == TGeoParaboloid::Class() )  {
       const TGeoParaboloid* sh = (const TGeoParaboloid*) shape;
       log << " dz:" << sh->GetDz() << " RLo:" << sh->GetRlo() << " Rhi:" << sh->GetRhi();
     }
-    else if (cl == TGeoSphere::Class()) {
+    else if ( cl == TGeoSphere::Class() )   {
       const TGeoSphere* sh = (const TGeoSphere*) shape;
       log << " rmin:" << sh->GetRmin() << " rmax:" << sh->GetRmax()
           << " Phi1:" << sh->GetPhi1() << " Phi2:" << sh->GetPhi2()
           << " Theta1:" << sh->GetTheta1() << " Theta2:" << sh->GetTheta2();
     }
-    else if (cl == TGeoTorus::Class()) {
+    else if ( cl == TGeoTorus::Class() )   {
       const TGeoTorus* sh = (const TGeoTorus*) shape;
       log << " rmin:" << sh->GetRmin() << " rmax:" << sh->GetRmax() << " r:" << sh->GetR()
           << " Phi1:" << sh->GetPhi1() << " dPhi:" << sh->GetDphi();
     }
-    else if (cl == TGeoArb8::Class()) {
+    else if ( cl == TGeoArb8::Class() )   {
       TGeoArb8* sh = (TGeoArb8*) shape;
       const Double_t* v = sh->GetVertices();
       log << " dz:" << sh->GetDz();
@@ -1204,7 +1277,7 @@ namespace dd4hep {
         log << " y[" << i << "]:" << *v; ++v;
       }
     }
-    else if (cl == TGeoXtru::Class()) {
+    else if ( cl == TGeoXtru::Class() )   {
       const TGeoXtru* sh = (const TGeoXtru*) shape;
       log << " X:   " << sh->GetX(0)
           << " Y:   " << sh->GetY(0)
@@ -1214,7 +1287,7 @@ namespace dd4hep {
           << " Nvtx:" << sh->GetNvert()
           << " Nz:  " << sh->GetNz();
     }
-    else if (shape->IsA() == TGeoCompositeShape::Class()) {
+    else if (shape->IsA() == TGeoCompositeShape::Class() )   {
       const TGeoCompositeShape* sh = (const TGeoCompositeShape*) shape;
       const TGeoBoolNode* boolean = sh->GetBoolNode();
       const TGeoShape* left  = boolean->GetLeftShape();

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -104,10 +104,15 @@ Solid_type<T>::divide(const Volume& voldiv, const string& divname,
                       int iaxis, int ndiv, double start, double step)   const {
   T* p = this->ptr();
   if ( p )  {
-    VolumeMulti mv(p->Divide(voldiv.ptr(), divname.c_str(), iaxis, ndiv, start, step));
-    return mv.ptr();
+    auto* pdiv = p->Divide(voldiv.ptr(), divname.c_str(), iaxis, ndiv, start, step);
+    if ( pdiv )   {
+      VolumeMulti mv(pdiv);
+      return mv.ptr();
+    }
+    except("dd4hep","Volume: Failed to divide volume %s -> %s [Invalid result]",
+	   voldiv.name(), divname.c_str());
   }
-  except("dd4hep","Volume: Attempt to divide an invalid logical volume.");
+  except("dd4hep","Volume: Attempt to divide an invalid logical volume to %s.", divname.c_str());
   return 0;
 }
 

--- a/DDG4/include/DDG4/Geant4AssemblyVolume.h
+++ b/DDG4/include/DDG4/Geant4AssemblyVolume.h
@@ -13,10 +13,10 @@
 #ifndef DDG4_GEANT4ASSEMBLYVOLUME_H
 #define DDG4_GEANT4ASSEMBLYVOLUME_H
 
-// ROOT includes
+/// ROOT includes
 #include "TGeoNode.h"
 
-// Geant4 include files
+/// Geant4 include files
 #include "G4AssemblyVolume.hh"
 
 /// C/C++ include files
@@ -29,6 +29,7 @@ namespace dd4hep {
   namespace sim {
 
     /// Forward declarations
+    class Geant4Converter;
     class Geant4GeometryInfo;
     
     /// Hack! Wrapper around G4AssemblyVolume to access protected members.
@@ -59,21 +60,20 @@ namespace dd4hep {
       Geant4AssemblyVolume& operator=(const Geant4AssemblyVolume& copy) = delete;
       /// Default destructor
       virtual ~Geant4AssemblyVolume();
-      
+      /// Place logical daughter volume into the assembly
       long placeVolume(const TGeoNode* n, G4LogicalVolume* pPlacedVolume, G4Transform3D& transformation);
-      
+      /// Place daughter assembly into the assembly      
       long placeAssembly(const TGeoNode* n, Geant4AssemblyVolume* pPlacedVolume, G4Transform3D& transformation);
-      
-      void imprint(Geant4GeometryInfo& info,
-                   const TGeoNode* n,
-                   Chain chain,
-                   Geant4AssemblyVolume* pAssembly,
-                   G4LogicalVolume*  pMotherLV,
-                   G4Transform3D&    transformation,
-                   G4int copyNumBase,
-                   G4bool surfCheck );
+      /// Expand all daughter placements and expand the contained assemblies to imprints
+      void imprint(const Geant4Converter& cnv,
+                   const TGeoNode*        n,
+                   Chain                  chain,
+                   Geant4AssemblyVolume*  pAssembly,
+                   G4LogicalVolume*       pMotherLV,
+                   G4Transform3D&         transformation,
+                   G4int                  copyNumBase,
+                   G4bool                 surfCheck );
     };
   }
 }
-
 #endif

--- a/DDG4/src/Geant4AssemblyVolume.cpp
+++ b/DDG4/src/Geant4AssemblyVolume.cpp
@@ -91,14 +91,16 @@ void Geant4AssemblyVolume::imprint(const Geant4Converter& cnv,
 	   "Geant4Converter","++ Assembly: %s", detail::tools::placementPath(chain).c_str());
   std::vector<G4AssemblyTriplet>::iterator iter = par_ass->GetTripletsIterator();
   for( unsigned int i = 0, n = par_ass->TotalTriplets(); i < n; i++, iter++ )  {
-    Chain new_chain = chain;
-    const auto& triplet = *iter;
-    const TGeoNode* node = pParentAssembly->m_entries[i];
+    Chain            new_chain = chain;
+    const auto&        triplet = *iter;
+    const TGeoNode*       node = pParentAssembly->m_entries[i];
     Geant4AssemblyVolume* avol = pParentAssembly->m_places[i];
-
+    std::string           path;
+    
     new_chain.emplace_back(node);
-    printout(cnv.debugPlacements ? ALWAYS : DEBUG,
-	     " Assembly: Entry: %s",detail::tools::placementPath(new_chain).c_str());
+
+    path = detail::tools::placementPath(new_chain);
+    printout(cnv.debugPlacements ? ALWAYS : DEBUG, " Assembly: Entry: %s", path.c_str());
 
     G4Transform3D Ta( *(triplet.GetRotation()), triplet.GetTranslation() );
     if ( triplet.IsReflection() )  {
@@ -141,22 +143,17 @@ void Geant4AssemblyVolume::imprint(const Geant4Converter& cnv,
                                                   numberOfDaughters + i,
                                                   surfCheck );
 
-      // Register the physical volume created by us so we can delete it later
-      //
-      //fPVStore.emplace_back( pvPlaced.first );
       info.g4VolumeImprints[vol].emplace_back(new_chain,pvPlaced.first);
       printout(cnv.debugPlacements ? ALWAYS : DEBUG,
-	       "Geant4Converter","++ Place %svolume %s in assembly.",
-	       triplet.IsReflection() ? "REFLECTED " : "",
-	       detail::tools::placementPath(new_chain).c_str());
+	       "Geant4Converter", "++ Place %svolume %s in assembly.",
+	       triplet.IsReflection() ? "REFLECTED " : "", path.c_str());
       printout(cnv.debugPlacements ? ALWAYS : DEBUG,
-	       "Geant4Converter"," Assembly:Parent: %s %s %p G4:%s Daughter: %s",
-	       parent->GetName(), node->GetName(), (void*)node, pvName.str().c_str(),
-	       detail::tools::placementPath(new_chain).c_str());
+	       "Geant4Converter", " Assembly:Parent: %s %s %p G4:%s",
+	       parent->GetName(), node->GetName(),
+	       (void*)node, pvName.str().c_str());
       if ( pvPlaced.second )  {
         G4Exception("Geant4AssemblyVolume::imprint(..)", "GeomVol0003", FatalException,
                     "Fancy construct popping new mother from the stack!");
-        //fPVStore.emplace_back( pvPlaced.second );
       }
     }
     else if ( triplet.GetAssembly() )  {

--- a/DDG4/src/Geant4AssemblyVolume.cpp
+++ b/DDG4/src/Geant4AssemblyVolume.cpp
@@ -78,6 +78,7 @@ void Geant4AssemblyVolume::imprint(const Geant4Converter& cnv,
     static void imprintsCountPlus(G4AssemblyVolume* p)
     {  _Wrap* w = (_Wrap*)p; w->ImprintsCountPlus(); }
   };
+  std::string       path;
   TGeoVolume*       vol = parent->GetVolume();
   G4AssemblyVolume* par_ass = pParentAssembly->m_assembly;
   Geant4GeometryInfo&  info = cnv.data();
@@ -87,20 +88,20 @@ void Geant4AssemblyVolume::imprint(const Geant4Converter& cnv,
   numberOfDaughters++;
   _Wrap::imprintsCountPlus(par_ass);
 
-  printout(cnv.debugPlacements ? ALWAYS : DEBUG,
-	   "Geant4Converter","++ Assembly: %s", detail::tools::placementPath(chain).c_str());
+  path = detail::tools::placementPath(chain);
+  printout(cnv.debugPlacements ? ALWAYS : DEBUG, "Geant4Converter",
+	   "++ Assembly: %s", path.c_str());
   std::vector<G4AssemblyTriplet>::iterator iter = par_ass->GetTripletsIterator();
   for( unsigned int i = 0, n = par_ass->TotalTriplets(); i < n; i++, iter++ )  {
     Chain            new_chain = chain;
     const auto&        triplet = *iter;
     const TGeoNode*       node = pParentAssembly->m_entries[i];
     Geant4AssemblyVolume* avol = pParentAssembly->m_places[i];
-    std::string           path;
     
     new_chain.emplace_back(node);
-
     path = detail::tools::placementPath(new_chain);
-    printout(cnv.debugPlacements ? ALWAYS : DEBUG, " Assembly: Entry: %s", path.c_str());
+    printout(cnv.debugPlacements ? ALWAYS : DEBUG, "Geant4Converter",
+	     " Assembly: Entry: %s", path.c_str());
 
     G4Transform3D Ta( *(triplet.GetRotation()), triplet.GetTranslation() );
     if ( triplet.IsReflection() )  {

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -773,7 +773,7 @@ void* Geant4Converter::handlePlacement(const string& name, const TGeoNode* node)
         Geant4AssemblyVolume* ass = (Geant4AssemblyVolume*)info.g4AssemblyVolumes[node];
         Geant4AssemblyVolume::Chain chain;
         chain.emplace_back(node);
-        ass->imprint(info, node, chain, ass, (*volIt).second, transform, copy, checkOverlaps);
+        ass->imprint(*this, node, chain, ass, (*volIt).second, transform, copy, checkOverlaps);
         return nullptr;
       }
       else if ( node != info.manager->GetTopNode() && volIt == info.g4Volumes.end() )  {

--- a/examples/ClientTests/src/VolumeDivisionTest_geo.cpp
+++ b/examples/ClientTests/src/VolumeDivisionTest_geo.cpp
@@ -28,18 +28,36 @@ static Ref_t create_element(Detector& description, xml_h xml_det, SensitiveDetec
   Box          box(100, 100, 100);
   Volume       vol(det_name+"_vol", box, description.air());
   DetElement   det(det_name,x_det.typeStr(), x_det.id());
+  TGeoVolumeMulti* mvol;
   VolumeMulti  mv;
 
-  mv = box.divide(vol.ptr(), "Div", 1, 3, -100, 10);
-  printout(ALWAYS,"VolumeMultiTester","+++ VolumeMulti %p",mv.ptr());
-  printout(ALWAYS,"VolumeMultiTester","+++ VolumeMulti %s",mv.name());
-  printout(ALWAYS,"VolumeMultiTester","+++ VolumeMulti %s",mv->IsA()->GetName());
+  mv = box.divide(vol.ptr(), "Div1", 1, 3, -100, 10);
+  printout(ALWAYS, "VolumeMultiTester", "+++ VolumeMulti %p type: %s [%s] solid: %p",
+	   mv.ptr(), mv.name(), mv->IsA()->GetName(), mv.solid().ptr());
+  // printout(ALWAYS, "VolumeMultiTester", "+++ VolumeMulti %s", mv.solid().name());
+  // printout(ALWAYS, "VolumeMultiTester", "+++ VolumeMulti %s", mv.solid().type());
+  mvol = (TGeoVolumeMulti*)mv.ptr();
+  for( int i=0, n=mvol->GetNvolumes(); i<n; ++i )   {
+    Volume vv = mvol->GetVolume(i);
+    printout(ALWAYS, "VolumeMultiTester",
+	     "+++ Volume[%03d] %p name: %s [%s] solid: %s tag: '%s'",
+	     i, vv.ptr(), vv.name(), vv->IsA()->GetName(),
+	     vv.solid().type(), vv.solid()->GetTitle());
+  }
 
-  mv = box.divide(vol.ptr(), "Div2", 1, 3, 0, 50);
-  printout(ALWAYS,"VolumeMultiTester","+++ VolumeMulti %p",mv.ptr());
-  printout(ALWAYS,"VolumeMultiTester","+++ VolumeMulti %s",mv.name());
-  printout(ALWAYS,"VolumeMultiTester","+++ VolumeMulti %s",mv->IsA()->GetName());
-
+  mv = box.divide(vol.ptr(), "Div2", 1, 3,    0, 50);
+  printout(ALWAYS, "VolumeMultiTester", "+++ VolumeMulti %p type: %s [%s] solid: %p",
+	   mv.ptr(), mv.name(), mv->IsA()->GetName(), mv.solid().ptr());
+  // printout(ALWAYS, "VolumeMultiTester", "+++ VolumeMulti %s", mv.solid().name());
+  // printout(ALWAYS, "VolumeMultiTester", "+++ VolumeMulti %s", mv.solid().type());
+  mvol = (TGeoVolumeMulti*)mv.ptr();
+  for( int i=0, n=mvol->GetNvolumes(); i<n; ++i )   {
+    Volume vv = mvol->GetVolume(i);
+    printout(ALWAYS, "VolumeMultiTester",
+	     "+++ Volume[%03d] %p name: %s [%s] solid: %s tag: '%s'",
+	     i, vv.ptr(), vv.name(), vv->IsA()->GetName(),
+	     vv.solid().type(), vv.solid()->GetTitle());
+  }
   PlacedVolume pv = description.pickMotherVolume(det).placeVolume(vol);
   pv.addPhysVolID("system",x_det.id());
   det.setPlacement(pv);


### PR DESCRIPTION
BEGINRELEASENOTES
- On divisions the created solids did not carry the proper tag to identify them.
  This PR fixes this issue when multi-volumes are imported in dd4hep.
  See issue https://github.com/AIDASoft/DD4hep/issues/833

ENDRELEASENOTES