### PR TITLE
Do not propagate CMAKE_BUILD_TYPE in DD4hepConfig.cmake

### DIFF
--- a/cmake/DD4hepConfig.cmake.in
+++ b/cmake/DD4hepConfig.cmake.in
@@ -43,11 +43,6 @@ set (CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH} ${@CMAKE_PROJECT_NAME@_DIR}/cmake  
 # ---------- include dirs -----------------------------------------------------
 set(@CMAKE_PROJECT_NAME@_INCLUDE_DIRS "")
 
-# ---------- default build type  --------------------------------------------------------
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  set (CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "One of: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
-endif()
-
 
 FIND_DEPENDENCY(Boost REQUIRED)
 DD4HEP_SETUP_BOOST_TARGETS()


### PR DESCRIPTION
BEGINRELEASENOTES
- Do not propagate CMAKE_BUILD_TYPE in DD4hepConfig.cmake

ENDRELEASENOTES
Resolves #839 