### PR TITLE
Enable C to avoid cmake problems in certain environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ ENDIF()
 #############################################################
 
 ENABLE_LANGUAGE(CXX)
+ENABLE_LANGUAGE(C)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard used for compiling")


### PR DESCRIPTION

BEGINRELEASENOTES
- Explicitly enable `C` as language to avoid problems in the build file generation step of cmake (see spack/spack#24232)

ENDRELEASENOTES