### PR TITLE
Added VisAttr ref extension compact construction

### DIFF
--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -831,8 +831,8 @@ template <> void Converter<VisAttr>::operator()(xml_h e) const {
     if(!refAttr.isValid() )  {
         throw runtime_error("reference VisAttr " + refName + " does not exist");
     }
-    // Not sure if there is an easy deep copy constructor
-    // Just copying things manually
+    // Just copying things manually.
+    // I think a handle's copy constructor/assignment would reuse the underlying pointer... maybe?
     refAttr.argb(alpha,red,green,blue);
     attr.setColor(alpha,red,green,blue);
     attr.setDrawingStyle( refAttr.drawingStyle());

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -825,7 +825,9 @@ template <> void Converter<VisAttr>::operator()(xml_h e) const {
   float red   = 1.0;
   float green = 1.0;
   float blue  = 1.0;
+  bool use_ref = false;
   if(e.hasAttr(_U(ref))) {
+    use_ref = true;
     auto refName = e.attr<string>(_U(ref));
     const auto refAttr = description.visAttributes(refName);
     if(!refAttr.isValid() )  {
@@ -860,7 +862,8 @@ template <> void Converter<VisAttr>::operator()(xml_h e) const {
       attr.setLineStyle(VisAttr::DASHED);
   }
   else {
-    attr.setLineStyle(VisAttr::SOLID);
+    if (!use_ref)
+      attr.setLineStyle(VisAttr::SOLID);
   }
   if (e.hasAttr(_U(drawingStyle))) {
     string ds = e.attr<string>(_U(drawingStyle));
@@ -870,12 +873,15 @@ template <> void Converter<VisAttr>::operator()(xml_h e) const {
       attr.setDrawingStyle(VisAttr::SOLID);
   }
   else {
-    attr.setDrawingStyle(VisAttr::SOLID);
+    if (!use_ref)
+      attr.setDrawingStyle(VisAttr::SOLID);
   }
   if (e.hasAttr(_U(showDaughters)))
     attr.setShowDaughters(e.attr<bool>(_U(showDaughters)));
-  else
-    attr.setShowDaughters(true);
+  else {
+    if (!use_ref)
+      attr.setShowDaughters(true);
+  }
   description.addVisAttribute(attr);
 }
 


### PR DESCRIPTION
Closes https://github.com/AIDASoft/DD4hep/issues/841

BEGINRELEASENOTES
 - Using `ref="OtherVisName"` attribute with the `vis` tag, the visualization attribute is an extension of
`"OtherVisName"` which is used to initialize the new vis attribute.
 - The new VisAttr inherits all the properties  of the ref and additional arguments override these values.

Example where the only difference is the `alpha` value.

```
  <vis name="SiVertexBarrelModuleVis"
       alpha="1.0" r="1.0" g="0.75" b="0.76"
       drawingStyle="wireframe"
       showDaughters="false"
       visible="true"/>

  <vis name="SiVertexEndcapModuleVis"
       ref="SiVertexBarrelModuleVis"
       alpha="0.5"/>
```
ENDRELEASENOTES


