### PR TITLE
WIP: Added DD4POD output datamodel and plugin

### DIFF
--- a/DDG4/dd4pod/CMakeLists.txt
+++ b/DDG4/dd4pod/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+
+message(" ======================= ")
+message(" ${podio_INCLUDE_DIR}")
+find_package(podio )
+#if(NOT podio_FOUND)
+
+if(DD4HEP_BUILD_DD4POD AND podio_FOUND) 
+
+set(dd4pod_include_dir ${CMAKE_CURRENT_BINARY_DIR})
+set(dd4pod_source_dir ${CMAKE_CURRENT_BINARY_DIR}/src)
+PODIO_GENERATE_DATAMODEL(dd4pod dd4hep.yaml headers sources OUTPUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR})
+
+add_library(DD4pod SHARED ${sources})
+
+target_link_libraries(DD4POD
+  PUBLIC podio::podio
+  PUBLIC podio::podioRootIO
+  PUBLIC DD4hep::DDCore
+  PUBLIC DD4hep::DDG4
+  )
+target_include_directories(DD4POD
+  PUBLIC  ${podio_INCLUDE_DIR}
+  PUBLIC $<BUILD_INTERFACE:${dd4pod_include_dir}>
+  $<INSTALL_INTERFACE:include>)
+
+target_compile_features(DD4pod
+  PUBLIC cxx_auto_type
+  PUBLIC cxx_trailing_return_types
+  PRIVATE cxx_variadic_templates
+  PRIVATE cxx_std_17)
+
+message("headers: ${headers}")
+PODIO_GENERATE_DICTIONARY(DD4POD ${headers} 
+  SELECTION ${dd4pod_source_dir}/selection.xml
+  OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}DD4pod${CMAKE_SHARED_LIBRARY_SUFFIX}
+  )
+set_target_properties(DD4POD-dictgen PROPERTIES EXCLUDE_FROM_ALL TRUE)
+target_sources(DD4POD PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/DD4POD.cxx)
+
+dd4hep_add_plugin(DD4PODIO
+    SOURCES 
+    plugins/Geant4Output2Podio.cxx
+    NOINSTALL
+    )
+target_link_libraries(DD4PODIO
+  PUBLIC DD4POD
+  #PUBLIC DDG4_PIDsdet
+  )
+target_include_directories(DD4pod
+  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/plugins>
+  )
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dd4pod
+  DESTINATION include
+  FILES_MATCHING PATTERN *.h
+  )
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/DD4PODDict.rootmap"
+  "${CMAKE_CURRENT_BINARY_DIR}/libDD4POD_rdict.pcm"
+  DESTINATION lib)
+
+
+install(TARGETS DD4pod DD4podIO
+  EXPORT DDhep
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  INCLUDES DESTINATION include
+  )
+
+endif()
+

--- a/DDG4/dd4pod/dd4hep.yaml
+++ b/DDG4/dd4pod/dd4hep.yaml
@@ -1,0 +1,125 @@
+---
+options :
+  # should getters / setters be prefixed with get / set?
+  getSyntax: False
+  # should POD members be exposed with getters/setters in classes that have them as members?
+  exposePODMembers: False
+  includeSubfolder: True
+
+components:
+  dd4pod::ThreeVector:
+    Members:
+      - double x
+      - double y
+      - double z
+
+  dd4pod::FourVector :
+    Members :
+      - double x
+      - double y
+      - double z
+      - double t
+
+
+  dd4pod::MonteCarloContrib:
+    #Description: "Podio implementation of dd4hep's dd4hep::sim::MonteCarloContrib class"
+    #Author : "W.Armstrong"
+    Members:
+      - int    trackID // track id
+      - int    pdgID   // pdgID
+      - double deposit // en deposit
+      - double time    // time
+      - double length  // length
+      - double x       // x
+      - double y       // x
+      - double z       // x
+
+datatypes :
+
+  dd4pod::Geant4Particle:
+    Description: "Podio implementation of dd4hep's dd4hep::sim::Geant4Particle class"
+    Author : "W.Armstrong"
+    Members:
+      - int ID          // x
+      - int g4Parent    // x
+      - int reason      // x
+      - int mask        // x
+      - int steps       // x
+      - int secondaries // x
+      - int pdgID       // x
+      - int status      // x
+      - std::array<int,2> colorFlow // x
+      - int  genStatus // x
+      - int  charge    // x
+      - std::array<int,1> spare    // x
+      - std::array<float,3>  spin  // x
+      - double vsx   // x startpoint
+      - double vsy   // y startpoint
+      - double vsz   // z startpoint
+      - double vex   // x endpoint
+      - double vey   // y endpoint
+      - double vez   // z endpoint
+      - double psx   // px at startpoint
+      - double psy   // py at startpoint 
+      - double psz   // pz at startpoint 
+      - double pex   // px at endpoint
+      - double pey   // py at endpoint
+      - double pez   // pz at endpoint 
+      - double mass  // mass [GeV]
+      - double time  // time [ns]
+      - double properTime // x
+    VectorMembers:
+      - int parents    // parent ids
+      - int daughters  // daughter ids
+        #    OneToManyRelations:
+        #- dd4pod::Geant4Particle parents  // x
+        #- dd4pod::Geant4Particle daughters  // x
+    ExtraCode :
+      declaration: "
+      double Px()  const {return psx();}\n
+      double Py()  const {return psy();}\n
+      double Pz()  const {return psz();}\n
+      double Px2() const {return psx()*psx();}\n
+      double Py2() const {return psy()*psy();}\n
+      double Pz2() const {return psz()*psz();}\n
+      //ROOT::Math::XYZTVector PVec() const { return  ROOT::Math::XYZTVector(Px(),Py(),Pz(),std::sqrt(Px2()+Py2()+Pz2()+mass()*mass()));     }\n
+      //double theta() const { return  ROOT::Math::XYZVector(Px(),Py(),Pz()).Theta();}\n
+      "
+
+  dd4pod::PhotoMultiplierHit:
+    Description: "Podio implementation of a pmt hit "
+    Author : "W.Armstrong"
+    Members:
+      - long long                 cellID   // cellID
+      - long                      flag     // User flag to classify hits
+      - long                      g4ID     // Original Geant 4 track identifier of the creating track (debugging)
+      - dd4pod::FourVector        position // position 
+      - dd4pod::FourVector        momentum // momentum
+      - double                    length   // length 
+      - dd4pod::MonteCarloContrib truth    // truth 
+      - double                    energy   // photon energy
+
+  dd4pod::TrackerHit:
+    Description: "Podio implementation of dd4hep's dd4hep::sim::Geant4Tracker::Hit class"
+    Author : "W.Armstrong"
+    Members:
+      - long long                 cellID        // cellID
+      - long                      flag          // User flag to classify hits
+      - long                      g4ID          // Original Geant4 track identifier of the creating track (debugging)
+      - dd4pod::FourVector        position      // position 
+      - dd4pod::FourVector        momentum      // momentum
+      - double                    length        // length 
+      - dd4pod::MonteCarloContrib truth         // truth 
+      - double                    energyDeposit // energyDeposit
+
+  dd4pod::CalorimeterHit:
+    Description: "Podio implementation of dd4hep's dd4hep::sim::Geant4Calorimeter::Hit class"
+    Author : "W.Armstrong"
+    Members:
+      - long long                 cellID        // cellID 
+      - long                      flag          // User flag to classify hits
+      - long                      g4ID          // Original Geant4 track identifier of the creating track (debugging)
+      - dd4pod::FourVector        position      // position
+      - dd4pod::MonteCarloContrib truth         // truth
+      - double                    energyDeposit // energyDeposit
+

--- a/DDG4/dd4pod/plugins/Geant4Output2Podio.cxx
+++ b/DDG4/dd4pod/plugins/Geant4Output2Podio.cxx
@@ -1,0 +1,363 @@
+#include "Geant4Output2Podio.h"
+#include "DD4hep/InstanceCount.h"
+#include "DD4hep/Primitives.h"
+#include "DD4hep/Printout.h"
+#include "DDG4/Geant4Data.h"
+#include "DDG4/Geant4HitCollection.h"
+#include "DDG4/Geant4Particle.h"
+#include "DD4hep/DD4hepUnits.h"
+
+#include "TBuffer.h"
+
+#include "CLHEP/Units/SystemOfUnits.h"
+#include "G4ParticleDefinition.hh"
+
+#include "dd4pod/ThreeVector.h"
+#include "dd4pod/TrackerHitCollection.h"
+#include "dd4pod/CalorimeterHitCollection.h"
+#include "dd4pod/Geant4ParticleCollection.h"
+
+#include "dd4pod/PhotoMultiplierHitCollection.h"
+#include "PMTHit.h"
+
+// Geant4 include files
+#include "G4HCofThisEvent.hh"
+using std::string;
+
+namespace dd4hep::sim {
+
+  /// Standard constructor
+  Geant4Output2Podio::Geant4Output2Podio(Geant4Context* ctxt, const string& nam)
+      : Geant4OutputAction(ctxt, nam) {
+    declareProperty("HandleMCTruth", m_handleMCTruth = true);
+    declareProperty("DisabledCollections", m_disabledCollections);
+    declareProperty("EnabledCollections", m_enabledCollections);
+    declareProperty("DisableParticles", m_disableParticles);
+    InstanceCount::increment(this);
+  }
+
+  /// Default destructor
+  Geant4Output2Podio::~Geant4Output2Podio() {
+    std::cout << "deleting ouput2podio\n";
+    if (writer) {
+      writer->finish();
+      delete writer;
+    }
+    writer = nullptr;
+    InstanceCount::decrement(this);
+    // if (m_file) {
+    //  TDirectory::TContext ctxt(m_file);
+    //  m_tree->Write();
+    //  m_file->Close();
+    //  m_tree = 0;
+    //  detail::deletePtr (m_file);
+    //}
+  }
+
+  /// Callback to store the Geant4 run information
+  void Geant4Output2Podio::beginRun(const G4Run* run) {
+    std::cout << " Begin of run action \n";
+    if (!writer)
+      writer = new podio::ROOTWriter(m_output, &store);
+    Geant4OutputAction::beginRun(run);
+  }
+  /// Callback to store the Geant4 run information
+  void Geant4Output2Podio::endRun(const G4Run*  run) {
+    std::cout << " end of run\n";
+    store.clearCollections();
+    //if (writer)
+    //  writer->finish();
+    Geant4OutputAction::endRun(run);
+  }
+
+  ///// Fill single EVENT branch entry (Geant4 collection data)
+  // int Geant4Output2Podio::fill(const string& nam, const ComponentCast& type,
+  // void* ptr) {
+  //  if (m_file) {
+  //    TBranch* b = 0;
+  //    Branches::const_iterator i = m_branches.find(nam);
+  //    if (i == m_branches.end()) {
+  //      // create new branch if type exists
+  //      TClass* cl = TBuffer::GetClass(type.type);
+  //      if (cl) {
+  //        b = m_tree->Branch(nam.c_str(), cl->GetName(), (void*) 0);
+  //        b->SetAutoDelete(false);
+  //        m_branches.emplace(nam, b);
+  //      }
+  //      else {
+  //        throw runtime_error("No ROOT TClass object availible for object
+  //        type:"
+  //        + typeName(type.type));
+  //      }
+  //    }
+  //    else {
+  //      b = (*i).second;
+  //    }
+  //    Long64_t evt = b->GetEntries(), nevt = b->GetTree()->GetEntries(), num =
+  //    nevt - evt; if (nevt > evt) {
+  //      b->SetAddress(0);
+  //      while (num > 0) {
+  //        b->Fill();
+  //        --num;
+  //      }
+  //    }
+  //    b->SetAddress(&ptr);
+  //    int nbytes = b->Fill();
+  //    if (nbytes < 0) {
+  //      throw runtime_error("Failed to write ROOT collection:" + nam + "!");
+  //    }
+  //    return nbytes;
+  //  }
+  //  return 0;
+  //}
+
+  void Geant4Output2Podio::saveRun(const G4Run* /* run */) {
+  }
+
+  /// Commit data at end of filling procedure
+  void Geant4Output2Podio::commit(OutputContext<G4Event>& ctxt) {
+    if (writer)  writer->writeEvent();
+    store.clearCollections();
+  }
+
+
+  /// Callback to store the Geant4 event
+  void Geant4Output2Podio::saveEvent(OutputContext<G4Event>& /* ctxt */) {
+    if (!writer){
+      //std::cout << "creating writer in saveEVent\n";
+      writer = new podio::ROOTWriter(m_output, &store);
+    }
+    if (!m_disableParticles) {
+      Geant4ParticleMap* parts = context()->event().extension<Geant4ParticleMap>();
+      if (!(store.getCollectionIDTable()->present("mcparticles"))) {
+        //std::cout << " creating mcparticles\n";
+        auto& pcol = store.create<dd4pod::Geant4ParticleCollection>("mcparticles");
+        pcol.clear();
+        writer->registerForWrite("mcparticles");
+      }
+      podio::CollectionBase* podcol = nullptr;
+      if (store.get(store.getCollectionIDTable()->collectionID("mcparticles"), podcol)) {
+        auto podcol2 = dynamic_cast<dd4pod::Geant4ParticleCollection*>(podcol);
+        // copy all the hits
+        if (parts) {
+          using ParticleMap              = Geant4ParticleMap::ParticleMap;
+          const ParticleMap& pm          = parts->particles();
+          // loop over particle and copy them to podio data model
+          //std::cout << pm.size() <<  " particles\n";
+          for (const auto& i : pm) {
+            auto part = (dd4hep::sim::Geant4Particle*)(i.second);
+            dd4pod::Geant4Particle podpart(
+                (int)part->id, (int)part->g4Parent, (int)part->reason, (int)part->mask, (int)part->steps,
+                (int)part->secondaries, (int)part->pdgID, (int)part->status,
+                std::array<int, 2>{{part->colorFlow[0], part->colorFlow[1]}}, (int)part->genStatus, (int)part->charge,
+                std::array<int, 1>{{(int)part->_spare[0]}},
+                std::array<float, 3>{{(float)part->spin[0], (float)part->spin[1], (float)part->spin[2]}},
+                (double)part->vsx, (double)part->vsy, (double)part->vsz, 
+                (double)part->vex, (double)part->vey, (double)part->vez, 
+                (double)part->psx/1000.0, (double)part->psy/1000.0, (double)part->psz/1000.0, 
+                (double)part->pex/1000.0, (double)part->pey/1000.0, (double)part->pez/1000.0, 
+                (double)part->mass/1000.0, (double)part->time, (double)part->properTime);
+            for (const auto& ip : part->parents) {
+              podpart.addparents(ip);
+            }
+            for (const auto& ip : part->daughters) {
+              podpart.adddaughters(ip);
+            }
+            podcol2->push_back(podpart);
+          }
+        }
+      }
+    }
+  }
+
+  /// Callback to store each Geant4 hit collection
+  void Geant4Output2Podio::saveCollection(OutputContext<G4Event>& /* ctxt */, G4VHitsCollection* collection) {
+    Geant4HitCollection* coll    = dynamic_cast<Geant4HitCollection*>(collection);
+    std::string          hc_name = collection->GetName();
+    for (const auto& n : m_disabledCollections) {
+      if (n == hc_name) {
+        return;
+      }
+    }
+    size_t  nhits = coll->GetSize();
+    TClass* cl    = TBuffer::GetClass(coll->vector_type().type());
+    auto    cn    = cl->GetName();
+    if (cl) {
+      // populate the collections
+      //std::cout << cl->GetName() << "\n";
+      // not ideal comparison
+      if (std::string("vector<dd4hep::sim::Geant4Calorimeter::Hit*>") == cn) {
+        if (!(store.getCollectionIDTable()->present(hc_name))) {
+          auto& pcol = store.create<dd4pod::CalorimeterHitCollection>(hc_name);
+          writer->registerForWrite(hc_name);
+        }
+        podio::CollectionBase* podcol = nullptr;
+        //std::cout << nhits << " cal hits\n";
+        if (store.get(store.getCollectionIDTable()->collectionID(hc_name),
+                      podcol)) {
+          auto podcol2 =
+              dynamic_cast<dd4pod::CalorimeterHitCollection*>(podcol);
+          // copy all the hits
+          for (size_t i = 0; i < nhits; ++i) {
+            dd4hep::sim::Geant4HitData* h = coll->hit(i);
+
+            auto cal_hit =
+                dynamic_cast<dd4hep::sim::Geant4Calorimeter::Hit*>(h);
+            //Geant4HitData::Contributions& c = cal_hit->truth;
+            //for (Geant4HitData::Contributions::iterator j = c.begin(); j != c.end(); ++j) {
+            //  Geant4HitData::Contribution& t       = *j;
+            //  int                          trackID = t.trackID;
+            //  t.trackID = m_truth->particleID(trackID);
+            //}
+            if (cal_hit) {
+              auto phit = podcol2->create();
+              phit.cellID(cal_hit->cellID);
+              phit.flag(cal_hit->flag);
+              phit.g4ID(cal_hit->g4ID);
+              phit.position({cal_hit->position.x(), cal_hit->position.y(),
+                             cal_hit->position.z(), 0.0});
+              const auto& first_truth = cal_hit->truth[0];
+              phit.truth(dd4pod::MonteCarloContrib({
+                (int)first_truth.trackID, 
+                (int)first_truth.pdgID,
+                (double)first_truth.deposit/1000.0,
+                (double)first_truth.time, 
+                (double)first_truth.length,
+                (double)first_truth.x, 
+                (double)first_truth.y,
+                (double)first_truth.z}));
+              //phit.truth({cal_hit->truth.trackID, cal_hit->truth.pdgID, cal_hit->truth.deposit, cal_hit->truth.time,
+              //            cal_hit->truth.length, cal_hit->truth.x, cal_hit->truth.y, cal_hit->truth.z});
+              phit.energyDeposit(cal_hit->energyDeposit/1000.0);
+            }
+          }
+        }
+      } else if (std::string("vector<dd4hep::sim::Geant4Tracker::Hit*>") == cn) {
+        //std::cout << "track hit\n";
+        if (!(store.getCollectionIDTable()->present(hc_name))) {
+          auto& pcol = store.create<dd4pod::TrackerHitCollection>(hc_name);
+          writer->registerForWrite(hc_name);
+        }
+        podio::CollectionBase* podcol = nullptr;
+        //std::cout << nhits << " trk hits\n";
+        if (store.get(store.getCollectionIDTable()->collectionID(hc_name), podcol)) {
+          auto podcol2 =
+              dynamic_cast<dd4pod::TrackerHitCollection*>(podcol);
+          // copy all the hits
+          for (size_t i = 0; i < nhits; ++i) {
+            dd4hep::sim::Geant4HitData* h = coll->hit(i);
+            auto trk_hit = dynamic_cast<dd4hep::sim::Geant4Tracker::Hit*>(h);
+
+            //Geant4HitData::Contribution& t       = trk_hit->truth;
+            //int                          trackID = t.trackID;
+            //t.trackID                            = m_truth->particleID(trackID);
+            if (trk_hit) {
+              auto phit = podcol2->create();
+              phit.cellID(trk_hit->cellID);
+              phit.flag(trk_hit->flag);
+              phit.g4ID(trk_hit->g4ID);
+              phit.position({trk_hit->position.x(), trk_hit->position.y(),
+                             trk_hit->position.z()});
+              phit.momentum({trk_hit->momentum.x()/1000.0, trk_hit->momentum.y()/1000.0,
+                             trk_hit->momentum.z()/1000.0});
+              phit.length(trk_hit->length);
+              phit.truth(dd4pod::MonteCarloContrib({
+                (int)trk_hit->truth.trackID, 
+                (int)trk_hit->truth.pdgID,
+                (double)trk_hit->truth.deposit/1000.0,
+                (double)trk_hit->truth.time, 
+                (double)trk_hit->truth.length,
+                (double)trk_hit->truth.x, 
+                (double)trk_hit->truth.y,
+                (double)trk_hit->truth.z}));
+              phit.energyDeposit(trk_hit->energyDeposit/1000.0);
+            }
+          }
+        }
+      } else if (std::string("vector<npdet::PMTHit*>") == cn) {
+        //std::cout << "track hit\n";
+        if (!(store.getCollectionIDTable()->present(hc_name))) {
+          auto& pcol = store.create<dd4pod::PhotoMultiplierHitCollection>(hc_name);
+          writer->registerForWrite(hc_name);
+        }
+        podio::CollectionBase* podcol = nullptr;
+        if (store.get(store.getCollectionIDTable()->collectionID(hc_name), podcol)) {
+          auto podcol2 =
+              dynamic_cast<dd4pod::PhotoMultiplierHitCollection*>(podcol);
+          // copy all the hits
+          for (size_t i = 0; i < nhits; ++i) {
+            //auto h = coll->hit(i);
+            dd4hep::sim::Geant4HitData* h = coll->hit(i);
+            auto trk_hit = dynamic_cast<npdet::PMTHit*>(h);
+            //Geant4HitData::Contribution& t       = trk_hit->truth;
+            //int                          trackID = t.trackID;
+            //t.trackID                            = m_truth->particleID(trackID);
+            if (trk_hit) {
+              auto phit = podcol2->create();
+              phit.cellID(trk_hit->cellID);
+              phit.flag(trk_hit->flag);
+              phit.g4ID(trk_hit->g4ID);
+              phit.position({trk_hit->position.x(), trk_hit->position.y(),
+                             trk_hit->position.z()});
+              phit.momentum({trk_hit->momentum.x()/1000.0, trk_hit->momentum.y()/1000.0,
+                             trk_hit->momentum.z()/1000.0});
+              phit.length(trk_hit->length);
+              phit.truth({trk_hit->truth.trackID, trk_hit->truth.pdgID,
+                trk_hit->truth.deposit/1000.0,
+                trk_hit->truth.time, trk_hit->truth.length,
+                trk_hit->truth.x, trk_hit->truth.y,
+                trk_hit->truth.z});
+              phit.energy(trk_hit->energy/1000.0);
+            }
+          }
+        }
+      } else { 
+         //std::cout << " unknown hit class name " << cn  << "\n";
+      }
+    } else {
+      throw std::runtime_error("No ROOT TClass object availible for object type" );
+    }
+    //
+    // if (coll) {
+    //  vector<void*> hits;
+    //  coll->getHitsUnchecked(hits);
+    //  size_t nhits = coll->GetSize();
+    //  if (m_handleMCTruth && m_truth && nhits > 0) {
+    //    hits.reserve(nhits);
+    //    try {
+    //      for (size_t i = 0; i < nhits; ++i) {
+    //        auto h       = coll->hit(i);
+    //        auto trk_hit = dynamic_cast<dd4pod::TrackerHit*>(h);
+    //        if (0 != trk_hit) {
+    //          Geant4HitData::Contribution& t       = trk_hit->truth;
+    //          int                          trackID = t.trackID;
+    //          t.trackID                            =
+    //          m_truth->particleID(trackID);
+    //        }
+    //        auto cal_hit = dynamic_cast<dd4pod::CalorimeterHit*>(h);
+    //        if (0 != cal_hit) {
+    //          Geant4HitData::Contributions& c = cal_hit->truth;
+    //          for (Geant4HitData::Contributions::iterator j = c.begin();
+    //               j != c.end(); ++j) {
+    //            Geant4HitData::Contribution& t       = *j;
+    //            int                          trackID = t.trackID;
+    //            t.trackID = m_truth->particleID(trackID);
+    //          }
+    //        }
+    //      }
+    //    } catch (...) {
+    //      printout(ERROR, name(), "+++ Exception while saving collection %s.",
+    //               hc_nam.c_str());
+    //    }
+    //  }
+    //  fill(hc_nam, coll->vector_type(), &hits);
+    //  }
+  }
+}  // namespace dd4hep::sim
+
+using namespace dd4hep::sim;
+
+#include "DDG4/Factories.h"
+
+// clang-format off
+DECLARE_GEANT4ACTION(Geant4Output2Podio)

--- a/DDG4/dd4pod/plugins/Geant4Output2Podio.h
+++ b/DDG4/dd4pod/plugins/Geant4Output2Podio.h
@@ -1,0 +1,85 @@
+#ifndef DD4HEP_DDG4_GEANT4Output2Podio_H
+#define DD4HEP_DDG4_GEANT4Output2Podio_H
+
+#include "DDG4/Geant4OutputAction.h"
+//#include "podio/GenericParameters.h"
+#include "podio/CollectionBase.h"
+#include "podio/CollectionIDTable.h"
+
+#include "podio/EventStore.h"
+#include "podio/ROOTWriter.h"
+
+namespace dd4pod {
+class Geant4Particle;
+class Geant4ParticleCollection;
+}
+
+namespace dd4hep {
+
+
+  class ComponentCast;
+
+  namespace sim {
+
+    class Geant4Particle;
+
+    /** Saves output to podio data model.
+     *
+     * Uses the podio data model "dd4pod" as the output. 
+     */
+    class Geant4Output2Podio: public Geant4OutputAction {
+    protected:
+     void
+     ConstructParticle(dd4pod::Geant4ParticleCollection* col,
+                       dd4hep::sim::Geant4Particle*      part);
+
+     /// Flag if Monte-Carlo truth should be followed and checked
+     bool m_handleMCTruth;
+
+     /// Property: vector with disabled collections
+     std::vector<std::string> m_disabledCollections;
+
+     /// Property: vector with disabled collections
+     std::vector<std::string> m_enabledCollections;
+
+     /// Property: vector with disabled collections
+     bool m_disableParticles = false;
+
+     podio::EventStore  store;
+     podio::ROOTWriter* writer = nullptr;
+
+     std::map<std::string, podio::CollectionBase*>               m_col_map;
+     std::vector<std::pair<std::string, podio::CollectionBase*>> m_collections;
+     std::vector<std::pair<std::string, podio::CollectionBase*>>
+                               m_readCollections;
+     podio::CollectionIDTable* m_collectionIDs;
+
+    public:
+      Geant4Output2Podio(Geant4Context* context, const std::string& nam);
+      virtual ~Geant4Output2Podio();
+      
+      ///// Fill single EVENT branch entry (Geant4 collection data)
+      //int fill(const std::string& nam, const ComponentCast& type, void* ptr);
+
+      /// Callback to store the Geant4 run information
+      virtual void beginRun(const G4Run* run);
+
+      /// Callback to store the Geant4 run information
+      virtual void endRun(const G4Run* run);
+
+      /// Callback to store the Geant4 run information
+      virtual void saveRun(const G4Run*  run );
+
+      /// Callback to store each Geant4 hit collection
+      virtual void saveCollection(OutputContext<G4Event>& ctxt, G4VHitsCollection* collection);
+
+      /// Callback to store the Geant4 event
+      virtual void saveEvent(OutputContext<G4Event>& ctxt);
+
+      /// Commit data at end of filling procedure
+      virtual void commit(OutputContext<G4Event>& ctxt);
+    };
+
+  }    // End namespace sim
+}      // End namespace dd4hep
+#endif // DD4HEP_DDG4_GEANT4Output2Podio_H


### PR DESCRIPTION
- DD4pod is a small PODIO datamodel and output action plugin which is
designed to mirror Geant4Output2Root
- The datamodel isn't a perfect match (mostly due to missing data types
in PODIO)
- Also, would like to add PhotonCounter but that can be a separate merge
request.



BEGINRELEASENOTES
- DD4pod is a small PODIO datamodel and output action plugin which is
designed to mirror Geant4Output2Root
- The datamodel isn't a perfect match (mostly due to missing data types
in PODIO)

ENDRELEASENOTES