### PR TITLE
[testing] separate import test for ddg4 and rest of dd4hep

### DIFF
--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -51,6 +51,11 @@ ADD_TEST( t_test_python_import "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
 SET_TESTS_PROPERTIES( t_test_python_import PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
 if (DD4HEP_USE_GEANT4)
+
+  ADD_TEST( t_test_python_import_ddg4 "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+    pytest ${PROJECT_SOURCE_DIR}/DDTest/python/test_import_ddg4.py)
+  SET_TESTS_PROPERTIES( t_test_python_import_ddg4 PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+
   foreach(TEST_NAME
       test_EventReaders
       )

--- a/DDTest/python/test_import.py
+++ b/DDTest/python/test_import.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """
-Some imports to make sure that the DD4hep environment is complete
+Some imports to make sure that the DD4hep environment is complete.
+Since it can be disabled in CMake, the import of DDG4 is tested in another file.
 """
 from __future__ import absolute_import, unicode_literals, print_function
 import traceback
@@ -11,7 +12,6 @@ parametrize = pytest.mark.parametrize
 
 moduleNames = [
     'dd4hep',
-    'DDG4',
     'DDRec',
     'DDDigi',
     ]

--- a/DDTest/python/test_import_ddg4.py
+++ b/DDTest/python/test_import_ddg4.py
@@ -5,8 +5,8 @@ This file adds a test for the DDG4 python module.
 """
 
 from __future__ import absolute_import
-import pytest
 from test_import import test_module
+
 
 def test_module_ddg4():
     test_module('DDG4')

--- a/DDTest/python/test_import_ddg4.py
+++ b/DDTest/python/test_import_ddg4.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+"""
+Some imports to make sure that the DD4hep environment is complete.
+This file adds a test for the DDG4 python module.
+"""
+
+from __future__ import absolute_import
+from test_import import test_module, parametrize
+
+
+moduleNames = [
+    'DDG4',
+    ]
+
+
+@parametrize('moduleName', moduleNames)
+def test_module_ddg4(moduleName):
+    test_module(moduleName)

--- a/DDTest/python/test_import_ddg4.py
+++ b/DDTest/python/test_import_ddg4.py
@@ -8,15 +8,5 @@ from __future__ import absolute_import
 import pytest
 from test_import import test_module
 
-
-parametrize = pytest.mark.parametrize
-
-
-moduleNames = [
-    'DDG4',
-    ]
-
-
-@parametrize('moduleName', moduleNames)
-def test_module_ddg4(moduleName):
+def test_module_ddg4():
     test_module('DDG4')

--- a/DDTest/python/test_import_ddg4.py
+++ b/DDTest/python/test_import_ddg4.py
@@ -5,7 +5,11 @@ This file adds a test for the DDG4 python module.
 """
 
 from __future__ import absolute_import
-from test_import import test_module, parametrize
+import pytest
+from test_import import test_module
+
+
+parametrize = pytest.mark.parametrize
 
 
 moduleNames = [
@@ -15,4 +19,4 @@ moduleNames = [
 
 @parametrize('moduleName', moduleNames)
 def test_module_ddg4(moduleName):
-    test_module(moduleName)
+    test_module('DDG4')


### PR DESCRIPTION
This avoids a test failure when DD4hep is built with `-DDD4HEP_USE_GEANT4=OFF` - since there is no DDG4 module built in this case, the test trying to import it is doomed to fail. So I propose test for the import of DDG4 in a separate file / test that is only enabled when DDG4 is built.

Due to the `from test_import import *` the new test actually tests also the other imports (again), but at least there is no code duplication.



BEGINRELEASENOTES
- [testing] separate import test for ddg4 and rest of dd4hep

ENDRELEASENOTES