### PR TITLE
Use G4OpticalParameters to set Cerenkov/Scintillation parameters

### DIFF
--- a/DDG4/plugins/Geant4CerenkovPhysics.cpp
+++ b/DDG4/plugins/Geant4CerenkovPhysics.cpp
@@ -28,6 +28,7 @@
 #include "DDG4/Geant4PhysicsList.h"
 
 /// Geant4 include files
+#include "G4OpticalParameters.hh"
 #include "G4ParticleTableIterator.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTypes.hh"
@@ -76,12 +77,21 @@ namespace dd4hep {
              yes_no(m_trackSecondariesFirst), yes_no(m_stackPhotons),
              yes_no(m_trackSecondariesFirst));
         G4Cerenkov* process = new G4Cerenkov(name());
+#if G4VERSION_NUMBER >= 1070
+        G4OpticalParameters* params = G4OpticalParameters::Instance();
+        params->SetCerenkovVerboseLevel(m_verbosity);
+        params->SetCerenkovMaxPhotonsPerStep(m_maxNumPhotonsPerStep);
+        params->SetCerenkovMaxBetaChange(m_maxBetaChangePerStep);
+        params->SetCerenkovTrackSecondariesFirst(m_trackSecondariesFirst);
+        params->SetCerenkovStackPhotons(m_stackPhotons);
+#else
         process->SetVerboseLevel(m_verbosity);
         process->SetMaxNumPhotonsPerStep(m_maxNumPhotonsPerStep);
         process->SetMaxBetaChangePerStep(m_maxBetaChangePerStep);
         process->SetTrackSecondariesFirst(m_trackSecondariesFirst);
 #if G4VERSION_NUMBER>1030
         process->SetStackPhotons(m_stackPhotons);
+#endif
 #endif
         auto pit = G4ParticleTable::GetParticleTable()->GetIterator();
         pit->reset();

--- a/DDG4/plugins/Geant4CerenkovPhysics.cpp
+++ b/DDG4/plugins/Geant4CerenkovPhysics.cpp
@@ -28,13 +28,16 @@
 #include "DDG4/Geant4PhysicsList.h"
 
 /// Geant4 include files
-#include "G4OpticalParameters.hh"
 #include "G4ParticleTableIterator.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTypes.hh"
 #include "G4ParticleTable.hh"
 #include "G4ProcessManager.hh"
 #include "G4Version.hh"
+
+#if G4VERSION_NUMBER >= 1070
+#include "G4OpticalParameters.hh"
+#endif
 
 #include "G4Cerenkov.hh"
 

--- a/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
+++ b/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
@@ -34,6 +34,7 @@
 #include "G4OpRayleigh.hh"
 #include "G4OpMieHG.hh"
 #include "G4OpBoundaryProcess.hh"
+#include "G4OpticalParameters.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTypes.hh"
 #include "G4ParticleTable.hh"
@@ -81,11 +82,18 @@ namespace dd4hep {
         G4OpRayleigh*         fRayleighScatteringProcess = new G4OpRayleigh();
         G4OpMieHG*            fMieHGScatteringProcess    = new G4OpMieHG();
 
+#if G4VERSION_NUMBER >= 1070
+        G4OpticalParameters* params = G4OpticalParameters::Instance();
+        params->SetAbsorptionVerboseLevel(m_verbosity);
+        params->SetRayleighVerboseLevel(m_verbosity);
+        params->SetMieVerboseLevel(m_verbosity);
+        params->SetBoundaryVerboseLevel(m_verbosity);
+#else
         fAbsorptionProcess->SetVerboseLevel(m_verbosity);
         fRayleighScatteringProcess->SetVerboseLevel(m_verbosity);
         fMieHGScatteringProcess->SetVerboseLevel(m_verbosity);
         fBoundaryProcess->SetVerboseLevel(m_verbosity);
-
+#endif
         G4ProcessManager* pmanager = particle->GetProcessManager();
         pmanager->AddDiscreteProcess(fAbsorptionProcess);
         pmanager->AddDiscreteProcess(fRayleighScatteringProcess);

--- a/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
+++ b/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
@@ -40,6 +40,10 @@
 #include "G4ParticleTable.hh"
 #include "G4ProcessManager.hh"
 
+#if G4VERSION_NUMBER >= 1070
+#include "G4OpticalParameters.hh"
+#endif
+
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
 

--- a/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
+++ b/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
@@ -67,6 +67,7 @@ namespace dd4hep {
         : Geant4PhysicsList(ctxt, nam)
       {
         declareProperty("VerboseLevel", m_verbosity = 0);
+        declareProperty("BoundaryInvokeSD", m_boundaryInvokeSD = false);
       }
       /// Default destructor
       virtual ~Geant4OpticalPhotonPhysics() = default;
@@ -92,11 +93,15 @@ namespace dd4hep {
         params->SetRayleighVerboseLevel(m_verbosity);
         params->SetMieVerboseLevel(m_verbosity);
         params->SetBoundaryVerboseLevel(m_verbosity);
+        params->SetBoundaryInvokeSD(m_boundaryInvokeSD);
 #else
         fAbsorptionProcess->SetVerboseLevel(m_verbosity);
         fRayleighScatteringProcess->SetVerboseLevel(m_verbosity);
         fMieHGScatteringProcess->SetVerboseLevel(m_verbosity);
         fBoundaryProcess->SetVerboseLevel(m_verbosity);
+#if G4VERSION_NUMBER >= 1000
+        fBoundaryProcess->SetInvokeSD(m_boundaryInvokeSD);
+#endif
 #endif
         G4ProcessManager* pmanager = particle->GetProcessManager();
         pmanager->AddDiscreteProcess(fAbsorptionProcess);
@@ -106,6 +111,7 @@ namespace dd4hep {
       }
     private:
       int         m_verbosity;
+      bool        m_boundaryInvokeSD;
     };
   }
 }

--- a/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
+++ b/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
@@ -34,7 +34,6 @@
 #include "G4OpRayleigh.hh"
 #include "G4OpMieHG.hh"
 #include "G4OpBoundaryProcess.hh"
-#include "G4OpticalParameters.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTypes.hh"
 #include "G4ParticleTable.hh"

--- a/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
+++ b/DDG4/plugins/Geant4OpticalPhotonPhysics.cpp
@@ -39,6 +39,7 @@
 #include "G4ParticleTypes.hh"
 #include "G4ParticleTable.hh"
 #include "G4ProcessManager.hh"
+#include "G4Version.hh"
 
 #if G4VERSION_NUMBER >= 1070
 #include "G4OpticalParameters.hh"

--- a/DDG4/plugins/Geant4ScintillationPhysics.cpp
+++ b/DDG4/plugins/Geant4ScintillationPhysics.cpp
@@ -29,6 +29,7 @@
 
 /// Geant4 include files
 #include "G4Version.hh"
+#include "G4OpticalParameters.hh"
 #include "G4ParticleTableIterator.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4LossTableManager.hh"
@@ -80,6 +81,15 @@ namespace dd4hep {
              yes_no(m_finiteRiseTime), yes_no(m_stackPhotons),
              yes_no(m_trackSecondariesFirst));
         G4Scintillation* process = new G4Scintillation(name());
+#if G4VERSION_NUMBER >= 1070
+        G4OpticalParameters* params = G4OpticalParameters::Instance();
+        params->SetScintVerboseLevel(m_verbosity);
+        params->SetScintFiniteRiseTime(m_finiteRiseTime);
+        params->SetScintStackPhotons(m_stackPhotons);
+        params->SetScintTrackSecondariesFirst(m_trackSecondariesFirst);
+        params->SetScintYieldFactor(m_scintillationYieldFactor);
+        params->SetScintExcitationRatio(m_scintillationExcitationRatio);
+#else
         process->SetVerboseLevel(m_verbosity);
         process->SetFiniteRiseTime(m_finiteRiseTime);
 #if G4VERSION_NUMBER>1030
@@ -88,6 +98,7 @@ namespace dd4hep {
         process->SetTrackSecondariesFirst(m_trackSecondariesFirst);
         process->SetScintillationYieldFactor(m_scintillationYieldFactor);
         process->SetScintillationExcitationRatio(m_scintillationExcitationRatio);
+#endif
         // Use Birks Correction in the Scintillation process
         if ( G4Threading::IsMasterThread() )  {
           G4EmSaturation* emSaturation =

--- a/DDG4/plugins/Geant4ScintillationPhysics.cpp
+++ b/DDG4/plugins/Geant4ScintillationPhysics.cpp
@@ -106,10 +106,10 @@ namespace dd4hep {
         process->SetScintillationYieldFactor(m_scintillationYieldFactor);
         process->SetScintillationExcitationRatio(m_scintillationExcitationRatio);
 #if G4VERSION_NUMBER >= 940
-        process->SetScintByParticleType(m_byParticleType);
+        process->SetScintillationByParticleType(m_byParticleType);
 #endif
 #if G4VERSION_NUMBER >= 1030
-        process->SetScintTrackInfo(m_trackInfo);
+        process->SetScintillationTrackInfo(m_trackInfo);
 #endif
 #endif
         // Use Birks Correction in the Scintillation process

--- a/DDG4/plugins/Geant4ScintillationPhysics.cpp
+++ b/DDG4/plugins/Geant4ScintillationPhysics.cpp
@@ -29,7 +29,6 @@
 
 /// Geant4 include files
 #include "G4Version.hh"
-#include "G4OpticalParameters.hh"
 #include "G4ParticleTableIterator.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4LossTableManager.hh"
@@ -38,6 +37,10 @@
 #include "G4ParticleTable.hh"
 #include "G4EmSaturation.hh"
 #include "G4Threading.hh"
+
+#if G4VERSION_NUMBER >= 1070
+#include "G4OpticalParameters.hh"
+#endif
 
 #include "G4Scintillation.hh"
 

--- a/DDG4/plugins/Geant4ScintillationPhysics.cpp
+++ b/DDG4/plugins/Geant4ScintillationPhysics.cpp
@@ -71,6 +71,8 @@ namespace dd4hep {
         declareProperty("FiniteRiseTime",                m_finiteRiseTime = false);
         declareProperty("TrackSecondariesFirst",         m_trackSecondariesFirst = false);
         declareProperty("StackPhotons",                  m_stackPhotons = true);
+        declareProperty("ByParticleType",                m_byParticleType = false);
+        declareProperty("TrackInfo",                     m_trackInfo = false);
         declareProperty("VerboseLevel",                  m_verbosity = 0);
       }
       /// Default destructor
@@ -92,15 +94,23 @@ namespace dd4hep {
         params->SetScintTrackSecondariesFirst(m_trackSecondariesFirst);
         params->SetScintYieldFactor(m_scintillationYieldFactor);
         params->SetScintExcitationRatio(m_scintillationExcitationRatio);
+        params->SetScintByParticleType(m_byParticleType);
+        params->SetScintTrackInfo(m_trackInfo);
 #else
         process->SetVerboseLevel(m_verbosity);
         process->SetFiniteRiseTime(m_finiteRiseTime);
-#if G4VERSION_NUMBER>1030
+#if G4VERSION_NUMBER >= 1030
         process->SetStackPhotons(m_stackPhotons);
 #endif
         process->SetTrackSecondariesFirst(m_trackSecondariesFirst);
         process->SetScintillationYieldFactor(m_scintillationYieldFactor);
         process->SetScintillationExcitationRatio(m_scintillationExcitationRatio);
+#if G4VERSION_NUMBER >= 940
+        process->SetScintByParticleType(m_byParticleType);
+#endif
+#if G4VERSION_NUMBER >= 1030
+        process->SetScintTrackInfo(m_trackInfo);
+#endif
 #endif
         // Use Birks Correction in the Scintillation process
         if ( G4Threading::IsMasterThread() )  {
@@ -128,6 +138,8 @@ namespace dd4hep {
       bool   m_stackPhotons;
       bool   m_finiteRiseTime;
       bool   m_trackSecondariesFirst;
+      bool   m_byParticleType;
+      bool   m_trackInfo;
     };
   }
 }


### PR DESCRIPTION
This introduces the use of G4OpticalParameters for setting of optical processes, cerenkov, and scintillation since the former approach ceased working as of geant4.10.7.

BEGINRELEASENOTES
- Use G4OpticalParameters in geant4.10.7 and newer

ENDRELEASENOTES