### PR TITLE
Move termination handler from DDCore to DDG4 (Issue  #874)

### DIFF
--- a/DDCore/include/DD4hep/DetElement.h
+++ b/DDCore/include/DD4hep/DetElement.h
@@ -437,6 +437,8 @@ namespace dd4hep {
     const Children& children() const;
     /// Access to individual children by name
     DetElement child(const std::string& name) const;
+    /// Access to individual children by name. Have option to not throw an exception
+    DetElement child(const std::string& child_name, bool throw_if_not_found) const;
     /// Access to the detector elements's parent
     DetElement parent() const;
     /// Access to the world object. Only possible once the geometry is closed.

--- a/DDCore/src/DetElement.cpp
+++ b/DDCore/src/DetElement.cpp
@@ -220,6 +220,22 @@ DetElement DetElement::child(const string& child_name) const {
   throw runtime_error("dd4hep: DetElement::child: Self is not defined [Invalid Handle]");
 }
 
+/// Access to individual children by name. Have option to not throw an exception
+DetElement DetElement::child(const string& child_name, bool throw_if_not_found) const {
+  if (isValid()) {
+    const Children& c = ptr()->children;
+    Children::const_iterator i = c.find(child_name);
+    if ( i != c.end() ) return (*i).second;
+    if ( throw_if_not_found )   {
+      throw runtime_error("dd4hep: DetElement::child Unknown child with name: "+child_name);
+    }
+  }
+  if ( throw_if_not_found )   {
+    throw runtime_error("dd4hep: DetElement::child: Self is not defined [Invalid Handle]");
+  }
+  return DetElement();
+}
+
 /// Access to the detector elements's parent
 DetElement DetElement::parent() const {
   Object* o = ptr();

--- a/DDCore/src/DetElement.cpp
+++ b/DDCore/src/DetElement.cpp
@@ -214,9 +214,10 @@ DetElement DetElement::child(const string& child_name) const {
   if (isValid()) {
     const Children& c = ptr()->children;
     Children::const_iterator i = c.find(child_name);
-    return i == c.end() ? DetElement() : (*i).second;
+    if ( i != c.end() ) return (*i).second;
+    throw runtime_error("dd4hep: DetElement::child Unknown child with name: "+child_name);
   }
-  return DetElement();
+  throw runtime_error("dd4hep: DetElement::child: Self is not defined [Invalid Handle]");
 }
 
 /// Access to the detector elements's parent

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -181,7 +181,6 @@ DetectorImp::DetectorImp()
 DetectorImp::DetectorImp(const string& name)
   : TNamed(), DetectorData(), DetectorLoad(this), m_buildType(BUILD_NONE)
 {
-  static bool first = true;
 #if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,22,7)
     printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
     if ( TGeoManager::GetDefaultUnits() != TGeoManager::kG4Units )  {
@@ -196,7 +195,9 @@ DetectorImp::DetectorImp(const string& name)
       TGeoManager::LockDefaultUnits(kTRUE);
     }
 #else
+  static bool first = true;
   if ( first )    {
+    first = false;
 #if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
     printout(WARNING,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
     TGeoManager::SetDefaultG4Units();

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -135,24 +135,6 @@ namespace {
     static Instances s_inst;
     return s_inst;
   }
-
-  void description_unexpected()    {
-    try  {
-      throw;
-    }  catch( exception& e )  {
-      cout << "\n"
-           << "**************************************************** \n"
-           << "*  A runtime error has occured :                     \n"
-           << "*    " << e.what()   << endl
-           << "*  the program will have to be terminated - sorry.   \n"
-           << "**************************************************** \n"
-           << endl ;
-
-      set_terminate(std::terminate);
-      // this provokes ROOT seg fault and stack trace (comment out to avoid it)
-      exit(1) ;
-    }
-  }
 }
 
 string dd4hep::versionString(){
@@ -226,11 +208,6 @@ DetectorImp::DetectorImp(const string& name)
   }
 #endif
 
-  if ( first )    {
-    first = false;
-    set_terminate( description_unexpected );
-  }
-  
   SetName(name.c_str());
   SetTitle("DD4hep detector description object");
   //DetectorGuard(this).lock(gGeoManager);

--- a/DDCore/src/gdml/GdmlPlugins.cpp
+++ b/DDCore/src/gdml/GdmlPlugins.cpp
@@ -76,7 +76,7 @@ static long gdml_parse(Detector& description, int argc, char** argv) {
         const auto& e = elements[i];
         if ( e == world.name() )
           continue;
-        child = parent.child(e);
+        child = parent.child(e, false);
         if ( child.isValid() )  {
           parent = child;
           continue;

--- a/DDG4/src/Geant4Kernel.cpp
+++ b/DDG4/src/Geant4Kernel.cpp
@@ -41,6 +41,21 @@ using namespace dd4hep::sim;
 namespace {
   G4Mutex kernel_mutex=G4MUTEX_INITIALIZER;
   dd4hep::dd4hep_ptr<Geant4Kernel> s_main_instance(0);
+  void description_unexpected()    {
+    try  {
+      throw;
+    }  catch( exception& e )  {
+      cout << "\n"
+           << "**************************************************** \n"
+           << "*  A runtime error has occured :                     \n"
+           << "*    " << e.what()   << endl
+           << "*  the program will have to be terminated - sorry.   \n"
+           << "**************************************************** \n"
+           << endl ;
+      // this provokes ROOT seg fault and stack trace (comment out to avoid it)
+      exit(1) ;
+    }
+  }
 }
 
 /// Standard constructor
@@ -147,6 +162,8 @@ Geant4Kernel& Geant4Kernel::instance(Detector& description) {
   if ( 0 == s_main_instance.get() )   {
     G4AutoLock protection_lock(&kernel_mutex);    {
       if ( 0 == s_main_instance.get() )   { // Need to check again!
+        /// Install here the termination handler
+        std::set_terminate(description_unexpected);
         s_main_instance.adopt(new Geant4Kernel(description));
       }
     }


### PR DESCRIPTION
BEGINRELEASENOTES
- To not compromize client code with an enforced termination handler, the DD4hep termination handler
moved to DDG4, where it actually is needed. In DDG4 the termination handler is activated when the main
Geant4Kernel instance is created.
Reasoning: Please see issue https://github.com/AIDASoft/DD4hep/issues/874 .
- Throw an exception if clients ask a DetElement handle for a child by name if such a child is not present or the handle is invalid. This is the new default now. The old behaviour is kept with a second accessor for children by name, with an explicit statement that an exception is unwanted such as: child = DetElement::child("name", false)
Please see issue: https://github.com/AIDASoft/DD4hep/issues/878.
ENDRELEASENOTES