### PR TITLE
WIP: Added the default move constructor to ConditionObject

### DIFF
--- a/DDCore/include/DD4hep/NamedObject.h
+++ b/DDCore/include/DD4hep/NamedObject.h
@@ -45,11 +45,15 @@ namespace dd4hep {
     NamedObject() = default;
     /// Copy constructor
     NamedObject(const NamedObject& c) = default;
+    /// Move constructor
+    NamedObject(NamedObject&& c) = default;
+
     /// Default destructor
     virtual ~NamedObject() = default;
     /// Assignment operator
     NamedObject& operator=(const NamedObject& c) = default;
-
+    /// Move assignment operator
+    NamedObject& operator=(NamedObject&& c) = default;
     /// Access name
     const char* GetName()  const  {
       return name.c_str();

--- a/DDCore/include/DD4hep/detail/ConditionsInterna.h
+++ b/DDCore/include/DD4hep/detail/ConditionsInterna.h
@@ -85,12 +85,16 @@ namespace dd4hep {
       ConditionObject();
       /// No copy constructor
       ConditionObject(const ConditionObject&) = delete;
+      // Move constructor
+      ConditionObject(ConditionObject&&) = default;
       /// Standard constructor
       ConditionObject(const std::string& nam,const std::string& tit="");
       /// Standard Destructor
       virtual ~ConditionObject();
       /// No assignment operation
       ConditionObject& operator=(const ConditionObject&) = delete;
+      /// Move assignment operator
+      ConditionObject& operator=(ConditionObject&&) = default;
       /// Increase reference counter (Used by persistency mechanism)
       ConditionObject* addRef()  {  ++refCount; return this;         }
       /// Release object (Used by persistency mechanism)

--- a/DDCore/include/DD4hep/detail/ConditionsInterna.h
+++ b/DDCore/include/DD4hep/detail/ConditionsInterna.h
@@ -54,6 +54,12 @@ namespace dd4hep {
      *  \author  M.Frank
      *  \version 1.0
      *  \ingroup DD4HEP_CONDITIONS
+     *
+     * The copy and move constructors have been removed from this class. It would be
+     * unsafe to copy or move an instance of it as:
+     *  - we do not know how to copy the OpaqueDataBlock member "data"
+     *  - there are potentially Handles pointing to instantiated ConditionObjects that would be invalid
+     *    after a copy or move.
      */
     class ConditionObject
 #if defined(DD4HEP_CONDITIONS_HAVE_NAME)
@@ -85,16 +91,16 @@ namespace dd4hep {
       ConditionObject();
       /// No copy constructor
       ConditionObject(const ConditionObject&) = delete;
-      // Move constructor
-      ConditionObject(ConditionObject&&) = default;
+      // No move constructor
+      ConditionObject(ConditionObject&&) = delete;
       /// Standard constructor
       ConditionObject(const std::string& nam,const std::string& tit="");
       /// Standard Destructor
       virtual ~ConditionObject();
       /// No assignment operation
       ConditionObject& operator=(const ConditionObject&) = delete;
-      /// Move assignment operator
-      ConditionObject& operator=(ConditionObject&&) = default;
+      /// No move assignment operator
+      ConditionObject& operator=(ConditionObject&&) = delete;
       /// Increase reference counter (Used by persistency mechanism)
       ConditionObject* addRef()  {  ++refCount; return this;         }
       /// Release object (Used by persistency mechanism)


### PR DESCRIPTION
Added the default move constructor and default move assignment operator to dd4hep::detail::ConditionObject and dd4hep::NamedObject.
This allows storing ConditionObject in std::vector

BEGINRELEASENOTES
- Added the default move constructor and default move assignment operator to dd4hep::detail::ConditionObject and dd4hep::NamedObject
ENDRELEASENOTES