### PR TITLE
Add diquarks to default DDG4 rejectPDGs list

### DIFF
--- a/DDG4/python/DDSim/Helper/Physics.py
+++ b/DDG4/python/DDSim/Helper/Physics.py
@@ -17,13 +17,13 @@ class Physics(ConfigHelper):
     self._list = "FTFP_BERT"
     self._decays = False
     self._pdgfile = None
-    self._rejectPDGs = {1, 2, 3, 4, 5, 6, # quarks
-                        21, 23, 24, 25, # bosons
-                        1103, # d? diquarks
+    self._rejectPDGs = {1, 2, 3, 4, 5, 6,  # quarks
+                        21, 23, 24, 25,  # bosons
+                        1103,  # d? diquarks
                         2101, 2103, 2203,  # u? diquarks
-                        3101, 3103, 3201, 3203, 3303, # s? diquarks
-                        4101, 4103, 4201, 4203, 4301, 4303, 4403, # c? diquarks
-                        5101, 5103, 5201, 5203, 5301, 5303, 5401, 5403, 5503} # b? diquarks
+                        3101, 3103, 3201, 3203, 3303,  # s? diquarks
+                        4101, 4103, 4201, 4203, 4301, 4303, 4403,  # c? diquarks
+                        5101, 5103, 5201, 5203, 5301, 5303, 5401, 5403, 5503}  # b? diquarks
     self._zeroTimePDGs = {11, 13, 15, 17}
     self._userFunctions = []
 

--- a/DDG4/python/DDSim/Helper/Physics.py
+++ b/DDG4/python/DDSim/Helper/Physics.py
@@ -17,7 +17,13 @@ class Physics(ConfigHelper):
     self._list = "FTFP_BERT"
     self._decays = False
     self._pdgfile = None
-    self._rejectPDGs = {1, 2, 3, 4, 5, 6, 21, 23, 24, 25}
+    self._rejectPDGs = {1, 2, 3, 4, 5, 6, # quarks
+                        21, 23, 24, 25, # bosons
+                        1103, # d? diquarks
+                        2101, 2103, 2203,  # u? diquarks
+                        3101, 3103, 3201, 3203, 3303, # s? diquarks
+                        4101, 4103, 4201, 4203, 4301, 4303, 4403, # c? diquarks
+                        5101, 5103, 5201, 5203, 5301, 5303, 5401, 5403, 5503} # b? diquarks
     self._zeroTimePDGs = {11, 13, 15, 17}
     self._userFunctions = []
 


### PR DESCRIPTION
Per #883 diquarks are treated as stable by geant4 but they can have nominally non-zero travel times inside an event graph and should be explicitly rejected. This adds all diquarks, including diquarks with b-quarks.

BEGINRELEASENOTES
- Add diquarks to default DDG4 rejectPDGs list

ENDRELEASENOTES