### PR TITLE
Rework EDM4hep output action

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -355,6 +355,7 @@ void Geant4Output2EDM4hep::saveParticles(Geant4ParticleMap* particles)    {
         int iqdau = (*k).second;
         auto qdau = (*mcpc)[iqdau];
         qdau.addToParents(q);
+        q.addToDaughters(qdau);
       }
 
       for (const auto& ipar : p->parents) {
@@ -367,6 +368,7 @@ void Geant4Output2EDM4hep::saveParticles(Geant4ParticleMap* particles)    {
           int iqpar = (*k).second;
           auto qpar = (*mcpc)[iqpar];
           q.addToParents(qpar);
+          qpar.addToDaughters(q);
         }
       }
     }


### PR DESCRIPTION
BEGINRELEASENOTES
- Rework the EDM4hep output action. The major reason is the renaming of the default types in AIDASoft/podio#205 and its effects on EDM4hep (key4hep/EDM4hep#132). These changes are:
  - Use `auto` wherever possible to remove any explicit mentioning of EDM4hep types.
  - Switch to range-based for-loops where possible
  - Keep an internal map of the collections to get rid of the `const_cast`s that were used before.
- EDM4hep output: Make sure that the daughter relations are also set, because that is not done automatically in EDM4hep but is in LCIO.

ENDRELEASENOTES

Keeping explicit typenames out of the implementation makes it possible to have this work with current and future EDM4hep versions.