### PR TITLE
Changes for Geant4 11.0.0; Allow for Geant4 builds without GDML

### DIFF
--- a/DDG4/CMakeLists.txt
+++ b/DDG4/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(DDG4
   DD4hep::DDCore
   Geant4::Interface
   )
-
+#
 #Ensure our own includes come before those of the system
 target_include_directories(DDG4 BEFORE
   PUBLIC
@@ -34,6 +34,12 @@ target_include_directories(DDG4 BEFORE
   $<INSTALL_INTERFACE:include>
 )
 
+if(NOT Geant4_gdml_FOUND)
+  dd4hep_print("|++> Geant4 has no GDML library present....do not build corresponding features")
+  target_compile_definitions(DDG4 PUBLIC -DGEANT4_NO_GDML)
+else()
+  dd4hep_print("|++> Geant4 GDML library present....build G4 GDML components")
+endif()
 #-----------------------------------------------------------------------------------
 dd4hep_add_dictionary( G__DDG4
   SOURCES python/DDG4Dict.C
@@ -129,13 +135,16 @@ ENDIF()
 #   install(TARGETS DDG4Reco EXPORT DD4hep LIBRARY DESTINATION lib)
 # ENDIF()
 #-----------------------------------------------------------------------------------
-add_executable(g4gdmlDisplay g4gdmlDisplay.cpp)
+if(Geant4_gdml_FOUND)
+  add_executable(g4gdmlDisplay g4gdmlDisplay.cpp)
+  target_link_libraries(g4gdmlDisplay DDG4)
+  install(TARGETS g4gdmlDisplay EXPORT DD4hep RUNTIME DESTINATION bin)
+endif()
+#
 #-----------------------------------------------------------------------------------
 add_executable(g4FromXML g4FromXML.cpp)
-#-----------------------------------------------------------------------------------
-target_link_libraries(g4gdmlDisplay DDG4)
 target_link_libraries(g4FromXML DDG4)
-
+#
 #---Package installation procedure(s) ----------------------------------------------
 file(GLOB DDG4_python python/*.py python/*.C)
 install(FILES ${DDG4_python} DESTINATION ${DD4HEP_PYTHON_INSTALL_DIR})
@@ -163,8 +172,7 @@ install(DIRECTORY examples DESTINATION examples/DDG4)
 
 set_target_properties(DDG4 DDG4Plugins PROPERTIES VERSION ${DD4hep_VERSION} SOVERSION ${DD4hep_SOVERSION})
 
-
-install(TARGETS DDG4 DDG4Plugins g4gdmlDisplay g4FromXML
+install(TARGETS DDG4 DDG4Plugins g4FromXML
   EXPORT DD4hep
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/DDG4/plugins/Geant4DetectorGeometryConstruction.cpp
+++ b/DDG4/plugins/Geant4DetectorGeometryConstruction.cpp
@@ -118,9 +118,9 @@ namespace dd4hep {
 #include <G4VSolid.hh>
 #include "CLHEP/Units/SystemOfUnits.h"
 
-//#ifdef GEANT4_HAS_GDML
+#ifndef GEANT4_NO_GDML
 #include <G4GDMLParser.hh>
-//#endif
+#endif
 
 #include <cmath>
 
@@ -403,11 +403,13 @@ int Geant4DetectorGeometryConstruction::checkVolume(const char* vol_path)  {
 
 /// Write GDML file
 int Geant4DetectorGeometryConstruction::writeGDML(const char* output)  {
+#ifdef GEANT4_NO_GDML
+  warning("+++ writeGDML: GDML not found in the present Geant4 build! Output: %s not written", output);
+#else
   G4VPhysicalVolume* w  = context()->world();
   if ( output && ::strlen(output) > 0 && output != m_dumpGDML.c_str() )
     m_dumpGDML = output;
 
-  //#ifdef GEANT4_HAS_GDML
   if ( !m_dumpGDML.empty() ) {
     G4GDMLParser parser;
     parser.Write(m_dumpGDML.c_str(), w);
@@ -424,7 +426,7 @@ int Geant4DetectorGeometryConstruction::writeGDML(const char* output)  {
     }
   }
   warning("+++ writeGDML: Neither property DumpGDML nor environment DUMP_GDML set. No file written!");
-  //#endif
+#endif
   return 0;
 }
 

--- a/DDG4/plugins/Geant4GDMLWriteAction.cpp
+++ b/DDG4/plugins/Geant4GDMLWriteAction.cpp
@@ -89,7 +89,9 @@ namespace dd4hep {
 #include "DDG4/Geant4UIMessenger.h"
 
 // Geant 4 includes
+#ifndef GEANT4_NO_GDML
 #include "G4GDMLParser.hh"
+#endif
 #include "G4Version.hh"
 
 // C/C++ include files
@@ -143,6 +145,9 @@ void Geant4GDMLWriteAction::writeGDML()   {
     warning("+++ GDML file %s already exists. Overwriting existing file.", fname.c_str());
     ::unlink(fname.c_str());
   }
+#ifdef GEANT4_NO_GDML
+  warning("+++ writeGDML: GDML not found in the present Geant4 build! Output: %s not written", fname.c_str());
+#else
   unique_ptr<G4GDMLParser> parser(new G4GDMLParser());
   parser->SetRegionExport(m_exportRegions != 0);
   parser->SetEnergyCutsExport(m_exportEnergyCuts != 0);
@@ -151,6 +156,7 @@ void Geant4GDMLWriteAction::writeGDML()   {
 #endif
   info("+++ Writing GDML file: %s", fname.c_str());
   parser->Write(fname, context()->world());
+#endif
 }
 
 #include "DDG4/Factories.h"

--- a/DDG4/plugins/Geant4ScintillationPhysics.cpp
+++ b/DDG4/plugins/Geant4ScintillationPhysics.cpp
@@ -42,7 +42,7 @@
 #include "G4OpticalParameters.hh"
 
 /// This is a beta release problem:
-#if G4VERSION_NUMBER == 1100
+#if G4VERSION_NUMBER == 110000
 #include "G4OpticalParameters.hh"
 #pragma message("Geant4 version 11 beta: temporary fix to be removed!")
 void G4OpticalParameters::SetScintExcitationRatio(double) {}
@@ -83,6 +83,12 @@ namespace dd4hep {
         declareProperty("ByParticleType",                m_byParticleType = false);
         declareProperty("TrackInfo",                     m_trackInfo = false);
         declareProperty("VerboseLevel",                  m_verbosity = 0);
+        declareProperty("BoundaryInvokeSD",              m_boundaryInvokeSD = false);
+        declareProperty("WLSTimeProfile",                m_WLSTimeProfile);
+        declareProperty("WLS2TimeProfile",               m_WLS2TimeProfile);
+        declareProperty("CerenkovMaxPhotonsPerStep",     m_CerenkovMaxPhotonsPerStep = -1);
+        declareProperty("CerenkovMaxBetaChange",         m_CerenkovMaxBetaChange = -1.0);
+        // declareProperty("ScintEnhancedTimeConstants",    m_ScintEnhancedTimeConstants=false);
       }
       /// Default destructor
       virtual ~Geant4ScintillationPhysics() = default;
@@ -97,12 +103,21 @@ namespace dd4hep {
         G4Scintillation* process = new G4Scintillation(name());
 #if G4VERSION_NUMBER >= 1070
         G4OpticalParameters* params = G4OpticalParameters::Instance();
+#if G4VERSION_NUMBER >= 1100
+        if ( m_CerenkovMaxPhotonsPerStep > 0 )
+          params->SetCerenkovMaxPhotonsPerStep(m_CerenkovMaxPhotonsPerStep);
+        if ( m_CerenkovMaxBetaChange > 0e0 )
+          params->SetCerenkovMaxBetaChange(m_CerenkovMaxBetaChange);
+        if ( !m_WLSTimeProfile.empty()  )
+          params->SetWLSTimeProfile(m_WLS2TimeProfile);
+        if ( !m_WLS2TimeProfile.empty() )
+          params->SetWLS2TimeProfile(m_WLS2TimeProfile);
+        params->SetBoundaryInvokeSD(m_boundaryInvokeSD);
+#endif
         params->SetScintVerboseLevel(m_verbosity);
         params->SetScintFiniteRiseTime(m_finiteRiseTime);
         params->SetScintStackPhotons(m_stackPhotons);
         params->SetScintTrackSecondariesFirst(m_trackSecondariesFirst);
-        params->SetScintYieldFactor(m_scintillationYieldFactor);
-        params->SetScintExcitationRatio(m_scintillationExcitationRatio);
         params->SetScintByParticleType(m_byParticleType);
         params->SetScintTrackInfo(m_trackInfo);
 #else
@@ -112,8 +127,13 @@ namespace dd4hep {
         process->SetStackPhotons(m_stackPhotons);
 #endif
         process->SetTrackSecondariesFirst(m_trackSecondariesFirst);
+#if G4VERSION_NUMBER == 110000
+        /// Not yet implemented in G4 11.0.0. Only declared in the header
+        // params->SetScintEnhancedTimeConstants(m_ScintEnhancedTimeConstants);
+        /// These were only in the beta release:
         process->SetScintillationYieldFactor(m_scintillationYieldFactor);
         process->SetScintillationExcitationRatio(m_scintillationExcitationRatio);
+#endif
 #if G4VERSION_NUMBER >= 940
         process->SetScintillationByParticleType(m_byParticleType);
 #endif
@@ -141,14 +161,36 @@ namespace dd4hep {
       }
 
     private:
+      /// G4 11 beta, then disappeared....
       double m_scintillationYieldFactor;
+      /// G4 11 beta, then disappeared....
       double m_scintillationExcitationRatio;
+
+      /// G4OpticalParameters: "VerboseLevel"
       int    m_verbosity;
+      /// G4OpticalParameters: "CerenkovStackPhotons"
       bool   m_stackPhotons;
+      /// G4OpticalParameters: "ScintFiniteRiseTime"
       bool   m_finiteRiseTime;
+      /// G4OpticalParameters: "ScintTrackSecondariesFirst"
       bool   m_trackSecondariesFirst;
+      /// G4OpticalParameters: "ScintByParticleType"
       bool   m_byParticleType;
+      /// G4OpticalParameters: "ScintTrackInfo"
       bool   m_trackInfo;
+
+      /// G4OpticalParameters: "BoundaryInvokeSD"
+      bool m_boundaryInvokeSD;
+      /// G4OpticalParameters: "WLSTimeProfile"
+      std::string m_WLSTimeProfile;
+      /// G4OpticalParameters: "WLS2TimeProfile";
+      std::string m_WLS2TimeProfile;
+      /// G4OpticalParameters: "CerenkovMaxBetaChange"
+      double m_CerenkovMaxBetaChange;
+      /// G4OpticalParameters: "CerenkovMaxPhotonsPerStep"
+      int  m_CerenkovMaxPhotonsPerStep;
+      /// G4OpticalParameters: "ScintEnhancedTimeConstants"
+      bool m_ScintEnhancedTimeConstants;
     };
   }
 }


### PR DESCRIPTION

BEGINRELEASENOTES
- Changes for Geant4 11.0.0.
  Propagate additional setup properties for optical parameters in Geant4ScintillationPhysics.
  Other required changes were already included when preparing for the Geant4 beta release.
- Allow for Geant4 builds without GDML.
  Enable conditional build if the Geant4 build does not support GDML 

ENDRELEASENOTES