### PR TITLE
DDsim helper commands for momentumMin and momentumMax

### DIFF
--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -26,6 +26,8 @@ class Gun(ConfigHelper):
     self.phiMax = None
     self.thetaMin = None
     self.thetaMax = None
+    self.momentumMin = None
+    self.momentumMax = None
 
     self._distribution_EXTRA = {'choices': ['uniform', 'cos(theta)',
                                             'eta', 'pseudorapidity',
@@ -111,7 +113,9 @@ class Gun(ConfigHelper):
   def setOptions(self, ddg4Gun):
     """set the starting properties of the DDG4 particle gun"""
     try:
-      ddg4Gun.energy = self.energy
+      ddg4Gun.energy = self.energy # ddg4Gun.energy actually sets momentum
+      ddg4Gun.MomentumMin = self.energy
+      ddg4Gun.MomentumMax = self.energy
       ddg4Gun.particle = self.particle
       ddg4Gun.multiplicity = self.multiplicity
       ddg4Gun.position = self.position
@@ -130,6 +134,10 @@ class Gun(ConfigHelper):
       if self.phiMax is not None:
         ddg4Gun.PhiMax = self.phiMax
         ddg4Gun.isotrop = True
+      if self.momentumMin is not None:
+        ddg4Gun.MomentumMin = self.momentumMin
+      if self.momentumMax is not None:
+        ddg4Gun.MomentumMax = self.momentumMax
     except Exception as e:  # pylint: disable=W0703
       logger.error("parsing gun options:\n%s\nException: %s " % (self, e))
       exit(1)

--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -26,6 +26,7 @@ class Gun(ConfigHelper):
     self.phiMax = None
     self.thetaMin = None
     self.thetaMax = None
+    self._momentumMin_EXTRA = {'help': "Minimal momentum when using distribution (default = 0.0)"}
     self.momentumMin = None
     self.momentumMax = None
 
@@ -113,8 +114,8 @@ class Gun(ConfigHelper):
   def setOptions(self, ddg4Gun):
     """set the starting properties of the DDG4 particle gun"""
     try:
-      ddg4Gun.energy = self.energy # ddg4Gun.energy actually sets momentum
-      ddg4Gun.MomentumMin = self.energy
+      ddg4Gun.energy = self.energy  # ddg4Gun.energy actually sets momentum
+      ddg4Gun.MomentumMin = 0.0
       ddg4Gun.MomentumMax = self.energy
       ddg4Gun.particle = self.particle
       ddg4Gun.multiplicity = self.multiplicity


### PR DESCRIPTION
This completes (finally) https://github.com/AIDASoft/DD4hep/pull/872 and closes https://github.com/AIDASoft/DD4hep/issues/862.

BEGINRELEASENOTES
- Support `ddsim --gun.momentumMin 1*GeV --momentumMax 10*GeV` (default remains momentumMin = 0.0)
ENDRELEASENOTES