### PR TITLE
Fix plugin name discrepancies for DDEve

### DIFF
--- a/DDEve/DDEve/DDG4IO.C
+++ b/DDEve/DDEve/DDG4IO.C
@@ -120,7 +120,7 @@ namespace {
 }
 
 #include "DD4hep/Factories.h"
-DECLARE_CONSTRUCTOR(DDEve_DDG4HitAccess,_convertHit)
-DECLARE_CONSTRUCTOR(DDEve_DDG4ParticleAccess,_convertParticle)
+DECLARE_CONSTRUCTOR(DD4hep_DDEve_DDG4HitAccess,_convertHit)
+DECLARE_CONSTRUCTOR(DD4hep_DDEve_DDG4ParticleAccess,_convertParticle)
 #endif
 

--- a/DDEve/include/DDEve/DisplayConfiguration.h
+++ b/DDEve/include/DDEve/DisplayConfiguration.h
@@ -102,7 +102,7 @@ namespace dd4hep {
       } data;
       std::string name;
       std::string hits;
-      std::string use  {"true"};
+      std::string use;
       int type;
       /// Default constructor
       Config();

--- a/DDEve/include/DDEve/Factories.h
+++ b/DDEve/include/DDEve/Factories.h
@@ -28,6 +28,6 @@ namespace {
 }
 
 #define DECLARE_VIEW_FACTORY(x) \
-DD4HEP_PLUGINSVC_FACTORY(x,dd4hep_DDEve_##x,dd4hep::View*(dd4hep::Display*, const char*),__LINE__)
+DD4HEP_PLUGINSVC_FACTORY(x,DD4hep_DDEve_##x,dd4hep::View*(dd4hep::Display*, const char*),__LINE__)
 
 #endif // DDEVE_FACTORIES_H

--- a/DDEve/lcio/LCIOEventHandler.cpp
+++ b/DDEve/lcio/LCIOEventHandler.cpp
@@ -70,7 +70,7 @@ static void* _create(const char*)  {
   return eh;
 }
 using namespace dd4hep::detail;
-DECLARE_CONSTRUCTOR(DDEve_LCIOEventHandler,_create)
+DECLARE_CONSTRUCTOR(DD4hep_DDEve_LCIOEventHandler,_create)
 
 /// Standard constructor
 LCIOEventHandler::LCIOEventHandler() : EventHandler(), m_lcReader(0), m_event(0) {

--- a/DDEve/src/DDG4EventHandler.cpp
+++ b/DDEve/src/DDG4EventHandler.cpp
@@ -42,18 +42,18 @@ namespace {
   }
 }
 using namespace dd4hep::detail;
-DECLARE_CONSTRUCTOR(DDEve_DDG4EventHandler,_create)
+DECLARE_CONSTRUCTOR(DD4hep_DDEve_DDG4EventHandler,_create)
 
 /// Standard constructor
 DDG4EventHandler::DDG4EventHandler() : EventHandler(), m_file(0,0), m_entry(-1) {
-  void* ptr = PluginService::Create<void*>("DDEve_DDG4HitAccess",(const char*)"");
+  void* ptr = PluginService::Create<void*>("DD4hep_DDEve_DDG4HitAccess",(const char*)"");
   if ( 0 == ptr )   {
-    throw runtime_error("FATAL: Failed to access function pointer from factory DDEve_DDG4HitAccess");
+    throw runtime_error("FATAL: Failed to access function pointer from factory DD4hep_DDEve_DDG4HitAccess");
   }
   m_simhitConverter = FCN(ptr).hits;
-  ptr = PluginService::Create<void*>("DDEve_DDG4ParticleAccess",(const char*)"");
+  ptr = PluginService::Create<void*>("DD4hep_DDEve_DDG4ParticleAccess",(const char*)"");
   if ( 0 == ptr )   {
-    throw runtime_error("FATAL: Failed to access function pointer from factory DDEve_DDG4ParticleAccess");
+    throw runtime_error("FATAL: Failed to access function pointer from factory DD4hep_DDEve_DDG4ParticleAccess");
   }
   m_particleConverter = FCN(ptr).particles;
 }

--- a/DDEve/src/DisplayConfigurationParser.cpp
+++ b/DDEve/src/DisplayConfigurationParser.cpp
@@ -83,17 +83,17 @@ namespace {
 static void extract(DisplayConfiguration::Config& c, xml_h e, int typ)   {
   c.name  = e.attr<string>(_U(name));
   c.type = typ;
-  c.data.defaults.show_evt  = e.hasAttr(u_show_evt) ? e.attr<int>(u_show_evt) :  1;
-  c.data.defaults.load_geo  = e.hasAttr(u_load_geo) ? e.attr<int>(u_load_geo) : -1;
-  c.data.defaults.color = e.hasAttr(_U(color)) ? e.attr<int>(_U(color)) : 0xBBBBBB;
-  c.data.defaults.alpha = e.hasAttr(_U(alpha)) ? e.attr<float>(_U(alpha)) : -1.0;
-  c.data.calo3d.emax    = e.hasAttr(u_emax) ? e.attr<float>(u_emax) : 25.0;
-  c.data.calo3d.towerH  = e.hasAttr(u_towerH) ? e.attr<float>(u_towerH) : 25.0;
-  if ( e.hasAttr(_U(dz))   ) c.data.calo3d.dz = e.attr<float>(_U(dz));
+  c.data.defaults.show_evt  = e.hasAttr(u_show_evt) ? e.attr<int>(u_show_evt)  :  1;
+  c.data.defaults.load_geo  = e.hasAttr(u_load_geo) ? e.attr<int>(u_load_geo)  : -1;
+  c.data.defaults.color     = e.hasAttr(_U(color))  ? e.attr<int>(_U(color))   : 0xBBBBBB;
+  c.data.defaults.alpha     = e.hasAttr(_U(alpha))  ? e.attr<float>(_U(alpha)) : -1.0;
+  c.data.calo3d.emax        = e.hasAttr(u_emax)     ? e.attr<float>(u_emax)    : 25.0;
+  c.data.calo3d.towerH      = e.hasAttr(u_towerH)   ? e.attr<float>(u_towerH)  : 25.0;
+  if ( e.hasAttr(_U(dz))   ) c.data.calo3d.dz   = e.attr<float>(_U(dz));
   if ( e.hasAttr(_U(rmin)) ) c.data.calo3d.rmin = e.attr<float>(_U(rmin));
-  if ( e.hasAttr(_U(threshold)) ) c.data.calo3d.threshold = e.attr<float>(_U(threshold));
+  if ( e.hasAttr(u_use)    ) c.use  = e.attr<string>(u_use);
   if ( e.hasAttr(u_hits)   ) c.hits = e.attr<string>(u_hits);
-  if ( e.hasAttr(u_use)    ) c.use = e.attr<string>(u_use);
+  if ( e.hasAttr(_U(threshold)) ) c.data.calo3d.threshold = e.attr<float>(_U(threshold));
 }
 
 /** Convert display configuration objects of  tag type ddeve/detelement
@@ -222,7 +222,7 @@ template <> void Converter<collection>::operator()(xml_h e)  const  {
   c.name = e.attr<string>(_U(name));
   c.hits = e.attr<string>(u_hits);
   c.type = DisplayConfiguration::COLLECTION;
-  c.use  = e.hasAttr(u_use) ? e.attr<string>(u_use) : string("true");
+  c.use  = e.hasAttr(u_use) ? e.attr<string>(u_use) : string();
   c.data.hits.size  = e.attr<float>(_U(size));
   c.data.hits.type  = e.attr<float>(_U(type));
   c.data.hits.color = e.hasAttr(_U(color))  ? e.attr<int>(_U(color)) : kRed;

--- a/DDEve/src/GenericEventHandler.cpp
+++ b/DDEve/src/GenericEventHandler.cpp
@@ -107,14 +107,14 @@ bool GenericEventHandler::Open(const string& file_type, const string& file_name)
     detail::deletePtr(m_current);
     //  prefer event handler configured in xml
     if ( file_type.find("FCC") != string::npos ) {
-      m_current = (EventHandler*)PluginService::Create<void*>("DDEve_FCCEventHandler",(const char*)0);
+      m_current = (EventHandler*)PluginService::Create<void*>("DD4hep_DDEve_FCCEventHandler",(const char*)0);
     }
     // fall back to defaults according to file ending
     else if ( idx != string::npos )   {
-      m_current = (EventHandler*)PluginService::Create<void*>("DDEve_LCIOEventHandler",(const char*)0);
+      m_current = (EventHandler*)PluginService::Create<void*>("DD4hep_DDEve_LCIOEventHandler",(const char*)0);
     }
     else if ( idr != string::npos )   {
-      m_current = (EventHandler*)PluginService::Create<void*>("DDEve_DDG4EventHandler",(const char*)0);
+      m_current = (EventHandler*)PluginService::Create<void*>("DD4hep_DDEve_DDG4EventHandler",(const char*)0);
     }
     else   {
       throw runtime_error("Attempt to open file:"+file_name+" of unknown type:"+file_type);

--- a/DDEve/src/MultiView.cpp
+++ b/DDEve/src/MultiView.cpp
@@ -72,7 +72,7 @@ View& MultiView::Build(TEveWindow* slot)   {
   /// First panel
   if ( panels.size()>0)   {
     const DisplayConfiguration::Config& cfg = panels[0];
-    string typ = "DD4hep__"+cfg.use;
+    string typ = "DD4hep_DDEve_"+cfg.use;
     v = PluginService::Create<View*>(typ.c_str(),m_eve,cfg.name.c_str());
   }
   else  {
@@ -84,7 +84,7 @@ View& MultiView::Build(TEveWindow* slot)   {
   /// Second panel
   if ( panels.size()>1)   {
     const DisplayConfiguration::Config& cfg = panels[1];
-    string typ = "DD4hep__"+cfg.use;
+    string typ = "DD4hep_DDEve_"+cfg.use;
     v = PluginService::Create<View*>(typ.c_str(),m_eve,cfg.name.c_str());
   }
   else  {


### PR DESCRIPTION
BEGINRELEASENOTES
- The refactoring of namespaces (some years ago) left some factory name discrepancies in DDEve.
This PR fixes them and re-enables the various views and projections.
See issue https://github.com/AIDASoft/DD4hep/issues/893.
- There are still some issues when loading a new file, which are not yet entirely understood.
The suspicion is that the displayed 2D histograms somehow "reside" in the opened file and disappear
when the file is closed. This however needs confirmation (and eventually fixing).
ENDRELEASENOTES