### PR TITLE
edm4hep: don't add particle as parent to its daughters

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -354,7 +354,6 @@ void Geant4Output2EDM4hep::saveParticles(Geant4ParticleMap* particles)    {
         }
         int iqdau = (*k).second;
         auto qdau = (*mcpc)[iqdau];
-        qdau.addToParents(q);
         q.addToDaughters(qdau);
       }
 
@@ -368,7 +367,6 @@ void Geant4Output2EDM4hep::saveParticles(Geant4ParticleMap* particles)    {
           int iqpar = (*k).second;
           auto qpar = (*mcpc)[iqpar];
           q.addToParents(qpar);
-          qpar.addToDaughters(q);
         }
       }
     }


### PR DESCRIPTION
Also, don't add particle as daughter to its parents.

This addresses an issue with fully duplicated entries in the parents and
daughters relations for MCParticles. After this bugfix, only a single
entry for each parents is entered in the parents relations, similar for
daughters. More demonstrated behavior in pull request comments.

BEGINRELEASENOTES
- edm4hep: don't add particle as parent to its daughters, and vice versa
ENDRELEASENOTES