### PR TITLE
Handle material properties (and const properties) beyond the G4 material table

### DIFF
--- a/DDCore/include/XML/UnicodeValues.h
+++ b/DDCore/include/XML/UnicodeValues.h
@@ -320,6 +320,7 @@ UNICODE (offset);
 UNICODE (open);
 UNICODE (operation);
 UNICODE (opticalsurface);
+UNICODE (option);
 UNICODE (overlap);
 UNICODE (outer);
 UNICODE (outer_field);

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -139,7 +139,8 @@ static long display(Detector& description, int argc, char** argv) {
         "     -detector <string> Top level DetElement path. Default: '/world'                \n"
         "     -option   <string> ROOT Draw option.    Default: 'ogl'                         \n"
         "     -level    <number> Visualization level  [TGeoManager::SetVisLevel]  Default: 4 \n"
-        "     -visopt   <number> Visualization option [TGeoManager::SetVisOption] Default: 1 \n"       
+        "     -visopt   <number> Visualization option [TGeoManager::SetVisOption] Default: 1\n"       
+        "     -load              Only load the geometry. Do not invoke the display          \n"
         "     -help              Print this help output  \n"       
         "     Arguments given: " << arguments(argc,argv) << endl << flush;
       ::exit(EINVAL);

--- a/examples/OpticalSurfaces/compact/ReadMaterialProperties.xml
+++ b/examples/OpticalSurfaces/compact/ReadMaterialProperties.xml
@@ -20,6 +20,10 @@
     <comment>Test reading of TGeo's Material Properties</comment>
   </info>
 
+  <debug>
+    <type name="materials" value="1"/>
+  </debug>
+
   <define>
     <constant name="world_side" value="1*m"/>
     <constant name="world_x" value="world_side/2"/>
@@ -200,11 +204,26 @@
               4.136*eV 
     "/>
     </ignore>
+
+    <matrix name= "Water__SpecialMine" option="Geant4-ignore" coldim="1" values="  
+              2.034*eV 
+              2.068*eV 
+              2.103*eV 
+              2.139*eV 
+              2.177*eV 
+              2.216*eV 
+    "/>
   </properties>
 
   <includes>
     <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
   </includes>
+
+  <properties>
+    <constant name="Birk__Water|Geant4-ignore" value="12.345678"/>
+    <constant name="Water__Mine|Geant4-ignore" value="87.654321"/>
+  </properties>
+
   <materials>
     <material name="Air">
       <D type="density" unit="g/cm3" value="0.0012"/>
@@ -227,6 +246,24 @@
       <property name="ABSLENGTH"     ref="ABSLENGTH__0x123aff00"/>
       <property name="FASTCOMPONENT" ref="FASTCOMPONENT__0x123aff00"/>
       <property name="SLOWCOMPONENT" ref="SLOWCOMPONENT__0x123aff00"/>
+      <!-- Properties ignored by Geant4 -->
+      <property name="Property_of_mine" ref="Water__SpecialMine"/>
+      <constant name="BirksConstant"    ref="Birk__Water|Geant4-ignore"/>
+      <!-- Constants  ignored by Geant4 -->
+      <constant name="Constant_of_mine" ref="Water__Mine|Geant4-ignore"/>
     </material>
   </materials>
+
+  <readouts>
+    <readout name="Hits">
+      <id>system:8,box:8</id>
+    </readout>
+  </readouts>
+    
+  <detectors>
+    <detector id="1" name="MaterialTester" type="MaterialTester" readout="Hits">
+      <box x="50*cm" y="50*cm" z="50*cm" material="Water"/>
+      <test name="Water"/>
+    </detector>
+  </detectors>
 </lccdd>

--- a/examples/OpticalSurfaces/scripts/ReadMaterialProperties.py
+++ b/examples/OpticalSurfaces/scripts/ReadMaterialProperties.py
@@ -54,9 +54,8 @@ def run():
   # Configure G4 geometry setup
   seq, act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
   act.DebugMaterials = True
-  act.DebugVolumes   = True
-  act.DebugShapes    = True
-
+  act.DebugVolumes = True
+  act.DebugShapes = True
 
   # Setup particle gun
   gun = geant4.setupGun("Gun", particle='gamma', energy=5 * keV, multiplicity=1)

--- a/examples/OpticalSurfaces/scripts/ReadMaterialProperties.py
+++ b/examples/OpticalSurfaces/scripts/ReadMaterialProperties.py
@@ -1,0 +1,75 @@
+# ==========================================================================
+#  AIDA Detector description implementation
+# --------------------------------------------------------------------------
+# Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+# All rights reserved.
+#
+# For the licensing terms see $DD4hepINSTALL/LICENSE.
+# For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+#
+# ==========================================================================
+#
+from __future__ import absolute_import, unicode_literals
+import os
+import sys
+import DDG4
+from DDG4 import OutputLevel as Output
+from g4units import keV
+#
+#
+"""
+
+   dd4hep simulation example setup using the python configuration
+
+   @author  M.Frank
+   @version 1.0
+
+"""
+
+
+def run():
+  kernel = DDG4.Kernel()
+  install_dir = os.environ['DD4hepExamplesINSTALL']
+  kernel.loadGeometry(str("file:" + install_dir + "/examples/OpticalSurfaces/compact/ReadMaterialProperties.xml"))
+
+  DDG4.importConstants(kernel.detectorDescription(), debug=False)
+  geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')
+  geant4.printDetectors()
+  # Configure UI
+  if len(sys.argv) > 1:
+    geant4.setupCshUI(macro=sys.argv[1])
+  else:
+    geant4.setupCshUI()
+
+  # Configure field
+  geant4.setupTrackingField(prt=True)
+  # Configure Event actions
+  prt = DDG4.EventAction(kernel, 'Geant4ParticlePrint/ParticlePrint')
+  prt.OutputLevel = Output.DEBUG
+  prt.OutputType = 3  # Print both: table and tree
+  kernel.eventAction().adopt(prt)
+
+  generator_output_level = Output.INFO
+
+  # Configure G4 geometry setup
+  seq, act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
+  act.DebugMaterials = True
+  act.DebugVolumes   = True
+  act.DebugShapes    = True
+
+
+  # Setup particle gun
+  gun = geant4.setupGun("Gun", particle='gamma', energy=5 * keV, multiplicity=1)
+  gun.OutputLevel = generator_output_level
+
+  geant4.setupTracker('MaterialTester')
+
+  # Now build the physics list:
+  phys = geant4.setupPhysics('QGSP_BERT')
+  phys.dump()
+
+  geant4.execute()
+
+
+if __name__ == "__main__":
+  run()


### PR DESCRIPTION

BEGINRELEASENOTES
See for the example
-- /examples/ClientTests/src/MaterialTester_geo.cpp
-- /examples/OpticalSurfaces/compact/ReadMaterialProperties.xml
-- /examples/OpticalSurfaces/scripts/ReadMaterialProperties.py

The python file is only there to show that the G4 simulation does not get screwed.....
Otherwise: to define properties, which do not participate in Geant4:
```
    <material name="Water">
      <D type="density" value="1.0" unit="g/cm3"/>
      <composite n="2" ref="H"/>
      <composite n="1" ref="O"/>
      <!-- Properties used by Geant4    -->
      <property name="RINDEX"        ref="RINDEX__0x123aff00"/>
      <property name="ABSLENGTH"     ref="ABSLENGTH__0x123aff00"/>
      <property name="FASTCOMPONENT" ref="FASTCOMPONENT__0x123aff00"/>
      <property name="SLOWCOMPONENT" ref="SLOWCOMPONENT__0x123aff00"/>
      <!-- Properties ignored by Geant4 -->
      <property name="Property_of_mine" ref="Water__0x123aff00"/>
      <constant name="BirksConstant"    ref="Birk__Water|Geant4-ignore"/>
      <!-- Constants  ignored by Geant4 -->
      <constant name="Constant_of_mine" ref="Water__Mine|Geant4-ignore"/>
    </material>
```
where:
```
  <properties>
    <constant name="Birk__Water|Geant4-ignore" value="12.345678"/>
    <constant name="Water__Mine|Geant4-ignore" value="87.654321"/>
  </properties>
```
and
```
    <matrix name= "Water__0x123aff00" option="Geant4-ignore" coldim="1" values="  
              2.034*eV 
              2.068*eV 
              2.103*eV 
              2.139*eV 
              2.177*eV 
              2.216*eV 
    "/>
  </properties>
```
For non-const properties you have to set the option to "Geant4-ignore",
otherwise you append the string to the name. The "ref" string in the material
and the property must match.
In the program you can then access the propertiers by name like this:
```
Material material(...)
double v = material->GetConstProperty("BirksConstant");
TGDMLMatrix* m = material->GetProperty("Property_of_mine");
```
like any other property. See for details:
/examples/ClientTests/src/MaterialTester_geo.cpp lines 78-108

ENDRELEASENOTES