### PR TITLE
Fix a bug that cannot set G4 const property

### DIFF
--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -464,7 +464,7 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
       }
       int idx = -1;
       try   {
-        idx = tab->GetPropertyIndex(named->GetName());
+        idx = tab->GetConstPropertyIndex(named->GetName());
       }
       catch(const std::exception& e)   {
         exc_str = e.what();


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix a bug that cannot set G4 const property, following up #884 

ENDRELEASENOTES

DD4hep version ≥ `v01-20` seems to be unable to set `G4MaterialConstProperty` due to the tiny [implicit change](
https://github.com/AIDASoft/DD4hep/commit/9ef9c77445c7ed178120c82aa48773645149b4db#diff-43381ae75e36f7a80176a39548c81d22b246168042d522d5880c27d65d2a801cL422-R439) introduced while following up on the recent GEANT4 v11.0 updates.

It looks like a simple change `GetPropertyIndex(named->GetName())` into `GetConstPropertyIndex(named->GetName())` gives a reasonable fix, the simulation works with both table property and const property. Please take a look and let me know if you have any feedback.

