### PR TITLE
edm4hep: Put event and run number into event metadata

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -65,6 +65,9 @@ namespace dd4hep {
       for(auto const& ival: this->strParameters()) {
         lcparameters.setValues(ival.first, ival.second);
       }
+
+      lcparameters.setValues("eventNumber", this->eventNumber());
+      lcparameters.setValues("runNumber", this->runNumber());
     }
 
     class  Geant4ParticleMap;


### PR DESCRIPTION

BEGINRELEASENOTES
- Add `eventNumber` and `runNumber` into the event metadata for edm4hep output

ENDRELEASENOTES