### PR TITLE
Prevent crash at load time if LD_LIBRARY_PATH is not set

### DIFF
--- a/GaudiPluginService/src/PluginServiceV2.cpp
+++ b/GaudiPluginService/src/PluginServiceV2.cpp
@@ -156,7 +156,9 @@ namespace Gaudi {
           std::regex  line_format{"^(?:[[:space:]]*(?:(v[0-9]+)::)?([^:]+):(.*[^[:space:]]))?[[:space:]]*(?:#.*)?$"};
           std::smatch matches;
 
-          std::string search_path = std::getenv( envVar.c_str() );
+          std::string search_path;
+          const char* envPtr = std::getenv( envVar.c_str() );
+          if ( envPtr ) search_path = envPtr;
           if ( search_path.empty() ) {
             return;
           }


### PR DESCRIPTION
I found in Gaudi a logic error in the way the plugin service initializes the factories search path (see https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1316) and the issue is present in DD4hep too.

The problem is that the search path string is initialized from the return value of [`std::getenv`](https://en.cppreference.com/w/cpp/utility/program/getenv), which is `nullptr` if the environment variable is not set. Initializing a string from `nullptr` might result in an exception (not caught) or in a segfault (depending on the implementation).

BEGINRELEASENOTES
- Plugin Service: check that the `LD_LIBRARY_PATH` (or `PATH` or `DYLD_LIBRAY_PATH`) are actually set before trying to use them (to avoid a crash)

ENDRELEASENOTES