### PR TITLE
Ddsim multiple compactFiles

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,118 +3,6 @@ stages:
     - documentation
     - deployment
 
-centos7-gcc10-Geant10.6:
-  stage: build
-  tags:
-    - docker
-  image: ghcr.io/aidasoft/centos7:latest
-  script:
-    - source /cvmfs/sft.cern.ch/lcg/views/LCG_98/x86_64-centos7-gcc10-opt/setup.sh
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 ..
-    - ninja -k 0
-    - ninja install
-    - . ../bin/thisdd4hep.sh
-    - ctest --output-on-failure -j4
-    - cd ../examples/
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_CXX_STANDARD=17 ..
-    - ninja -k 0
-    - ninja install
-    - ctest --output-on-failure
-
-centos7-gcc9-Geant10.6:
-  stage: build
-  tags:
-    - docker
-  image: ghcr.io/aidasoft/centos7:latest
-  script:
-    - source /cvmfs/sft.cern.ch/lcg/views/LCG_98/x86_64-centos7-gcc9-opt/setup.sh
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 ..
-    - ninja -k 0
-    - ninja install
-    - . ../bin/thisdd4hep.sh
-    - ctest --output-on-failure -j4
-    - cd ../examples/
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_CXX_STANDARD=17  ..
-    - ninja -k 0
-    - ninja install
-    - ctest --output-on-failure
-
-centos7-gcc10-Geant10.6-XERCESC:
-  stage: build
-  tags:
-    - docker
-  image: ghcr.io/aidasoft/centos7:latest
-  script:
-    - source /cvmfs/sft.cern.ch/lcg/views/LCG_98/x86_64-centos7-gcc10-opt/setup.sh
-    - unset CPATH
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -DDD4HEP_USE_XERCESC=ON -DCMAKE_CXX_STANDARD=17 ..
-    - ninja -k 0
-    - ninja install
-    - . ../bin/thisdd4hep.sh
-    - ctest --output-on-failure -j4
-    - cd ../examples/
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_XERCESC=ON -DCMAKE_CXX_STANDARD=17 ..
-    - ninja -k 0
-    - ninja install
-    - ctest --output-on-failure
-
-centos7-gcc10-Geant10.6-Python3:
-  stage: build
-  tags:
-    - docker
-  image: ghcr.io/aidasoft/centos7:latest
-  script:
-    - source /cvmfs/sft.cern.ch/lcg/views/LCG_98python3/x86_64-centos7-gcc10-opt/setup.sh
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -DDD4HEP_USE_XERCESC=ON -DCMAKE_CXX_STANDARD=17 ..
-    - ninja -k 0
-    - ninja install
-    - . ../bin/thisdd4hep.sh
-    - ctest --output-on-failure -j4
-    - cd ../examples/
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_CXX_STANDARD=17  ..
-    - ninja -k 0
-    - ninja install
-    - ctest --output-on-failure
-
-
-centos7-clang10-Geant10.6-XERCESC:
-  stage: build
-  tags:
-    - docker
-  image: ghcr.io/aidasoft/centos7:latest
-  script:
-    - source /cvmfs/sft.cern.ch/lcg/views/LCG_98/x86_64-centos7-clang10-opt/setup.sh
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DDD4HEP_USE_GEANT4=ON -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -DDD4HEP_USE_XERCESC=ON -DCMAKE_CXX_STANDARD=17 ..
-    - ninja -k 0
-    - ninja install
-    - . ../bin/thisdd4hep.sh
-    - ctest --output-on-failure -j4
-    - cd ../examples/
-    - mkdir build
-    - cd build
-    - cmake -GNinja -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_XERCESC=ON -DCMAKE_CXX_STANDARD=17 ..
-    - ninja -k 0
-    - ninja install
-    - ctest --output-on-failure
-
 mac1015-clang110-Geant10.6:
   stage: build
   tags:
@@ -185,6 +73,7 @@ Python:
 # Compile Doxygen reference
 doxygen:
     stage: documentation
+    needs: ["Python"]
     tags:
         - docker
     image: ghcr.io/aidasoft/centos7:latest
@@ -204,6 +93,7 @@ doxygen:
 # Compile LaTeX user manual:
 usermanuals:
     stage: documentation
+    needs: ["Python"]
     tags:
       - docker
     image: ghcr.io/aidasoft/centos7:latest
@@ -244,9 +134,7 @@ deploy-documentation:
     stage: deployment
     tags:
       - docker
-    dependencies:
-        - usermanuals
-        - doxygen
+    needs: ["usermanuals", "doxygen"]
     # Docker image with tools to deploy to EOS
     image: gitlab-registry.cern.ch/ci-tools/ci-web-deployer:latest
     script:

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -63,7 +63,7 @@ class DD4hepSimulation(object):
 
   def __init__(self):
     self.steeringFile = None
-    self.compactFile = ""
+    self.compactFile = []
     self.inputFiles = []
     self.outputFile = "dummyOutput.slcio"
     self.runType = "batch"
@@ -145,8 +145,8 @@ class DD4hepSimulation(object):
     if self._argv is None:
       self._argv = list(argv) if argv else list(sys.argv)
 
-    parser.add_argument("--compactFile", action="store", default=self.compactFile,
-                        help="The compact XML file")
+    parser.add_argument("--compactFile", nargs='+', action="extend", default=self.compactFile, type=str,
+                        help="The compact XML file, or multiple compact files, if the last one is the closer.")
 
     parser.add_argument("--runType", action="store", choices=("batch", "vis", "run", "shell"), default=self.runType,
                         help="The type of action to do in this invocation"  # Note: implicit string concatenation
@@ -301,7 +301,8 @@ class DD4hepSimulation(object):
     kernel = DDG4.Kernel()
     dd4hep.setPrintLevel(self.printLevel)
 
-    kernel.loadGeometry(str("file:" + self.compactFile))
+    for compactFile in self.compactFile:
+      kernel.loadGeometry(str("file:" + compactFile))
     detectorDescription = kernel.detectorDescription()
 
     DDG4.importConstants(detectorDescription)


### PR DESCRIPTION

BEGINRELEASENOTES
- DDSim: add possibility to use individual compact files, e.g.:
    ddsim --compactFile $DD4hep/examples/CLICSiD/compact/SiD_multiple_inputs.xml $DD4hep/examples/CLICSiD/compact/SiD_detectors_1.xml --compactFile $DD4hep/examples/CLICSiD/compact/SiD_detectors_2.xml $DD4hep/examples/CLICSiD/compact/SiD_close.xml --runType shell

ENDRELEASENOTES

Also some tweaks for gitlab ci used for building the doxygen documentation