### PR TITLE
DDSim: make sure compactFile is a list

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -227,7 +227,7 @@ class DD4hepSimulation(object):
     self._dumpParameter = parsed.dumpParameter
     self._dumpSteeringFile = parsed.dumpSteeringFile
 
-    self.compactFile = parsed.compactFile
+    self.compactFile = ConfigHelper.makeList(parsed.compactFile)
     self.inputFiles = parsed.inputFiles
     self.inputFiles = self.__checkFileFormat(self.inputFiles, POSSIBLEINPUTFILES)
     self.outputFile = parsed.outputFile


### PR DESCRIPTION
Just adding to #914, fixing for backward compatibility if there is a steering file with a string in compactFile