### PR TITLE
DDSim: compactFile can only be one instance, otherwise we cannot over…

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -19,7 +19,7 @@ from DDSim.Helper.Filter import Filter
 from DDSim.Helper.Random import Random
 from DDSim.Helper.Action import Action
 from DDSim.Helper.OutputConfig import OutputConfig
-from DDSim.Helper.ConfigHelper import ConfigHelper, ExtendAction
+from DDSim.Helper.ConfigHelper import ConfigHelper
 from DDSim.Helper.MagneticField import MagneticField
 from DDSim.Helper.ParticleHandler import ParticleHandler
 from DDSim.Helper.Gun import Gun
@@ -131,8 +131,6 @@ class DD4hepSimulation(object):
 
     parser = argparse.ArgumentParser("Running DD4hep Simulations:",
                                      formatter_class=argparse.RawTextHelpFormatter)
-    # add myextend for python2.7
-    parser.register('action', 'myextend', ExtendAction)
 
     parser.add_argument("--steeringFile", "-S", action="store", default=self.steeringFile,
                         help="Steering file to change default behaviour")
@@ -147,7 +145,8 @@ class DD4hepSimulation(object):
     if self._argv is None:
       self._argv = list(argv) if argv else list(sys.argv)
 
-    parser.add_argument("--compactFile", nargs='+', action="myextend", default=self.compactFile, type=str,
+    parser.add_argument("--compactFile", nargs='+', action="store",
+                        default=ConfigHelper.makeList(self.compactFile), type=str,
                         help="The compact XML file, or multiple compact files, if the last one is the closer.")
 
     parser.add_argument("--runType", action="store", choices=("batch", "vis", "run", "shell"), default=self.runType,

--- a/DDG4/python/DDSim/Helper/ConfigHelper.py
+++ b/DDG4/python/DDSim/Helper/ConfigHelper.py
@@ -14,8 +14,6 @@ call for the parser object create an additional member::
 
 from __future__ import absolute_import, unicode_literals
 
-import argparse
-
 import ddsix as six
 
 
@@ -132,11 +130,3 @@ class ConfigHelper(object):
                               dest="%s.%s" % (name, var),
                               **optionsDict
                               )
-
-
-class ExtendAction(argparse.Action):
-  """Class to add the extend action for argparse to python2.7"""
-  def __call__(self, parser, namespace, values, option_string=None):
-    items = getattr(namespace, self.dest) or []
-    items.extend(values)
-    setattr(namespace, self.dest, items)


### PR DESCRIPTION
…write what is in the steeringfile, still takes multiple XML files

Another correction for #914 
So only one option of `--compactFile` is possible (with multiple options), not multiple compactFiles that extend the list.
Will update the release notes in the other PR