### PR TITLE
DDSim: add option to set userInputPlugin for simulation

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -7,9 +7,10 @@ Based on M. Frank and F. Gaede runSim.py
 
 """
 from __future__ import absolute_import, unicode_literals, division, print_function
-__RCSID__ = "$Id$"
-import sys
+
 import os
+import sys
+import traceback
 from DDSim.Helper.Meta import Meta
 from DDSim.Helper.LCIO import LCIO
 from DDSim.Helper.HepMC3 import HepMC3
@@ -249,6 +250,9 @@ class DD4hepSimulation(object):
     self.vertexSigma = parsed.vertexSigma
 
     self._consistencyChecks()
+
+    if self.printLevel <= 2:  # VERBOSE or DEBUG
+      logger.setLevel(logging.DEBUG)
 
     # self.__treatUnknownArgs( parsed, unknown )
     self.__parseAllHelper(parsed)
@@ -570,6 +574,8 @@ class DD4hepSimulation(object):
               obj.setOption(var, parsedDict[key])
             except RuntimeError as e:
               self._errorMessages.append("ERROR: %s " % e)
+              if logger.level <= logging.DEBUG:
+                self._errorMessages.append(traceback.format_exc())
 
   def __checkOutputLevel(self, level):
     """return outputlevel as int so we don't have to import anything for faster startup"""

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -393,11 +393,16 @@ class DD4hepSimulation(object):
       logger.info("++++ Adding Geant4 General Particle Source ++++")
       actionList.append(self._g4gps)
 
-    if self.inputConfig.userInputPlugin:
-      gen = self.inputConfig.userInputPlugin(self)
+    start = 4
+    for index, plugin in enumerate(self.inputConfig.userInputPlugin, start=start):
+      gen = plugin(self)
+      gen.Mask = index
+      start = index + 1
       actionList.append(gen)
+      self.__applyBoostOrSmear(kernel, actionList, index)
+      logger.info("++++ Adding User Plugin %s ++++", gen.Name)
 
-    for index, inputFile in enumerate(self.inputFiles, start=4):
+    for index, inputFile in enumerate(self.inputFiles, start=start):
       if inputFile.endswith(".slcio"):
         gen = DDG4.GeneratorAction(kernel, "LCIOInputAction/LCIO%d" % index)
         gen.Parameters = self.lcio.getParameters()

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -19,6 +19,7 @@ from DDSim.Helper.Filter import Filter
 from DDSim.Helper.Random import Random
 from DDSim.Helper.Action import Action
 from DDSim.Helper.OutputConfig import OutputConfig
+from DDSim.Helper.InputConfig import InputConfig
 from DDSim.Helper.ConfigHelper import ConfigHelper
 from DDSim.Helper.MagneticField import MagneticField
 from DDSim.Helper.ParticleHandler import ParticleHandler
@@ -95,6 +96,7 @@ class DD4hepSimulation(object):
     self.field = MagneticField()
     self.action = Action()
     self.outputConfig = OutputConfig()
+    self.inputConfig = InputConfig()
     self.guineapig = GuineaPig()
     self.lcio = LCIO()
     self.hepmc3 = HepMC3()
@@ -390,6 +392,10 @@ class DD4hepSimulation(object):
       self._g4gps.Mask = 3
       logger.info("++++ Adding Geant4 General Particle Source ++++")
       actionList.append(self._g4gps)
+
+    if self.inputConfig.userInputPlugin:
+      gen = self.inputConfig.userInputPlugin(self)
+      actionList.append(gen)
 
     for index, inputFile in enumerate(self.inputFiles, start=4):
       if inputFile.endswith(".slcio"):

--- a/DDG4/python/DDSim/Helper/InputConfig.py
+++ b/DDG4/python/DDSim/Helper/InputConfig.py
@@ -9,13 +9,13 @@ class InputConfig(ConfigHelper):
 
   def __init__(self):
     super(InputConfig, self).__init__()
-    self._userPlugin = None
+    self._userPlugin = []
 
   @property
   def userInputPlugin(self):
-    """Set a function to configure an inputStep.
+    """Set one or more functions to configure input steps.
 
-    The function must take a ``DD4hepSimulation`` object as its only argument and return the created generatorAction
+    The functions must take a ``DD4hepSimulation`` object as their only argument and return the created generatorAction
     ``gen`` (for example).
 
     For example one can add this to the ddsim steering file:
@@ -37,13 +37,24 @@ class InputConfig(ConfigHelper):
         return gen
 
       SIM.inputConfig.userInputPlugin = exampleUserPlugin
+
+    Repeat function definition and assignment to add multiple input steps
+
     """
     return self._userPlugin
 
   @userInputPlugin.setter
   def userInputPlugin(self, userInputPluginConfig):
-    if userInputPluginConfig is None:
+    if not userInputPluginConfig:
       return
+
+    if isinstance(userInputPluginConfig, list):
+      if not all(callable(func) for func in userInputPluginConfig):
+        raise RuntimeError("Some provided userPlugins are not a callable function")
+      self._userPlugin = userInputPluginConfig
+      return
+
     if not callable(userInputPluginConfig):
-      raise RuntimeError("The provided userPlugin is not a callable function.")
-    self._userPlugin = userInputPluginConfig
+      raise RuntimeError("The provided userPlugin is not a callable function: %s, %s" % (type(userInputPluginConfig),
+                                                                                         repr(userInputPluginConfig)))
+    self._userPlugin.append(userInputPluginConfig)

--- a/DDG4/python/DDSim/Helper/InputConfig.py
+++ b/DDG4/python/DDSim/Helper/InputConfig.py
@@ -1,0 +1,49 @@
+"""Class for input plugin configuration"""
+
+from __future__ import absolute_import, unicode_literals
+from DDSim.Helper.ConfigHelper import ConfigHelper
+
+
+class InputConfig(ConfigHelper):
+  """Configuration for Input Files."""
+
+  def __init__(self):
+    super(InputConfig, self).__init__()
+    self._userPlugin = None
+
+  @property
+  def userInputPlugin(self):
+    """Set a function to configure an inputStep.
+
+    The function must take a ``DD4hepSimulation`` object as its only argument and return the created generatorAction
+    ``gen`` (for example).
+
+    For example one can add this to the ddsim steering file:
+
+      def exampleUserPlugin(dd4hepSimulation):
+        '''Example code for user created plugin.
+
+        :param DD4hepSimulation dd4hepSimulation: The DD4hepSimulation instance, so all parameters can be accessed
+        :return: GeneratorAction
+        '''
+        from DDG4 import GeneratorAction, Kernel
+        # Geant4InputAction is the type of plugin, Cry1 just an identifier
+        gen = GeneratorAction(Kernel(), 'Geant4InputAction/Cry1' , True)
+        # CRYEventReader is the actual plugin, steeringFile its constructor parameter
+        gen.Input = 'CRYEventReader|' + 'steeringFile'
+        # we can give a dictionary of Parameters that has to be interpreted by the setParameters function of the plugin
+        gen.Parameters = {'DataFilePath': '/path/to/files/data'}
+        gen.enableUI()
+        return gen
+
+      SIM.inputConfig.userInputPlugin = exampleUserPlugin
+    """
+    return self._userPlugin
+
+  @userInputPlugin.setter
+  def userInputPlugin(self, userInputPluginConfig):
+    if userInputPluginConfig is None:
+      return
+    if not callable(userInputPluginConfig):
+      raise RuntimeError("The provided userPlugin is not a callable function.")
+    self._userPlugin = userInputPluginConfig


### PR DESCRIPTION
BEGINRELEASENOTES
- DDSim: add option to set userInputPlugin for simulation by adding a plugin for themselves, and this to the ddsim steering file (for #940)
   ```python
      def exampleUserPlugin(dd4hepSimulation):
        '''Example code for user created plugin.

        :param DD4hepSimulation dd4hepSimulation: The DD4hepSimulation instance, so all parameters can be accessed
        :return: GeneratorAction
        '''
        from DDG4 import GeneratorAction, Kernel
        # Geant4InputAction is the type of plugin, Cry1 just an identifier
        gen = GeneratorAction(Kernel(), 'Geant4InputAction/Cry1' , True)
        # CRYEventReader is the actual plugin, steeringFile its constructor parameter
        gen.Input = 'CRYEventReader|' + 'steeringFile'
        # we can give a dictionary of Parameters that has to be interpreted by the setParameters function of the plugin
        gen.Parameters = {'DataFilePath': '/path/to/files/data'}
        gen.enableUI()
        return gen

      SIM.inputConfig.userInputPlugin = exampleUserPlugin
   ```

ENDRELEASENOTES