### PR TITLE
ddsim: remove `--gun.energy` option (as confusing alias for `--gun.momentumMax`)

### DIFF
--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -14,7 +14,6 @@ class Gun(ConfigHelper):
 
   def __init__(self):
     super(Gun, self).__init__()
-    self.energy = 10 * GeV
     self.particle = "mu-"
     self.multiplicity = 1
     self._position = (0.0, 0.0, 0.0)
@@ -28,7 +27,7 @@ class Gun(ConfigHelper):
     self.thetaMax = None
     self._momentumMin_EXTRA = {'help': "Minimal momentum when using distribution (default = 0.0)"}
     self.momentumMin = None
-    self.momentumMax = None
+    self.momentumMax = 10 * GeV
 
     self._distribution_EXTRA = {'choices': ['uniform', 'cos(theta)',
                                             'eta', 'pseudorapidity',
@@ -114,9 +113,6 @@ class Gun(ConfigHelper):
   def setOptions(self, ddg4Gun):
     """set the starting properties of the DDG4 particle gun"""
     try:
-      ddg4Gun.energy = self.energy  # ddg4Gun.energy actually sets momentum
-      ddg4Gun.MomentumMin = 0.0
-      ddg4Gun.MomentumMax = self.energy
       ddg4Gun.particle = self.particle
       ddg4Gun.multiplicity = self.multiplicity
       ddg4Gun.position = self.position
@@ -135,10 +131,10 @@ class Gun(ConfigHelper):
       if self.phiMax is not None:
         ddg4Gun.PhiMax = self.phiMax
         ddg4Gun.isotrop = True
+      ddg4Gun.MomentumMin = 0.0
       if self.momentumMin is not None:
         ddg4Gun.MomentumMin = self.momentumMin
-      if self.momentumMax is not None:
-        ddg4Gun.MomentumMax = self.momentumMax
+      ddg4Gun.MomentumMax = self.momentumMax
     except Exception as e:  # pylint: disable=W0703
       logger.error("parsing gun options:\n%s\nException: %s " % (self, e))
       exit(1)

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -90,7 +90,7 @@ if (DD4HEP_USE_GEANT4)
     ADD_TEST( t_test_ddsim_${OUTPUT_FILE} "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
       ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml --runType=batch -G -N=2
       --outputFile=testSid${OUTPUT_FILE}
-      --gun.position \"0.0 0.0 1.0*cm\" --gun.direction \"1.0 0.0 1.0\" --gun.energy 100*GeV --part.userParticleHandler=)
+      --gun.position \"0.0 0.0 1.0*cm\" --gun.direction \"1.0 0.0 1.0\" --gun.momentumMax 100*GeV --part.userParticleHandler=)
     SET_TESTS_PROPERTIES( t_test_ddsim_${OUTPUT_FILE} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
   endforeach()
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Removed `--gun.energy` option from ddsim. The `--gun.momentumMax` should be used instead.
ENDRELEASENOTES

The issue is that, currently, `--gun.energy x` generates particles in the range [0, x], which is a bit surprising.

I was getting a confusing results from using this option (imagine getting a flat spectrum from what is supposed to be a fixed energy gun). It doesn't do what the name suggests and there is no help message to clarify that. I propose to remove it.