### PR TITLE
Ddsim fix fix gun energy

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,7 +58,7 @@ jobs:
               "LCG_99/x86_64-centos8-gcc10-opt",
               "LCG_99/x86_64-ubuntu2004-gcc9-opt",
               "dev3/x86_64-centos7-clang12-opt",
-              "dev4/x86_64-centos7-gcc10-opt"]
+              "dev4/x86_64-centos7-gcc11-opt"]
     steps:
     - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@v2

--- a/DDG4/include/DDG4/Geant4IsotropeGenerator.h
+++ b/DDG4/include/DDG4/Geant4IsotropeGenerator.h
@@ -40,12 +40,8 @@ namespace dd4hep {
       double      m_thetaMin;
       /// Property: Maximal theta angular value
       double      m_thetaMax;
-      /// Property: Minimal momentum value
-      double      m_momentumMin;
-      /// Property: Maximal momentum value
-      double      m_momentumMax;
       
-      /// Particle modification. Caller presets defaults to: ( direction = m_direction, momentum = m_energy)
+      /// Particle modification. Caller presets defaults to: ( direction = m_direction,  momentum = [m_momentumMin, m_momentumMax])
       /** Use this function to implement isotrop guns, multiple guns etc. 
           User must return a UNIT vector, which gets scaled with momentum.
       */
@@ -58,8 +54,6 @@ namespace dd4hep {
       void getParticleDirectionCosTheta(int num, ROOT::Math::XYZVector& direction, double& momentum) const;
       /// Uniform particle distribution
       void getParticleDirectionUniform(int num, ROOT::Math::XYZVector& direction, double& momentum) const;
-      /// Uniform particle momentum
-      void getParticleMomentumUniform(double& momentum) const;
 
     public:
       /// Inhibit default constructor

--- a/DDG4/include/DDG4/Geant4ParticleGenerator.h
+++ b/DDG4/include/DDG4/Geant4ParticleGenerator.h
@@ -46,8 +46,12 @@ namespace dd4hep {
       std::string m_particleName;
       /// Pointer to geant4 particle definition
       G4ParticleDefinition* m_particle;
-      /// Property: Particle energy
+      /// Property: Fixed momentum value, overwrites momentumMin and momentumMax if set
       double m_energy;
+      /// Property: Minimal momentum value
+      double m_momentumMin;
+      /// Property: Maximal momentum value
+      double m_momentumMax;
       /// Property: Desired multiplicity of the particles to be shot
       int m_multiplicity;
       /// Property: User mask passed to all particles in the generated interaction
@@ -64,6 +68,8 @@ namespace dd4hep {
           User must return a UNIT vector, which gets scaled with momentum.
       */
       virtual void getParticleDirection(int num, ROOT::Math::XYZVector& direction, double& momentum) const;
+      /// Uniform particle momentum
+      void getParticleMomentumUniform(double& momentum) const;
 
       /// Print single particle interaction identified by its mask
       virtual void printInteraction(int mask)  const;

--- a/DDG4/include/DDG4/Geant4ParticleGun.h
+++ b/DDG4/include/DDG4/Geant4ParticleGun.h
@@ -63,7 +63,7 @@ namespace dd4hep {
       bool m_print;
       /// Shot number in sequence
       int m_shotNo;
-      /// Particle modification. Caller presets defaults to: ( direction = m_direction, momentum = m_energy)
+      /// Particle modification. Caller presets defaults to: ( direction = m_direction, momentum = [m_momentumMin, m_momentumMax])
       virtual void getParticleDirection(int, ROOT::Math::XYZVector& direction, double& momentum) const;
     public:
       /// Standard constructor

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -763,7 +763,7 @@ class Geant4:
     gun = GeneratorAction(self.kernel(), typ + "/" + name, True)
     for i in args.items():
       setattr(gun, i[0], i[1])
-    gun.energy = energy
+    gun.Energy = energy
     gun.particle = particle
     gun.multiplicity = multiplicity
     gun.position = position

--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -14,7 +14,6 @@ class Gun(ConfigHelper):
 
   def __init__(self):
     super(Gun, self).__init__()
-    self.energy = 10 * GeV
     self.particle = "mu-"
     self.multiplicity = 1
     self._position = (0.0, 0.0, 0.0)
@@ -28,7 +27,7 @@ class Gun(ConfigHelper):
     self.thetaMax = None
     self._momentumMin_EXTRA = {'help': "Minimal momentum when using distribution (default = 0.0)"}
     self.momentumMin = None
-    self.momentumMax = None
+    self.momentumMax = 10 * GeV
 
     self._distribution_EXTRA = {'choices': ['uniform', 'cos(theta)',
                                             'eta', 'pseudorapidity',
@@ -114,9 +113,6 @@ class Gun(ConfigHelper):
   def setOptions(self, ddg4Gun):
     """set the starting properties of the DDG4 particle gun"""
     try:
-      ddg4Gun.energy = self.energy  # ddg4Gun.energy actually sets momentum
-      ddg4Gun.MomentumMin = 0.0
-      ddg4Gun.MomentumMax = self.energy
       ddg4Gun.particle = self.particle
       ddg4Gun.multiplicity = self.multiplicity
       ddg4Gun.position = self.position
@@ -135,10 +131,10 @@ class Gun(ConfigHelper):
       if self.phiMax is not None:
         ddg4Gun.PhiMax = self.phiMax
         ddg4Gun.isotrop = True
+      ddg4Gun.MomentumMin = 0.0
       if self.momentumMin is not None:
         ddg4Gun.MomentumMin = self.momentumMin
-      if self.momentumMax is not None:
-        ddg4Gun.MomentumMax = self.momentumMax
+      ddg4Gun.MomentumMax = self.momentumMax
     except Exception as e:  # pylint: disable=W0703
       logger.error("parsing gun options:\n%s\nException: %s " % (self, e))
       exit(1)

--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -27,7 +27,11 @@ class Gun(ConfigHelper):
     self.thetaMax = None
     self._momentumMin_EXTRA = {'help': "Minimal momentum when using distribution (default = 0.0)"}
     self.momentumMin = None
+    self._momentumMax_EXTRA = {'help': "Maximal momentum when using distribution (default = 0.0)"}
     self.momentumMax = 10 * GeV
+    self._energy_EXTRA = {'help': "The kinetic energy for the particle gun.\n\n"
+                          "If not None, it will overwrite the setting of momentumMin and momentumMax"}
+    self.energy = None
 
     self._distribution_EXTRA = {'choices': ['uniform', 'cos(theta)',
                                             'eta', 'pseudorapidity',
@@ -113,6 +117,8 @@ class Gun(ConfigHelper):
   def setOptions(self, ddg4Gun):
     """set the starting properties of the DDG4 particle gun"""
     try:
+      if self.energy:
+        ddg4Gun.Energy = self.energy
       ddg4Gun.particle = self.particle
       ddg4Gun.multiplicity = self.multiplicity
       ddg4Gun.position = self.position

--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -26,7 +26,7 @@ class Gun(ConfigHelper):
     self.thetaMin = None
     self.thetaMax = None
     self._momentumMin_EXTRA = {'help': "Minimal momentum when using distribution (default = 0.0)"}
-    self.momentumMin = None
+    self.momentumMin = 0 * GeV
     self._momentumMax_EXTRA = {'help': "Maximal momentum when using distribution (default = 0.0)"}
     self.momentumMax = 10 * GeV
     self._energy_EXTRA = {'help': "The kinetic energy for the particle gun.\n\n"
@@ -137,9 +137,8 @@ class Gun(ConfigHelper):
       if self.phiMax is not None:
         ddg4Gun.PhiMax = self.phiMax
         ddg4Gun.isotrop = True
-      ddg4Gun.MomentumMin = 0.0
-      if self.momentumMin is not None:
-        ddg4Gun.MomentumMin = self.momentumMin
+      # this avoids issues if momentumMin is None because of previous default
+      ddg4Gun.MomentumMin = self.momentumMin if self.momentumMin else 0.0
       ddg4Gun.MomentumMax = self.momentumMax
     except Exception as e:  # pylint: disable=W0703
       logger.error("parsing gun options:\n%s\nException: %s " % (self, e))

--- a/DDG4/src/Geant4IsotropeGenerator.cpp
+++ b/DDG4/src/Geant4IsotropeGenerator.cpp
@@ -29,24 +29,12 @@ Geant4IsotropeGenerator::Geant4IsotropeGenerator(Geant4Context* ctxt, const stri
   declareProperty("PhiMax", m_phiMax = 2.0*M_PI);
   declareProperty("ThetaMin", m_thetaMin = 0.0);
   declareProperty("ThetaMax", m_thetaMax = M_PI);
-  declareProperty("MomentumMin", m_momentumMin =  0.0);
-  declareProperty("MomentumMax", m_momentumMax = -1.0);
   declareProperty("Distribution", m_distribution = "uniform" );
 }
 
 /// Default destructor
 Geant4IsotropeGenerator::~Geant4IsotropeGenerator() {
   InstanceCount::decrement(this);
-}
-
-/// Uniform momentum distribution
-void Geant4IsotropeGenerator::getParticleMomentumUniform(double& momentum) const  {
-  Geant4Event&  evt = context()->event();
-  Geant4Random& rnd = evt.random();
-  if (m_momentumMax < m_momentumMin)
-    momentum = m_momentumMin+(momentum-m_momentumMin)*rnd.rndm();
-  else
-    momentum = m_momentumMin+(m_momentumMax-m_momentumMin)*rnd.rndm();
 }
 
 /// Uniform particle distribution
@@ -128,7 +116,7 @@ void Geant4IsotropeGenerator::getParticleDirectionFFbar(int, ROOT::Math::XYZVect
   }
 }
 
-/// Particle modification. Caller presets defaults to: ( direction = m_direction, momentum = m_energy)
+/// Particle modification. Caller presets defaults to: ( direction = m_direction, momentum = [mMin, mMax])
 void Geant4IsotropeGenerator::getParticleDirection(int num, ROOT::Math::XYZVector& direction, double& momentum) const   {
   switch(::toupper(m_distribution[0]))  {
   case 'C':  // cos(theta)

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -90,7 +90,7 @@ if (DD4HEP_USE_GEANT4)
     ADD_TEST( t_test_ddsim_${OUTPUT_FILE} "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
       ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml --runType=batch -G -N=2
       --outputFile=testSid${OUTPUT_FILE}
-      --gun.position \"0.0 0.0 1.0*cm\" --gun.direction \"1.0 0.0 1.0\" --gun.energy 100*GeV --part.userParticleHandler=)
+      --gun.position \"0.0 0.0 1.0*cm\" --gun.direction \"1.0 0.0 1.0\" --gun.momentumMax 100*GeV --part.userParticleHandler=)
     SET_TESTS_PROPERTIES( t_test_ddsim_${OUTPUT_FILE} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
   endforeach()
 

--- a/doc/usermanuals/DDG4/sections/Setup.tex
+++ b/doc/usermanuals/DDG4/sections/Setup.tex
@@ -597,7 +597,7 @@ def run():
 
   # Setup particle gun
   gun = DDG4.GeneratorAction(kernel,"Geant4ParticleGun/Gun")
-  gun.energy   = 0.5*GeV
+  gun.Energy   = 0.5*GeV
   gun.particle = 'e-'
   gun.multiplicity = 1
   gun.enableUI()

--- a/examples/ClientTests/scripts/NestedBoxReflection.py
+++ b/examples/ClientTests/scripts/NestedBoxReflection.py
@@ -112,7 +112,7 @@ def run():
   gen.mask = 4
   gen.isotrop = True
   gen.particle = 'e+'
-  gen.energy = 100 * GeV
+  gen.Energy = 100 * GeV
   gen.multiplicity = 200
   gen.position = (0 * m, 0 * m, 0 * m)
   gen.direction = (0, 0, 1.)


### PR DESCRIPTION
Alternative to #945  (@wdconinc @veprbl )

BEGINRELEASENOTES
- DDSim: restore the fixed momentum behaviour of `--gun.energy`, independent of the isotrop setting for the particle gun. If gun.energy is set, the momentum will have this value. If it is not set, momentumMin and momentumMax will be used to pick a value.

ENDRELEASENOTES