### PR TITLE
DDSim: use python executable based on what the system has

### DIFF
--- a/DDG4/CMakeLists.txt
+++ b/DDG4/CMakeLists.txt
@@ -149,7 +149,9 @@ target_link_libraries(g4FromXML DDG4)
 file(GLOB DDG4_python python/*.py python/*.C)
 install(FILES ${DDG4_python} DESTINATION ${DD4HEP_PYTHON_INSTALL_DIR})
 
-install(PROGRAMS python/DDSim/bin/ddsim.py DESTINATION bin RENAME ddsim)
+get_filename_component(PYTHON_INTERPRETER_BINARY ${Python_EXECUTABLE} NAME)
+configure_file(python/DDSim/bin/ddsim.in.py ${CMAKE_BINARY_DIR}/bin/ddsim @ONLY)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/ddsim DESTINATION bin)
 
 install(PROGRAMS python/bin/checkOverlaps.py DESTINATION bin RENAME checkOverlaps)
 install(PROGRAMS python/bin/checkGeometry.py DESTINATION bin RENAME checkGeometry)

--- a/DDG4/python/DDSim/bin/ddsim.in.py
+++ b/DDG4/python/DDSim/bin/ddsim.in.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env @PYTHON_INTERPRETER_BINARY@
 """
 
 DD4hep simulation with some argument parsing


### PR DESCRIPTION

BEGINRELEASENOTES
- DDSim: find the python executable used during build and set that for the hashbang, e.g. python3.9 instead of python. Fixes #952

ENDRELEASENOTES

- [x] let's see if the tests still work like this