### PR TITLE
Revert "Set locale to C before parsing XML files"

### DIFF
--- a/DDCore/src/DetectorLoad.cpp
+++ b/DDCore/src/DetectorLoad.cpp
@@ -21,7 +21,6 @@
 // C/C++ include files
 #include <stdexcept>
 #include <clocale>
-#include <cstring>
 
 #ifndef __TIXML__
 #include "xercesc/dom/DOMException.hpp"

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -509,7 +509,6 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
       tab->AddConstProperty(named->GetName(), value * conv);
     }
 #endif
-
     // Set Birk's constant if it was supplied in the material table of the TGeoMaterial
     auto* ionisation = mat->GetIonisation();
     stringstream str;


### PR DESCRIPTION
Reverts AIDASoft/DD4hep#954
Setting the locale is not simple if the locale should be set afterwards to the system locale.

Reason:
Normally at startup of a user program the locale is "C" and not the OS locale.
However apparently the constructor std::locale("") returns the OS locale and not the current locale of the program.
Hence reverting back and forth between C and OS-locale is not the same if the initial program locale is C....

Hence, either @veprbl  is unhappy or @benjaminhuth .... but instead of creating confusion it is better to do nothing.
Consequently https://github.com/AIDASoft/DD4hep/issues/913 will be closed without action.