### PR TITLE
feat: support `--runType qt` in `ddsim`

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -149,7 +149,8 @@ class DD4hepSimulation(object):
                         default=ConfigHelper.makeList(self.compactFile), type=str,
                         help="The compact XML file, or multiple compact files, if the last one is the closer.")
 
-    parser.add_argument("--runType", action="store", choices=("batch", "vis", "run", "shell", "qt"), default=self.runType,
+    parser.add_argument("--runType", action="store", choices=("batch", "vis", "run", "shell", "qt"),
+                        default=self.runType,
                         help="The type of action to do in this invocation"  # Note: implicit string concatenation
                         "\nbatch: just simulate some events, needs numberOfEvents, and input file or gun"
                         "\nvis: enable visualisation, run the macroFile if it is set"

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -322,20 +322,19 @@ class DD4hepSimulation(object):
     simple.printDetectors()
 
     if self.runType == "vis":
-      simple.setupUI(typ="csh", vis=True, macro=self.macroFile)
+      simple.setupUI(typ="tcsh", vis=True, macro=self.macroFile)
     elif self.runType == "qt":
       simple.setupUI(typ="qt", vis=True, macro=self.macroFile)
     elif self.runType == "run":
-      simple.setupUI(typ="csh", vis=False, macro=self.macroFile, ui=False)
+      simple.setupUI(typ="tcsh", vis=False, macro=self.macroFile, ui=False)
     elif self.runType == "shell":
-      simple.setupUI(typ="csh", vis=False, macro=None, ui=True)
+      simple.setupUI(typ="tcsh", vis=False, macro=None, ui=True)
     elif self.runType == "batch":
-      simple.setupUI(typ="csh", vis=False, macro=None, ui=False)
+      simple.setupUI(typ="tcsh", vis=False, macro=None, ui=False)
     else:
       logger.error("unknown runType")
       exit(1)
 
-    # kernel.UI="csh"
     kernel.NumEvents = self.numberOfEvents
 
     # -----------------------------------------------------------------------------------

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -108,9 +108,6 @@ class DD4hepSimulation(object):
 
     self._argv = None
 
-    # use TCSH geant UI instead of QT
-    os.environ['G4UI_USE_TCSH'] = "1"
-
   def readSteeringFile(self):
     """Reads a steering file and sets the parameters to that of the
     DD4hepSimulation object present in the steering file.
@@ -152,10 +149,11 @@ class DD4hepSimulation(object):
                         default=ConfigHelper.makeList(self.compactFile), type=str,
                         help="The compact XML file, or multiple compact files, if the last one is the closer.")
 
-    parser.add_argument("--runType", action="store", choices=("batch", "vis", "run", "shell"), default=self.runType,
+    parser.add_argument("--runType", action="store", choices=("batch", "vis", "run", "shell", "qt"), default=self.runType,
                         help="The type of action to do in this invocation"  # Note: implicit string concatenation
                         "\nbatch: just simulate some events, needs numberOfEvents, and input file or gun"
                         "\nvis: enable visualisation, run the macroFile if it is set"
+                        "\nqt: enable visualisation in Qt shell, run the macroFile if it is set"
                         "\nrun: run the macroFile and exit"
                         "\nshell: enable interactive session")
 
@@ -324,6 +322,8 @@ class DD4hepSimulation(object):
 
     if self.runType == "vis":
       simple.setupUI(typ="csh", vis=True, macro=self.macroFile)
+    elif self.runType == "qt":
+      simple.setupUI(typ="qt", vis=True, macro=self.macroFile)
     elif self.runType == "run":
       simple.setupUI(typ="csh", vis=False, macro=self.macroFile, ui=False)
     elif self.runType == "shell":


### PR DESCRIPTION
This adds a run type `qt` for `ddsim`. Sometimes it's convenient to be able to open the Qt interface, open a visualization, and browse the geometry tree.

BEGINRELEASENOTES
- ddsin: Add `--runType qt` support for enabling the graphical Qt interface for geant4
- ddsim: change shell type to tcsh: enabling tab completion when Geant4 offers it

ENDRELEASENOTES