### PR TITLE
geoConverter plugin to pure ROOT TGeo format (not ROOT persistency)

### DIFF
--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -829,6 +829,41 @@ static long dump_geometry2root(Detector& description, int argc, char** argv) {
 }
 DECLARE_APPLY(DD4hep_Geometry2ROOT,dump_geometry2root)
 
+/// Basic entry point to dump a dd4hep geometry as TGeo to a ROOT file
+/**
+ *  Factory: DD4hep_Geometry2TGeo
+ *
+ *  \author  W.Deconinck
+ *  \version 1.0
+ *  \date    14/09/2022
+ */
+static long dump_geometry2tgeo(Detector& description, int argc, char** argv) {
+  if ( argc > 0 )   {
+    string output( argc == 1 ? argv[0] : "" );
+    printout(INFO,"Geometry2TGeo","+++ output: %d %s", argc, output.c_str());
+    for(int i = 0; i < argc && argv[i]; ++i)  {
+      if ( 0 == ::strncmp("-output",argv[i],4) )
+        output = argv[++i];
+    }
+    if ( output.empty() )   {
+      cout <<
+        "Usage: -plugin <name> -arg [-arg]                                             \n"
+        "     name:   factory name     DD4hepGeometry2TGeo                             \n"
+        "     -output <string>         Output file name.                               \n"
+        "\tArguments given: " << arguments(argc,argv) << endl << flush;
+      ::exit(EINVAL);
+    }
+    printout(INFO,"Geometry2TGeo","+++ Dump geometry to root file:%s",output.c_str());
+    if ( description.manager().Export(output.c_str()) > 1 ) {
+      return 1;
+    }
+  }
+  printout(ERROR,"Geometry2TGeo","+++ No output file name given.");
+  return 0;
+}
+DECLARE_APPLY(DD4hep_Geometry2TGeo,dump_geometry2tgeo)
+DECLARE_APPLY(DD4hepGeometry2TGeo,dump_geometry2tgeo)
+
 /// Basic entry point to load a dd4hep geometry directly from the ROOT file
 /**
  *  Factory: DD4hep_RootLoader

--- a/UtilityApps/src/converter.cpp
+++ b/UtilityApps/src/converter.cpp
@@ -23,9 +23,10 @@ namespace {
     std::cout <<
       "geoConverter -opt [-opt]                                                        \n"
       "        Action flags:               Usage is exclusive, 1 required!             \n"
-      "        -compact2description               Convert compact xml geometry to description.     \n"
+      "        -compact2description        Convert compact xml geometry to description.\n"
       "        -compact2gdml               Convert compact xml geometry to gdml.       \n"
-      "        -compact2pandora            Convert compact xml to pandora xml          \n"
+      "        -compact2pandora            Convert compact xml to pandora xml.         \n"
+      "        -compact2tgeo               Convert compact xml to TGeo in ROOT file.   \n"
       "        -compact2vis                Convert compact xml to visualisation attrs\n\n"
       "        -input  <file>  [REQUIRED]  Specify input file.                         \n"
       "        -output <file>  [OPTIONAL]  Specify output file.                        \n"
@@ -50,6 +51,7 @@ namespace {
     bool compact2description = false;
     bool compact2gdml = false;
     bool compact2pand = false;
+    bool compact2tgeo = false;
     bool compact2vis  = false;
     int output = 0;
     std::vector<char*> geo_files;
@@ -61,6 +63,8 @@ namespace {
           compact2gdml = true;
         else if ( strncmp(argv[i],"-compact2pandora",12)==0 )
           compact2pand = true;
+        else if ( strncmp(argv[i],"-compact2tgeo",12)==0 )
+          compact2tgeo = true;
         else if ( strncmp(argv[i],"-compact2vis",12)==0 )
           compact2vis = true;
         else if ( strncmp(argv[i],"-input",2)==0 )
@@ -80,7 +84,7 @@ namespace {
         usage();
       }
     }
-    if ( geo_files.empty() || (!compact2description && !compact2gdml && !compact2pand && !compact2vis))
+    if ( geo_files.empty() || (!compact2description && !compact2gdml && !compact2pand && !compact2tgeo && !compact2vis))
       usage();
 
     dd4hep::Detector& description = dd4hep_instance();
@@ -98,6 +102,8 @@ namespace {
       run_plugin(description,"DD4hepGeometry2GDML",output,&argv[output]);
     else if ( compact2pand )
       run_plugin(description,"DD4hepGeometry2PANDORA",output,&argv[output]);
+    else if ( compact2tgeo )
+      run_plugin(description,"DD4hepGeometry2TGeo",argc-output,&argv[output]);
     else if ( compact2vis && ascii )
       run_plugin(description,"DD4hepGeometry2VISASCII",output,&argv[output]);
     else if ( compact2vis )


### PR DESCRIPTION
As we continue to upstream some of our local EIC tools, here is functionality we have been using to export dd4hep to a TGeo tree in a ROOT file. As far as we know, this is not otherwise possible with command-line tools. This is different from the exports to ROOT persistency provided by DD4hep_Geometry2ROOT and intended for exports to TGeo objects that only need a standard ROOT installation to visualize (as primary application).

BEGINRELEASENOTES
- `geoConverter -compact2tgeo` to write TGeo geometry to ROOT file

ENDRELEASENOTES