### PR TITLE
Use explicit namespace in DDCond dictionary

### DIFF
--- a/DDCond/src/ConditionsDictionary.h
+++ b/DDCond/src/ConditionsDictionary.h
@@ -37,39 +37,36 @@ namespace { class ConditionsDictionary {};   }
 #pragma link C++ namespace dd4hep::detail;
 #pragma link C++ namespace dd4hep::cond;
 
-using namespace dd4hep;
-using namespace dd4hep::cond;
-
 // These are necessary to support interactivity
-#pragma link C++ class UserPool-;
-#pragma link C++ class UpdatePool-;
-#pragma link C++ class ConditionsPool-;
-#pragma link C++ class ConditionsManager-;
-#pragma link C++ class ConditionsManagerObject-;
-#pragma link C++ class ConditionsIOVPool-;
-#pragma link C++ class ConditionsContent-;
-#pragma link C++ class ConditionsLoadInfo-;
-#pragma link C++ class ConditionsContent::LoadInfo<std::string>-;
-#pragma link C++ class std::map<Condition::key_type,ConditionsLoadInfo* >-;
-#pragma link C++ class std::map<Condition::key_type,ConditionDependency* >-;
+#pragma link C++ class dd4hep::cond::UserPool-;
+#pragma link C++ class dd4hep::cond::UpdatePool-;
+#pragma link C++ class dd4hep::cond::ConditionsPool-;
+#pragma link C++ class dd4hep::cond::ConditionsManager-;
+#pragma link C++ class dd4hep::cond::ConditionsManagerObject-;
+#pragma link C++ class dd4hep::cond::ConditionsIOVPool-;
+#pragma link C++ class dd4hep::cond::ConditionsContent-;
+#pragma link C++ class dd4hep::cond::ConditionsLoadInfo-;
+#pragma link C++ class dd4hep::cond::ConditionsContent::LoadInfo<std::string>-;
+#pragma link C++ class std::map<dd4hep::Condition::key_type,dd4hep::cond::ConditionsLoadInfo* >-;
+#pragma link C++ class std::map<dd4hep::Condition::key_type,dd4hep::cond::ConditionDependency* >-;
 
 // std::shared_ptr<T> is not yet supported by ROOT!
-//#pragma link C++ class std::shared_ptr<ConditionsPool>-;
-//#pragma link C++ class std::map<IOV::Key,std::shared_ptr<ConditionsPool> >-;
+//#pragma link C++ class std::shared_ptr<dd4hep::cond::ConditionsPool>-;
+//#pragma link C++ class std::map<dd4hep::IOV::Key,std::shared_ptr<dd4hep::cond::ConditionsPool> >-;
 
 // This one we need to save conditions pool to file
 #pragma link C++ class std::pair<std::string,IOV::Key>+;
 #pragma link C++ class std::pair<std::pair<std::string,int>, IOV::Key>+;
 #pragma link C++ class std::pair<std::string,std::pair<std::pair<std::string,int>,IOV::Key> >+;
 
-template class std::list< std::pair< std::pair< std::string, std::pair< std::pair<std::string,int>, IOV::Key> >, std::vector<Condition> > >;
-#pragma link C++ class std::list<std::pair<std::pair<std::string,std::pair<std::pair<std::string,int>,IOV::Key> >, std::vector<Condition> > >+;
+template class std::list< std::pair< std::pair< std::string, std::pair< std::pair<std::string,int>, dd4hep::IOV::Key> >, std::vector<dd4hep::Condition> > >;
+#pragma link C++ class std::list<std::pair<std::pair<std::string,std::pair<std::pair<std::string,int>,dd4hep::IOV::Key> >, std::vector<dd4hep::Condition> > >+;
 
-//#pragma link C++ class std::list<ConditionsRootPersistency::Pool>+;
-//#pragma link C++ class std::list<ConditionsRootPersistency::IOVPool>+;
+//#pragma link C++ class std::list<dd4hep::cond::ConditionsRootPersistency::Pool>+;
+//#pragma link C++ class std::list<dd4hep::cond::ConditionsRootPersistency::IOVPool>+;
 
-#pragma link C++ class ConditionsRootPersistency+;
-#pragma link C++ class ConditionsTreePersistency+;
+#pragma link C++ class dd4hep::cond::ConditionsRootPersistency+;
+#pragma link C++ class dd4hep::cond::ConditionsTreePersistency+;
 
 #endif
 


### PR DESCRIPTION
Having a `using namespace` in the ROOT dictionary headers is a bad idea because those headers are used in the global translation unit used by ROOT (cling or cppyy).

In my specific case I get an error because in LHCb we have a class called `Condition` (without namespace) and clang is not able to decide what to use:
```
G__DDCond dictionary payload:145:126: error: reference to 'Condition' is ambiguous
template class std::list< std::pair< std::pair< std::string, std::pair< std::pair<std::string,int>, IOV::Key> >, std::vector<Condition> > >;
                                                                                                                             ^
Forward declarations from .../LHCbDict.rootmap:8:7: note: candidate found by name lookup is 'Condition'
class Condition;
      ^
.../include/DD4hep/Conditions.h:51:9: note: candidate found by name lookup is 'dd4hep::Condition'
  class Condition: public Handle<detail::ConditionObject> {
        ^
```

This pull requests modify the declaration of the classes to add to the dictionary of DDCond  so that the namespace is explicit.

Note that other dictionaries (not addressed here) have the same problem (there's even a `using namespace std`).

BEGINRELEASENOTES

- Use explicit namespaces in DDCond dictionary

ENDRELEASENOTES