### PR TITLE
Remove using declarations in root-cling dictionary files

### DIFF
--- a/DDCore/src/GeoDictionary.h
+++ b/DDCore/src/GeoDictionary.h
@@ -35,8 +35,6 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-using namespace std;
-
 #pragma link C++ namespace dd4hep;
 
 // Volume.h
@@ -49,19 +47,19 @@ using namespace std;
 #pragma link C++ class dd4hep::PlacedVolume::Processor+;
 
 #ifndef __ROOTCLING__
-template vector<pair<string, int> >;
-template vector<pair<string, int> >::iterator;
+template std::vector<std::pair<std::string, int> >;
+template std::vector<std::pair<std::string, int> >::iterator;
 #endif
-#pragma link C++ class vector<pair<string, int> >+;
-#pragma link C++ class vector<pair<string, int> >::iterator;
+#pragma link C++ class std::vector<std::pair<std::string, int> >+;
+#pragma link C++ class std::vector<std::pair<std::string, int> >::iterator;
 #pragma link C++ class dd4hep::PlacedVolumeExtension::VolIDs+;
 #pragma link C++ class dd4hep::PlacedVolumeExtension::Parameterisation+;
 #pragma link C++ class dd4hep::PlacedVolumeExtension::Parameterisation::Dimension+;
 #pragma link C++ class dd4hep::PlacedVolumeExtension+;
-#pragma link C++ class vector<dd4hep::PlacedVolume>+;
+#pragma link C++ class std::vector<dd4hep::PlacedVolume>+;
 #pragma link C++ class dd4hep::Handle<TGeoNode>+;
-#pragma link C++ class vector<TGeoNode*>+;
-#pragma link C++ class vector<TGeoVolume*>+;
+#pragma link C++ class std::vector<TGeoNode*>+;
+#pragma link C++ class std::vector<TGeoVolume*>+;
 
 
 // Shapes.h

--- a/DDCore/src/PropertyDictionary.h
+++ b/DDCore/src/PropertyDictionary.h
@@ -39,8 +39,6 @@ namespace dd4hep {
 #pragma link off all classes;
 #pragma link off all functions;
 
-using namespace std;
-
 #pragma link C++ class dd4hep::Property;
 #if defined(DD4HEP_HAVE_ALL_PARSERS)
 template class dd4hep::PropertyValue<char>;

--- a/DDCore/src/RootDictionary.h
+++ b/DDCore/src/RootDictionary.h
@@ -98,8 +98,6 @@ namespace dd4hep   {   namespace Parsers   {
 #pragma link off all classes;
 #pragma link off all functions;
 
-using namespace std;
-
 #pragma link C++ namespace dd4hep;
 
 #pragma link C++ namespace dd4hep::tools;
@@ -115,32 +113,32 @@ using namespace std;
 #pragma link C++ enum dd4hep::PrintLevel;
 
 #ifndef __ROOTCLING__
-template pair<unsigned int, string>;
+template std::pair<unsigned int, std::string>;
 template class dd4hep::Handle<dd4hep::NamedObject>;
-template class pair< string, dd4hep::Handle<dd4hep::NamedObject> >;
-template class map< string, dd4hep::Handle<dd4hep::NamedObject> >;
-template class pair<dd4hep::Callback,unsigned long>;
+template class std::pair< string, dd4hep::Handle<dd4hep::NamedObject> >;
+template class std::map< string, dd4hep::Handle<dd4hep::NamedObject> >;
+template class std::pair<dd4hep::Callback,unsigned long>;
 #endif
 
 #pragma link C++ class DD4hepRootPersistency+;
 #pragma link C++ class DD4hepRootCheck+;
 
-#pragma link C++ class pair<unsigned int,string>+;
+#pragma link C++ class std::pair<unsigned int,std::string>+;
 //#pragma link C++ class dd4hep::Callback+;
-#pragma link C++ class pair<dd4hep::Callback,unsigned long>+;
+#pragma link C++ class std::pair<dd4hep::Callback,unsigned long>+;
 #pragma link C++ class dd4hep::NamedObject+;
 #pragma link C++ class dd4hep::Ref_t+;
 #pragma link C++ class dd4hep::Handle<dd4hep::NamedObject>+;
-#pragma link C++ class pair<string, dd4hep::Handle<dd4hep::NamedObject> >+;
-#pragma link C++ class map<string, dd4hep::Handle<dd4hep::NamedObject> >+;
-#pragma link C++ class map<string, dd4hep::Handle<dd4hep::NamedObject> >::iterator;
-#pragma link C++ class map<string, dd4hep::Handle<dd4hep::NamedObject> >::const_iterator;
+#pragma link C++ class std::pair<std::string, dd4hep::Handle<dd4hep::NamedObject> >+;
+#pragma link C++ class std::map<std::string, dd4hep::Handle<dd4hep::NamedObject> >+;
+#pragma link C++ class std::map<std::string, dd4hep::Handle<dd4hep::NamedObject> >::iterator;
+#pragma link C++ class std::map<std::string, dd4hep::Handle<dd4hep::NamedObject> >::const_iterator;
 #pragma link C++ class dd4hep::detail::DD4hepUI;
 
 #ifdef R__MACOSX
 // We only need these declarations for the clang compiler
-#pragma link C++ function operator==( const map<string, dd4hep::Handle<dd4hep::NamedObject> >::iterator&,const map<string, dd4hep::Handle<dd4hep::NamedObject> >::iterator& );
-#pragma link C++ function operator!=( const map<string, dd4hep::Handle<dd4hep::NamedObject> >::iterator&,const map<string, dd4hep::Handle<dd4hep::NamedObject> >::iterator& );
+#pragma link C++ function operator==( const std::map<std::string, dd4hep::Handle<dd4hep::NamedObject> >::iterator&,const std::map<std::string, dd4hep::Handle<dd4hep::NamedObject> >::iterator& );
+#pragma link C++ function operator!=( const std::map<std::string, dd4hep::Handle<dd4hep::NamedObject> >::iterator&,const std::map<std::string, dd4hep::Handle<dd4hep::NamedObject> >::iterator& );
 #endif
 
 #pragma link C++ class dd4hep::BasicGrammar+;
@@ -160,8 +158,8 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::DetectorData::ObjectHandleMap+;
 #pragma link C++ class dd4hep::Detector::PropertyValues+;
 #pragma link C++ class dd4hep::Detector::Properties+;
-#pragma link C++ class pair<dd4hep::IDDescriptor,dd4hep::DDSegmentation::Segmentation*>+;
-#pragma link C++ class map<dd4hep::Readout,pair<dd4hep::IDDescriptor,dd4hep::DDSegmentation::Segmentation*> >+;
+#pragma link C++ class std::pair<dd4hep::IDDescriptor,dd4hep::DDSegmentation::Segmentation*>+;
+#pragma link C++ class std::map<dd4hep::Readout,pair<dd4hep::IDDescriptor,dd4hep::DDSegmentation::Segmentation*> >+;
 
 // These below are the Namedobject instances to be generated ....
 //#pragma link C++ class dd4hep::Detector::HandleMap+;
@@ -175,10 +173,10 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::VolumeManagerContext+;
 #pragma link C++ class dd4hep::detail::VolumeManagerContextExtension+;
 #pragma link C++ class dd4hep::Handle<dd4hep::detail::VolumeManagerObject>+;
-#pragma link C++ class pair<Long64_t,dd4hep::VolumeManager>+;
-#pragma link C++ class map<dd4hep::DetElement,dd4hep::VolumeManager>+;
-#pragma link C++ class map<dd4hep::VolumeID,dd4hep::VolumeManager>+;
-#pragma link C++ class map<dd4hep::VolumeID,dd4hep::VolumeManagerContext*>+;
+#pragma link C++ class std::pair<Long64_t,dd4hep::VolumeManager>+;
+#pragma link C++ class std::map<dd4hep::DetElement,dd4hep::VolumeManager>+;
+#pragma link C++ class std::map<dd4hep::VolumeID,dd4hep::VolumeManager>+;
+#pragma link C++ class std::map<dd4hep::VolumeID,dd4hep::VolumeManagerContext*>+;
 
 #pragma link C++ class dd4hep::CartesianField+;
 #pragma link C++ class dd4hep::CartesianField::Object+;
@@ -201,7 +199,7 @@ template class dd4hep::Handle<TNamed>;
 
 // Objects.h
 #pragma link C++ class dd4hep::Author+;
-#pragma link C++ class vector<dd4hep::Author>+;
+#pragma link C++ class std::vector<dd4hep::Author>+;
 
 #pragma link C++ class dd4hep::Header+;
 #pragma link C++ class dd4hep::HeaderObject+;
@@ -210,35 +208,35 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::Constant+;
 #pragma link C++ class dd4hep::ConstantObject+;
 #pragma link C++ class dd4hep::Handle<dd4hep::ConstantObject>+;
-#pragma link C++ class vector<dd4hep::Constant>+;
+#pragma link C++ class std::vector<dd4hep::Constant>+;
 
 #pragma link C++ class dd4hep::Atom+;
-#pragma link C++ class vector<dd4hep::Atom>+;
+#pragma link C++ class std::vector<dd4hep::Atom>+;
 #pragma link C++ class dd4hep::Handle<TGeoElement>+;
 
 #pragma link C++ class dd4hep::Material+;
-#pragma link C++ class vector<dd4hep::Material>+;
+#pragma link C++ class std::vector<dd4hep::Material>+;
 #pragma link C++ class dd4hep::Handle<TGeoMedium>+;
 
 #pragma link C++ class dd4hep::VisAttr+;
-#pragma link C++ class vector<dd4hep::VisAttr>+;
+#pragma link C++ class std::vector<dd4hep::VisAttr>+;
 #pragma link C++ class dd4hep::VisAttrObject+;
 #pragma link C++ class dd4hep::Handle<dd4hep::VisAttrObject>+;
 
 #pragma link C++ class dd4hep::Limit+;
-#pragma link C++ class set<dd4hep::Limit>+;
-#pragma link C++ class vector<dd4hep::Limit>+;
+#pragma link C++ class std::set<dd4hep::Limit>+;
+#pragma link C++ class std::vector<dd4hep::Limit>+;
 #pragma link C++ class dd4hep::LimitSet+;
-#pragma link C++ class vector<dd4hep::LimitSet>+;
+#pragma link C++ class std::vector<dd4hep::LimitSet>+;
 #pragma link C++ class dd4hep::LimitSetObject+;
 #pragma link C++ class dd4hep::Handle<dd4hep::LimitSetObject>+;
 #pragma link C++ class dd4hep::Region+;
 #pragma link C++ class dd4hep::RegionObject+;
 #pragma link C++ class dd4hep::Handle<dd4hep::RegionObject>+;
-#pragma link C++ class vector<dd4hep::Region>+;
+#pragma link C++ class std::vector<dd4hep::Region>+;
 
 // Readout.h
-#pragma link C++ class vector<pair<size_t,string> >+;
+#pragma link C++ class std::vector<pair<size_t,string> >+;
 #pragma link C++ class dd4hep::Segmentation+;
 #pragma link C++ class dd4hep::SegmentationObject+;
 #pragma link C++ class dd4hep::Handle<dd4hep::SegmentationObject>+;
@@ -247,11 +245,11 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::HitCollection+;
 #pragma link C++ class dd4hep::ReadoutObject+;
 #pragma link C++ class dd4hep::Handle<dd4hep::ReadoutObject>+;
-#pragma link C++ class vector<dd4hep::HitCollection>+;
-#pragma link C++ class vector<dd4hep::Readout>+;
-#pragma link C++ class vector<dd4hep::HitCollection*>+;
-#pragma link C++ class vector<const dd4hep::HitCollection*>+;
-#pragma link C++ class vector<dd4hep::IDDescriptor>+;
+#pragma link C++ class std::vector<dd4hep::HitCollection>+;
+#pragma link C++ class std::vector<dd4hep::Readout>+;
+#pragma link C++ class std::vector<dd4hep::HitCollection*>+;
+#pragma link C++ class std::vector<const dd4hep::HitCollection*>+;
+#pragma link C++ class std::vector<dd4hep::IDDescriptor>+;
 
 // Alignment stuff
 #pragma link C++ class dd4hep::Delta+;
@@ -263,7 +261,7 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::AlignmentCondition+;
 #pragma link C++ class dd4hep::detail::AlignmentObject+;
 #pragma link C++ class dd4hep::Handle<dd4hep::detail::AlignmentObject>+;
-#pragma link C++ class pair<dd4hep::DetElement,dd4hep::AlignmentCondition>+;
+#pragma link C++ class std::pair<dd4hep::DetElement,dd4hep::AlignmentCondition>+;
 //#pragma link C++ class dd4hep::Grammar<dd4hep::detail::AlignmentObject>+;
 
 #pragma link C++ class dd4hep::align::GlobalAlignment+;
@@ -271,9 +269,9 @@ template class dd4hep::Handle<TNamed>;
 
 // Conditions stuff
 #pragma link C++ class dd4hep::Condition+;
-#pragma link C++ class vector<dd4hep::Condition>+;
+#pragma link C++ class std::vector<dd4hep::Condition>+;
 #pragma link C++ class dd4hep::ConditionKey+;
-#pragma link C++ class vector<dd4hep::ConditionKey>+;
+#pragma link C++ class std::vector<dd4hep::ConditionKey>+;
 #pragma link C++ class dd4hep::detail::ConditionObject+;
 #pragma link C++ class dd4hep::Handle<dd4hep::detail::ConditionObject>+;
 #pragma link C++ class dd4hep::OpaqueData+;
@@ -287,21 +285,21 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::DetElement::Processor+;
 #pragma link C++ class dd4hep::DetElementObject+;
 #pragma link C++ class dd4hep::Handle<dd4hep::DetElementObject>+;
-#pragma link C++ class vector<dd4hep::DetElement>+;
-#pragma link C++ class pair<string,dd4hep::DetElement>+;
-#pragma link C++ class map<string,dd4hep::DetElement>+;
-#pragma link C++ class map<string,dd4hep::DetElement>::iterator;
-#pragma link C++ class map<string,dd4hep::DetElement>::const_iterator;
+#pragma link C++ class std::vector<dd4hep::DetElement>+;
+#pragma link C++ class std::pair<std::string,dd4hep::DetElement>+;
+#pragma link C++ class std::map<std::string,dd4hep::DetElement>+;
+#pragma link C++ class std::map<std::string,dd4hep::DetElement>::iterator;
+#pragma link C++ class std::map<std::string,dd4hep::DetElement>::const_iterator;
 
 #pragma link C++ class dd4hep::DetectorProcessor+;
 #pragma link C++ class dd4hep::DetectorScanner+;
 
-#pragma link C++ class pair<dd4hep::DetElement,dd4hep::VolumeManager>+;
+#pragma link C++ class std::pair<dd4hep::DetElement,dd4hep::VolumeManager>+;
 
 #ifdef R__MACOSX
 // We only need these declarations for the clang compiler
-#pragma link C++ function operator==( const map<string, dd4hep::DetElement >::iterator&,const map<string, dd4hep::DetElement >::iterator& );
-#pragma link C++ function operator!=( const map<string, dd4hep::DetElement >::iterator&,const map<string, dd4hep::DetElement >::iterator& );
+#pragma link C++ function operator==( const std::map<std::string, dd4hep::DetElement >::iterator&,const std::map<std::string, dd4hep::DetElement >::iterator& );
+#pragma link C++ function operator!=( const std::map<std::string, dd4hep::DetElement >::iterator&,const std::map<std::string, dd4hep::DetElement >::iterator& );
 #endif
 
 #pragma link C++ class dd4hep::SensitiveDetector+;
@@ -309,26 +307,26 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::Handle<dd4hep::SensitiveDetectorObject>+;
 #pragma link C++ class vector<dd4hep::SensitiveDetector>+;
 
-#pragma link C++ class pair<string, string>+;
-#pragma link C++ class map<string, string>+;
-#pragma link C++ class map<string, string>::iterator;
-#pragma link C++ class map<string, string>::const_iterator;
+#pragma link C++ class std::pair<std::string, std::string>+;
+#pragma link C++ class std::map<std::string, std::string>+;
+#pragma link C++ class std::map<std::string, std::string>::iterator;
+#pragma link C++ class std::map<std::string, std::string>::const_iterator;
 
 #ifdef R__MACOSX
 // We only need these declarations for the clang compiler
-#pragma link C++ function operator==( const map<string, string>::iterator&, const map<string, string>::iterator& );
-#pragma link C++ function operator!=( const map<string, string>::iterator&, const map<string, string>::iterator& );
+#pragma link C++ function operator==( const std::map<std::string, std::string>::iterator&, const std::map<std::string, std::string>::iterator& );
+#pragma link C++ function operator!=( const std::map<std::string, std::string>::iterator&, const std::map<std::string, std::string>::iterator& );
 #endif
 
-#pragma link C++ class pair<string, map<string, string> >+;
-#pragma link C++ class map<string, map<string, string> >+;
-#pragma link C++ class map<string, map<string,string>>::iterator;
-#pragma link C++ class map<string, map<string,string>>::const_iterator;
+#pragma link C++ class std::pair<std::string, std::map<std::string, std::string> >+;
+#pragma link C++ class std::map<std::string, std::map<std::string, std::string> >+;
+#pragma link C++ class std::map<std::string, std::map<std::string,std::string>>::iterator;
+#pragma link C++ class std::map<std::string, std::map<std::string,std::string>>::const_iterator;
 
 #ifdef R__MACOSX
 // We only need these declarations for the clang compiler
-#pragma link C++ function operator==( const map<string, map<string,string>>::iterator&, const map<string, map<string,string>>::iterator& );
-#pragma link C++ function operator!=( const map<string, map<string,string>>::iterator&, const map<string, map<string,string>>::iterator& );
+#pragma link C++ function operator==( const std::map<std::string, std::map<std::string,std::string>>::iterator&, const std::map<std::string, std::map<std::string,std::string>>::iterator& );
+#pragma link C++ function operator!=( const std::map<std::string, std::map<std::string,std::string>>::iterator&, const std::map<std::string, std::map<std::string,std::string>>::iterator& );
 #endif
 
 #pragma link C++ class dd4hep::Detector+;
@@ -336,8 +334,8 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ class dd4hep::detail::interp;
 #pragma link C++ class dd4hep::detail::eval;
 
-#pragma link C++ function dd4hep::run_interpreter(const string& name);
-#pragma link C++ function dd4hep::_toDictionary(const string&, const string&);
+#pragma link C++ function dd4hep::run_interpreter(const std::string& name);
+#pragma link C++ function dd4hep::_toDictionary(const std::string&, const std::string&);
 #pragma link C++ function dd4hep::toStringSolid(const TGeoShape*, int);
 #pragma link C++ function dd4hep::toStringMesh(const TGeoShape*, int);
 #pragma link C++ function dd4hep::toStringMesh(dd4hep::PlacedVolume, int);

--- a/DDCore/src/SegmentationDictionary.h
+++ b/DDCore/src/SegmentationDictionary.h
@@ -57,15 +57,15 @@ typedef dd4hep::DDSegmentation::CellID CellID;
 #pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<float>+;
 #pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<double>+;
 #pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<string>+;
-#pragma link C++ class map<string,dd4hep::DDSegmentation::TypedSegmentationParameter<string>* >+;
-#pragma link C++ class map<string,dd4hep::DDSegmentation::TypedSegmentationParameter<double>* >+;
-#pragma link C++ class map<string,dd4hep::DDSegmentation::TypedSegmentationParameter<float>* >+;
+#pragma link C++ class std::map<std::string,dd4hep::DDSegmentation::TypedSegmentationParameter<string>* >+;
+#pragma link C++ class std::map<std::string,dd4hep::DDSegmentation::TypedSegmentationParameter<double>* >+;
+#pragma link C++ class std::map<std::string,dd4hep::DDSegmentation::TypedSegmentationParameter<float>* >+;
 
 /// Severe problem due to template specialization!
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<int> >+;
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<float> >+;
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<double> >+;
-#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<vector<string> >+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<std::vector<int> >+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<std::vector<float> >+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<std::vector<double> >+;
+#pragma link C++ class dd4hep::DDSegmentation::TypedSegmentationParameter<std::vector<std::string> >+;
 
 #pragma link C++ class dd4hep::DDSegmentation::Segmentation+;
 #pragma link C++ class dd4hep::DDSegmentation::CartesianGrid+;

--- a/DDEve/include/DDEve/Dictionary.h
+++ b/DDEve/include/DDEve/Dictionary.h
@@ -66,7 +66,6 @@ namespace  {
 }
 
 #if defined(__CINT__) || defined(__MAKECINT__) || defined(__CLING__) || defined(__ROOTCLING__)
-using namespace dd4hep;
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
@@ -74,44 +73,44 @@ using namespace dd4hep;
 #pragma link C++ namespace dd4hep;
 
 //==================================================================================
-#pragma link C++ function EveDisplay(const char* xmlFile, const char* eventFileName);
+#pragma link C++ function dd4hep::EveDisplay(const char* xmlFile, const char* eventFileName);
 
-#pragma link C++ class DDEve;
-#pragma link C++ class Display;
-#pragma link C++ class Annotation;
-#pragma link C++ class ElementList;
-#pragma link C++ class FrameControl;
-#pragma link C++ class EventHandler;
-#pragma link C++ class EventConsumer;
-#pragma link C++ class DDG4EventHandler;
-#pragma link C++ class GenericEventHandler;
-#pragma link C++ class EventControl;
+#pragma link C++ class dd4hep::DDEve;
+#pragma link C++ class dd4hep::Display;
+#pragma link C++ class dd4hep::Annotation;
+#pragma link C++ class dd4hep::ElementList;
+#pragma link C++ class dd4hep::FrameControl;
+#pragma link C++ class dd4hep::EventHandler;
+#pragma link C++ class dd4hep::EventConsumer;
+#pragma link C++ class dd4hep::DDG4EventHandler;
+#pragma link C++ class dd4hep::GenericEventHandler;
+#pragma link C++ class dd4hep::EventControl;
 
-#pragma link C++ class DisplayConfiguration::Config;
+#pragma link C++ class dd4hep::DisplayConfiguration::Config;
 //#pragma link C++ class std::list<DisplayConfiguration::Config>;
-#pragma link C++ class DisplayConfiguration::ViewConfig;
+#pragma link C++ class dd4hep::DisplayConfiguration::ViewConfig;
 //#pragma link C++ class std::list<DisplayConfiguration::ViewConfig>;
-#pragma link C++ class DisplayConfiguration;
+#pragma link C++ class dd4hep::DisplayConfiguration;
 
-#pragma link C++ class View;
-#pragma link C++ class View3D;
-#pragma link C++ class Projection;
-#pragma link C++ class RhoZProjection;
-#pragma link C++ class RhoPhiProjection;
-#pragma link C++ class CaloLego;
-#pragma link C++ class Calo2DProjection;
-#pragma link C++ class Calo3DProjection;
-#pragma link C++ class MultiView;
+#pragma link C++ class dd4hep::View;
+#pragma link C++ class dd4hep::View3D;
+#pragma link C++ class dd4hep::Projection;
+#pragma link C++ class dd4hep::RhoZProjection;
+#pragma link C++ class dd4hep::RhoPhiProjection;
+#pragma link C++ class dd4hep::CaloLego;
+#pragma link C++ class dd4hep::Calo2DProjection;
+#pragma link C++ class dd4hep::Calo3DProjection;
+#pragma link C++ class dd4hep::MultiView;
 
-#pragma link C++ class PopupMenu;
-#pragma link C++ class ViewMenu;
-#pragma link C++ class DD4hepMenu;
-#pragma link C++ class ContextMenu;
-#pragma link C++ class ContextMenuHandler;
-#pragma link C++ class EveUserContextMenu;
-#pragma link C++ class ElementListContextMenu;
-#pragma link C++ class EveShapeContextMenu;
-#pragma link C++ class EvePgonSetProjectedContextMenu;
+#pragma link C++ class dd4hep::PopupMenu;
+#pragma link C++ class dd4hep::ViewMenu;
+#pragma link C++ class dd4hep::DD4hepMenu;
+#pragma link C++ class dd4hep::ContextMenu;
+#pragma link C++ class dd4hep::ContextMenuHandler;
+#pragma link C++ class dd4hep::EveUserContextMenu;
+#pragma link C++ class dd4hep::ElementListContextMenu;
+#pragma link C++ class dd4hep::EveShapeContextMenu;
+#pragma link C++ class dd4hep::EvePgonSetProjectedContextMenu;
 
 
 #endif

--- a/DDG4/include/DDG4/DDG4Dict.h
+++ b/DDG4/include/DDG4/DDG4Dict.h
@@ -52,8 +52,6 @@ namespace { class DDG4Dict {};   }
 #pragma link off all classes;
 #pragma link off all functions;
 
-using namespace std;
-
 /// Define namespaces
 #pragma link C++ namespace dd4hep;
 #pragma link C++ namespace dd4hep::sim;
@@ -72,34 +70,34 @@ using namespace std;
 #pragma link C++ class dd4hep::dd4hep_ptr<dd4hep::sim::ParticleExtension>;
 
 #pragma link C++ class dd4hep::sim::Geant4Particle+;
-#pragma link C++ class vector<dd4hep::sim::Geant4Particle*>+;
-#pragma link C++ class map<int,dd4hep::sim::Geant4Particle*>+;
-#pragma link C++ class map<int,dd4hep::sim::Geant4Particle*>::iterator;
-#pragma link C++ class map<int,dd4hep::sim::Geant4Particle*>::const_iterator;
+#pragma link C++ class std::vector<dd4hep::sim::Geant4Particle*>+;
+#pragma link C++ class std::map<int,dd4hep::sim::Geant4Particle*>+;
+#pragma link C++ class std::map<int,dd4hep::sim::Geant4Particle*>::iterator;
+#pragma link C++ class std::map<int,dd4hep::sim::Geant4Particle*>::const_iterator;
 
 #ifdef R__MACOSX
 // We only need these declarations for the clang compiler
-#pragma link C++ function operator==( const map<int,dd4hep::sim::Geant4Particle*>::iterator&, const map<int,dd4hep::sim::Geant4Particle*>::iterator& );
-#pragma link C++ function operator!=( const map<int,dd4hep::sim::Geant4Particle*>::iterator&, const map<int,dd4hep::sim::Geant4Particle*>::iterator& );
+#pragma link C++ function operator==( const std::map<int,dd4hep::sim::Geant4Particle*>::iterator&, const std::map<int,dd4hep::sim::Geant4Particle*>::iterator& );
+#pragma link C++ function operator!=( const std::map<int,dd4hep::sim::Geant4Particle*>::iterator&, const std::map<int,dd4hep::sim::Geant4Particle*>::iterator& );
 #endif
 
 //#pragma link C++ class type_info;
 
 /// Dictionaires for basic Hit data structures
 #pragma link C++ class dd4hep::sim::Geant4HitData+;
-#pragma link C++ class vector<dd4hep::sim::Geant4HitData*>+;
+#pragma link C++ class std::vector<dd4hep::sim::Geant4HitData*>+;
 #pragma link C++ class dd4hep::sim::Geant4HitData::Contribution+;
 #pragma link C++ class dd4hep::sim::Geant4HitData::Contributions+;
 
 /// Dictionaires for Tracker Hit data structures
 #pragma link C++ class dd4hep::sim::Geant4Tracker+;
 #pragma link C++ class dd4hep::sim::Geant4Tracker::Hit+;
-#pragma link C++ class vector<dd4hep::sim::Geant4Tracker::Hit*>+;
+#pragma link C++ class std::vector<dd4hep::sim::Geant4Tracker::Hit*>+;
 
 /// Dictionaires for Calorimeter Hit data structures
 #pragma link C++ class dd4hep::sim::Geant4Calorimeter+;
 #pragma link C++ class dd4hep::sim::Geant4Calorimeter::Hit+;
-#pragma link C++ class vector<dd4hep::sim::Geant4Calorimeter::Hit*>+;
+#pragma link C++ class std::vector<dd4hep::sim::Geant4Calorimeter::Hit*>+;
 
 #endif
 

--- a/DDG4/include/DDG4/DDG4Dict.h
+++ b/DDG4/include/DDG4/DDG4Dict.h
@@ -86,6 +86,7 @@ namespace { class DDG4Dict {};   }
 /// Dictionaires for basic Hit data structures
 #pragma link C++ class dd4hep::sim::Geant4HitData+;
 namespace dd4hep { namespace sim { typedef Geant4HitData* Geant4HitData_ptr_t; }}
+#pragma link C++ typedef Geant4HitData_ptr_t;
 #pragma link C++ class std::vector<dd4hep::sim::Geant4HitData_ptr_t>+;
 #pragma link C++ class dd4hep::sim::Geant4HitData::Contribution+;
 #pragma link C++ class dd4hep::sim::Geant4HitData::Contributions+;

--- a/DDG4/include/DDG4/DDG4Dict.h
+++ b/DDG4/include/DDG4/DDG4Dict.h
@@ -85,7 +85,8 @@ namespace { class DDG4Dict {};   }
 
 /// Dictionaires for basic Hit data structures
 #pragma link C++ class dd4hep::sim::Geant4HitData+;
-#pragma link C++ class std::vector<dd4hep::sim::Geant4HitData*>+;
+namespace dd4hep { namespace sim { typedef Geant4HitData* Geant4HitData_ptr_t; }}
+#pragma link C++ class std::vector<dd4hep::sim::Geant4HitData_ptr_t>+;
 #pragma link C++ class dd4hep::sim::Geant4HitData::Contribution+;
 #pragma link C++ class dd4hep::sim::Geant4HitData::Contributions+;
 


### PR DESCRIPTION
BEGINRELEASENOTES
Remove using declarations in root-cling dictionary files to avoid interpreter clashes with the global namespace

Affected files:
-   DDCore/src/GeoDictionary.h
-   DDCore/src/PropertyDictionary.h
-   DDCore/src/RootDictionary.h
-   DDCore/src/SegmentationDictionary.h
-   DDEve/include/DDEve/Dictionary.h
-   DDG4/include/DDG4/DDG4Dict.h

ENDRELEASENOTES