### PR TITLE
fix: set tessellated solid closure flag in geant4

### DIFF
--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -274,6 +274,7 @@ namespace dd4hep {
         }
         g4->AddFacet(g4f);
       }
+      g4->SetSolidClosed(sh->IsClosedBody());
       return g4;
     }
     


### PR DESCRIPTION
The `G4TessellatedSolid` created in the `Geant4ShapeConverter` is by default [not closed](https://github.com/Geant4/geant4/blob/v11.0.3/source/geometry/solids/specific/src/G4TessellatedSolid.cc#L165) (v11.0.3). This sets the closure of the `G4TessellatedSolid` based on the closure of `TGeoTessellated` (with [`IsBodyClosed`](https://github.com/root-project/root/blob/v6-26-06/geom/geom/inc/TGeoTessellated.h#L141)), to ensure that closed solids are converted into closed solids.

BEGINRELEASENOTES
- Ensure that closed tessellated solids are converted to closed solids in geant4 

ENDRELEASENOTES