### PR TITLE
Export DD4HEP_RELAX_PYVER to generated cmake config

### DIFF
--- a/cmake/DD4hepConfig.cmake.in
+++ b/cmake/DD4hepConfig.cmake.in
@@ -32,6 +32,7 @@ set ( DD4HEP_USE_LCIO                          @DD4HEP_USE_LCIO@ )
 set ( DD4HEP_USE_XERCESC                       @DD4HEP_USE_XERCESC@ )
 set ( DD4HEP_USE_TBB                           @DD4HEP_USE_TBB@ )
 set ( DD4HEP_USE_GEANT4_UNITS                  @DD4HEP_USE_GEANT4_UNITS@ )
+set ( DD4HEP_RELAX_PYVER                       @DD4HEP_RELAX_PYVER@ )
 set ( @CMAKE_PROJECT_NAME@_BUILD_CXX_STANDARD  @CMAKE_CXX_STANDARD@ )
 
 include ( ${@CMAKE_PROJECT_NAME@_DIR}/cmake/DD4hep.cmake )


### PR DESCRIPTION
This variable was previously not exported, and the corresponding relaxed python version check was not executed because of this. This means DD4HEP_RELAX_PYVER was functional in the DD4hep build itself, but not in downstream builds.

BEGINRELEASENOTES
- DD4HEP_RELAX_PYVER is exported to `DD4hepConfig.cmake`.

ENDRELEASENOTES