### PR TITLE
feat: Allow HepMC3 ROOT input files in ddsim

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -39,7 +39,7 @@ try:
 except ImportError:
   ARGCOMPLETEENABLED = False
 
-POSSIBLEINPUTFILES = (".stdhep", ".slcio", ".HEPEvt", ".hepevt", ".hepmc", ".hepmc3", ".pairs")
+POSSIBLEINPUTFILES = (".stdhep", ".slcio", ".HEPEvt", ".hepevt", ".hepmc", ".hepmc3", ".hepmc3.tree.root", ".pairs")
 
 
 class DD4hepSimulation(object):
@@ -403,7 +403,7 @@ class DD4hepSimulation(object):
       elif inputFile.endswith(".hepevt"):
         gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepevt%d" % index)
         gen.Input = "Geant4EventReaderHepEvtLong|" + inputFile
-      elif inputFile.endswith((".hepmc", ".hepmc3")):
+      elif inputFile.endswith((".hepmc", ".hepmc3", ".hepmc3.tree.root")):
         if self.hepmc3.useHepMC3:
           gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index)
           gen.Parameters = self.hepmc3.getParameters()
@@ -527,7 +527,7 @@ class DD4hepSimulation(object):
       fileNames = [fileNames]
     if not all(fileName.endswith(extensions) for fileName in fileNames):
       self._errorMessages.append("ERROR: Unknown fileformat for file: %s" % fileNames)
-    if not self.hepmc3.useHepMC3 and any(fileName.endswith(".hepmc3") for fileName in fileNames):
+    if not self.hepmc3.useHepMC3 and any(fileName.endswith((".hepmc3", ".hepmc3.tree.root")) for fileName in fileNames):
       self._errorMessages.append("ERROR: HepMC3 files require the use of HepMC3 library")
     return fileNames
 


### PR DESCRIPTION
This enables ddsim to accept `--inputFiles example.hepmc3.tree.root` files as produced by the [HepMC3 rootIO writers](https://gitlab.cern.ch/hepmc/HepMC3/-/tree/master/rootIO/include/HepMC3).

There are two rootIO writers: `WriterRoot` writes HepMC3 objects to a ROOT file, while `WriterRootTree` writes a ROOT TTree with events. There are two corresponding rootIO readers. When HepMC3's `deduce_reader` is passed a `.root` file, it only [attempts to use](https://gitlab.cern.ch/hepmc/HepMC3/-/blob/master/include/HepMC3/ReaderFactory.h#L107) the `WriterRootTree`.

Since `.root` is a bit too generic as an extension (it does not indicate the data model) and since ddsim already uses multiple extensions in output formates, e.g. `.edm4hep.root`, I considered that the intent is best conveyed with `.hepmc3.tree.root` (making it clear that the HepMC3 data model is used, stored in TTrees, inside the ROOT file format).

With this change it is now also possible to run ddsim against remote HepMC3 events on an xrootd server, e.g.
```
ddsim --compactFile $DD4hepINSTALL/DDDetectors/compact/SiD.xml -N 10 --inputFiles root://dtn-eic.jlab.org//work/eic2/users/wdconinc/pythia8NCDIS_5x41_minQ2\=1_beamEffects_xAngle\=-0.025_hiDiv_vtxfix_1.hepmc3.tree.root --outputFile output.edm4hep.root
```

~~Related to #989 as well, this adds another corner case for something that needs to be excepted if no HepMC3 support is available and when Geant4EventReaderHepMC must be used. I am not sure what logic you think is best, both in #989 and here, so I am going to leave this as a draft PR for discussion. I wonder if it makes sense to require `.hepmc3` and `.hepmc3.tree.root` for all HepMC3 files, which must be handled with the HepMC3 library.~~ Changed to require extension `.hepmc3.tree.root`.

BEGINRELEASENOTES
- Allow HepMC3 ROOT input files in ddsim

ENDRELEASENOTES