### PR TITLE
feat: allow asymmetric tracking region, default to symmetric

### DIFF
--- a/DDG4/plugins/Geant4TCUserParticleHandler.cpp
+++ b/DDG4/plugins/Geant4TCUserParticleHandler.cpp
@@ -91,7 +91,7 @@ DECLARE_GEANT4ACTION(Geant4TCUserParticleHandler)
 Geant4TCUserParticleHandler::Geant4TCUserParticleHandler(Geant4Context* ctxt, const std::string& nam)
 : Geant4UserParticleHandler(ctxt,nam)
 {
-  declareProperty("TrackingVolume_Zmin",m_zTrackerMin=1e100);
+  declareProperty("TrackingVolume_Zmin",m_zTrackerMin=-1e100);
   declareProperty("TrackingVolume_Zmax",m_zTrackerMax=1e100);
   declareProperty("TrackingVolume_Rmax",m_rTracker=1e100);
 }
@@ -102,7 +102,7 @@ void Geant4TCUserParticleHandler::end(const G4Track* /* track */, Particle& p)  
   double r_prod = std::sqrt(p.vsx*p.vsx + p.vsy*p.vsy);
   double z_prod = p.vsz;
   bool starts_in_trk_vol = ( r_prod <= m_rTracker
-    && z_prod >= (m_zTrackerMin == 1e100? -m_zTrackerMax : -m_zTrackerMin)
+    && z_prod >= (m_zTrackerMin == -1e100? m_zTrackerMax : m_zTrackerMin)
     && z_prod <= m_zTrackerMax
   )  ;
 
@@ -119,7 +119,7 @@ void Geant4TCUserParticleHandler::end(const G4Track* /* track */, Particle& p)  
   double r_end  = std::sqrt(p.vex*p.vex + p.vey*p.vey);
   double z_end  = p.vez;
   bool ends_in_trk_vol =  ( r_end <= m_rTracker
-     && z_end >= (m_zTrackerMin == 1e100? -m_zTrackerMax : -m_zTrackerMin)
+     && z_end >= (m_zTrackerMin == -1e100? m_zTrackerMax : m_zTrackerMin)
      && z_end <= m_zTrackerMax
   ) ;
 

--- a/DDG4/plugins/Geant4TCUserParticleHandler.cpp
+++ b/DDG4/plugins/Geant4TCUserParticleHandler.cpp
@@ -102,7 +102,7 @@ void Geant4TCUserParticleHandler::end(const G4Track* /* track */, Particle& p)  
   double r_prod = std::sqrt(p.vsx*p.vsx + p.vsy*p.vsy);
   double z_prod = p.vsz;
   bool starts_in_trk_vol = ( r_prod <= m_rTracker
-    && z_prod >= (m_zTrackerMin == -1e100? m_zTrackerMax : m_zTrackerMin)
+    && z_prod >= (m_zTrackerMin == -1e100? -m_zTrackerMax : m_zTrackerMin)
     && z_prod <= m_zTrackerMax
   )  ;
 
@@ -119,7 +119,7 @@ void Geant4TCUserParticleHandler::end(const G4Track* /* track */, Particle& p)  
   double r_end  = std::sqrt(p.vex*p.vex + p.vey*p.vey);
   double z_end  = p.vez;
   bool ends_in_trk_vol =  ( r_end <= m_rTracker
-     && z_end >= (m_zTrackerMin == -1e100? m_zTrackerMax : m_zTrackerMin)
+     && z_end >= (m_zTrackerMin == -1e100? -m_zTrackerMax : m_zTrackerMin)
      && z_end <= m_zTrackerMax
   ) ;
 

--- a/DDG4/plugins/Geant4TCUserParticleHandler.cpp
+++ b/DDG4/plugins/Geant4TCUserParticleHandler.cpp
@@ -43,7 +43,7 @@ namespace dd4hep {
      * @version 1.0
      */
     class Geant4TCUserParticleHandler : public Geant4UserParticleHandler  {
-      double m_zTracker, m_rTracker;
+      double m_zTrackerMin, m_zTrackerMax, m_rTracker;
     public:
       /// Standard constructor
       Geant4TCUserParticleHandler(Geant4Context* context, const std::string& nam);
@@ -91,7 +91,8 @@ DECLARE_GEANT4ACTION(Geant4TCUserParticleHandler)
 Geant4TCUserParticleHandler::Geant4TCUserParticleHandler(Geant4Context* ctxt, const std::string& nam)
 : Geant4UserParticleHandler(ctxt,nam)
 {
-  declareProperty("TrackingVolume_Zmax",m_zTracker=1e100);
+  declareProperty("TrackingVolume_Zmin",m_zTrackerMin=1e100);
+  declareProperty("TrackingVolume_Zmax",m_zTrackerMax=1e100);
   declareProperty("TrackingVolume_Rmax",m_rTracker=1e100);
 }
 
@@ -99,8 +100,11 @@ Geant4TCUserParticleHandler::Geant4TCUserParticleHandler(Geant4Context* ctxt, co
 void Geant4TCUserParticleHandler::end(const G4Track* /* track */, Particle& p)  {
 
   double r_prod = std::sqrt(p.vsx*p.vsx + p.vsy*p.vsy);
-  double z_prod = std::fabs(p.vsz);
-  bool starts_in_trk_vol = ( r_prod <= m_rTracker && z_prod <= m_zTracker )  ;
+  double z_prod = p.vsz;
+  bool starts_in_trk_vol = ( r_prod <= m_rTracker
+    && z_prod >= (m_zTrackerMin == 1e100? -m_zTrackerMax : -m_zTrackerMin)
+    && z_prod <= m_zTrackerMax
+  )  ;
 
   dd4hep::detail::ReferenceBitMask<int> reason(p.reason);
 
@@ -113,8 +117,11 @@ void Geant4TCUserParticleHandler::end(const G4Track* /* track */, Particle& p)  
   }
 
   double r_end  = std::sqrt(p.vex*p.vex + p.vey*p.vey);
-  double z_end  = std::fabs(p.vez);
-  bool ends_in_trk_vol =  ( r_end <= m_rTracker && z_end <= m_zTracker ) ;
+  double z_end  = p.vez;
+  bool ends_in_trk_vol =  ( r_end <= m_rTracker
+     && z_end >= (m_zTrackerMin == 1e100? -m_zTrackerMax : -m_zTrackerMin)
+     && z_end <= m_zTrackerMax
+  ) ;
 
   // created and ended in calo but not primary particle
   //

--- a/DDG4/python/DDSim/Helper/ParticleHandler.py
+++ b/DDG4/python/DDSim/Helper/ParticleHandler.py
@@ -141,8 +141,8 @@ class ParticleHandler(ConfigHelper):
       try:
         user.TrackingVolume_Zmin = DDG4.tracker_region_zmin
       except AttributeError as e:
-        logger.info("Attribute tracker_region_zmin for asymmetric tracker region missing %s", e)
-        logger.info("  will use symmetric region defined by tracker_region_zmax")
+        logger.debug("Attribute tracker_region_zmin for asymmetric tracker region missing %s", e)
+        logger.debug("  will use symmetric region defined by tracker_region_zmax")
         user.TrackingVolume_Zmin = str(-float(user.TrackingVolume_Zmax))
 
       logger.info(" *** definition of tracker region *** ")

--- a/DDG4/python/DDSim/Helper/ParticleHandler.py
+++ b/DDG4/python/DDSim/Helper/ParticleHandler.py
@@ -143,7 +143,7 @@ class ParticleHandler(ConfigHelper):
       except AttributeError as e:
         logger.info("Attributes tracker_region_zmin for asymmetric tracker region missing %s", e)
         logger.info("  will use symmetric region defined by tracker_region_zmax")
-        user.TrackingVolume_Zmin = user.TrackingVolume_Zmax
+        user.TrackingVolume_Zmin = str(-float(user.TrackingVolume_Zmax))
 
       logger.info(" *** definition of tracker region *** ")
       logger.info("    tracker_region_zmin = %s", user.TrackingVolume_Zmin)

--- a/DDG4/python/DDSim/Helper/ParticleHandler.py
+++ b/DDG4/python/DDSim/Helper/ParticleHandler.py
@@ -131,16 +131,26 @@ class ParticleHandler(ConfigHelper):
       try:
         user.TrackingVolume_Zmax = DDG4.tracker_region_zmax
         user.TrackingVolume_Rmax = DDG4.tracker_region_rmax
-        logger.info(" *** definition of tracker region *** ")
-        logger.info("    tracker_region_zmax = %s", user.TrackingVolume_Zmax)
-        logger.info("    tracker_region_rmax = %s", user.TrackingVolume_Rmax)
-        logger.info(" ************************************ ")
       except AttributeError as e:
         logger.error("Attribute of tracker region missing in detector model %s", e)
         logger.error("   make sure to specify the global constants tracker_region_zmax and tracker_region_rmax ")
         logger.error("   this is needed for the MC-truth link of created sim-hits  !  ")
         logger.error(" Or Disable the User Particle Handler with --part.userParticleHandler=''")
         exit(1)
+
+      try:
+        user.TrackingVolume_Zmin = DDG4.tracker_region_zmin
+      except AttributeError as e:
+        logger.info("Attributes tracker_region_zmin for asymmetric tracker region missing %s", e)
+        logger.info("  will use symmetric region defined by tracker_region_zmax")
+        user.TrackingVolume_Zmin = user.TrackingVolume_Zmax
+
+      logger.info(" *** definition of tracker region *** ")
+      logger.info("    tracker_region_zmin = %s", user.TrackingVolume_Zmin)
+      logger.info("    tracker_region_zmax = %s", user.TrackingVolume_Zmax)
+      logger.info("    tracker_region_rmax = %s", user.TrackingVolume_Rmax)
+      logger.info(" ************************************ ")
+
       part.adopt(user)
 
     return

--- a/DDG4/python/DDSim/Helper/ParticleHandler.py
+++ b/DDG4/python/DDSim/Helper/ParticleHandler.py
@@ -141,7 +141,7 @@ class ParticleHandler(ConfigHelper):
       try:
         user.TrackingVolume_Zmin = DDG4.tracker_region_zmin
       except AttributeError as e:
-        logger.info("Attributes tracker_region_zmin for asymmetric tracker region missing %s", e)
+        logger.info("Attribute tracker_region_zmin for asymmetric tracker region missing %s", e)
         logger.info("  will use symmetric region defined by tracker_region_zmax")
         user.TrackingVolume_Zmin = str(-float(user.TrackingVolume_Zmax))
 


### PR DESCRIPTION
At the EIC (and other asymmetric colliders) the detector layout is asymmetric. Thus, we wish to define asymmetric tracking regions. This PR introduces `tracker_region_zmin` which is the (signed) negative z position of the tracking region. If not specified, it is set to the negative of zmax and an info message is printed (ensuring backwards compatibility).

BEGINRELEASENOTES
- DDG4: Geant4TCUserParticleHandler: Allow for asymmetric tracking region with `tracker_region_zmin`

ENDRELEASENOTES