### PR TITLE
Fix for HepMC vertex issue (fixes #1013)

### DIFF
--- a/DDG4/hepmc/HepMC3EventReader.cpp
+++ b/DDG4/hepmc/HepMC3EventReader.cpp
@@ -151,7 +151,7 @@ HEPMC3EventReader::readParticles(int event_number, Vertices& vertices, Particles
 
       vtx->x = p->vex;
       vtx->y = p->vey;
-      vtx->z = p->vez
+      vtx->z = p->vez;
       vtx->time = p->time;
 
       vtx->out.insert(p->id) ;

--- a/DDG4/hepmc/HepMC3EventReader.cpp
+++ b/DDG4/hepmc/HepMC3EventReader.cpp
@@ -140,23 +140,18 @@ HEPMC3EventReader::readParticles(int event_number, Vertices& vertices, Particles
       // Therefore, p->vsx etc. is not suitable to cover situations with multiple
       // particles coming from different vertices.
       // Intuitively, one should add vertices for all particles that have a parent,
-      // but this heritage is handled differently in other places so the
-      // fix is to use this parentless particles's end vertices.
+      // but heritage is handled differently in other places so the
+      // fix is to use these parentless particles' end vertices.
+      // Note that for a particle without end vertex (such as in a particle gun),
+      // it defaults to (0,0,0). This cannot be fixed, the information simply isn't in the HepMC file
+      // Having a parent enforces a vertex, having none forbids one.
+
       Geant4Vertex* vtx = new Geant4Vertex ;
       vertices.emplace_back( vtx );
-      auto x = p->vex;
-      auto y = p->vey;
-      auto z = p->vez;
-      // For a particle without end vertex (such as in a particle gun),
-      // it defaults to (0,0,0) so we need to catch that situation
-      if ( x==0E0 && y==0E0 && z==0E0 ){
-	x = p->vsx;
-	y = p->vsy;
-	z = p->vsz;
-      }
-      vtx->x = x;
-      vtx->y = y;
-      vtx->z = z;
+
+      vtx->x = p->vex;
+      vtx->y = p->vey;
+      vtx->z = p->vez
       vtx->time = p->time;
 
       vtx->out.insert(p->id) ;

--- a/DDG4/hepmc/HepMC3EventReader.cpp
+++ b/DDG4/hepmc/HepMC3EventReader.cpp
@@ -134,17 +134,11 @@ HEPMC3EventReader::readParticles(int event_number, Vertices& vertices, Particles
     p->genStatus = genStatus&G4PARTICLE_GEN_STATUS_MASK;
 
     if ( p->parents.size() == 0 )  {
-      // This is a bit unintuitive. A particle without a parent in HepMC
-      // can only be (something like) a beam particle, and it is attached
-      // to the root vertex, by default (0,0,0) and equal for all parent-less particles.
-      // Therefore, p->vsx etc. is not suitable to cover situations with multiple
-      // particles coming from different vertices.
-      // Intuitively, one should add vertices for all particles that have a parent,
-      // but heritage is handled differently in other places so the
-      // fix is to use these parentless particles' end vertices.
-      // Note that for a particle without end vertex (such as in a particle gun),
-      // it defaults to (0,0,0). This cannot be fixed, the information simply isn't in the HepMC file
-      // Having a parent enforces a vertex, having none forbids one.
+      // A particle without a parent in HepMC3 can only be (something like) a beam particle, and it is attached to the
+      // root vertex, by default (0,0,0) and equal for all parent-less particles.  Therefore we can take the end vertex
+      // of the parentless particle as the start vertex for outgoing particles.  Note that for a particle without end
+      // vertex (such as in a particle gun), it defaults to (0,0,0). This cannot be fixed, the information simply isn't
+      // in the HepMC file. Having a parent enforces a vertex, having no parent forbids a vertex.
 
       Geant4Vertex* vtx = new Geant4Vertex ;
       vertices.emplace_back( vtx );

--- a/DDG4/include/DDG4/Geant4Particle.h
+++ b/DDG4/include/DDG4/Geant4Particle.h
@@ -273,13 +273,13 @@ namespace dd4hep {
       return ROOT::Math::PxPyPzM4D<double>(p->psx,p->psy,p->psz,p->mass);
     }
 
-    /// Access patricle momentum, energy as 4 vector
+    /// Access start vertex as 3-vector
     inline ROOT::Math::Cartesian3D<double> Geant4ParticleHandle::startVertex() const {
       const Geant4Particle* p = particle;
       return ROOT::Math::Cartesian3D<double>(p->vsx,p->vsy,p->vsz);
     }
 
-    /// Access patricle momentum, energy as 4 vector
+    /// Access end start vertex as 3-vector
     inline ROOT::Math::Cartesian3D<double> Geant4ParticleHandle::endVertex()  const {
       const Geant4Particle* p = particle;
       return ROOT::Math::Cartesian3D<double>(p->vex,p->vey,p->vez);


### PR DESCRIPTION
BEGINRELEASENOTES
- Final state HepMC particles were all attached to (0,0,0). Fixed by switching vertex creation for parentless particles to using their end-point instead, fixes #1013
ENDRELEASENOTES