### PR TITLE
Fix build with GCC 8

### DIFF
--- a/DDDigi/include/DDDigi/DigiROOTInput.h
+++ b/DDDigi/include/DDDigi/DigiROOTInput.h
@@ -50,7 +50,7 @@ namespace dd4hep {
       /// Current input id
       mutable int                    m_curr_input  { 0 };
       /// Connection parameters to the "current" input source
-      mutable std::unique_ptr<internals_t> imp     { };
+      mutable std::unique_ptr<internals_t> imp;
 
       /// Open new input file
       void open_new_file()  const;

--- a/DDDigi/include/DDDigi/DigiROOTOutput.h
+++ b/DDDigi/include/DDDigi/DigiROOTOutput.h
@@ -60,7 +60,7 @@ namespace dd4hep {
       bool  m_disableParticles      { false };
 
       /// Connection parameters to the "current" output source
-      std::unique_ptr<internals_t> imp     { };
+      std::unique_ptr<internals_t> imp;
 
     protected:
       /// Define standard assignments and constructors


### PR DESCRIPTION
It appears GCC had a bug, fixed in GCC 9.2, that incorrectly checks for a complete type in std::unique_ptr initialized with braces even if the constructors and the destructor are defined out-of-line, when the type is complete.

BEGINRELEASENOTES
- Fix build with GCC 8

ENDRELEASENOTES