### PR TITLE
Fix compiler warnings

### DIFF
--- a/DDDigi/src/DigiKernel.cpp
+++ b/DDDigi/src/DigiKernel.cpp
@@ -367,6 +367,7 @@ void DigiKernel::register_monitor(DigiAction* action, TNamed* object)  const    
 
 /// Submit a bunch of actions to be executed in parallel
 void DigiKernel::submit (DigiContext& context, ParallelCall*const algorithms[], std::size_t count, void* data, bool parallel)  const    {
+  (void)parallel; // Silence compiler warning when not using TBB
   const char* tag = context.event->id();
 #ifdef DD4HEP_USE_TBB
   bool para = parallel && (internals->tbb_init && internals->num_threads > 0);

--- a/DDTest/src/test_example.cc
+++ b/DDTest/src/test_example.cc
@@ -18,7 +18,7 @@ int main(int /* argc */, char** /* argv */ ){
 
     // ----- example test for testing two expressions for equality:
 
-    test( "Example", "Example", "example test - string comparison " ); // this test will pass
+    test( std::string("Example"), std::string("Example"), "example test - string comparison " ); // this test will pass
 
     //test( "Example", "BadExample", "example test - string comparison " ); //  this test will fail
 


### PR DESCRIPTION
BEGINRELEASENOTES

- Fix compiler warning about unused variable
- Fix warning in example test and fix also the test, it was comparing `char* == char*` which is almost never true

ENDRELEASENOTES