### PR TITLE
Improve GDML export procedures

### DIFF
--- a/DDCore/include/XML/XMLElements.h
+++ b/DDCore/include/XML/XMLElements.h
@@ -97,6 +97,11 @@ namespace dd4hep {
     /// Dump DOM tree of a document
     void dumpTree(XmlDocument* doc);
 
+    /// Change floating point precision on conversion to string
+    int set_float_precision(int precision);
+    /// Access floating point precision on conversion to string
+    int get_float_precision();
+
     /// Convert xml attribute to STL string  \ingroup DD4HEP_XML
     std::string _toString(const Attribute attr);
     /// Convert xml string to STL string  \ingroup DD4HEP_XML

--- a/DDCore/src/XML/XMLElements.cpp
+++ b/DDCore/src/XML/XMLElements.cpp
@@ -37,6 +37,7 @@
 using namespace std;
 using namespace dd4hep::xml;
 static const size_t INVALID_NODE = ~0U;
+static int          s_float_precision = -1;
 
 // Forward declarations
 namespace dd4hep {
@@ -218,6 +219,19 @@ namespace {
 #endif
 }
 
+/// Change floating point precision on conversion to string
+int dd4hep::xml::set_float_precision(int precision)    {
+  int tmp = s_float_precision;
+  s_float_precision = precision;
+  return tmp;
+}
+
+/// Access floating point precision on conversion to string
+int dd4hep::xml::get_float_precision()    {
+  return s_float_precision;
+}
+
+/// Convert attribute value to string
 string dd4hep::xml::_toString(Attribute attr) {
   if (attr)
     return _toString(attribute_value(attr));
@@ -266,11 +280,21 @@ string dd4hep::xml::_toString(long v, const char* fmt)   {
 
 /// Format single procision float number (32 bits) to string with arbitrary format
 string dd4hep::xml::_toString(float v, const char* fmt) {
+  if ( s_float_precision >= 0 )   {
+    char format[32];
+    ::snprintf(format, sizeof(format), "%%.%de", s_float_precision);
+    return __to_string(v, format);
+  }
   return __to_string(v, fmt);
 }
 
 /// Format double procision float number (64 bits) to string with arbitrary format
 string dd4hep::xml::_toString(double v, const char* fmt) {
+  if ( s_float_precision >= 0 )   {
+    char format[32];
+    ::snprintf(format, sizeof(format), "%%.%de", s_float_precision);
+    return __to_string(v, format);
+  }
   return __to_string(v, fmt);
 }
 
@@ -278,6 +302,7 @@ string dd4hep::xml::_toString(double v, const char* fmt) {
 string dd4hep::xml::_toString(const Strng_t& s)   {
   return _toString(Tag_t(s));
 }
+
 /// Convert Tag_t to std::string
 string dd4hep::xml::_toString(const Tag_t& s)     {
   return s.str();

--- a/DDCore/src/gdml/GdmlPlugins.cpp
+++ b/DDCore/src/gdml/GdmlPlugins.cpp
@@ -181,8 +181,8 @@ static long gdml_extract(Detector& description, int argc, char** argv) {
       if ( de.isValid() )   {
         TGDMLWrite extract;
         TUri uri(output.c_str());
-        extract.SetFltPrecision(precision);
-#if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
+        description.manager().SetExportPrecision(precision);
+#if   ROOT_VERSION_CODE >= ROOT_VERSION(6,27,1)
         extract.SetIgnoreDummyMaterial(true);
         extract.SetNamingSpeed(TGDMLWrite::kfastButUglySufix);
 #if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
@@ -237,7 +237,7 @@ static long gdml_extract(Detector& description, int argc, char** argv) {
       if ( a._node )    {
         TGDMLWrite extract;
         TUri uri(output.c_str());
-        extract.SetFltPrecision(precision);
+        description.manager().SetExportPrecision(precision);
 #if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
         extract.SetIgnoreDummyMaterial(true);
         extract.SetNamingSpeed(TGDMLWrite::kfastButUglySufix);

--- a/DDCore/src/gdml/GdmlPlugins.cpp
+++ b/DDCore/src/gdml/GdmlPlugins.cpp
@@ -181,6 +181,9 @@ static long gdml_extract(Detector& description, int argc, char** argv) {
       if ( de.isValid() )   {
         TGDMLWrite extract;
         TUri uri(output.c_str());
+        extract.SetFltPrecision(precision);
+#if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
+        extract.SetIgnoreDummyMaterial(true);
         extract.SetNamingSpeed(TGDMLWrite::kfastButUglySufix);
 #if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
         extract.SetFltPrecision(precision);
@@ -234,6 +237,9 @@ static long gdml_extract(Detector& description, int argc, char** argv) {
       if ( a._node )    {
         TGDMLWrite extract;
         TUri uri(output.c_str());
+        extract.SetFltPrecision(precision);
+#if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
+        extract.SetIgnoreDummyMaterial(true);
         extract.SetNamingSpeed(TGDMLWrite::kfastButUglySufix);
 #if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
         extract.SetFltPrecision(precision);

--- a/DDCore/src/gdml/GdmlPlugins.cpp
+++ b/DDCore/src/gdml/GdmlPlugins.cpp
@@ -182,12 +182,9 @@ static long gdml_extract(Detector& description, int argc, char** argv) {
         TGDMLWrite extract;
         TUri uri(output.c_str());
         description.manager().SetExportPrecision(precision);
-#if   ROOT_VERSION_CODE >= ROOT_VERSION(6,27,1)
+#if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
         extract.SetIgnoreDummyMaterial(true);
         extract.SetNamingSpeed(TGDMLWrite::kfastButUglySufix);
-#if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
-        extract.SetFltPrecision(precision);
-        extract.SetIgnoreDummyMaterial(true);
         extract.WriteGDMLfile(&description.manager(), de.placement().ptr(), uri.GetRelativePart());
 #elif ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
         extract.WriteGDMLfile(&description.manager(), de.placement().ptr(), uri.GetRelativePart());
@@ -241,9 +238,6 @@ static long gdml_extract(Detector& description, int argc, char** argv) {
 #if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
         extract.SetIgnoreDummyMaterial(true);
         extract.SetNamingSpeed(TGDMLWrite::kfastButUglySufix);
-#if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
-        extract.SetFltPrecision(precision);
-        extract.SetIgnoreDummyMaterial(true);
         extract.WriteGDMLfile(&description.manager(), a._node, uri.GetRelativePart());
 #elif ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
         extract.WriteGDMLfile(&description.manager(), a._node, uri.GetRelativePart());

--- a/DDCore/src/plugins/DetectorChecksum.cpp
+++ b/DDCore/src/plugins/DetectorChecksum.cpp
@@ -89,7 +89,7 @@ std::stringstream DetectorChecksum::logger()   const    {
 }
 
 DetectorChecksum::entry_t DetectorChecksum::make_entry(std::stringstream& log)   const {
-  std::string data(std::move(log.str()));
+  std::string data(log.str());
   hash_t hash_value = hash64(data.c_str(), data.length());
   return { hash_value, std::move(data) };
 }
@@ -1176,9 +1176,9 @@ void DetectorChecksum::dump_elements()   const   {
 void DetectorChecksum::dump_materials()   const   {
   const auto& geo = data().mapOfMaterials;
   for(const auto& e : geo)   {
-    Material m = e.first;
+    Material material = e.first;
     printout(ALWAYS, "DetectorChecksum", "+++ Material  %-32s    0x%016lx%s",
-	     m.name(), e.second.hash, debug > 2 ? ("\n"+e.second.data).c_str() : "");
+	     material.name(), e.second.hash, debug > 2 ? ("\n"+e.second.data).c_str() : "");
   }
 }
 
@@ -1186,9 +1186,9 @@ void DetectorChecksum::dump_materials()   const   {
 void DetectorChecksum::dump_solids()   const   {
   const auto& geo = data().mapOfSolids;
   for(const auto& e : geo)   {
-    Solid s = e.first;
+    Solid solid = e.first;
     printout(ALWAYS, "DetectorChecksum", "+++ Solid     %-32s    0x%016lx%s",
-	     s.name(), e.second.hash, debug > 2 ? ("\n"+e.second.data).c_str() : "");
+	     solid.name(), e.second.hash, debug > 2 ? ("\n"+e.second.data).c_str() : "");
   }
 }
 
@@ -1196,9 +1196,9 @@ void DetectorChecksum::dump_solids()   const   {
 void DetectorChecksum::dump_volumes()   const   {
   const auto& geo = data().mapOfVolumes;
   for(const auto& e : geo)   {
-    Volume v = e.first;
+    Volume volume = e.first;
     printout(ALWAYS, "DetectorChecksum", "+++ Volume    %-32s    0x%016lx%s",
-	     v.name(), e.second.hash, debug > 2 ? ("\n"+e.second.data).c_str() : "");
+	     volume.name(), e.second.hash, debug > 2 ? ("\n"+e.second.data).c_str() : "");
   }
 }
 
@@ -1251,9 +1251,9 @@ void DetectorChecksum::dump_iddescriptors()   const   {
 void DetectorChecksum::dump_segmentations()   const   {
   const auto& geo = data().mapOfSegmentations;
   for(const auto& e : geo)   {
-    Segmentation s = e.first;
+    Segmentation segmentation = e.first;
     printout(ALWAYS, "DetectorChecksum", "+++ Segment   %-32s    0x%016lx%s",
-	     s.name(), e.second.hash, debug > 2 ? ("\n"+e.second.data).c_str() : "");
+	     segmentation.name(), e.second.hash, debug > 2 ? ("\n"+e.second.data).c_str() : "");
   }
 }
 

--- a/DDDigi/plugins/DigiSegmentDepositExtractor.cpp
+++ b/DDDigi/plugins/DigiSegmentDepositExtractor.cpp
@@ -35,27 +35,27 @@ namespace dd4hep {
     public:
       /// Standard constructor
       DigiSegmentDepositExtractor(const DigiKernel& kernel, const std::string& nam)
-	: DigiContainerProcessor(kernel, nam) {}
+        : DigiContainerProcessor(kernel, nam) {}
 
       template <typename T> void copy_deposits(const T& cont, work_t& work, const predicate_t& predicate)  const  {
-	DepositVector deposits(cont.name, work.environ.output.mask);
-	for( const auto& dep : cont )   {
-	  if( predicate(dep) )   {
-	    CellID        cell = dep.first;
-	    EnergyDeposit depo = dep.second;
-	    deposits.data.emplace_back(cell, std::move(depo));
-	  }
-	}
+        DepositVector deposits(cont.name, work.environ.output.mask);
+        for( const auto& dep : cont )   {
+          if( predicate(dep) )   {
+            CellID        cell = dep.first;
+            EnergyDeposit depo = dep.second;
+            deposits.emplace(cell, std::move(depo));
+          }
+        }
         work.environ.output.data.put(deposits.key, std::move(deposits));
       }
       /// Main functional callback
       virtual void execute(DigiContext&, work_t& work, const predicate_t& predicate)  const override final  {
-	if ( const auto* m = work.get_input<DepositMapping>() )
-	  copy_deposits(*m, work, predicate);
-	else if ( const auto* v = work.get_input<DepositVector>() )
-	  copy_deposits(*v, work, predicate);
-	else
-	  except("Request to handle unknown data type: %s", work.input_type_name().c_str());
+        if ( const auto* m = work.get_input<DepositMapping>() )
+          copy_deposits(*m, work, predicate);
+        else if ( const auto* v = work.get_input<DepositVector>() )
+          copy_deposits(*v, work, predicate);
+        else
+          except("Request to handle unknown data type: %s", work.input_type_name().c_str());
       }
     };
   }    // End namespace digi

--- a/DDDigi/python/DDDigiDict.C
+++ b/DDDigi/python/DDDigiDict.C
@@ -192,11 +192,27 @@ namespace dd4hep {
 #pragma link off all classes;
 #pragma link off all functions;
 
-using namespace std;
-
 #pragma link C++ namespace dd4hep;
 #pragma link C++ namespace dd4hep::digi;
 
+///---- Digi data item wrappers
+//#pragma link C++ class dd4hep::digi::Key;
+#pragma link C++ class std::pair<dd4hep::digi::Key, dd4hep::digi::Particle>;
+#pragma link C++ class std::map<dd4hep::digi::Key, dd4hep::digi::Particle>;
+#pragma link C++ class std::vector<std::pair<dd4hep::digi::Key, dd4hep::digi::Particle> >;
+
+#pragma link C++ class std::pair<dd4hep::CellID, dd4hep::digi::EnergyDeposit>+;
+#pragma link C++ class std::map<dd4hep::CellID, dd4hep::digi::EnergyDeposit>+;
+#pragma link C++ class std::vector<std::pair<dd4hep::CellID, dd4hep::digi::EnergyDeposit> >+;
+
+#pragma link C++ class dd4hep::digi::Particle+;
+#pragma link C++ class dd4hep::digi::EnergyDeposit+;
+#pragma link C++ class dd4hep::digi::ParticleMapping;
+#pragma link C++ class dd4hep::digi::DepositMapping+;
+#pragma link C++ class dd4hep::digi::DepositVector+;
+#pragma link C++ class dd4hep::digi::DigiEvent;
+
+///---- action dictionaries
 #pragma link C++ class dd4hep::digi::KernelHandle;
 #pragma link C++ class dd4hep::digi::ActionHandle;
 
@@ -218,14 +234,5 @@ using namespace std;
 #pragma link C++ class dd4hep::digi::DigiSegmentSplitter;
 
 #pragma link C++ class dd4hep::digi::DigiDepositMonitor;
-
-/// Digi data item wrappers
-#pragma link C++ class dd4hep::digi::Particle+;
-#pragma link C++ class dd4hep::digi::EnergyDeposit+;
-#pragma link C++ class dd4hep::digi::ParticleMapping+;
-#pragma link C++ class dd4hep::digi::DepositMapping+;
-#pragma link C++ class dd4hep::digi::DepositVector+;
-
-#pragma link C++ class dd4hep::digi::DigiEvent;
 
 #endif

--- a/DDDigi/python/DDDigiDict.C
+++ b/DDDigi/python/DDDigiDict.C
@@ -197,6 +197,10 @@ namespace dd4hep {
 
 ///---- Digi data item wrappers
 //#pragma link C++ class dd4hep::digi::Key;
+#pragma link C++ class std::pair<dd4hep::digi::Key::key_type, dd4hep::digi::Particle>+;
+#pragma link C++ class std::map<dd4hep::digi::Key::key_type, dd4hep::digi::Particle>+;
+#pragma link C++ class std::vector<std::pair<dd4hep::digi::Key::key_type, dd4hep::digi::Particle> >+;
+
 #pragma link C++ class std::pair<dd4hep::digi::Key, dd4hep::digi::Particle>;
 #pragma link C++ class std::map<dd4hep::digi::Key, dd4hep::digi::Particle>;
 #pragma link C++ class std::vector<std::pair<dd4hep::digi::Key, dd4hep::digi::Particle> >;
@@ -205,9 +209,10 @@ namespace dd4hep {
 #pragma link C++ class std::map<dd4hep::CellID, dd4hep::digi::EnergyDeposit>+;
 #pragma link C++ class std::vector<std::pair<dd4hep::CellID, dd4hep::digi::EnergyDeposit> >+;
 
+#pragma link C++ class dd4hep::digi::History+;
 #pragma link C++ class dd4hep::digi::Particle+;
 #pragma link C++ class dd4hep::digi::EnergyDeposit+;
-#pragma link C++ class dd4hep::digi::ParticleMapping;
+#pragma link C++ class dd4hep::digi::ParticleMapping+;
 #pragma link C++ class dd4hep::digi::DepositMapping+;
 #pragma link C++ class dd4hep::digi::DepositVector+;
 #pragma link C++ class dd4hep::digi::DigiEvent;

--- a/DDDigi/src/DigiContainerProcessor.cpp
+++ b/DDDigi/src/DigiContainerProcessor.cpp
@@ -122,10 +122,10 @@ void DigiContainerProcessor::execute(context_t&         /* context   */,
 
 /// Main functional callback adapter
 void DigiDepositsProcessor::execute(context_t& context, work_t& work, const predicate_t& predicate)  const   {
-  if ( auto* v = work.get_input<DepositVector>() )
-    m_handleVector(context,  *v, work, predicate);
-  else if ( auto* m = work.get_input<DepositMapping>() )
-    m_handleMapping(context, *m, work, predicate);
+  if ( auto* vector_data = work.get_input<DepositVector>() )
+    m_handleVector(context,  *vector_data, work, predicate);
+  else if ( auto* mapped_data = work.get_input<DepositMapping>() )
+    m_handleMapping(context, *mapped_data, work, predicate);
   else
     except("Request to handle unknown data type: %s", work.input_type_name().c_str());
 }

--- a/DDDigi/src/DigiData.cpp
+++ b/DDDigi/src/DigiData.cpp
@@ -121,15 +121,15 @@ const Particle& History::hist_entry_t::get_particle(const DigiEvent& event)  con
   static Key item_key("MCParticles",0x0);
   Key key(this->source);
   const auto& segment = event.get_segment(this->source.segment());
-  const auto& particles = segment.get<ParticleMapping>(key.set_item(item_key.item()));
-  return particles.get(this->source);
+  const auto& particle_data = segment.get<ParticleMapping>(key.set_item(item_key.item()));
+  return particle_data.get(this->source);
 }
 
 const EnergyDeposit& History::hist_entry_t::get_deposit(const DigiEvent& event, Key::itemkey_type container_item)  const {
   Key key(this->source);
   const auto& segment = event.get_segment(this->source.segment());
-  const auto& hits = segment.get<DepositVector>(key.set_item(container_item));
-  return hits.at(this->source.item());
+  const auto& hit_data = segment.get<DepositVector>(key.set_item(container_item));
+  return hit_data.at(this->source.item());
 }
 
 /// Retrieve the weighted momentum of all contributing particles
@@ -337,7 +337,7 @@ void ParticleMapping::insert(Key particle_key, const Particle& particle_data)  {
 
 /// Insert new entry
 void ParticleMapping::emplace(Key particle_key, Particle&& particle_data)  {
-  data.emplace(particle_key, std::move(particle_data)).second;
+  data.emplace(particle_key, std::move(particle_data));
 }
 
 /// Access particle by key

--- a/DDDigi/src/DigiData.cpp
+++ b/DDDigi/src/DigiData.cpp
@@ -120,16 +120,16 @@ std::pair<std::size_t,std::size_t> History::drop()   {
 const Particle& History::hist_entry_t::get_particle(const DigiEvent& event)  const  {
   static Key item_key("MCParticles",0x0);
   Key key(this->source);
-  const auto& segment = event.get_segment(this->source.segment());
+  const auto& segment = event.get_segment(Key(this->source).segment());
   const auto& particle_data = segment.get<ParticleMapping>(key.set_item(item_key.item()));
   return particle_data.get(this->source);
 }
 
 const EnergyDeposit& History::hist_entry_t::get_deposit(const DigiEvent& event, Key::itemkey_type container_item)  const {
   Key key(this->source);
-  const auto& segment = event.get_segment(this->source.segment());
+  const auto& segment = event.get_segment(Key(this->source).segment());
   const auto& hit_data = segment.get<DepositVector>(key.set_item(container_item));
-  return hit_data.at(this->source.item());
+  return hit_data.at(Key(this->source).item());
 }
 
 /// Retrieve the weighted momentum of all contributing particles
@@ -305,7 +305,7 @@ void DepositMapping::remove(iterator position)   {
 std::size_t ParticleMapping::insert(const ParticleMapping& updates)    {
   std::size_t update_size = updates.size();
   for( const ParticleMapping::value_type& c : updates )
-    this->insert(Key(c.first), c.second);
+    this->insert(c.first, c.second);
   return update_size;
 }
 

--- a/DDDigi/src/DigiMonitorParser.cpp
+++ b/DDDigi/src/DigiMonitorParser.cpp
@@ -25,12 +25,12 @@ namespace dd4hep   {
     // ========================================================================
     std::ostream& toStream(const dd4hep::digi::H1DParams& o, std::ostream& s)   {
       return s << "( "
-	       << '"' << o.name  << '"' << " , "
-	       << '"' << o.title << '"' << " , "
-	       << o.nbin_x << " , "
-	       << o.min_x  << " , "
-	       << o.max_x
-	       << " )" ;
+               << '"' << o.name  << '"' << " , "
+               << '"' << o.title << '"' << " , "
+               << o.nbin_x << " , "
+               << o.min_x  << " , "
+               << o.max_x
+               << " )" ;
     }
 
     // ========================================================================
@@ -50,45 +50,45 @@ namespace dd4hep   {
       struct Operations {
         // Some magic:
         template <typename A, typename B = boost::fusion::unused_type,
-		  typename C = boost::fusion::unused_type,
-		  typename D = boost::fusion::unused_type>
+	          typename C = boost::fusion::unused_type,
+	          typename D = boost::fusion::unused_type>
         struct result { typedef void type; };
         // Actions:
         // --------------------------------------------------------------------
         void operator()(dd4hep::digi::H1DParams& val, const int bin, tag_nbin_x) const {
-	  val.nbin_x = bin;
+          val.nbin_x = bin;
         }
 
         void operator()(dd4hep::digi::H1DParams& val, const float x, tag_min_x) const {
-	  val.min_x = x;
+          val.min_x = x;
         }
 
         void operator()(dd4hep::digi::H1DParams& val, const float x, tag_max_x) const {
-	  val.max_x = x;
+          val.max_x = x;
         }
 
-        void operator()(dd4hep::digi::H1DParams& val, const std::string& name, tag_name) const {
-	  val.name = name;
+        void operator()(dd4hep::digi::H1DParams& val, const std::string& nam, tag_name) const {
+          val.name = nam;
         }
 
-        void operator()(dd4hep::digi::H1DParams& val, const std::string& title, tag_title) const {
-	  val.title = title;
+        void operator()(dd4hep::digi::H1DParams& val, const std::string& tit, tag_title) const {
+          val.title = tit;
         }
 
       };
     public:
       H1DParamsGrammar() : H1DParamsGrammar::base_type(para)      {
-	para = qi::lit('(')
-	  >> name[op(qi::_val, qi::_1, tag_name())]
-	  >> ','
-	  >> title[op(qi::_val, qi::_1, tag_title())]
-	  >> ','
-	  >> qi::int_[op(qi::_val, qi::_1, tag_nbin_x())]
-	  >> ','
-	  >> qi::double_[op(qi::_val, qi::_1, tag_min_x())]
-	  >> ','
-	  >> qi::double_[op(qi::_val, qi::_1, tag_max_x())]
-	  >> ')';
+        para = qi::lit('(')
+          >> name[op(qi::_val, qi::_1, tag_name())]
+          >> ','
+          >> title[op(qi::_val, qi::_1, tag_title())]
+          >> ','
+          >> qi::int_[op(qi::_val, qi::_1, tag_nbin_x())]
+          >> ','
+          >> qi::double_[op(qi::_val, qi::_1, tag_min_x())]
+          >> ','
+          >> qi::double_[op(qi::_val, qi::_1, tag_max_x())]
+          >> ')';
       }
       qi::rule<Iterator, dd4hep::digi::H1DParams(), Skipper> para;
       StringGrammar<Iterator, Skipper> name;
@@ -107,15 +107,15 @@ namespace dd4hep   {
     // ========================================================================
     std::ostream& toStream(const dd4hep::digi::H2DParams& o, std::ostream& s)   {
       return s << "[ "
-	       << '"' << o.name << "\" , "
-	       << '"' << o.title << "\" , "
-	       << o.nbin_x << " , "
-	       << o.min_x  << " , "
-	       << o.max_x  << " , "
-	       << o.nbin_y << " , "
-	       << o.min_y  << " , "
-	       << o.max_y
-	       << " ]" ;
+               << '"' << o.name << "\" , "
+               << '"' << o.title << "\" , "
+               << o.nbin_x << " , "
+               << o.min_x  << " , "
+               << o.max_x  << " , "
+               << o.nbin_y << " , "
+               << o.min_y  << " , "
+               << o.max_y
+               << " ]" ;
     }
     // ========================================================================
     template< typename Iterator, typename Skipper>
@@ -137,56 +137,56 @@ namespace dd4hep   {
       struct Operations {
         // Some magic:
         template <typename A, typename B = boost::fusion::unused_type,
-		  typename C = boost::fusion::unused_type,
-		  typename D = boost::fusion::unused_type>
+	          typename C = boost::fusion::unused_type,
+	          typename D = boost::fusion::unused_type>
         struct result { typedef void type; };
         // Actions:
         // --------------------------------------------------------------------
         void operator()(dd4hep::digi::H2DParams& val, const int bin, tag_nbin_x) const {
-	  val.nbin_x = bin;
+          val.nbin_x = bin;
         }
         void operator()(dd4hep::digi::H2DParams& val, const float x, tag_min_x) const {
-	  val.min_x = x;
+          val.min_x = x;
         }
         void operator()(dd4hep::digi::H2DParams& val, const float x, tag_max_x) const {
-	  val.max_x = x;
+          val.max_x = x;
         }
         void operator()(dd4hep::digi::H2DParams& val, const int bin, tag_nbin_y) const {
-	  val.nbin_y = bin;
+          val.nbin_y = bin;
         }
         void operator()(dd4hep::digi::H2DParams& val, const float y, tag_min_y) const {
-	  val.min_y = y;
+          val.min_y = y;
         }
         void operator()(dd4hep::digi::H2DParams& val, const float y, tag_max_y) const {
-	  val.max_y = y;
+          val.max_y = y;
         }
         void operator()(dd4hep::digi::H2DParams& val, const std::string& name, tag_name) const {
-	  val.name = name;
+          val.name = name;
         }
         void operator()(dd4hep::digi::H2DParams& val, const std::string& title, tag_title) const {
-	  val.title = title;
+          val.title = title;
         }
 
       };
     public:
       H2DParamsGrammar() : H2DParamsGrammar::base_type(para)      {
 	para = qi::lit('[')
-	  >> name[op(qi::_val, qi::_1, tag_name())]
-	  >> ','
-	  >> title[op(qi::_val, qi::_1, tag_title())]
-	  >> ','
-	  >> qi::int_[op(qi::_val, qi::_1, tag_nbin_x())]
-	  >> ','
-	  >> qi::float_[op(qi::_val, qi::_1, tag_min_x())]
-	  >> ','
-	  >> qi::float_[op(qi::_val, qi::_1, tag_max_x())]
-	  >> ','
-	  >> qi::int_[op(qi::_val, qi::_1, tag_nbin_y())]
-	  >> ','
-	  >> qi::float_[op(qi::_val, qi::_1, tag_min_y())]
-	  >> ','
-	  >> qi::float_[op(qi::_val, qi::_1, tag_max_y())]
-	  >> ']' ;
+          >> name[op(qi::_val, qi::_1, tag_name())]
+          >> ','
+          >> title[op(qi::_val, qi::_1, tag_title())]
+          >> ','
+          >> qi::int_[op(qi::_val, qi::_1, tag_nbin_x())]
+          >> ','
+          >> qi::float_[op(qi::_val, qi::_1, tag_min_x())]
+          >> ','
+          >> qi::float_[op(qi::_val, qi::_1, tag_max_x())]
+          >> ','
+          >> qi::int_[op(qi::_val, qi::_1, tag_nbin_y())]
+          >> ','
+          >> qi::float_[op(qi::_val, qi::_1, tag_min_y())]
+          >> ','
+          >> qi::float_[op(qi::_val, qi::_1, tag_max_y())]
+          >> ']' ;
         }
         qi::rule<Iterator, dd4hep::digi::H2DParams(), Skipper> para;
         StringGrammar<Iterator, Skipper> name;

--- a/DDDigi/src/DigiStoreDump.cpp
+++ b/DDDigi/src/DigiStoreDump.cpp
@@ -72,9 +72,9 @@ template <> std::string DigiStoreDump::data_header(Key key, const std::string& t
 
 template <> std::vector<std::string>
 DigiStoreDump::dump_history(DigiContext& context, 
-			    Key key,
-			    const std::pair<const Key, Particle>& data,
-			    std::size_t seq_no)  const
+                            Key key,
+                            const std::pair<const ParticleMapping::key_type, Particle>& data,
+                            std::size_t seq_no)  const
 {
   std::stringstream str;
   auto& ev = *(context.event);
@@ -102,9 +102,9 @@ DigiStoreDump::dump_history(DigiContext& context,
 
 template <> std::vector<std::string> 
 DigiStoreDump::dump_history(DigiContext& context,
-			    Key container_key,
-			    const std::pair<const CellID, EnergyDeposit>& data,
-			    std::size_t seq_no)  const
+                            Key container_key,
+                            const std::pair<const DepositMapping::key_type, EnergyDeposit>& data,
+                            std::size_t seq_no)  const
 {
   std::string line;
   std::stringstream str;


### PR DESCRIPTION
BEGINRELEASENOTES
- Improve GDML export procedures
  -- Allow to set export precision in the plugin
  -- New ROOT release needed to properly export surfaces (current ROOT GDML export does not handle this currectly)
     See ROOT PR https://github.com/root-project/root/pull/11886
     See ROOT PR https://github.com/root-project/root/pull/11887
     See ROOT PR https://github.com/root-project/root/pull/11888
     See ROOT PR https://github.com/root-project/root/pull/11889
     See ROOT PR https://github.com/root-project/root/pull/11895
- Remove some build errors for MAC
ENDRELEASENOTES