### PR TITLE
Add track momentum to the MonteCarloContribution of Geant4Hit structure

### DIFF
--- a/DDG4/include/DDG4/DDG4Dict.h
+++ b/DDG4/include/DDG4/DDG4Dict.h
@@ -142,7 +142,7 @@ namespace dd4hep {
     /// Default constructor
     inline Geant4Tracker::Hit::Hit() : length(0), energyDeposit(0e0)  {    }
     /// Initializing constructor
-    inline Geant4Tracker::Hit::Hit(int, int, double, double)   {}
+    //inline Geant4Tracker::Hit::Hit(int, int, double, double)   {}
     /// Default destructor
     inline Geant4Tracker::Hit::~Hit()  {    }
     /// Explicit assignment operation

--- a/DDG4/include/DDG4/Geant4Data.h
+++ b/DDG4/include/DDG4/Geant4Data.h
@@ -211,7 +211,7 @@ namespace dd4hep {
 	  y = float(pos_y);
 	  z = float(pos_z);
 	}
-	/// Access position
+	/// Access momentum
 	Direction momentum() const   {
 	  return Direction(px, py, pz);
 	}

--- a/DDG4/include/DDG4/Geant4Data.h
+++ b/DDG4/include/DDG4/Geant4Data.h
@@ -15,8 +15,8 @@
 #define DDG4_GEANT4DATA_H
 
 // Framework include files
-#include "DD4hep/Memory.h"
-#include "Math/Vector3D.h"
+#include <DD4hep/Memory.h>
+#include <Math/Vector3D.h>
 
 // C/C++ include files
 #include <set>
@@ -138,66 +138,94 @@ namespace dd4hep {
       class MonteCarloContrib {
       public:
         /// Geant 4 Track identifier
-        int trackID;
+        int trackID = -1;
         /// Particle ID from the PDG table
-        int pdgID;
+        int pdgID = -1;
         /// Total energy deposit in this hit
-        double deposit;
+        double deposit = 0.0;
         /// Timestamp when this energy was deposited
         double time;
         /// Length of this step
         double length = 0.0;
         /// Proper position of the hit contribution
-        float  x,y,z;
+        float  x = 0.0, y = 0.0, z = 0.0;
+        /// Proper particle momentum when generating the hit of the contributing particle
+        float  px = 0.0, py = 0.0, pz = 0.0;
 
         /// Default constructor
-        MonteCarloContrib()
-          : trackID(-1), pdgID(-1), deposit(0.0), time(0.0), x(0), y(0), z(0) {
-        }
+        MonteCarloContrib() = default;
+        /// Copy constructor
+        MonteCarloContrib(const MonteCarloContrib& c) = default;
+        /// Move constructor
+        MonteCarloContrib(MonteCarloContrib&& c) = default;
+#if 0
         /// Initializing constructor
         MonteCarloContrib(int track_id, int pdg, double dep, double time_stamp, double len)
-          : trackID(track_id), pdgID(pdg), deposit(dep), time(time_stamp), length(len), x(0), y(0), z(0) {
+          : trackID(track_id), pdgID(pdg), deposit(dep), time(time_stamp), length(len) {
         }
+#endif
         /// Initializing constructor
-        MonteCarloContrib(int track_id, int pdg, double dep, double time_stamp, double len, float* pos)
+        MonteCarloContrib(int track_id, int pdg, double dep, double time_stamp, double len, float* pos, float* mom)
           : trackID(track_id), pdgID(pdg), deposit(dep), time(time_stamp), length(len),
-            x(pos[0]), y(pos[1]), z(pos[2])
+            x(pos[0]), y(pos[1]), z(pos[2]), px(mom[0]), py(mom[1]), pz(mom[2])
         {
         }
         /// Initializing constructor
-        MonteCarloContrib(int track_id, int pdg, double dep, double time_stamp, double len, double* pos)
+        MonteCarloContrib(int track_id, int pdg, double dep, double time_stamp, double len, double* pos, double* mom)
           : trackID(track_id), pdgID(pdg), deposit(dep), time(time_stamp), length(len),
-            x(pos[0]), y(pos[1]), z(pos[2])
+            x(float(pos[0])), y(float(pos[1])), z(float(pos[2])),
+	    px(float(mom[0])), py(float(mom[1])), pz(float(mom[2]))
         {
         }
-        /// Copy constructor
-        MonteCarloContrib(const MonteCarloContrib& c)
-          : trackID(c.trackID), pdgID(c.pdgID), deposit(c.deposit), time(c.time), length(c.length),
-            x(c.x), y(c.y), z(c.z) {
+        /// Initializing constructor
+        MonteCarloContrib(int track_id, int pdg, double dep, double time_stamp, double len, const Position& pos, const Direction& mom)
+          : trackID(track_id), pdgID(pdg), deposit(dep), time(time_stamp), length(len),
+            x(float(pos.x())), y(float(pos.y())), z(float(pos.z())),
+	    px(float(mom.x())), py(float(mom.y())), pz(float(mom.z()))
+        {
         }
-        /// Assignment operator
-        MonteCarloContrib& operator=(const MonteCarloContrib& c)  {
-          if ( this != &c )  {
-            trackID = c.trackID;
-            pdgID   = c.pdgID;
-            deposit = c.deposit;
-            time    = c.time;
-            length  = c.length;
-            x       = c.x;
-            y       = c.y;
-            z       = c.z;
-          }
-          return *this;
-        }
+        /// Assignment operator (move)
+        MonteCarloContrib& operator=(MonteCarloContrib&& c) = default;
+        /// Assignment operator (copy)
+        MonteCarloContrib& operator=(const MonteCarloContrib& c) = default;
         /// Clear data content
         void clear() {
           x = y = z = 0.0;
+          px = py = pz = 0.0;
           time  = deposit = length = 0.0;
           pdgID = trackID = -1;
         }
 	/// Access position
 	Position position() const   {
 	  return Position(x, y, z);
+	}
+	/// Set position of the contribution
+	void setPosition(const Position& pos)   {
+	  x = pos.x();
+	  y = pos.y();
+	  z = pos.z();
+	}
+	/// Set position of the contribution
+	void setPosition(double pos_x, double pos_y, double pos_z)   {
+	  x = float(pos_x);
+	  y = float(pos_y);
+	  z = float(pos_z);
+	}
+	/// Access position
+	Direction momentum() const   {
+	  return Direction(px, py, pz);
+	}
+	/// Set memonetum of the contribution
+	void setMomentum(const Direction& dir)   {
+	  px = dir.x();
+	  py = dir.y();
+	  pz = dir.z();
+	}
+	/// Set memonetum of the contribution
+	void setMomentum(double mom_x, double mom_y, double mom_z)   {
+	  px = float(mom_x);
+	  py = float(mom_y);
+	  pz = float(mom_z);
 	}
       };
       typedef MonteCarloContrib Contribution;
@@ -254,7 +282,7 @@ namespace dd4hep {
         /// copy constructor
         Hit(const Hit& c) = delete;
         /// Initializing constructor
-        Hit(int track_id, int pdg_id, double deposit, double time_stamp);
+        Hit(int track_id, int pdg_id, double deposit, double time_stamp, double len, const Position& p, const Direction& d);
         /// Default destructor
         virtual ~Hit();
         /// Move assignment operator

--- a/DDG4/plugins/Geant4EscapeCounter.cpp
+++ b/DDG4/plugins/Geant4EscapeCounter.cpp
@@ -102,13 +102,25 @@ bool Geant4EscapeCounter::process(const G4Step* step, G4TouchableHistory* /* his
   Geant4TouchableHandler handler(step);
   string   hdlr_path  = handler.path();
   Position prePos     = h.prePos();
+  Position postPos    = h.postPos();
   Geant4HitCollection* coll = collection(m_collectionID);
-  SimpleTracker::Hit*  hit = new SimpleTracker::Hit(th.id(),th.pdgID(),h.deposit(),th.time());
+  SimpleTracker::Hit*  hit = new SimpleTracker::Hit();
+  hit->g4ID          = th.id();
+  hit->energyDeposit = h.deposit();
   hit->cellID        = volumeID(step);
   hit->energyDeposit = th.energy();
   hit->position      = prePos;
   hit->momentum      = h.trkMom();
-  hit->length        = 0;
+  hit->length        = (postPos-prePos).R();
+  hit->truth.trackID = th.id();
+  hit->truth.deposit = h.deposit();
+  hit->truth.pdgID   = th.pdgID();
+  hit->truth.deposit = h.deposit();
+  hit->truth.time    = th.time();
+  hit->truth.length  = hit->length;
+  hit->truth.x       = hit->position.x();
+  hit->truth.y       = hit->position.y();
+  hit->truth.z       = hit->position.z();
   coll->add(hit);
   mark(h.track);
 

--- a/DDG4/plugins/Geant4SDActions.cpp
+++ b/DDG4/plugins/Geant4SDActions.cpp
@@ -86,8 +86,8 @@ namespace dd4hep {
       Position  prePos    = h.prePos();
       Position  postPos   = h.postPos();
       Position  direction = postPos - prePos;
-      Position  pos       = mean_direction(prePos,postPos);
-      Direction mom       = 0.5*( h. preMom() + h.postMom() );
+      Position  pos       = mean_direction(prePos, postPos);
+      Direction mom       = 0.5 * (h.preMom() + h.postMom());
       double    hit_len   = direction.R();
 
       // if (hit_len > 0) {

--- a/DDG4/plugins/Geant4TrackerWeightedSD.cpp
+++ b/DDG4/plugins/Geant4TrackerWeightedSD.cpp
@@ -233,11 +233,9 @@ namespace dd4hep {
           
           Geant4Tracker::Hit* hit = new Geant4Tracker::Hit(pre.truth.trackID,
                                                            pre.truth.pdgID,
-                                                           deposit,time);
+                                                           deposit,time, step_length,
+							   pos, mom);
           hit->flag     = hit_flag;
-          hit->position = pos;
-          hit->momentum = mom;
-          hit->length   = step_length;
           hit->cellID   = cell;
           hit->g4ID     = g4ID;
 

--- a/examples/DDG4_MySensDet/src/MyTrackerHit.h
+++ b/examples/DDG4_MySensDet/src/MyTrackerHit.h
@@ -47,8 +47,9 @@ namespace SomeExperiment {
     /// Default constructor
     MyTrackerHit() = default;
     /// Initializing constructor
-    MyTrackerHit(int track_id, int pdg_id, double deposit, double time_stamp)
-      : dd4hep::sim::Geant4Tracker::Hit(track_id,pdg_id,deposit,time_stamp) {}
+    MyTrackerHit(int track_id, int pdg_id, double deposit, double time_stamp, double len,
+		 const dd4hep::Position& pos, const dd4hep::Direction& mom)
+      : dd4hep::sim::Geant4Tracker::Hit(track_id,pdg_id,deposit,time_stamp, len, pos, mom) {}
     /// Default destructor
     virtual ~MyTrackerHit() = default;
     /// Assignment operator

--- a/examples/DDG4_MySensDet/src/MyTrackerSDAction.cpp
+++ b/examples/DDG4_MySensDet/src/MyTrackerSDAction.cpp
@@ -63,13 +63,11 @@ namespace dd4hep {
       double   hit_len   = direction.R();
 
       // Somehow extract here the physics you want
-      MyTrackerSD::Hit* hit = new MyTrackerSD::Hit(h.trkID(), h.trkPdgID(), h.deposit(), h.track->GetGlobalTime());
+      MyTrackerSD::Hit* hit = new MyTrackerSD::Hit(h.trkID(), h.trkPdgID(), h.deposit(),
+						   h.track->GetGlobalTime(), hit_len,
+						   position, 0.5*(h. preMom() + h.postMom()));
       Geant4HitData::MonteCarloContrib contrib = Geant4HitData::extractContribution(step);
       hit->cellID        = cellID(step);
-      hit->energyDeposit = contrib.deposit;
-      hit->position      = position;
-      hit->momentum      = 0.5*(h. preMom() + h.postMom());
-      hit->length        = hit_len;
       hit->step_length   = hit_len;
       hit->prePos        = prePos;
       hit->postPos       = postPos;


### PR DESCRIPTION

BEGINRELEASENOTES
- This PR addresses issue https://github.com/AIDASoft/DD4hep/issues/1037
  Rather than adding the beta as a double it was chosen to add at each step the track momentum
  in floats which for 4 more bytes offers more information.
ENDRELEASENOTES