### PR TITLE
thisdd4hep: ensure we only prevent real duplicates, not paths that sh…

### DIFF
--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -34,7 +34,7 @@ dd4hep_add_path()   {
     local path_prefix=${2}
     eval path_value=\$$path_name
     # Prevent duplicates
-    path_value=`echo ${path_value} | tr : '\n' | grep -v "${path_prefix}" | tr '\n' : | sed 's|:$||'`
+    path_value=`echo ${path_value} | tr : '\n' | grep -v "^${path_prefix}$" | tr '\n' : | sed 's|:$||'`
     path_value="${path_prefix}${path_value:+:${path_value}}"
     eval export ${path_name}='${path_value}'
     unset path_value

--- a/cmake/thisdd4hep_only.sh
+++ b/cmake/thisdd4hep_only.sh
@@ -36,7 +36,7 @@ dd4hep_add_path()   {
     local path_prefix=${2}
     eval path_value=\$$path_name
     # Prevent duplicates
-    path_value=`echo ${path_value} | tr : '\n' | grep -v "${path_prefix}" | tr '\n' : | sed 's|:$||'`
+    path_value=`echo ${path_value} | tr : '\n' | grep -v "^${path_prefix}$" | tr '\n' : | sed 's|:$||'`
     path_value="${path_prefix}${path_value:+:${path_value}}"
     eval export ${path_name}='${path_value}'
     unset path_value


### PR DESCRIPTION
…are common content

BEGINRELEASENOTES
- thisdd4hep: fix an issue with environment paths getting dropped when they contain a complete substring of a path that is going to be added

ENDRELEASENOTES