### PR TITLE
ParticleHandler: account for modified stepping actions, where tracking…

### DIFF
--- a/DDG4/include/DDG4/Geant4ParticleHandler.h
+++ b/DDG4/include/DDG4/Geant4ParticleHandler.h
@@ -119,6 +119,9 @@ namespace dd4hep {
       Particle          m_currTrack;
       /// Map with stored MC Particles
       ParticleMap       m_particleMap;
+      /// Map with stored MC Particles that were suspended by the stepping action
+      ParticleMap       m_suspendedPM;
+      bool              m_haveSuspended = false;
       /// Map associating the G4Track identifiers with identifiers of existing MCParticles
       TrackEquivalents  m_equivalentTracks;
 

--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -316,16 +316,6 @@ void Geant4ParticleHandler::end(const G4Track* track)   {
   Geant4ParticleHandle ph(&m_currTrack);
   const int g4_id = h.id();
 
-  if(track->GetTrackStatus() == fSuspend) {
-    m_haveSuspended = true;
-    //track is already in particle map, we pick it up from there in begin again
-    if(m_particleMap.find(g4_id) != m_particleMap.end()) return;
-    //track is not already stored, keep it in special map
-    auto iPart = m_suspendedPM.emplace(g4_id, new Particle());
-    (iPart.first->second)->get_data(m_currTrack);
-    return; // we trust that we eventually return to this function with another status and go on then
-  }
-
   int track_reason = m_currTrack.reason;
   PropertyMask mask(m_currTrack.reason);
   // Update vertex end point and final momentum
@@ -401,6 +391,17 @@ void Geant4ParticleHandler::end(const G4Track* track)   {
     else
       ph.dumpWithVertex(outputLevel()+3,name(),"FATAL: No real particle parent present");
   }
+
+  if(track->GetTrackStatus() == fSuspend) {
+    m_haveSuspended = true;
+    //track is already in particle map, we pick it up from there in begin again
+    if(m_particleMap.find(g4_id) != m_particleMap.end()) return;
+    //track is not already stored, keep it in special map
+    auto iPart = m_suspendedPM.emplace(g4_id, new Particle());
+    (iPart.first->second)->get_data(m_currTrack);
+    return; // we trust that we eventually return to this function with another status and go on then
+  }
+
 }
 
 /// Pre-event action callback

--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -115,9 +115,8 @@ bool Geant4ParticleHandler::adopt(Geant4Action* action)    {
 void Geant4ParticleHandler::clear()  {
   detail::releaseObjects(m_particleMap);
   m_particleMap.clear();
-  //m_suspendedPM should already be empty and cleared...
-  detail::releaseObjects(m_suspendedPM);
-  m_suspendedPM.clear();
+  // m_suspendedPM should already be empty and cleared...
+  assert(m_suspendedPM.empty() && "There was something wrong with the particle record treatment, please open a bug report!");
   m_equivalentTracks.clear();
 }
 

--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -210,6 +210,13 @@ void Geant4ParticleHandler::begin(const G4Track* track)   {
   const G4PrimaryParticle* prim = h.primary();
   Particle* prim_part = 0;
 
+  // if particles are not tracked to the end, we pick up were we stopped previously
+  auto existingParticle = m_particleMap.find(h.id());
+  if(existingParticle != m_particleMap.end()) {
+    m_currTrack.get_data(*(existingParticle->second));
+    return;
+  }
+
   if ( prim )   {
     prim_part = m_primaryMap->get(prim);
     if ( !prim_part )  {

--- a/examples/DDG4/CMakeLists.txt
+++ b/examples/DDG4/CMakeLists.txt
@@ -96,6 +96,14 @@ if (DD4HEP_USE_GEANT4)
     REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
   #
+  # Test G4 stepping action
+  dd4hep_add_test_reg( DDG4_TestSteppingAction
+    COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
+    EXEC_ARGS  ${Python_EXECUTABLE} ${DDG4examples_INSTALL}/scripts/TestStepping.py -batch -events 3
+    REGEX_PASS " Track Calls Suspended: [1-9][0-9]*"
+    REGEX_FAIL " ERROR ;EXCEPTION;Exception"
+  )
+  #
   # Test G4 command UI
   dd4hep_add_test_reg( DDG4_UIManager
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"

--- a/examples/DDG4/scripts/TestStepping.py
+++ b/examples/DDG4/scripts/TestStepping.py
@@ -1,0 +1,86 @@
+# ==========================================================================
+#  AIDA Detector description implementation
+# --------------------------------------------------------------------------
+# Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+# All rights reserved.
+#
+# For the licensing terms see $DD4hepINSTALL/LICENSE.
+# For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+#
+# ==========================================================================
+#
+from __future__ import absolute_import, unicode_literals
+import logging
+#
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
+#
+#
+"""
+
+   dd4hep simulation example setup using the python configuration
+
+"""
+
+
+def run():
+  import os
+  import DDG4
+  from DDG4 import OutputLevel as Output
+  from g4units import GeV, keV
+
+  kernel = DDG4.Kernel()
+  install_dir = os.environ['DD4hepExamplesINSTALL']
+  kernel.loadGeometry(str("file:" + install_dir + "/examples/ClientTests/compact/SiliconBlock.xml"))
+
+  DDG4.importConstants(kernel.detectorDescription(), debug=False)
+  geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')
+  geant4.printDetectors()
+  # Configure UI
+  geant4.setupUI(typ="tcsh", vis=False, macro=None, ui=False)
+
+  # Configure field
+  geant4.setupTrackingField(prt=True)
+  # Configure Event actions
+  prt = DDG4.EventAction(kernel, 'Geant4ParticlePrint/ParticlePrint')
+  prt.OutputLevel = Output.DEBUG
+  prt.OutputType = 3  # Print both: table and tree
+  kernel.eventAction().adopt(prt)
+
+  generator_output_level = Output.INFO
+
+  # Configure G4 geometry setup
+  seq, act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
+  act.DebugMaterials = True
+  act.DebugElements = False
+  act.DebugVolumes = True
+  act.DebugShapes = True
+  act.DebugSurfaces = True
+
+  # Setup particle gun
+  gun = geant4.setupGun("Gun", particle='gamma', energy=1 * GeV, multiplicity=1)
+  gun.direction = (0.0, 0.0, 1.0)
+  gun.OutputLevel = generator_output_level
+  kernel.NumEvents = 2
+  # Instantiate the stepping action
+  stepping = DDG4.SteppingAction(kernel, 'TestSteppingAction/MyStepper')
+  kernel.steppingAction().add(stepping)
+
+  # And handle the simulation particles.
+  part = DDG4.GeneratorAction(kernel, "Geant4ParticleHandler/ParticleHandler")
+  kernel.generatorAction().adopt(part)
+  part.SaveProcesses = ['conv', 'Decay']
+  part.MinimalKineticEnergy = 1 * keV
+  part.KeepAllParticles = False
+  part.PrintEndTracking = True
+  part.enableUI()
+
+  # Now build the physics list:
+  phys = geant4.setupPhysics('QGSP_BERT')
+  phys.dump()
+  # Start the engine...
+  geant4.execute()
+
+
+if __name__ == "__main__":
+  run()

--- a/examples/DDG4/scripts/TestStepping.py
+++ b/examples/DDG4/scripts/TestStepping.py
@@ -61,7 +61,7 @@ def run():
   gun = geant4.setupGun("Gun", particle='gamma', energy=1 * GeV, multiplicity=1)
   gun.direction = (0.0, 0.0, 1.0)
   gun.OutputLevel = generator_output_level
-  kernel.NumEvents = 2
+  kernel.NumEvents = 10
   # Instantiate the stepping action
   stepping = DDG4.SteppingAction(kernel, 'TestSteppingAction/MyStepper')
   kernel.steppingAction().add(stepping)

--- a/examples/DDG4/src/TestSteppingAction.cpp
+++ b/examples/DDG4/src/TestSteppingAction.cpp
@@ -31,6 +31,7 @@ namespace dd4hep {
     class TestSteppingAction : public Geant4SteppingAction {
       std::size_t m_calls_steps { 0UL };
       std::size_t m_calls_suspended { 0UL };
+      std::size_t m_calls_kill { 0UL };
     
     public:
       /// Standard constructor
@@ -42,12 +43,16 @@ namespace dd4hep {
       virtual ~TestSteppingAction()   {
 	info("+++ Track Calls Steps: %ld", m_calls_steps);
 	info("+++ Track Calls Suspended: %ld", m_calls_suspended);
+	info("+++ Track Calls Killed: %ld", m_calls_kill);
       }
       /// stepping callback
       virtual void operator()(const G4Step* step, G4SteppingManager*) {
         if(m_calls_steps % 5 == 0 ) {
           ++m_calls_suspended;
           step->GetTrack()->SetTrackStatus(fSuspend);
+        } else if((m_calls_steps + 1) % 30 == 0 ) {
+          ++m_calls_kill;
+          step->GetTrack()->SetTrackStatus(fStopAndKill);
         }
 	++m_calls_steps;
       }

--- a/examples/DDG4/src/TestSteppingAction.cpp
+++ b/examples/DDG4/src/TestSteppingAction.cpp
@@ -1,0 +1,59 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//==========================================================================
+
+// Framework include files
+#include "DDG4/Geant4SteppingAction.h"
+
+#include <G4Step.hh>
+#include <G4TrackStatus.hh>
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+    
+    /// Class to count steps and suspend tracks every 5 steps
+    /** Class to count steps and suspens tracks every 5 steps
+     * Count steps and suspend
+     *
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class TestSteppingAction : public Geant4SteppingAction {
+      std::size_t m_calls_steps { 0UL };
+      std::size_t m_calls_suspended { 0UL };
+    
+    public:
+      /// Standard constructor
+      TestSteppingAction(Geant4Context* context, const std::string& nam)
+	: Geant4SteppingAction(context, nam) 
+      {
+      }
+      /// Default destructor
+      virtual ~TestSteppingAction()   {
+	info("+++ Track Calls Steps: %ld", m_calls_steps);
+	info("+++ Track Calls Suspended: %ld", m_calls_suspended);
+      }
+      /// stepping callback
+      virtual void operator()(const G4Step* step, G4SteppingManager*) {
+        if(m_calls_steps % 5 == 0 ) {
+          ++m_calls_suspended;
+          step->GetTrack()->SetTrackStatus(fSuspend);
+        }
+	++m_calls_steps;
+      }
+    };
+  }    // End namespace sim
+}      // End namespace dd4hep
+
+#include "DDG4/Factories.h"
+DECLARE_GEANT4ACTION_NS(dd4hep::sim,TestSteppingAction)


### PR DESCRIPTION
… of a particle could be paused and later restarted.

Pick up the particle information that we have stored and go on from there

BEGINRELEASENOTES
- ParticleHandler: account for modified stepping actions, where tracking of a particle could be paused and later restarted.

ENDRELEASENOTES


For #1036 I get this for 2 events now

```
root [2] EVENT->Scan("sqrt(MCParticles.psx^2 + MCParticles.psy^2 + MCParticles.psz^2 + MCParticles.mass^2):MCParticles.reason:MCParticles.pdgID:MCParticles.mask", "MCParticles.mask==1")
***********************************************************************
*    Row   * Instance * sqrt(MCPa * MCParticl * MCParticl * MCParticl *
***********************************************************************
*        0 *        0 *     10000 *       158 *        11 *         1 *
*        1 *        0 *     10000 *       158 *        11 *         1 *
***********************************************************************
==> 2 selected entries
(long long) 2
```
So the energy is the same as the initial one (10000) as opposed to some smaller number.