### PR TITLE
Geant4Data: bring back a 4 argument version of Hit constructor used i…

### DIFF
--- a/DDG4/include/DDG4/Geant4Data.h
+++ b/DDG4/include/DDG4/Geant4Data.h
@@ -282,7 +282,7 @@ namespace dd4hep {
         /// copy constructor
         Hit(const Hit& c) = delete;
         /// Initializing constructor
-        Hit(int track_id, int pdg_id, double deposit, double time_stamp, double len, const Position& p, const Direction& d);
+        Hit(int track_id, int pdg_id, double deposit, double time_stamp, double len=0.0, const Position& p={0.0, 0.0, 0.0}, const Direction& d={0.0, 0.0, 0.0});
         /// Default destructor
         virtual ~Hit();
         /// Move assignment operator


### PR DESCRIPTION
…n lcgeo

This 4 argument constructor is used in lcgeo (k4geo) code, so lcgeo is currently not compiling.
(Update for #1044)

* Maybe also used in other places, so better to keep the interface?