### PR TITLE
DD4hepBuild: add -Wno-psabi to compiler flags to ignore warnings abou…

### DIFF
--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -39,7 +39,7 @@ endmacro(dd4hep_use_python_executable)
 macro(dd4hep_set_compiler_flags)
   include(CheckCXXCompilerFlag)
 
-  SET(COMPILER_FLAGS -Wshadow -Wformat-security -Wno-long-long -Wdeprecated -fdiagnostics-color=auto -Wall -Wextra -pedantic)
+  SET(COMPILER_FLAGS -Wshadow -Wformat-security -Wno-long-long -Wdeprecated -fdiagnostics-color=auto -Wall -Wextra -pedantic -Wno-psabi)
 
   # AppleClang/Clang specific warning flags
   if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")


### PR DESCRIPTION

BEGINRELEASENOTES
- add -Wno-psabi to compiler flags to ignore warnings about ABI changes that we will never have issues with. Fixes #1043 

ENDRELEASENOTES

The check_cxx_flag we loop should make this gcc conditional, and not used with clang