### PR TITLE
Require compatible podio version

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["LCG_102/x86_64-centos7-clang12-opt"]
+        LCG: ["dev4/x86_64-centos7-clang12-opt"]
     steps:
     - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,12 @@ endif()
 
 if(DD4HEP_USE_EDM4HEP)
   find_package(EDM4HEP REQUIRED)
+
+  set(podio_required 0.16.0)
+  find_package(podio REQUIRED ${podio_required})
+  if(NOT podio_VERSION VERSION_GREATER_EQUAL podio_required)
+    message(FATAL_ERROR "podio found version ${podio_VERSION} is insufficient (${podio_required})")
+  endif()
 #  DD4HEP_SETUP_EDM4HEP_TARGETS()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,12 +151,7 @@ endif()
 
 if(DD4HEP_USE_EDM4HEP)
   find_package(EDM4HEP REQUIRED)
-
-  set(podio_required 0.16.0)
-  find_package(podio REQUIRED ${podio_required})
-  if(NOT podio_VERSION VERSION_GREATER_EQUAL podio_required)
-    message(FATAL_ERROR "podio found version ${podio_VERSION} is insufficient (${podio_required})")
-  endif()
+  find_package(podio 0.16.0 REQUIRED)
 #  DD4HEP_SETUP_EDM4HEP_TARGETS()
 endif()
 


### PR DESCRIPTION
I believe DDDigi implicitly requires podio>=0.16.0 if edm4hep is enabled. CMake does not check this so far, I'm adding a CMake-level check here.

Let me know what you think!

BEGINRELEASENOTES
- Check podio version for compatibility in cmake
ENDRELEASENOTES