### PR TITLE
DD4hep.cmake: respect DYLD_LIBRARY_PATH when running listcomponents

### DIFF
--- a/.github/utils/ctest2junit.xsl
+++ b/.github/utils/ctest2junit.xsl
@@ -1,0 +1,116 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/Site">
+    <testsuite>
+      <xsl:variable name="BuildName"><xsl:value-of select="@BuildName"/></xsl:variable>
+      <xsl:variable name="BuildStamp"><xsl:value-of select="@BuildStamp"/></xsl:variable>
+      <xsl:variable name="Name"><xsl:value-of select="@Name"/></xsl:variable>
+      <xsl:variable name="Generator"><xsl:value-of select="@Generator"/></xsl:variable>
+      <xsl:variable name="CompilerName"><xsl:value-of select="@CompilerName"/></xsl:variable>
+      <xsl:variable name="OSName"><xsl:value-of select="@OSName"/></xsl:variable>
+      <xsl:variable name="Hostname"><xsl:value-of select="@Hostname"/></xsl:variable>
+      <xsl:variable name="OSRelease"><xsl:value-of select="@OSRelease"/></xsl:variable>
+      <xsl:variable name="OSVersion"><xsl:value-of select="@OSVersion"/></xsl:variable>
+      <xsl:variable name="OSPlatform"><xsl:value-of select="@OSPlatform"/></xsl:variable>
+      <xsl:variable name="Is64Bits"><xsl:value-of select="@Is64Bits"/></xsl:variable>
+      <xsl:variable name="VendorString"><xsl:value-of select="@VendorString"/></xsl:variable>
+      <xsl:variable name="VendorID"><xsl:value-of select="@VendorID"/></xsl:variable>
+      <xsl:variable name="FamilyID"><xsl:value-of select="@FamilyID"/></xsl:variable>
+      <xsl:variable name="ModelID"><xsl:value-of select="@ModelID"/></xsl:variable>
+      <xsl:variable name="ProcessorCacheSize"><xsl:value-of select="@ProcessorCacheSize"/></xsl:variable>
+      <xsl:variable name="NumberOfLogicalCPU"><xsl:value-of select="@NumberOfLogicalCPU"/></xsl:variable>
+      <xsl:variable name="NumberOfPhysicalCPU"><xsl:value-of select="@NumberOfPhysicalCPU"/></xsl:variable>
+      <xsl:variable name="TotalVirtualMemory"><xsl:value-of select="@TotalVirtualMemory"/></xsl:variable>
+      <xsl:variable name="TotalPhysicalMemory"><xsl:value-of select="@TotalPhysicalMemory"/></xsl:variable>
+      <xsl:variable name="LogicalProcessorsPerPhysical"><xsl:value-of select="@LogicalProcessorsPerPhysical"/></xsl:variable>
+      <xsl:variable name="ProcessorClockFrequency"><xsl:value-of select="@ProcessorClockFrequency"/></xsl:variable>
+      <properties>
+        <property name="BuildName" value="{$BuildName}" />
+        <property name="BuildStamp" value="{$BuildStamp}" />
+        <property name="Name" value="{$Name}" />
+        <property name="Generator" value="{$Generator}" />
+        <property name="CompilerName" value="{$CompilerName}" />
+        <property name="OSName" value="{$OSName}" />
+        <property name="Hostname" value="{$Hostname}" />
+        <property name="OSRelease" value="{$OSRelease}" />
+        <property name="OSVersion" value="{$OSVersion}" />
+        <property name="OSPlatform" value="{$OSPlatform}" />
+        <property name="Is64Bits" value="{$Is64Bits}" />
+        <property name="VendorString" value="{$VendorString}" />
+        <property name="VendorID" value="{$VendorID}" />
+        <property name="FamilyID" value="{$FamilyID}" />
+        <property name="ModelID" value="{$ModelID}" />
+        <property name="ProcessorCacheSize" value="{$ProcessorCacheSize}" />
+        <property name="NumberOfLogicalCPU" value="{$NumberOfLogicalCPU}" />
+        <property name="NumberOfPhysicalCPU" value="{$NumberOfPhysicalCPU}" />
+        <property name="TotalVirtualMemory" value="{$TotalVirtualMemory}" />
+        <property name="TotalPhysicalMemory" value="{$TotalPhysicalMemory}" />
+        <property name="LogicalProcessorsPerPhysical" value="{$LogicalProcessorsPerPhysical}" />
+        <property name="ProcessorClockFrequency" value="{$ProcessorClockFrequency}" />
+      </properties>
+      <xsl:apply-templates select="Testing/Test"/>
+
+      <system-out>
+        BuildName: <xsl:value-of select="$BuildName" />
+        BuildStamp: <xsl:value-of select="$BuildStamp" />
+        Name: <xsl:value-of select="$Name" />
+        Generator: <xsl:value-of select="$Generator" />
+        CompilerName: <xsl:value-of select="$CompilerName" />
+        OSName: <xsl:value-of select="$OSName" />
+        Hostname: <xsl:value-of select="$Hostname" />
+        OSRelease: <xsl:value-of select="$OSRelease" />
+        OSVersion: <xsl:value-of select="$OSVersion" />
+        OSPlatform: <xsl:value-of select="$OSPlatform" />
+        Is64Bits: <xsl:value-of select="$Is64Bits" />
+        VendorString: <xsl:value-of select="$VendorString" />
+        VendorID: <xsl:value-of select="$VendorID" />
+        FamilyID: <xsl:value-of select="$FamilyID" />
+        ModelID: <xsl:value-of select="$ModelID" />
+        ProcessorCacheSize: <xsl:value-of select="$ProcessorCacheSize" />
+        NumberOfLogicalCPU: <xsl:value-of select="$NumberOfLogicalCPU" />
+        NumberOfPhysicalCPU: <xsl:value-of select="$NumberOfPhysicalCPU" />
+        TotalVirtualMemory: <xsl:value-of select="$TotalVirtualMemory" />
+        TotalPhysicalMemory: <xsl:value-of select="$TotalPhysicalMemory" />
+        LogicalProcessorsPerPhysical: <xsl:value-of select="$LogicalProcessorsPerPhysical" />
+        ProcessorClockFrequency: <xsl:value-of select="$ProcessorClockFrequency" />
+      </system-out>
+    </testsuite>
+  </xsl:template>
+
+  <xsl:template match="Testing/Test">
+    <xsl:variable name="testcasename"><xsl:value-of select= "Name"/></xsl:variable>
+    <xsl:variable name="exectime">
+      <xsl:for-each select="Results/NamedMeasurement">
+        <xsl:if test="@name = 'Execution Time'">
+          <xsl:value-of select="."/>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <testcase name="{$testcasename}" classname="TestSuite" time="{$exectime}">
+      <xsl:if test="@Status = 'passed'">
+      </xsl:if>
+      <xsl:if test="@Status = 'failed'">
+        <xsl:variable name="failtype">
+          <xsl:for-each select="Results/NamedMeasurement">
+            <xsl:if test="@name = 'Exit Code'">
+              <xsl:value-of select="."/>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
+        <xsl:variable name="failcode">
+          <xsl:for-each select="Results/NamedMeasurement">
+            <xsl:if test="@name = 'Exit Value'">
+              <xsl:value-of select="."/>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
+        <error message="{$failtype} ({$failcode})"><xsl:value-of select="Results/Measurement/Value/text()" /></error>
+      </xsl:if>
+      <xsl:if test="@Status = 'notrun'">
+        <skipped><xsl:value-of select="Results/Measurement/Value/text()" /></skipped>
+      </xsl:if>
+    </testcase>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,14 +18,20 @@ mac11-clang12:
     - ninja
     - ninja install
     - . ../bin/thisdd4hep.sh
-    - ctest --output-on-failure -j4
+    - ctest --output-on-failure -j4 -T Test --no-compress-output --test-output-size-failed 1024000
     - cd ../examples/
     - mkdir build
     - cd build
     - cmake -GNinja -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_CXX_STANDARD=17 ..
     - ninja
     - ninja install
-    - ctest --output-on-failure -E t_ClientTests_Check_Shape_Eightpoint_Reflect_DetElement
+    - ctest --output-on-failure -E t_ClientTests_Check_Shape_Eightpoint_Reflect_DetElement -T Test --no-compress-output  --test-output-size-failed 1024000
+  after_script:
+    - xsltproc .github/utils/ctest2junit.xsl build/Testing/*/Test.xml > junit.xml
+    - xsltproc .github/utils/ctest2junit.xsl  examples/build/Testing/*/Test.xml > junit_examples.xml
+  artifacts:
+    reports:
+      junit: junit*.xml
 
 mac11-clang12-XERCESC:
   stage: build
@@ -42,14 +48,20 @@ mac11-clang12-XERCESC:
     - ninja
     - ninja install
     - . ../bin/thisdd4hep.sh
-    - ctest --output-on-failure -j4
+    - ctest --output-on-failure -j4 -T Test --no-compress-output --test-output-size-failed 1024000
     - cd ../examples/
     - mkdir build
     - cd build
     - cmake -GNinja -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_XERCESC=ON -DCMAKE_CXX_STANDARD=17 ..
     - ninja
     - ninja install
-    - ctest --output-on-failure -E t_ClientTests_Check_Shape_Eightpoint_Reflect_DetElement
+    - ctest --output-on-failure -E t_ClientTests_Check_Shape_Eightpoint_Reflect_DetElement -T Test --no-compress-output --test-output-size-failed 1024000
+  after_script:
+    - xsltproc .github/utils/ctest2junit.xsl build/Testing/*/Test.xml > junit_XERCES.xml
+    - xsltproc .github/utils/ctest2junit.xsl examples/build/Testing/*/Test.xml > junit_examples_XERCES.xml
+  artifacts:
+    reports:
+      junit: junit*.xml
 
 Python:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,12 +3,12 @@ stages:
     - documentation
     - deployment
 
-mac1015-clang110-Geant10.6:
+mac11-clang12:
   stage: build
   tags:
     - mac
   script:
-    - source /cvmfs/sft.cern.ch/lcg/views/LCG_98python3/x86_64-mac1015-clang110-opt/setup.sh
+    - source /cvmfs/sft.cern.ch/lcg/views/LCG_102/x86_64-mac11-clang120-opt/setup.sh
     - export CXX=clang++
     - export CC=clang
     - export FC=""
@@ -27,12 +27,12 @@ mac1015-clang110-Geant10.6:
     - ninja install
     - ctest --output-on-failure -E t_ClientTests_Check_Shape_Eightpoint_Reflect_DetElement
 
-mac1015-clang110-Geant10.6-XERCESC:
+mac11-clang12-XERCESC:
   stage: build
   tags:
     - mac
   script:
-    - source /cvmfs/sft.cern.ch/lcg/views/LCG_98python3/x86_64-mac1015-clang110-opt/setup.sh
+    - source /cvmfs/sft.cern.ch/lcg/views/LCG_102/x86_64-mac11-clang120-opt/setup.sh
     - export CXX=clang++
     - export CC=clang
     - export FC=""

--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -72,11 +72,10 @@ function(dd4hep_generate_rootmap library)
 
   if(APPLE)
     set(ENV_VAR DYLD_LIBRARY_PATH)
-    set(${ENV_VAR}_VALUE $<TARGET_FILE_DIR:${library}>:$<TARGET_FILE_DIR:DD4hep::DD4hepGaudiPluginMgr>)
   else()
     set(ENV_VAR LD_LIBRARY_PATH)
-    set(${ENV_VAR}_VALUE $<TARGET_FILE_DIR:${library}>:$<TARGET_FILE_DIR:DD4hep::DD4hepGaudiPluginMgr>:$ENV{${ENV_VAR}})
   endif()
+  set(${ENV_VAR}_VALUE $<TARGET_FILE_DIR:${library}>:$<TARGET_FILE_DIR:DD4hep::DD4hepGaudiPluginMgr>:$ENV{${ENV_VAR}})
 
   set(rootmapfile ${CMAKE_SHARED_MODULE_PREFIX}${library}.components)
 


### PR DESCRIPTION
Dropping DYLD_LIBRARY_PATH produces macOS-only issues when ROOT libraries are linked with -Drpath=ON. Users of a broken DYLD_LIBRARY_PATH should be able to unset it manually.

This partially reverts 65a090ff5191ad73d4a120bc4e18ab68159cbaae .

BEGINRELEASENOTES
- Pass `DYLD_LIBRARY_PATH` environment to listcomponents_dd4hep when generating rootmaps in CMake

ENDRELEASENOTES