### PR TITLE
Fix export of dd4hep::units to python

### DIFF
--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -411,6 +411,7 @@ class CommandLine:
       return self.data.get(attr)
     return None
 
+
 # ---------------------------------------------------------------------------
 #
 #  Import units from TGeo.
@@ -418,7 +419,6 @@ class CommandLine:
 #
 try:
   import_namespace_item('core', 'dd4hep_units')
-
 
   def import_units(ns=None):
     if ns is None:
@@ -435,7 +435,6 @@ try:
 
 except Exception as e:
   logger.warning('No units can be imported. ' + str(e))
-
 
   def import_units(ns=None):
     return 0

--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -10,7 +10,7 @@
 # ==========================================================================
 from __future__ import absolute_import, unicode_literals
 import cppyy
-import imp
+import importlib
 import logging
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ def compileAClick(dictionary, g4=True):
   gSystem.AddIncludePath(inc)
   gSystem.AddLinkedLibs(lib)
   logger.info('Loading AClick %s', dictionary)
-  package = imp.find_module('DDG4')
+  package = importlib.import_module('DDG4')
   dic = os.path.dirname(package[1]) + os.sep + dictionary
   gInterpreter.ProcessLine('.L ' + dic + '+')
   from ROOT import dd4hep as module
@@ -149,6 +149,7 @@ cond = dd4hep.cond
 tools = dd4hep.tools
 align = dd4hep.align
 detail = dd4hep.detail
+import imp
 units = imp.new_module('units')
 # ---------------------------------------------------------------------------
 import_namespace_item('tools', 'Evaluator')
@@ -405,70 +406,26 @@ class CommandLine:
       return self.data.get(attr)
     return None
 
-
 # ---------------------------------------------------------------------------
 #
 #  Import units from TGeo.
 #  Calling import_units makes all the units local to the dd4hep module.
 #
 try:
-  # from ROOT import TGeoUnit as TGeoUnits
+  import_namespace_item('core', 'dd4hep_units')
   def import_units(ns=None):
-    def import_unit(ns, nam):
-      setattr(ns, nam, getattr(core, nam))
-    items = [
-        # Length
-        'nanometer', 'micrometer', 'millimeter', 'centimeter', 'meter', 'kilometer', 'parsec', 'angstrom', 'fermi',
-        'nm', 'um', 'mm', 'cm', 'm', 'km', 'pc',
-        # Area
-        'millimeter2', 'centimeter2', 'meter2', 'kilometer2', 'barn', 'millibarn', 'microbarn', 'nanobarn', 'picobarn',
-        'mm2', 'cm2', 'm2', 'km2',
-        # Volume
-        'millimeter3', 'centimeter3', 'meter3', 'kilometer3', 'mm3', 'cm3', 'm3', 'km3',
-        # Angle
-        'radian', 'milliradian', 'degree', 'steradian', 'rad', 'mrad', 'sr', 'deg',
-        # Time & frequency
-        'nanosecond', 'second', 'millisecond', 'microsecond', 'picosecond', 'hertz',
-        'kilohertz', 'megahertz', 'ns', 's', 'ms',
-        # Electric charge
-        'eplus', 'e_SI', 'coulomb',
-        # Energy
-        'electronvolt', 'kiloelectronvolt', 'megaelectronvolt', 'gigaelectronvolt', 'teraelectronvolt',
-        'petaelectronvolt', 'joule', 'eV', 'keV', 'MeV', 'GeV', 'TeV', 'PeV',
-        # Mass
-        'milligram', 'gram', 'kilogram', 'mg', 'g', 'kg',
-        # Power, Force, Pressure
-        'watt', 'newton', 'hep_pascal', 'bar', 'atmosphere',
-        # Electrical current, potential, resistance
-        'nanoampere', 'microampere', 'milliampere', 'ampere', 'volt', 'kilovolt', 'megavolt', 'ohm',
-        # Electric capacitance
-        'picofarad', 'nanofarad', 'microfarad', 'millifarad', 'farad',
-        # Magnetic flux, field, Inductance, Temperature, substance
-        'weber', 'tesla', 'gauss', 'kilogauss', 'henry', 'kelvin', 'mole',
-        # Activity, dose intensity
-        'becquerel', 'curie', 'microgray', 'milligray', 'gray', 'kilogray',
-        # Luminous intensity, flux, Illuminance
-        'candela', 'lumen', 'lux',
-        # Misc
-        'perCent', 'perThousand', 'perMillion', 'pi', 'twopi', 'halfpi', 'pi2',
-        'Avogadro', 'c_light', 'c_squared', 'h_Planck', 'hbar_Planck', 'hbarc', 'hbarc_squared', 'electron_charge',
-        'e_squared', 'electron_mass_c2', 'proton_mass_c2', 'neutron_mass_c2', 'amu_c2', 'amu', 'mu0', 'epsilon0',
-        #
-        'elm_coupling', 'fine_structure_const', 'classic_electr_radius', 'electron_Compton_length', 'Bohr_radius',
-        'alpha_rcl2', 'twopi_mc2_rcl2', 'k_Boltzmann',
-        'Temperature_STP', 'Pressure_STP',
-        'Temperature_NTP', 'Pressure_NTP',
-        'kGasThreshold', 'universe_mean_density'
-        ]
     if ns is None:
       ns = name_space
     logger.debug('Importing units into namespace ' + str(ns.__name__))
-    for u in items:
-      if u[0] != '_':
-        import_unit(ns, u)
-    return len(items)
+    count = 0;
+    for nam in dir(dd4hep.dd4hep_units):
+      if nam[0] != '_':
+        count = count + 1
+        setattr(ns, nam, getattr(core.dd4hep_units, nam))
+        ##setattr(ns, nam, getattr(core, nam))
+    return count
 except Exception as e:
-  logger.warning('No units can be imported. %s' % str(e))
+  logger.warning('No units can be imported. ' + str(e))
 
   def import_units(ns=None):
     return 0

--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -10,15 +10,18 @@
 # ==========================================================================
 from __future__ import absolute_import, unicode_literals
 import cppyy
-import importlib
+import imp
 import logging
+
 
 logger = logging.getLogger(__name__)
 
-# We compile the DDG4 plugin on the fly if it does not exist using the AClick mechanism:
-
 
 def compileAClick(dictionary, g4=True):
+  """
+  We compile the DDG4 plugin on the fly if it does not exist using the AClick mechanism.
+
+  """
   from ROOT import gInterpreter, gSystem
   import os.path
   dd4hep = os.environ['DD4hepINSTALL']
@@ -32,7 +35,7 @@ def compileAClick(dictionary, g4=True):
   gSystem.AddIncludePath(inc)
   gSystem.AddLinkedLibs(lib)
   logger.info('Loading AClick %s', dictionary)
-  package = importlib.import_module('DDG4')
+  package = imp.find_module('DDG4')
   dic = os.path.dirname(package[1]) + os.sep + dictionary
   gInterpreter.ProcessLine('.L ' + dic + '+')
   from ROOT import dd4hep as module
@@ -40,6 +43,9 @@ def compileAClick(dictionary, g4=True):
 
 
 def loaddd4hep():
+  """
+  Import DD4hep module from ROOT using ROOT reflection
+  """
   import os
   import sys
   # Add ROOT to the python path in case it is not yet there....
@@ -149,7 +155,6 @@ cond = dd4hep.cond
 tools = dd4hep.tools
 align = dd4hep.align
 detail = dd4hep.detail
-import imp
 units = imp.new_module('units')
 # ---------------------------------------------------------------------------
 import_namespace_item('tools', 'Evaluator')
@@ -413,19 +418,24 @@ class CommandLine:
 #
 try:
   import_namespace_item('core', 'dd4hep_units')
+
+
   def import_units(ns=None):
     if ns is None:
       ns = name_space
+
     logger.debug('Importing units into namespace ' + str(ns.__name__))
-    count = 0;
+    count = 0
     for nam in dir(dd4hep.dd4hep_units):
       if nam[0] != '_':
         count = count + 1
         setattr(ns, nam, getattr(core.dd4hep_units, nam))
-        ##setattr(ns, nam, getattr(core, nam))
+        # setattr(ns, nam, getattr(core, nam))
     return count
+
 except Exception as e:
   logger.warning('No units can be imported. ' + str(e))
+
 
   def import_units(ns=None):
     return 0

--- a/DDCore/src/InstanceCount.cpp
+++ b/DDCore/src/InstanceCount.cpp
@@ -11,11 +11,12 @@
 //
 //==========================================================================
 
-// Framework include files
+/// Framework include files
 #include "DD4hep/InstanceCount.h"
 #include "DD4hep/Handle.h"
 #include "DD4hep/Memory.h"
-// C/C++ include files
+
+/// C/C++ include files
 #include <iostream>
 #include <iomanip>
 #include <cstdio>
@@ -24,7 +25,6 @@
 #include <mutex>
 #include <map>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Do not clutter global namespace
@@ -64,6 +64,7 @@ namespace {
 InstanceCount::InstanceCount() {
   s_thisCount.increment();
 }
+
 /// Standard destructor
 InstanceCount::~InstanceCount() {
   s_thisCount.decrement();
@@ -79,14 +80,17 @@ InstanceCount::~InstanceCount() {
     s_typCounts->clear();
   }
 }
+
 /// Check if tracing is enabled.
 bool InstanceCount::doTrace() {
   return s_trace_instances;
 }
+
 /// Enable/Disable tracing
 void InstanceCount::doTracing(bool value) {
   s_trace_instances = value;
 }
+
 /// Access counter object for local caching on optimizations
 InstanceCount::Counter* InstanceCount::getCounter(const std::type_info& typ) {
   Counter* cnt = s_trace_instances ? types()[&typ] : &s_nullCount;
@@ -146,57 +150,57 @@ void InstanceCount::dump(int typ) {
   bool need_footer = false;
   if ((typ & STRING) && s_strCounts.get()) {
     if ( !s_strCounts->empty() )  {
-      cout << "+--------------------------------------------------------------------------+" << endl;
-      cout << "|   I n s t a n c e   c o u n t e r s   b y    N A M E                     |" << endl;
-      cout << "+----------+---------+---------+-------------------------------------------+" << endl;
-      cout << "|   Total  |  Max    | Leaking |      Type identifier                      |" << endl;
-      cout << "+----------+---------+---------+-------------------------------------------+" << endl;
+      std::cout << "+--------------------------------------------------------------------------+" << std::endl;
+      std::cout << "|   I n s t a n c e   c o u n t e r s   b y    N A M E                     |" << std::endl;
+      std::cout << "+----------+---------+---------+-------------------------------------------+" << std::endl;
+      std::cout << "|   Total  |  Max    | Leaking |      Type identifier                      |" << std::endl;
+      std::cout << "+----------+---------+---------+-------------------------------------------+" << std::endl;
       long tot_instances=0, max_instances=0, now_instances=0;
       for ( const auto& i : *s_strCounts ) {
-        cout << "|" << setw(10) << i.second->total()
-             << "|" << setw(9)  << i.second->maximum()
-             << "|" << setw(9)  << i.second->value()
-             << "|" << i.first->substr(0,80) << endl;
+        std::cout << "|" << std::setw(10) << i.second->total()
+		  << "|" << std::setw(9)  << i.second->maximum()
+		  << "|" << std::setw(9)  << i.second->value()
+		  << "|" << i.first->substr(0,80) << std::endl;
         tot_instances += i.second->total();
         max_instances += i.second->maximum();
         now_instances += i.second->value();
       }
-      cout << "+----------+---------+---------+-------------------------------------------+" << endl;
-      cout << "|" << setw(10) << tot_instances
-           << "|" << setw(9)  << max_instances
-           << "|" << setw(9)  << now_instances
-           << "|" << "Grand total (Sum of all counters)" << endl;
+      std::cout << "+----------+---------+---------+-------------------------------------------+" << std::endl;
+      std::cout << "|" << std::setw(10) << tot_instances
+		<< "|" << std::setw(9)  << max_instances
+		<< "|" << std::setw(9)  << now_instances
+		<< "|" << "Grand total (Sum of all counters)" << std::endl;
       need_footer = true;
     }
   }
   if ((typ & TYPEINFO) && s_typCounts.get()) {
     if ( !s_typCounts->empty() ) {
-      cout << "+--------------------------------------------------------------------------+" << endl;
-      cout << "|   I n s t a n c e   c o u n t e r s   b y    T Y P E I N F O             |" << endl;
-      cout << "+----------+---------+---------+-------------------------------------------+" << endl;
-      cout << "|   Total  |  Max    | Leaking |      Type identifier                      |" << endl;
-      cout << "+----------+---------+---------+-------------------------------------------+" << endl;
+      std::cout << "+--------------------------------------------------------------------------+" << std::endl;
+      std::cout << "|   I n s t a n c e   c o u n t e r s   b y    T Y P E I N F O             |" << std::endl;
+      std::cout << "+----------+---------+---------+-------------------------------------------+" << std::endl;
+      std::cout << "|   Total  |  Max    | Leaking |      Type identifier                      |" << std::endl;
+      std::cout << "+----------+---------+---------+-------------------------------------------+" << std::endl;
       long tot_instances=0, max_instances=0, now_instances=0;
       for ( const auto& i : *s_typCounts ) {
-        string nam = typeName(*(i.first));
+	std::string nam = typeName(*(i.first));
         if ( nam.length() > 80 ) nam = nam.substr(0,80)+" ...";
-        cout << "|" << setw(10) << i.second->total()
-             << "|" << setw(9)  << i.second->maximum()
-             << "|" << setw(9)  << i.second->value()
-             << "|" << nam << endl;
+        std::cout << "|" << std::setw(10) << i.second->total()
+		  << "|" << std::setw(9)  << i.second->maximum()
+		  << "|" << std::setw(9)  << i.second->value()
+		  << "|" << nam << std::endl;
         tot_instances += i.second->total();
         max_instances += i.second->maximum();
         now_instances += i.second->value();
       }
-      cout << "+----------+---------+---------+-------------------------------------------+" << endl;
-      cout << "|" << setw(10) << tot_instances
-           << "|" << setw(9)  << max_instances
-           << "|" << setw(9)  << now_instances
-           << "|" << "Grand total (Sum of all counters)" << endl;
+      std::cout << "+----------+---------+---------+-------------------------------------------+" << std::endl;
+      std::cout << "|" << std::setw(10) << tot_instances
+		<< "|" << std::setw(9)  << max_instances
+		<< "|" << std::setw(9)  << now_instances
+		<< "|" << "Grand total (Sum of all counters)" << std::endl;
       need_footer = true;
     }
   }
   if (need_footer) {
-    cout << "+----------+-------+-------------------------------------------+" << endl;
+    std::cout << "+----------+-------+-------------------------------------------+" << std::endl;
   }
 }

--- a/DDCore/src/RootDictionary.h
+++ b/DDCore/src/RootDictionary.h
@@ -33,6 +33,7 @@
 #include "DD4hep/Conditions.h"
 #include "DD4hep/Alignments.h"
 #include "DD4hep/FieldTypes.h"
+#include "DD4hep/DD4hepUnits.h"
 #include "DD4hep/DetectorData.h"
 #include "DD4hep/DetectorProcessor.h"
 #include "DD4hep/ComponentProperties.h"
@@ -92,6 +93,291 @@ namespace dd4hep {
       }
     };
   }
+  class dd4hep_units  {
+  public:
+    static constexpr double millimeter       = dd4hep::mm;
+    static constexpr double millimeter2      = dd4hep::mm2;
+    static constexpr double millimeter3      = dd4hep::mm3;
+    static constexpr double centimeter       = dd4hep::centimeter;
+    static constexpr double centimeter2      = dd4hep::centimeter2;
+    static constexpr double centimeter3      = dd4hep::centimeter3;
+
+    static constexpr double meter            = dd4hep::meter;
+    static constexpr double meter2           = dd4hep::meter2;
+    static constexpr double meter3           = dd4hep::meter3;
+
+    static constexpr double kilometer        = dd4hep::kilometer;
+    static constexpr double kilometer2       = dd4hep::kilometer2;
+    static constexpr double kilometer3       = dd4hep::kilometer3;
+
+
+    static constexpr double parsec           = dd4hep::parsec;
+
+    static constexpr double micrometer       = dd4hep::micrometer;
+    static constexpr double nanometer        = dd4hep::nanometer;
+    static constexpr double angstrom         = dd4hep::angstrom;
+    static constexpr double fermi            = dd4hep::fermi;
+
+    static constexpr double barn             = dd4hep::barn;
+    static constexpr double millibarn        = dd4hep::millibarn;
+    static constexpr double microbarn        = dd4hep::microbarn;
+    static constexpr double nanobarn         = dd4hep::nanobarn;
+    static constexpr double picobarn         = dd4hep::picobarn;
+
+    // symbols
+    static constexpr double nm               = dd4hep::nm;
+    static constexpr double um               = dd4hep::um;
+
+    static constexpr double mm               = dd4hep::mm;
+    static constexpr double mm2              = dd4hep::mm2;
+    static constexpr double mm3              = dd4hep::mm3;
+
+    static constexpr double cm               = dd4hep::cm;
+    static constexpr double cm2              = dd4hep::cm2;
+    static constexpr double cm3              = dd4hep::cm3;
+
+    static constexpr double m                = dd4hep::m;
+    static constexpr double m2               = dd4hep::m2;
+    static constexpr double m3               = dd4hep::m3;
+
+    static constexpr double km               = dd4hep::km;
+    static constexpr double km2              = dd4hep::km2;
+    static constexpr double km3              = dd4hep::km3;
+
+    static constexpr double pc               = dd4hep::pc;
+    //
+    // Angle
+    //
+    static constexpr double radian           = dd4hep::radian;
+    static constexpr double milliradian      = dd4hep::milliradian;
+    static constexpr double degree           = dd4hep::degree;
+    static constexpr double steradian        = dd4hep::degree;
+
+    // symbols
+    static constexpr double rad              = dd4hep::rad;
+    static constexpr double mrad             = dd4hep::mrad;
+    static constexpr double sr               = dd4hep::sr;
+    static constexpr double deg              = dd4hep::deg;
+
+    //
+    // Time [T]
+    //
+    static constexpr double picosecond       = dd4hep::picosecond;
+    static constexpr double nanosecond       = dd4hep::nanosecond;
+    static constexpr double microsecond      = dd4hep::microsecond;
+    static constexpr double millisecond      = dd4hep::millisecond;
+    static constexpr double second           = dd4hep::second;
+
+    static constexpr double hertz            = dd4hep::hertz;
+    static constexpr double kilohertz        = dd4hep::kilohertz;
+    static constexpr double megahertz        = dd4hep::megahertz;
+    // symbols
+    static constexpr double ns               = dd4hep::ns;
+    static constexpr double s                = dd4hep::s;
+    static constexpr double ms               = dd4hep::ms;
+    //
+    // Electric charge [Q]
+    //
+    static constexpr double eplus            = dd4hep::eplus;
+    static constexpr double e_SI             = dd4hep::e_SI;
+    static constexpr double coulomb          = dd4hep::coulomb;
+    //
+    // Energy [E]
+    //
+    static constexpr double electronvolt     = dd4hep::electronvolt;
+    static constexpr double kiloelectronvolt = dd4hep::kiloelectronvolt;
+    static constexpr double megaelectronvolt = dd4hep::megaelectronvolt;
+    static constexpr double gigaelectronvolt = dd4hep::gigaelectronvolt;
+    static constexpr double teraelectronvolt = dd4hep::teraelectronvolt;
+    static constexpr double petaelectronvolt = dd4hep::petaelectronvolt;
+
+    static constexpr double joule            = dd4hep::joule;
+    static constexpr double kilojoule        = dd4hep::kilojoule;
+
+    // symbols
+    static constexpr double eV               = dd4hep::eV;
+    static constexpr double keV              = dd4hep::keV;
+    static constexpr double MeV              = dd4hep::MeV;
+    static constexpr double GeV              = dd4hep::GeV;
+    static constexpr double TeV              = dd4hep::TeV;
+    static constexpr double PeV              = dd4hep::PeV;
+    //
+    // Mass [E][T^2][L^-2]
+    //
+    static constexpr double kilogram         = dd4hep::kilogram;
+    static constexpr double gram             = dd4hep::gram;
+    static constexpr double milligram        = dd4hep::milligram;
+    // symbols
+    static constexpr double kg               = dd4hep::kg;
+    static constexpr double g                = dd4hep::g;
+    static constexpr double mg               = dd4hep::mg;
+    //
+    // Power [E][T^-1]
+    //
+    static constexpr double watt             = dd4hep::watt;
+    static constexpr double kilowatt         = dd4hep::kilowatt;
+    static constexpr double megawatt         = dd4hep::megawatt;
+    //
+    // Force [E][L^-1]
+    //
+    static constexpr double newton           = dd4hep::newton;
+    //
+    // Pressure [E][L^-3]
+    //
+    static constexpr double hep_pascal       = dd4hep::hep_pascal;
+    static constexpr double bar              = dd4hep::bar;
+    static constexpr double atmosphere       = dd4hep::atmosphere;
+    //
+    // Electric current [Q][T^-1]
+    //
+    static constexpr double ampere           = dd4hep::ampere;
+    static constexpr double milliampere      = dd4hep::milliampere;
+    static constexpr double microampere      = dd4hep::microampere;
+    static constexpr double nanoampere       = dd4hep::nanoampere;
+    //
+    // Electric potential [E][Q^-1]
+    //
+    static constexpr double megavolt         = dd4hep::megavolt;
+    static constexpr double kilovolt         = dd4hep::kilovolt;
+    static constexpr double volt             = dd4hep::volt;
+    //
+    // Electric resistance [E][T][Q^-2]
+    //
+    static constexpr double ohm              = dd4hep::ohm;
+    //
+    // Electric capacitance [Q^2][E^-1]
+    //
+    static constexpr double farad            = dd4hep::farad;
+    static constexpr double millifarad       = dd4hep::millifarad;
+    static constexpr double microfarad       = dd4hep::microfarad;
+    static constexpr double nanofarad        = dd4hep::nanofarad;
+    static constexpr double picofarad        = dd4hep::picofarad;
+    //
+    // Magnetic Flux [T][E][Q^-1]
+    //
+    static constexpr double weber            = dd4hep::weber;
+    //
+    // Magnetic Field [T][E][Q^-1][L^-2]
+    //
+    static constexpr double tesla            = dd4hep::tesla;
+
+    static constexpr double gauss            = dd4hep::gauss;
+    static constexpr double kilogauss        = dd4hep::kilogauss;
+    //
+    // Inductance [T^2][E][Q^-2]
+    //
+    static constexpr double henry            = dd4hep::henry;
+    //
+    // Temperature
+    //
+    static constexpr double kelvin           = dd4hep::kelvin;
+    //
+    // Amount of substance
+    //
+    static constexpr double mole             = dd4hep::mole;
+    //
+    // Activity [T^-1]
+    //
+    static constexpr double becquerel        = dd4hep::becquerel;
+    static constexpr double curie            = dd4hep::curie;
+    //
+    // Absorbed dose [L^2][T^-2]
+    //
+    static constexpr double gray             = dd4hep::gray;
+    static constexpr double kilogray         = dd4hep::kilogray;
+    static constexpr double milligray        = dd4hep::milligray;
+    static constexpr double microgray        = dd4hep::microgray;
+    //
+    // Luminous intensity [I]
+    //
+    static constexpr double candela          = dd4hep::candela;
+    //
+    // Luminous flux [I]
+    //
+    static constexpr double lumen            = dd4hep::lumen;
+    //
+    // Illuminance [I][L^-2]
+    //
+    static constexpr double lux              = dd4hep::lux;
+    //
+    // Miscellaneous
+    //
+    static constexpr double perCent          = dd4hep::perCent;
+    static constexpr double perThousand      = dd4hep::perThousand;
+    static constexpr double perMillion       = dd4hep::perMillion;
+
+    static constexpr double pi               = dd4hep::pi;
+    static constexpr double twopi            = dd4hep::twopi;
+    static constexpr double halfpi           = dd4hep::halfpi;
+    static constexpr double pi2              = dd4hep::pi2;
+    //
+    //
+    //
+    static constexpr double Avogadro         = dd4hep::Avogadro;
+    //
+    // c   = 299.792458 mm/ns
+    // c^2 = 898.7404 (mm/ns)^2
+    //
+    static constexpr double c_light          = dd4hep::c_light;
+      static constexpr double c_squared      = dd4hep::c_squared;
+    //
+    // h     = 4.13566e-12 MeV*ns
+    // hbar  = 6.58212e-13 MeV*ns
+    // hbarc = 197.32705e-12 MeV*mm
+    //
+    static constexpr double h_Planck         = dd4hep::h_Planck;
+    static constexpr double hbar_Planck      = dd4hep::hbar_Planck;
+    static constexpr double hbarc            = dd4hep::hbarc;
+    static constexpr double hbarc_squared    = dd4hep::hbarc_squared;
+    //
+    //
+    //
+    static constexpr double electron_charge  = dd4hep::electron_charge;
+    static constexpr double e_squared        = dd4hep::e_squared;
+    //
+    // amu_c2 - atomic equivalent mass unit
+    //        - AKA, unified atomic mass unit (u)
+    // amu    - atomic mass unit
+    //
+    static constexpr double electron_mass_c2 = dd4hep::electron_mass_c2;
+    static constexpr double proton_mass_c2   = dd4hep::proton_mass_c2;
+    static constexpr double neutron_mass_c2  = dd4hep::neutron_mass_c2;
+    static constexpr double amu_c2           = dd4hep::amu_c2;
+    static constexpr double amu              = dd4hep::amu;
+    //
+    // permeability of free space mu0    = 2.01334e-16 Mev*(ns*eplus)^2/mm
+    // permittivity of free space epsil0 = 5.52636e+10 eplus^2/(MeV*mm)
+    //
+    static constexpr double mu0              = dd4hep::mu0;
+    static constexpr double epsilon0         = dd4hep::epsilon0;
+    //
+    // electromagnetic coupling = 1.43996e-12 MeV*mm/(eplus^2)
+    //
+    static constexpr double elm_coupling     = dd4hep::elm_coupling;
+    static constexpr double fine_structure_const = dd4hep::fine_structure_const;
+    static constexpr double classic_electr_radius = dd4hep::classic_electr_radius;
+    static constexpr double electron_Compton_length = dd4hep::electron_Compton_length;
+    static constexpr double Bohr_radius      = dd4hep::Bohr_radius;
+    static constexpr double alpha_rcl2       = dd4hep::alpha_rcl2;
+    static constexpr double twopi_mc2_rcl2   = dd4hep::twopi_mc2_rcl2;
+    //
+    static constexpr double k_Boltzmann      = dd4hep::k_Boltzmann;
+    //
+    // IUPAC standard temperature and pressure (STP)
+    // STP uses 273.15 K (0 °C, 32 °F) and (since 1982) 1 bar (100 kPa) and not 1 atm!
+    static constexpr double Temperature_STP  = dd4hep::Temperature_STP;
+    static constexpr double Pressure_STP     = dd4hep::Pressure_STP;
+    //
+    // NTP uses the NIST convention: 20 °C (293.15 K, 68 °F), 1 atm (14.696 psi, 101.325 kPa)
+    static constexpr double Temperature_NTP  = dd4hep::Temperature_NTP;
+    static constexpr double Pressure_NTP     = dd4hep::Pressure_NTP;
+    //
+    static constexpr double kGasThreshold    = dd4hep::kGasThreshold;
+    static constexpr double universe_mean_density = dd4hep::universe_mean_density;
+
+    dd4hep_units() = default;
+    ~dd4hep_units() = default;
+  };
 }
 
 namespace dd4hep   {   namespace Parsers   {
@@ -131,6 +417,184 @@ namespace dd4hep   {   namespace Parsers   {
 #pragma link C++ function dd4hep::printout;
 #pragma link C++ function dd4hep::exception;
 
+// System of units:
+// Length [L]
+#pragma link C++ global dd4hep::fermi;
+#pragma link C++ global dd4hep::angstrom;
+#pragma link C++ global dd4hep::nanometer;
+#pragma link C++ global dd4hep::micrometer;
+#pragma link C++ global dd4hep::millimeter;
+#pragma link C++ global dd4hep::millimeter2;
+#pragma link C++ global dd4hep::millimeter3;
+#pragma link C++ global dd4hep::centimeter;
+#pragma link C++ global dd4hep::centimeter2;
+#pragma link C++ global dd4hep::centimeter3;
+#pragma link C++ global dd4hep::meter;
+#pragma link C++ global dd4hep::meter2;
+#pragma link C++ global dd4hep::meter3;
+#pragma link C++ global dd4hep::kilometer;
+#pragma link C++ global dd4hep::kilometer2;
+#pragma link C++ global dd4hep::kilometer3;
+#pragma link C++ global dd4hep::parsec;
+// Area/cross-section
+#pragma link C++ global dd4hep::barn;
+#pragma link C++ global dd4hep::millibarn;
+#pragma link C++ global dd4hep::microbarn;
+#pragma link C++ global dd4hep::nanobarn;
+#pragma link C++ global dd4hep::picobarn;
+#pragma link C++ global dd4hep::radian;
+#pragma link C++ global dd4hep::milliradian;
+#pragma link C++ global dd4hep::degree;
+#pragma link C++ global dd4hep::steradian;
+
+#pragma link C++ global dd4hep::nm;
+#pragma link C++ global dd4hep::um;
+#pragma link C++ global dd4hep::mm;
+#pragma link C++ global dd4hep::mm2;
+#pragma link C++ global dd4hep::mm3;
+#pragma link C++ global dd4hep::cm;
+#pragma link C++ global dd4hep::cm2;
+#pragma link C++ global dd4hep::cm3;
+#pragma link C++ global dd4hep::m;
+#pragma link C++ global dd4hep::m2;
+#pragma link C++ global dd4hep::m3;
+#pragma link C++ global dd4hep::km;
+#pragma link C++ global dd4hep::km2;
+#pragma link C++ global dd4hep::km3;
+#pragma link C++ global dd4hep::m;
+#pragma link C++ global dd4hep::m2;
+#pragma link C++ global dd4hep::pc;
+#pragma link C++ global dd4hep::rad;
+#pragma link C++ global dd4hep::mrad;
+#pragma link C++ global dd4hep::sr;
+// Time [T]
+#pragma link C++ global dd4hep::nanosecond;
+#pragma link C++ global dd4hep::second;
+#pragma link C++ global dd4hep::millisecond;
+#pragma link C++ global dd4hep::microsecond;
+#pragma link C++ global dd4hep::picosecond;
+#pragma link C++ global dd4hep::hertz;
+#pragma link C++ global dd4hep::kilohertz;
+#pragma link C++ global dd4hep::megahertz;
+
+#pragma link C++ global dd4hep::ns;
+#pragma link C++ global dd4hep::s;
+#pragma link C++ global dd4hep::ms;
+// Electric charge [Q]
+#pragma link C++ global dd4hep::eplus;
+#pragma link C++ global dd4hep::e_SI;
+#pragma link C++ global dd4hep::coulomb;
+// Energy [E]
+#pragma link C++ global dd4hep::joule;
+#pragma link C++ global dd4hep::kilojoule;
+#pragma link C++ global dd4hep::electronvolt;
+#pragma link C++ global dd4hep::kiloelectronvolt;
+#pragma link C++ global dd4hep::megaelectronvolt;
+#pragma link C++ global dd4hep::gigaelectronvolt;
+#pragma link C++ global dd4hep::teraelectronvolt;
+#pragma link C++ global dd4hep::petaelectronvolt;
+
+#pragma link C++ global dd4hep::eV;
+#pragma link C++ global dd4hep::keV;
+#pragma link C++ global dd4hep::MeV;
+#pragma link C++ global dd4hep::GeV;
+#pragma link C++ global dd4hep::TeV;
+#pragma link C++ global dd4hep::PeV;
+// Mass [E][T^2][L^-2]
+#pragma link C++ global dd4hep::milligram;
+#pragma link C++ global dd4hep::gram;
+#pragma link C++ global dd4hep::kilogram;
+#pragma link C++ global dd4hep::mg;
+#pragma link C++ global dd4hep::g;
+#pragma link C++ global dd4hep::kg;
+// Power [E][T^-1]
+#pragma link C++ global dd4hep::watt;
+#pragma link C++ global dd4hep::kilowatt;
+#pragma link C++ global dd4hep::megawatt;
+// Force [E][L^-1]
+#pragma link C++ global dd4hep::newton;
+// Pressure [E][L^-3]
+#pragma link C++ global dd4hep::hep_pascal;
+#pragma link C++ global dd4hep::bar;
+#pragma link C++ global dd4hep::atmosphere;
+// Electric current [Q][T^-1]
+#pragma link C++ global dd4hep::nanoampere;
+#pragma link C++ global dd4hep::microampere;
+#pragma link C++ global dd4hep::milliampere;
+#pragma link C++ global dd4hep::ampere;
+// Electric potential [E][Q^-1]
+#pragma link C++ global dd4hep::volt;
+#pragma link C++ global dd4hep::kilovolt;
+#pragma link C++ global dd4hep::megavolt;
+// Electric resistance [E][T][Q^-2]
+#pragma link C++ global dd4hep::ohm;
+// Electric capacitance [Q^2][E^-1]
+#pragma link C++ global dd4hep::picofarad;
+#pragma link C++ global dd4hep::nanofarad;
+#pragma link C++ global dd4hep::microfarad;
+#pragma link C++ global dd4hep::millifarad;
+#pragma link C++ global dd4hep::farad;
+// Magnetic Flux [T][E][Q^-1]
+#pragma link C++ global dd4hep::weber;
+// Magnetic Field [T][E][Q^-1][L^-2]
+#pragma link C++ global dd4hep::tesla;
+#pragma link C++ global dd4hep::gauss;
+#pragma link C++ global dd4hep::kilogauss;
+// Inductance [T^2][E][Q^-2]
+#pragma link C++ global dd4hep::henry;
+// Temperature
+#pragma link C++ global dd4hep::kelvin;
+// Amount of substance
+#pragma link C++ global dd4hep::mole;
+// Absorbed dose [L^2][T^-2]
+#pragma link C++ global dd4hep::microgray;
+#pragma link C++ global dd4hep::milligray;
+#pragma link C++ global dd4hep::gray;
+#pragma link C++ global dd4hep::kilogray;
+// Luminous intensity [I]
+#pragma link C++ global dd4hep::candela;
+// Illuminance [I][L^-2]
+#pragma link C++ global dd4hep::lux;
+// Miscellaneous
+#pragma link C++ global dd4hep::perCent;
+#pragma link C++ global dd4hep::perThousand;
+#pragma link C++ global dd4hep::perMillion;
+// Physical Constants
+#pragma link C++ global dd4hep::pi;
+#pragma link C++ global dd4hep::twopi;
+#pragma link C++ global dd4hep::halfpi;
+#pragma link C++ global dd4hep::pi2;
+#pragma link C++ global dd4hep::Avogadro;
+#pragma link C++ global dd4hep::c_light;
+#pragma link C++ global dd4hep::c_squared;
+#pragma link C++ global dd4hep::h_Planck;
+#pragma link C++ global dd4hep::hbar_Planck;
+#pragma link C++ global dd4hep::hbarc;
+#pragma link C++ global dd4hep::hbarc_squared;
+#pragma link C++ global dd4hep::electron_charge;
+#pragma link C++ global dd4hep::e_squared;
+#pragma link C++ global dd4hep::electron_mass_c2;
+#pragma link C++ global dd4hep::proton_mass_c2;
+#pragma link C++ global dd4hep::neutron_mass_c2;
+#pragma link C++ global dd4hep::amu_c2;
+#pragma link C++ global dd4hep::amu;
+#pragma link C++ global dd4hep::mu0;
+#pragma link C++ global dd4hep::epsilon0;
+#pragma link C++ global dd4hep::elm_coupling;
+#pragma link C++ global dd4hep::fine_structure_const;
+#pragma link C++ global dd4hep::classic_electr_radius;
+#pragma link C++ global dd4hep::electron_Compton_length;
+#pragma link C++ global dd4hep::Bohr_radius;
+#pragma link C++ global dd4hep::alpha_rcl2;
+#pragma link C++ global dd4hep::twopi_mc2_rcl2;
+#pragma link C++ global dd4hep::k_Boltzmann;
+#pragma link C++ global dd4hep::Temperature_STP;
+#pragma link C++ global dd4hep::Pressure_STP;
+#pragma link C++ global dd4hep::Temperature_NTP;
+#pragma link C++ global dd4hep::Pressure_NTP;
+#pragma link C++ global dd4hep::kGasThreshold;
+#pragma link C++ global dd4hep::universe_mean_density;
+
 #ifndef __ROOTCLING__
 template std::pair<unsigned int, std::string>;
 template class dd4hep::Handle<dd4hep::NamedObject>;
@@ -141,6 +605,7 @@ template class std::pair<dd4hep::Callback,unsigned long>;
 
 #pragma link C++ class DD4hepRootPersistency+;
 #pragma link C++ class DD4hepRootCheck+;
+#pragma link C++ class dd4hep::dd4hep_units;
 
 #pragma link C++ class std::pair<unsigned int,std::string>+;
 //#pragma link C++ class dd4hep::Callback+;

--- a/DDDigi/src/DigiROOTInput.cpp
+++ b/DDDigi/src/DigiROOTInput.cpp
@@ -121,6 +121,7 @@ std::unique_ptr<DigiROOTInput::inputsource_t> DigiROOTInput::internals_t::open_s
 	if ( m_parent->object_loading_is_enabled(b->GetName()) )   {
 	  TClass* cls = gROOT->GetClass( b->GetClassName(), kTRUE );
 	  Key key(b->GetName(), mask);
+	  b->SetAutoDelete(kFALSE);
 	  source->branches.emplace(key, container_t(key, *b, *cls));
 	}
       }

--- a/DDParsers/include/Evaluator/DD4hepUnits.h
+++ b/DDParsers/include/Evaluator/DD4hepUnits.h
@@ -166,11 +166,12 @@ namespace dd4hep {
     static constexpr double petaelectronvolt = 1.e+9 * megaelectronvolt;
 
     static constexpr double joule = electronvolt / e_SI;   // joule = 6.24150 e+12 * MeV
+    static constexpr double kilojoule = 1.e3*joule;
 
     // symbols
-    static constexpr double MeV = megaelectronvolt;
-    static constexpr double eV = electronvolt;
+    static constexpr double eV  = electronvolt;
     static constexpr double keV = kiloelectronvolt;
+    static constexpr double MeV = megaelectronvolt;
     static constexpr double GeV = gigaelectronvolt;
     static constexpr double TeV = teraelectronvolt;
     static constexpr double PeV = petaelectronvolt;
@@ -191,6 +192,8 @@ namespace dd4hep {
     // Power [E][T^-1]
     //
     static constexpr double watt = joule / second;   // watt = 6.24150 e+3 * MeV/ns
+    static constexpr double kilowatt = 1.e3*watt;
+    static constexpr double megawatt = 1.e6*watt;
 
     //
     // Force [E][L^-1]


### PR DESCRIPTION

BEGINRELEASENOTES
The export of dd4hep::units is problematic in the presence of identical libraries from DD4hep in the LD_LIBRARY_PATH:
- The ROOT auto-class loading tends to falsely load these libraries if constants from the dd4hep namespace are requested in python. This is clearly wrong: the original libraries may not be binary compatible. The 
- The export of the units using a helper class fixes this and ensures that the auto load mechanism is not automatically triggered. This is at least a formally correct solution until the auto load mechanism is better understood.

- In the ROOT loader for DDDigi the `TBranch::SetAutoDelete(true)` was not set causing eventually double deletion and arbitrary crashes. Data read by DDDigi are put on the store and deleted by the application to allow subsequent reading for feeding other threads. If ROOT would take care of the deletion, multi-threaded processing is not possible.
ENDRELEASENOTES