### PR TITLE
Propagate HepMC event weights to EDM4hep and LCIO outputs of ddsim

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -96,15 +96,19 @@ namespace dd4hep {
     
     template <> void EventParameters::extractParameters(podio::Frame& frame)   {
       for(auto const& p: this->intParameters()) {
-	std::cout << "Saving event parameter: " << p.first << std::endl;
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
         frame.putParameter(p.first, p.second);
       }
       for(auto const& p: this->fltParameters()) {
-	std::cout << "Saving event parameter: " << p.first << std::endl;
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
         frame.putParameter(p.first, p.second);
       }
       for(auto const& p: this->strParameters()) {
-	std::cout << "Saving event parameter: " << p.first << std::endl;
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
+        frame.putParameter(p.first, p.second);
+      }
+      for (auto const& p: this->dblParameters()) {
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
         frame.putParameter(p.first, p.second);
       }
     }
@@ -368,11 +372,13 @@ void Geant4Output2EDM4hep::saveEvent(OutputContext<G4Event>& ctxt)  {
   int runNumber(0), eventNumber(0);
   const int eventNumberOffset(m_eventNumberOffset > 0 ? m_eventNumberOffset : 0);
   const int runNumberOffset(m_runNumberOffset > 0 ? m_runNumberOffset : 0);
+  double eventWeight{0};
   // Get event number, run number and parameters from extension ...
   if ( parameters ) {
     runNumber = parameters->runNumber() + runNumberOffset;
     eventNumber = parameters->eventNumber() + eventNumberOffset;
     parameters->extractParameters(m_frame);
+    eventWeight = m_frame.getParameter<double>("EventWeights");
   } else { // ... or from DD4hep framework
     runNumber = m_runNo + runNumberOffset;
     eventNumber = ctxt.context->GetEventID() + eventNumberOffset;
@@ -384,6 +390,7 @@ void Geant4Output2EDM4hep::saveEvent(OutputContext<G4Event>& ctxt)  {
   auto header = header_collection.create();
   header.setRunNumber(runNumber);
   header.setEventNumber(eventNumber);
+  header.setWeight(eventWeight);
   //not implemented in EDM4hep ?  header.setDetectorName(context()->detectorDescription().header().name());
   header.setTimeStamp( std::time(nullptr) ) ;
   m_frame.put( std::move(header_collection), "EventHeader");

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -23,6 +23,7 @@
 /// podio include files
 #include <podio/Frame.h>
 #include <podio/ROOTFrameWriter.h>
+#include <podio/podioVersion.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -107,10 +108,13 @@ namespace dd4hep {
         printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
         frame.putParameter(p.first, p.second);
       }
+#if podio_VERSION_MAJOR > 0 || podio_VERSION_MINOR > 16 || podio_VERSION_PATCH > 2
+      // This functionality is only present in podio > 0.16.2
       for (auto const& p: this->dblParameters()) {
         printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
         frame.putParameter(p.first, p.second);
       }
+#endif
     }
   }    // End namespace sim
 }      // End namespace dd4hep
@@ -378,7 +382,10 @@ void Geant4Output2EDM4hep::saveEvent(OutputContext<G4Event>& ctxt)  {
     runNumber = parameters->runNumber() + runNumberOffset;
     eventNumber = parameters->eventNumber() + eventNumberOffset;
     parameters->extractParameters(m_frame);
+#if podio_VERSION_MAJOR > 0 || podio_VERSION_MINOR > 16 || podio_VERSION_PATCH > 2
+    // This functionality is only present in podio > 0.16.2
     eventWeight = m_frame.getParameter<double>("EventWeights");
+#endif
   } else { // ... or from DD4hep framework
     runNumber = m_runNo + runNumberOffset;
     eventNumber = ctxt.context->GetEventID() + eventNumberOffset;

--- a/DDG4/hepmc/HepMC3FileReader.cpp
+++ b/DDG4/hepmc/HepMC3FileReader.cpp
@@ -45,19 +45,28 @@ namespace dd4hep  {
           if(attr.second.size() > 1 or inAttr.first != 0){
             strstr << "_" << inAttr.first;
           }
-          auto attr_as_int = std::dynamic_pointer_cast<HepMC3::IntAttribute>(inAttr.second);
-          auto attr_as_flt = std::dynamic_pointer_cast<HepMC3::FloatAttribute>(inAttr.second);
-          if(attr_as_int) {
-            m_intValues[strstr.str()] = {attr_as_int->value()};
-          } else if(attr_as_flt) {
-            m_fltValues[strstr.str()] = {attr_as_flt->value()};
+          if(auto int_attr = std::dynamic_pointer_cast<HepMC3::IntAttribute>(inAttr.second)) {
+            m_intValues[strstr.str()] = {int_attr->value()};
+          } else if(auto flt_attr = std::dynamic_pointer_cast<HepMC3::FloatAttribute>(inAttr.second)) {
+            m_fltValues[strstr.str()] = {flt_attr->value()};
+          } else if(auto dbl_attr = std::dynamic_pointer_cast<HepMC3::DoubleAttribute>(inAttr.second)) {
+            m_dblValues[strstr.str()] = {dbl_attr->value()};
           } else { // anything else
             m_strValues[strstr.str()] = {inAttr.second->unparsed_string()};
           }
         }
       }
-    }
 
+      if (const auto& weights = genEvent.weights(); !weights.empty()) {
+        m_dblValues["EventWeights"] = weights;
+      }
+      // Not using the GenEven::weight_names here because that checks for
+      // emptyness and throws in that case. We don't care if we get an empty
+      // vector at this point
+      if (genEvent.run_info() && !genEvent.run_info()->weight_names().empty()) {
+        m_strValues["EventWeightNames"] = genEvent.weight_names();
+      }
+    }
 
     /// Base class to read hepmc3 event files
     /**

--- a/DDG4/include/DDG4/EventParameters.h
+++ b/DDG4/include/DDG4/EventParameters.h
@@ -35,6 +35,7 @@ namespace dd4hep  {
       std::map<std::string, std::vector<int>>         m_intValues {};
       std::map<std::string, std::vector<float>>       m_fltValues {};
       std::map<std::string, std::vector<std::string>> m_strValues {};
+      std::map<std::string, std::vector<double>>      m_dblValues {};
 
     public:
       /// Initializing constructor
@@ -61,6 +62,8 @@ namespace dd4hep  {
       auto const& fltParameters() const { return m_fltValues; }
       /// Get the string event parameters
       auto const& strParameters() const { return m_strValues; }
+      /// Get the double event parameters
+      auto const& dblParameters() const { return m_dblValues; }
 
     };
 

--- a/DDG4/lcio/Geant4Output2LCIO.cpp
+++ b/DDG4/lcio/Geant4Output2LCIO.cpp
@@ -55,9 +55,11 @@ namespace dd4hep {
       for(auto const& ival: this->strParameters()) {
         lcparameters.setValues(ival.first, ival.second);
       }
+#if LCIO_VERSION_GE(2, 17)
       for(auto const& ival: this->dblParameters()) {
         lcparameters.setValues(ival.first, ival.second);
       }
+#endif
     }
 
 
@@ -380,7 +382,9 @@ void Geant4Output2LCIO::saveEvent(OutputContext<G4Event>& ctxt)  {
     runNumber = parameters->runNumber() + runNumberOffset;
     eventNumber = parameters->eventNumber() + eventNumberOffset;
     parameters->extractParameters(*e);
+#if LCIO_VERSION_GE(2, 17)
     eventWeight = e->getParameters().getDoubleVal("EventWeights");
+#endif
   } else {  // ... or from DD4hep framework
     runNumber = m_runNo + runNumberOffset;
     eventNumber = ctxt.context->GetEventID() + eventNumberOffset;

--- a/DDG4/lcio/Geant4Output2LCIO.cpp
+++ b/DDG4/lcio/Geant4Output2LCIO.cpp
@@ -55,6 +55,9 @@ namespace dd4hep {
       for(auto const& ival: this->strParameters()) {
         lcparameters.setValues(ival.first, ival.second);
       }
+      for(auto const& ival: this->dblParameters()) {
+        lcparameters.setValues(ival.first, ival.second);
+      }
     }
 
 
@@ -371,11 +374,13 @@ void Geant4Output2LCIO::saveEvent(OutputContext<G4Event>& ctxt)  {
   int runNumber(0), eventNumber(0);
   const int eventNumberOffset(m_eventNumberOffset > 0 ? m_eventNumberOffset : 0);
   const int runNumberOffset(m_runNumberOffset > 0 ? m_runNumberOffset : 0);
+  double eventWeight{0};
   // Get event number, run number and parameters from extension ...
   if (parameters) {
     runNumber = parameters->runNumber() + runNumberOffset;
     eventNumber = parameters->eventNumber() + eventNumberOffset;
     parameters->extractParameters(*e);
+    eventWeight = e->getParameters().getDoubleVal("EventWeights");
   } else {  // ... or from DD4hep framework
     runNumber = m_runNo + runNumberOffset;
     eventNumber = ctxt.context->GetEventID() + eventNumberOffset;
@@ -383,6 +388,7 @@ void Geant4Output2LCIO::saveEvent(OutputContext<G4Event>& ctxt)  {
   print("+++ Saving LCIO event %d run %d ....", eventNumber, runNumber);
   e->setRunNumber(runNumber);
   e->setEventNumber(eventNumber);
+  e->setWeight(eventWeight);
   e->setDetectorName(context()->detectorDescription().header().name());
   saveEventParameters<int>(e, m_eventParametersInt);
   saveEventParameters<float>(e, m_eventParametersFloat);


### PR DESCRIPTION

BEGINRELEASENOTES
- Propagate HepMC event weights to EDM4hep and LCIO outputs of ddsim
  - Store all available weights and their names into the Frame / Event parameters, additionally store the first weight into the `weight` field of the `edm4hep::EventHeader`, resp. the `LCEvent`.
- Add a possibility to store `double` values in `DDG4::EventParameters`

ENDRELEASENOTES

Fixes #988 
- [x] Needs AIDASoft/podio#372