### PR TITLE
Prevent a compact file from being loaded twice

### DIFF
--- a/DDCore/include/Parsers/detail/Conversions.h
+++ b/DDCore/include/Parsers/detail/Conversions.h
@@ -18,7 +18,7 @@
  *  Note: Do NEVER include this file directly!
  *
  *  Use the specific include files in the XML or JSON directory!
- *  Also NO header guards!
+ *
  */
 
 

--- a/DDCore/include/XML/UnicodeValues.h
+++ b/DDCore/include/XML/UnicodeValues.h
@@ -225,6 +225,7 @@ UNICODE (idspecref);
 UNICODE (ignore);
 UNICODE (include);
 UNICODE (includes);
+UNICODE (incguard);
 UNICODE (incoming_r);
 UNICODE (info);
 UNICODE (inner);


### PR DESCRIPTION
Draft attempt at preventing compact files from being loaded twice.
The issues are that:
- the set containing already the list of files already loaded is in an anonymous namespace, but its access is  not multithread safe.
- the path of the XML is just normalized, as the dd4hep::Path::full_path does not seem to return the full path, so we are sensitive to the way the path is passed 

BEGINRELEASENOTES

- Prevent a compact file from being loaded twice if the debug option "incguard" has been set.

ENDRELEASENOTES