### PR TITLE
Geant4Output2EDM4hep: fix "non-trivial type in variadic function

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -97,21 +97,21 @@ namespace dd4hep {
     
     template <> void EventParameters::extractParameters(podio::Frame& frame)   {
       for(auto const& p: this->intParameters()) {
-        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
         frame.putParameter(p.first, p.second);
       }
       for(auto const& p: this->fltParameters()) {
-        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
         frame.putParameter(p.first, p.second);
       }
       for(auto const& p: this->strParameters()) {
-        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
         frame.putParameter(p.first, p.second);
       }
 #if podio_VERSION_MAJOR > 0 || podio_VERSION_MINOR > 16 || podio_VERSION_PATCH > 2
       // This functionality is only present in podio > 0.16.2
       for (auto const& p: this->dblParameters()) {
-        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
+        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
         frame.putParameter(p.first, p.second);
       }
 #endif


### PR DESCRIPTION
```
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-01.25/src/DD4hep/01.25/DDG4/edm4hep/Geant4Output2EDM4hep.cpp:100:80: error: cannot pass object of non-trivial type 'const std::basic_string<char>' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
                                                                               ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-01.25/src/DD4hep/01.25/DDG4/edm4hep/Geant4Output2EDM4hep.cpp:104:80: error: cannot pass object of non-trivial type 'const std::basic_string<char>' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
                                                                               ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-01.25/src/DD4hep/01.25/DDG4/edm4hep/Geant4Output2EDM4hep.cpp:108:80: error: cannot pass object of non-trivial type 'const std::basic_string<char>' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
        printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first);
```


BEGINRELEASENOTES
* DDG4: fix -Wnon-pod-varargs in Geant4Output2EDM4hep, which fails on clang

ENDRELEASENOTES