### PR TITLE
feat: add energy deposition test for OpticalTracker example

### DIFF
--- a/examples/OpticalTracker/CMakeLists.txt
+++ b/examples/OpticalTracker/CMakeLists.txt
@@ -57,3 +57,13 @@ dd4hep_add_test_reg( OpticalTracker_number_of_hits
   REGEX_FAIL "TEST: failed"
   DEPENDS OpticalTracker_simulation
   )
+
+# ---Test: Energy deposition
+dd4hep_add_test_reg( OpticalTracker_energy_deposition
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_OpticalTracker.sh"
+  EXEC_ARGS  root.exe -b -x -n -q -l
+             "${OpticalTracker_INSTALL}/scripts/test_energy_deposition.C(\"${OpticalTracker_INSTALL}/sim.root\")"
+  REGEX_PASS "TEST: passed"
+  REGEX_FAIL "TEST: failed"
+  DEPENDS OpticalTracker_simulation
+  )

--- a/examples/OpticalTracker/scripts/test_energy_deposition.C
+++ b/examples/OpticalTracker/scripts/test_energy_deposition.C
@@ -1,22 +1,20 @@
-#include "CLHEP/Units/SystemOfUnits.h"
-
 void test_energy_deposition(TString sim_file_name="sim.root") {
 
   // test requirements
-  const Double_t min_edep = 2*CLHEP::eV;
-  const Double_t max_edep = 5*CLHEP::eV;
+  const Double_t min_edep = 2 /*eV*/;
+  const Double_t max_edep = 5 /*eV*/;
 
   // get average energy deposition
   auto sim_file = new TFile(sim_file_name);
   auto t = (TTree*) sim_file->Get("EVENT");
   auto h = new TH1D("h","energy deposition",100,-1,20);
   t->Project("h","PFRICHHits.energyDeposit");
-  auto ave_edep = h->GetMean();
+  auto ave_edep = h->GetMean() * 1e6; // convert from MeV to eV
 
   // check if the average energy deposition is within expected range
   bool pass_test = ave_edep > min_edep && ave_edep < max_edep;
   std::cout << "TEST: " << (pass_test ? "passed" : "failed")
-    << " with average energy deposition = " << ave_edep/CLHEP::eV << " eV"
-    << " (expected in range (" << min_edep/CLHEP::eV << "," << max_edep/CLHEP::eV << ") eV)"
-    << std::endl;
+            << " with average energy deposition = " << ave_edep << " eV"
+            << " (expected in range (" << min_edep << "," << max_edep << ") eV)"
+            << std::endl;
 }

--- a/examples/OpticalTracker/scripts/test_energy_deposition.C
+++ b/examples/OpticalTracker/scripts/test_energy_deposition.C
@@ -1,0 +1,22 @@
+#include "CLHEP/Units/SystemOfUnits.h"
+
+void test_energy_deposition(TString sim_file_name="sim.root") {
+
+  // test requirements
+  const Double_t min_edep = 2*CLHEP::eV;
+  const Double_t max_edep = 5*CLHEP::eV;
+
+  // get average energy deposition
+  auto sim_file = new TFile(sim_file_name);
+  auto t = (TTree*) sim_file->Get("EVENT");
+  auto h = new TH1D("h","energy deposition",100,-1,20);
+  t->Project("h","PFRICHHits.energyDeposit");
+  auto ave_edep = h->GetMean();
+
+  // check if the average energy deposition is within expected range
+  bool pass_test = ave_edep > min_edep && ave_edep < max_edep;
+  std::cout << "TEST: " << (pass_test ? "passed" : "failed")
+    << " with average energy deposition = " << ave_edep/CLHEP::eV << " eV"
+    << " (expected in range (" << min_edep/CLHEP::eV << "," << max_edep/CLHEP::eV << ") eV)"
+    << std::endl;
+}


### PR DESCRIPTION
BEGINRELEASENOTES
- Add test for average energy deposition in `OpticalTracker` example, for `Geant4SensitiveAction<Geant4OpticalTracker>`

ENDRELEASENOTES