### PR TITLE
fix: fill energy deposition for `Geant4OpticalTracker`

### DIFF
--- a/DDG4/plugins/Geant4SDActions.cpp
+++ b/DDG4/plugins/Geant4SDActions.cpp
@@ -171,7 +171,9 @@ namespace dd4hep {
       double    hit_len   = direction.R();
       
       Hit* hit = new Hit(h.trkID(), h.trkPdgID(), h.deposit(), tim, hit_len, pos, mom);
-      hit->cellID = cellID(step);
+      hit->truth         = Hit::extractContribution(step);
+      hit->energyDeposit = hit->truth.deposit;
+      hit->cellID        = cellID(step);
       if (track->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()) {
         track->SetTrackStatus(fStopAndKill);
       }


### PR DESCRIPTION
Fix #1067

I'm not sure if this is the correct way to fix this, but it does restore the energy deposition distribution for the `OpticalTracker` example. In particular:
- does `hit->truth` need to be filled too?
- `step->GetTotalEnergyDeposit()` in the `print` statement is still always zero (but `hit->energyDeposit` looks correct)

BEGINRELEASENOTES
- fix: fill energy deposition for `Geant4SensitiveAction<Geant4OpticalTracker>`

ENDRELEASENOTES