### PR TITLE
Multiple commits. Please see release notes.

### DIFF
--- a/DDCore/include/DD4hep/DetectorData.h
+++ b/DDCore/include/DD4hep/DetectorData.h
@@ -58,9 +58,14 @@ namespace dd4hep {
      */
     class ObjectHandleMap: public Detector::HandleMap {
     public:
+      /// Name the map
+      std::string name;
+    public:
       /// Default constructor
-      ObjectHandleMap() {
-      }
+      ObjectHandleMap() = default;
+      /// Initializing constructor
+      ObjectHandleMap(const std::string& name);
+      /// Append entry to map
       void append(const Handle<NamedObject>& e, bool throw_on_doubles = true) {
         if (e.isValid()) {
           std::string n = e.name();
@@ -77,7 +82,7 @@ namespace dd4hep {
         }
         throw InvalidObjectError("Attempt to add an invalid object.");
       }
-
+      /// Append entry to map
       template <typename T> void append(const Handle<NamedObject>& e, bool throw_on_doubles = true) {
         T* obj = dynamic_cast<T*>(e.ptr());
         if (obj) {
@@ -145,6 +150,8 @@ namespace dd4hep {
     DetectorData();
     /// Default destructor
     virtual ~DetectorData();
+    /// Move constructor
+    DetectorData(DetectorData&& copy) = delete;
     /// Copy constructor
     DetectorData(const DetectorData& copy) = delete;
     /// Assignment operator
@@ -206,5 +213,10 @@ namespace dd4hep {
     const Detector::HandleMap& idSpecifications() const   {    return m_idDict;           }
   };
 
+  /// Initializing constructor
+  inline DetectorData::ObjectHandleMap::ObjectHandleMap(const std::string& nam)
+    : name(nam)
+  {
+  }
 }         /* End namespace dd4hep         */
 #endif // DD4HEP_DETECTORDATA_H

--- a/DDCore/include/DD4hep/Factories.h
+++ b/DDCore/include/DD4hep/Factories.h
@@ -317,6 +317,11 @@ namespace {
     template <> long XMLDocumentReaderFactory<xml_document_##name>::create(dd4hep::Detector& l,ns::xml_h e) {return func(l,e);} \
     DD4HEP_PLUGINSVC_FACTORY(xml_document_##name,name##_XML_reader,long(dd4hep::Detector*,ns::xml_h*),__LINE__)  }
 
+// Call function of the type [long (*func)(dd4hep::Detector& description, xml_h handle)]
+#define DECLARE_XML_PLUGIN(name,func)  DD4HEP_OPEN_PLUGIN(dd4hep,xml_document_##name)  { \
+    template <> long XMLDocumentReaderFactory<xml_document_##name>::create(dd4hep::Detector& l,ns::xml_h e) {return func(l,e);} \
+    DD4HEP_PLUGINSVC_FACTORY(xml_document_##name,name,long(dd4hep::Detector*,ns::xml_h*),__LINE__)  }
+
 // Call function of the type [NamedObject* (*func)(dd4hep::Detector& description, xml_h handle, ref_t reference)]
 #define DECLARE_XML_PROCESSOR_BASIC(name,func,deprecated)  DD4HEP_OPEN_PLUGIN(dd4hep,det_element_##name) {\
     template <> Ref_t XmlDetElementFactory< det_element_##name >::create(dd4hep::Detector& l,ns::xml_h e,ns::ref_t h) \

--- a/DDCore/include/DD4hep/GeoHandler.h
+++ b/DDCore/include/DD4hep/GeoHandler.h
@@ -48,17 +48,6 @@ namespace dd4hep {
      */
     class GeoHandlerTypes {
     public:
-#if 0
-      typedef std::set<const TGeoVolume*> ConstVolumeSet;
-      typedef std::map<SensitiveDetector, ConstVolumeSet> SensitiveVolumes;
-      typedef std::map<Region,   ConstVolumeSet>          RegionVolumes;
-      typedef std::map<LimitSet, ConstVolumeSet>          LimitVolumes;
-      typedef std::map<int, std::set<const TGeoNode*> >   Data;
-      typedef std::set<SensitiveDetector>                 SensitiveDetectorSet;
-      typedef std::set<Region>                            RegionSet;
-      typedef std::set<LimitSet>                          LimitSetSet;
-      typedef std::set<TNamed*>                           ObjectSet;
-#endif
       /// Data container to store information obtained during the geometry scan
       /**
        *  \author  M.Frank
@@ -101,6 +90,8 @@ namespace dd4hep {
       GeoHandler& i_collect(const TGeoNode* parent,
 			    const TGeoNode* node,
 			    int level, Region rg, LimitSet ls);
+      /// Assemble summary of the current node
+      void i_collect_node(const TGeoNode* node, GeometryInfo& info);
 
     private:
       /// Never call Copy constructor

--- a/DDCore/include/DD4hep/GeoHandler.h
+++ b/DDCore/include/DD4hep/GeoHandler.h
@@ -48,6 +48,17 @@ namespace dd4hep {
      */
     class GeoHandlerTypes {
     public:
+#if 0
+      typedef std::set<const TGeoVolume*> ConstVolumeSet;
+      typedef std::map<SensitiveDetector, ConstVolumeSet> SensitiveVolumes;
+      typedef std::map<Region,   ConstVolumeSet>          RegionVolumes;
+      typedef std::map<LimitSet, ConstVolumeSet>          LimitVolumes;
+      typedef std::map<int, std::set<const TGeoNode*> >   Data;
+      typedef std::set<SensitiveDetector>                 SensitiveDetectorSet;
+      typedef std::set<Region>                            RegionSet;
+      typedef std::set<LimitSet>                          LimitSetSet;
+      typedef std::set<TNamed*>                           ObjectSet;
+#endif
       /// Data container to store information obtained during the geometry scan
       /**
        *  \author  M.Frank
@@ -90,8 +101,6 @@ namespace dd4hep {
       GeoHandler& i_collect(const TGeoNode* parent,
 			    const TGeoNode* node,
 			    int level, Region rg, LimitSet ls);
-      /// Assemble summary of the current node
-      void i_collect_node(const TGeoNode* node, GeometryInfo& info);
 
     private:
       /// Never call Copy constructor

--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -264,6 +264,8 @@ namespace dd4hep {
 
     /// Check if placement is properly instrumented
     Object* data() const;
+    /// Access the object type from the class information
+    const char* type() const;
     /// Access the copy number of this placement within its mother
     int copyNumber() const;
     /// Volume material
@@ -272,6 +274,10 @@ namespace dd4hep {
     Volume volume() const;
     /// Parent volume (envelope)
     Volume motherVol() const;
+    /// Number of daughters placed in this volume
+    std::size_t num_daughters()  const;
+    /// Access the daughter by index
+    PlacedVolume daughter(std::size_t which)  const;
     /// Access the full transformation matrix to the parent volume
     const TGeoMatrix& matrix()  const;
     /// Access the translation vector to the parent volume
@@ -426,6 +432,9 @@ namespace dd4hep {
     
     /// Check if placement is properly instrumented
     Object* data() const;
+
+    /// Access the object type from the class information
+    const char* type() const;
 
     /// Create a reflected volume tree. The reflected volume has left-handed coordinates
     Volume reflect()  const;
@@ -634,7 +643,7 @@ namespace dd4hep {
     
     /// Test if this volume is an assembly structure
     bool isAssembly()   const;
-    
+
     /// Set the volume's option value
     const Volume& setOption(const std::string& opt) const;
     /// Access the volume's option value

--- a/DDCore/include/Parsers/detail/Dimension.h
+++ b/DDCore/include/Parsers/detail/Dimension.h
@@ -724,16 +724,26 @@ namespace dd4hep {
 
       /// Access "name" attribute as STL string
       std::string nameStr() const;
-      /// Access "ref" attribute as a string
-      std::string refStr() const;
+      /// Access "name" attribute as STL string. Return default value if not present
+      std::string nameStr(const std::string& default_value) const;
       /// Access "type" attribute as STL string
       std::string typeStr() const;
+      /// Access "type" attribute as STL string. Return default value if not present
+      std::string typeStr(const std::string& default_value) const;
       /// Access "value" attribute as STL string
       std::string valueStr() const;
+      /// Access "value" attribute as STL string. Return default value if not present
+      std::string valueStr(const std::string& default_value) const;
       /// Access "label" attribute as STL string
       std::string labelStr() const;
+      /// Access "label" attribute as STL string. Return default value if not present
+      std::string labelStr(const std::string& default_value) const;
       /// Access "symbol" attribute as STL string
       std::string symbolStr() const;
+      /// Access "symbol" attribute as STL string. Return default value if not present
+      std::string symbolStr(const std::string& default_value) const;
+      /// Access "ref" attribute as a string
+      std::string refStr() const;
       /// Access "module" attribute as STL string
       std::string moduleStr() const;
       /// Access "readout" attribute as STL string

--- a/DDCore/include/Parsers/detail/Dimension.imp
+++ b/DDCore/include/Parsers/detail/Dimension.imp
@@ -240,20 +240,26 @@ XML_CHILD_ACCESSOR_XML_DIM(beampipe)
 XML_CHILD_ACCESSOR_XML_DIM(shape)
 XML_CHILD_ACCESSOR_XML_DIM(solid)
 
-std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::padType() const {
-  return m_element.attr < std::string > (_U(pads));
-}
-
+/// Access "name" attribute as STL std::string
 std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::nameStr() const {
   return m_element.attr < std::string > (_U(name));
 }
 
-std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::refStr() const {
-  return m_element.attr < std::string > (_U(ref));
+/// Access "name" attribute as STL std::string. Return default value if not present
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::nameStr(const std::string& default_value) const {
+  Attribute attr = m_element.attr_nothrow(_U(name));
+  return attr ? m_element.attr < std::string >(attr) : default_value;
 }
 
+/// Access "type" attribute as STL std::string
 std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::typeStr() const {
   return m_element.attr < std::string > (_U(type));
+}
+
+/// Access "type" attribute as STL std::string. Return default value if not present
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::typeStr(const std::string& default_value) const {
+  Attribute attr = m_element.attr_nothrow(_U(type));
+  return attr ? m_element.attr < std::string >(attr) : default_value;
 }
 
 /// Access "value" attribute as STL std::string
@@ -261,14 +267,42 @@ std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::valueStr() const   {
   return m_element.attr < std::string > (_U(value));
 }
 
+/// Access "value" attribute as STL std::string. Return default value if not present
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::valueStr(const std::string& default_value) const   {
+  Attribute attr = m_element.attr_nothrow(_U(value));
+  return attr ? m_element.attr < std::string >(attr) : default_value;
+}
+
 /// Access "label" attribute as STL std::string
 std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::labelStr() const   {
   return m_element.attr < std::string > (_U(label));
 }
 
+/// Access "label" attribute as STL std::string. Return default value if not present
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::labelStr(const std::string& default_value) const   {
+  Attribute attr = m_element.attr_nothrow(_U(label));
+  return attr ? m_element.attr < std::string >(attr) : default_value;
+}
+
 /// Access "symbol" attribute as STL std::string
 std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::symbolStr() const   {
   return m_element.attr < std::string > (_U(symbol));
+}
+
+/// Access "symbol" attribute as STL std::string. Return default value if not present
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::symbolStr(const std::string& default_value) const   {
+  Attribute attr = m_element.attr_nothrow(_U(symbol));
+  return attr ? m_element.attr < std::string >(attr) : default_value;
+}
+
+/// Access "padType" attribute as STL std::string
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::padType() const {
+  return m_element.attr < std::string > (_U(pads));
+}
+
+/// Access "ref" attribute as STL std::string
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::refStr() const {
+  return m_element.attr < std::string > (_U(ref));
 }
 
 /// Access "region" attribute as STL std::string. If not present returns empty string.

--- a/DDCore/include/XML/UnicodeValues.h
+++ b/DDCore/include/XML/UnicodeValues.h
@@ -380,6 +380,7 @@ UNICODE (positionRPhiZ);
 UNICODE (pressure);
 UNICODE (projective_cylinder);
 UNICODE (projective_zplane);
+UNICODE (propagate);
 UNICODE (property);
 UNICODE (properties);
 UNICODE (psi);

--- a/DDCore/include/XML/Utilities.h
+++ b/DDCore/include/XML/Utilities.h
@@ -84,6 +84,60 @@ namespace dd4hep {
      *  @author F.Gaede, DESY
      */
     void setDetectorTypeFlag( dd4hep::xml::Handle_t e, dd4hep::DetElement sdet ) ; 
+
+    /// Configure volume properties from XML element
+    /**
+     *   Example:
+     *      <volume>
+     *         <regionref   name="world_region"/>
+     *         <limitsetref name="world_limits"/>
+     *         <visref      name="world_vis"/>
+     *      </volume>
+     *    
+     *      with
+     *      dd4hep::Detector&          detector:  Handle to dd4hep Detector instance
+     *      dd4hep::xml::Handle_t      element:   XML element <volume>
+     *      dd4hep::Volume             volume:    the volume to be configured.
+     *      bool                       propagate: apply setting also to all children
+     *      bool                       ignore_unknown_attr: Ignore unknown attrs
+     *
+     *   \return Number of properties changed
+     *
+     *   \author  M.Frank
+     *   \version 1.0
+     *   \date    03.03.23
+     */
+    std::size_t configVolume( dd4hep::Detector& detector,
+			      dd4hep::xml::Handle_t element,
+			      dd4hep::Volume volume,
+			      bool propagate,
+			      bool ignore_unknown_attr = false);
+
+    /// Configure sensitive detector from XML element
+    /**
+     *   Example:
+     *   <some-xml-tag debug="true">
+     *      <combine_hits    value="true"/>
+     *      <verbose         value="true"/>
+     *      <type            value="tracker"/>
+     *      <ecut            value="5*keV"/>
+     *      <hits_collection value="hits_collection_5"/>
+     *    </some-xml-tag>
+     *    
+     *    - The debug flag is optional.
+     *    - Not all child nodes are mandatory.
+     *      If not present, the attribute stays unchanged.
+     *
+     *   \return Number of properties changed
+     *
+     *   \author  M.Frank
+     *   \version 1.0
+     *   \date    03.03.23
+     */
+    std::size_t configSensitiveDetector( dd4hep::Detector& detector,
+					 dd4hep::SensitiveDetector sensitive,
+					 dd4hep::xml::Handle_t element);
+
   }       /* End namespace xml              */
 }         /* End namespace dd4hep           */
 #endif // XML_UTILITIES_H

--- a/DDCore/include/XML/XMLElements.h
+++ b/DDCore/include/XML/XMLElements.h
@@ -565,6 +565,11 @@ namespace dd4hep {
       return _toString(attr_value(tag_value));
     }
 
+    template <> INLINE Attribute Handle_t::attr<Attribute>(const XmlChar* tag_value, Attribute default_value) const {
+      Attribute a = attr_nothrow(tag_value);
+      return a ? a : default_value;
+    }
+
     template <> INLINE bool Handle_t::attr<bool>(const XmlChar* tag_value, bool default_value) const {
       Attribute a = attr_nothrow(tag_value);
       return a ? _toBool(attr_value(a)) : default_value;

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -636,12 +636,21 @@ Handle<NamedObject> DetectorImp::getRefChild(const HandleMap& e, const string& n
     return (*i).second;
   }
   if (do_throw) {
+    union ptr {
+      const ObjectHandleMap* omap;
+      const char* c;
+      const void* other;
+      ptr(const void* p) { other = p; }
+    };
     int cnt = 0;
-    cout << "GetRefChild: Failed to find child with name: " << name
-         << " Map contains " << e.size() << " elements." << endl;
+    std::string nam = "";
+    ptr m(&e), ref(this);
+    if ( ref.c > m.c && m.c < ref.c+sizeof(*this) ) nam = m.omap->name;
+    cout << "GetRefChild: Failed to find child with name: '" << name
+	 << "'. Map " << nam << " contains " << e.size() << " elements." << endl;
     for(i=e.begin(); i!=e.end(); ++i)
       cout << "   " << cnt << "  " << (*i).first << endl;
-    throw runtime_error("Cannot find a child with the reference name:" + name);
+    throw runtime_error(nam+": Cannot find a child with the reference name:" + name);
   }
   return 0;
 }

--- a/DDCore/src/GeoHandler.cpp
+++ b/DDCore/src/GeoHandler.cpp
@@ -87,48 +87,39 @@ GeoHandler& GeoHandler::collect(DetElement element) {
   return i_collect(par_node, element.placement().ptr(), 0, Region(), LimitSet());
 }
 
-/// Assemble summary of the current node
-void GeoHandler::i_collect_node(const TGeoNode* n, GeometryInfo& info)   {
-  TGeoVolume* v = n->GetVolume();
-  if (v) {
-    Material mat(v->GetMedium());
-    Volume   vol(v);
-    // Note : assemblies and the world do not have a real volume nor a material
-    if (info.volumeSet.find(vol) == info.volumeSet.end()) {
-      info.volumeSet.emplace(vol);
-      info.volumes.emplace_back(vol);
-    }
-    if ( mat.isValid() )
-      info.materials.emplace(mat);
-    if (dynamic_cast<Volume::Object*>(v)) {
-      VisAttr vis = vol.visAttributes();
-      //Region      reg = vol.region();
-      //LimitSet    lim = vol.limitSet();
-      //SensitiveDetector det = vol.sensitiveDetector();
-
-      if (vis.isValid())
-	info.vis.emplace(vis);
-      //if ( lim.isValid() ) info.limits[lim.ptr()].emplace(v);
-      //if ( reg.isValid() ) info.regions[reg.ptr()].emplace(v);
-      //if ( det.isValid() ) info.sensitives[det.ptr()].emplace(v);
-    }
-    collectSolid(info, v->GetName(), n->GetName(), v->GetShape(), n->GetMatrix());
-  }
-}
-
 GeoHandler& GeoHandler::collect(DetElement element, GeometryInfo& info) {
-
-  DetElement     par = element.parent();
-  TGeoNode*    place = element.placement().ptr();
+  DetElement par = element.parent();
   TGeoNode* par_node = par.isValid() ? par.placement().ptr() : nullptr;
-
   m_data->clear();
-  i_collect_node(place, info);
-  i_collect(par_node, place, 0, Region(), LimitSet());
+  i_collect(par_node, element.placement().ptr(), 0, Region(), LimitSet());
   for (auto i = m_data->rbegin(); i != m_data->rend(); ++i) {
     const auto& mapped = (*i).second;
     for (const TGeoNode* n : mapped )  {
-      i_collect_node(n, info);
+      TGeoVolume* v = n->GetVolume();
+      if (v) {
+        Material mat(v->GetMedium());
+        Volume   vol(v);
+        // Note : assemblies and the world do not have a real volume nor a material
+        if (info.volumeSet.find(vol) == info.volumeSet.end()) {
+          info.volumeSet.emplace(vol);
+          info.volumes.emplace_back(vol);
+        }
+        if ( mat.isValid() )
+          info.materials.emplace(mat);
+        if (dynamic_cast<Volume::Object*>(v)) {
+          VisAttr vis = vol.visAttributes();
+          //Region      reg = vol.region();
+          //LimitSet    lim = vol.limitSet();
+          //SensitiveDetector det = vol.sensitiveDetector();
+
+          if (vis.isValid())
+            info.vis.emplace(vis);
+          //if ( lim.isValid() ) info.limits[lim.ptr()].emplace(v);
+          //if ( reg.isValid() ) info.regions[reg.ptr()].emplace(v);
+          //if ( det.isValid() ) info.sensitives[det.ptr()].emplace(v);
+        }
+        collectSolid(info, v->GetName(), n->GetName(), v->GetShape(), n->GetMatrix());
+      }
     }
   }
   return *this;

--- a/DDCore/src/Volumes.cpp
+++ b/DDCore/src/Volumes.cpp
@@ -436,6 +436,11 @@ PlacedVolume::Object* PlacedVolume::data() const   {
   return o;
 }
 
+/// Access the object type from the class information
+const char* PlacedVolume::type() const   {
+  return m_element ? m_element->IsA()->GetName() : "UNKNOWN-PlacedVolume";
+}
+
 /// Access the copy number of this placement within its mother
 int PlacedVolume::copyNumber() const   {
   return m_element ? m_element->GetNumber() : -1;
@@ -454,6 +459,24 @@ Volume PlacedVolume::volume() const {
 /// Parent volume (envelope)
 Volume PlacedVolume::motherVol() const {
   return Volume(m_element ? m_element->GetMotherVolume() : 0);
+}
+
+/// Number of daughters placed in this volume
+std::size_t PlacedVolume::num_daughters()  const   {
+  return m_element ? m_element->GetNdaughters() : 0;
+}
+
+/// Access the daughter by index
+PlacedVolume PlacedVolume::daughter(std::size_t which)  const   {
+  if ( m_element )  {
+    if ( which < (std::size_t)m_element->GetNdaughters() )   {
+      return m_element->GetDaughter(which);
+    }
+    except("Volume","+++ Access daughter %ld of %s [Has only %d daughters]",
+	   which, m_element->GetName(), m_element->GetNdaughters());
+  }
+  except("Volume","+++ Cannot access daughters of a non-existing volume!");
+  return nullptr;
 }
 
 /// Access to the volume IDs
@@ -621,6 +644,11 @@ void Volume::enableCopyNumberCheck(bool value)    {
 Volume::Object* Volume::data() const   {
   Volume::Object* o = _userExtension(*this);
   return o;
+}
+
+/// Access the object type from the class information
+const char* Volume::type() const   {
+  return m_element ? m_element->IsA()->GetName() : "UNKNOWN-Volume";
 }
 
 /// Create a reflected volume tree. The reflected volume has left-handed coordinates

--- a/DDCore/src/plugins/DetElementConfig.cpp
+++ b/DDCore/src/plugins/DetElementConfig.cpp
@@ -1,0 +1,75 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+//
+// Framework includes
+#include <DD4hep/DetFactoryHelper.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Plugins.h>
+#include <XML/DocumentHandler.h>
+#include <XML/Utilities.h>
+
+// C/C++ include files
+#include <climits>
+
+/// Do not clutter global namespace
+namespace  {
+
+  using namespace dd4hep;
+
+  /// Call to add configuration a posteriori to a generic DetElement structure
+  /** Plugins to modify DetElement structures after creation.
+   *  - Delegate to XML Utilities
+   *  
+   *  \author M.Frank
+   *  \date   03.03.2023
+   */
+  long configure_detelement(Detector& detector, xml_h e)   {
+    xml_comp_t  x_det = e;
+    std::string path  = x_det.attr<std::string>(_U(path));
+    DetElement  det   = detail::tools::findElement(detector, path.c_str());
+    if ( det.isValid() )    {
+      std::size_t count = 0;
+      bool propagate = det == detector.world() ? false: x_det.attr<bool>(_U(propagate), false);
+      if ( xml_dim_t x_vol = x_det.child(_U(volume), false) )   {
+	count += xml::configVolume(detector, x_vol, det.volume(), propagate, false);
+      }
+      PrintLevel lvl = x_det.attr<xml::Attribute>(_U(debug), nullptr) ? ALWAYS : DEBUG;
+      printout(lvl, "DetElementConfig", "++ Applied %ld settings to %s", count, path.c_str());
+      return 1;
+    }
+    except("DetElementConfig","FAILED: No valid DetElement. Configuration could not be applied!");
+    return 0;
+  }
+  
+  /// Call to add a posteriori configuration to a generic DetElement structure
+  /** Plugins to modify Sensitive detector structures after creation.
+   *  - Delegate to XML Utilities
+   *  
+   *  \author M.Frank
+   *  \date   03.03.2023
+   */
+  long configure_sensitive(Detector& detector, xml_h e)   {
+    xml_comp_t c = e;
+    std::string name  = c.attr<std::string>(_U(detector));
+    std::size_t count = xml::configSensitiveDetector(detector, detector.sensitiveDetector(name), e);
+    PrintLevel  lvl   = c.attr<xml::Attribute>(_U(debug), nullptr) ? ALWAYS : DEBUG;
+    printout(lvl, "SensDetConfig", "++ Applied %ld settings to %s", count, name.c_str());
+    return 1;
+  }
+  
+}  // End namespace dd4hep
+/// Instantiate factory
+DECLARE_XML_PLUGIN(DD4hep_DetElementConfig, configure_detelement);
+/// Instantiate factory
+DECLARE_XML_PLUGIN(DD4hep_SensitiveDetectorConfig, configure_sensitive);

--- a/DDCore/src/plugins/DetElementConfig.cpp
+++ b/DDCore/src/plugins/DetElementConfig.cpp
@@ -70,6 +70,6 @@ namespace  {
   
 }  // End namespace dd4hep
 /// Instantiate factory
-DECLARE_XML_PLUGIN(DD4hep_DetElementConfig, configure_detelement);
+DECLARE_XML_PLUGIN(DD4hep_DetElementConfig, configure_detelement)
 /// Instantiate factory
-DECLARE_XML_PLUGIN(DD4hep_SensitiveDetectorConfig, configure_sensitive);
+DECLARE_XML_PLUGIN(DD4hep_SensitiveDetectorConfig, configure_sensitive)

--- a/DDG4/include/DDG4/Geant4Converter.h
+++ b/DDG4/include/DDG4/Geant4Converter.h
@@ -45,6 +45,8 @@ namespace dd4hep {
       bool debugReflections = false;
       /// Property: Flag to debug regions during conversion mechanism
       bool debugRegions     = false;
+      /// Property: Flag to debug LimitSets during conversion mechanism
+      bool debugLimits      = false;
       /// Property: Flag to debug surfaces during conversion mechanism
       bool debugSurfaces    = false;
 

--- a/DDG4/include/DDG4/Geant4UserLimits.h
+++ b/DDG4/include/DDG4/Geant4UserLimits.h
@@ -72,9 +72,11 @@ namespace dd4hep {
 
     public:
       /// Initializing Constructor
-      Geant4UserLimits(LimitSet ls);
+      Geant4UserLimits(LimitSet limitset);
       /// Standard destructor
       virtual ~Geant4UserLimits();
+      /// Update the object
+      virtual void update(LimitSet limitset);
       /// Access the user tracklength for a G4 track object
       virtual G4double GetMaxAllowedStep(const G4Track& track)
       {  return maxStepLength.value(track);    }

--- a/DDG4/plugins/Geant4DetectorGeometryConstruction.cpp
+++ b/DDG4/plugins/Geant4DetectorGeometryConstruction.cpp
@@ -48,6 +48,8 @@ namespace dd4hep {
       bool m_debugReflections       = false;
       /// Property: Flag to debug regions during conversion mechanism
       bool m_debugRegions           = false;
+      /// Property: Flag to debug limit sets during conversion mechanism
+      bool m_debugLimits            = false;
       /// Property: Flag to debug regions during conversion mechanism
       bool m_debugSurfaces          = false;
 
@@ -140,6 +142,7 @@ Geant4DetectorGeometryConstruction::Geant4DetectorGeometryConstruction(Geant4Con
   declareProperty("DebugPlacements",   m_debugPlacements);
   declareProperty("DebugReflections",  m_debugReflections);
   declareProperty("DebugRegions",      m_debugRegions);
+  declareProperty("DebugLimits",       m_debugLimits);
   declareProperty("DebugSurfaces",     m_debugSurfaces);
 
   declareProperty("PrintPlacements",   m_printPlacements);

--- a/UtilityApps/src/run_plugin.h
+++ b/UtilityApps/src/run_plugin.h
@@ -223,7 +223,7 @@ namespace {
 	result = run_plugin(description, name, a.first, a.second);
 	return result;
       }
-      std::cout << "WARNING: No plugin name supplied. "
+      std::cout << "WARNING: run_plugin: No plugin name supplied. "
 		<< "Implicitly assuming execution steered by XML." << std::endl;
       return ENOENT;
     }

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -322,7 +322,8 @@ endforeach()
 # IronCylinder has no segmentation!
 # MaterialTester no geometry
 # SectorBarrelCalorimeter is bad
-foreach (test Assemblies BoxTrafos CaloEndcapReflection LheD_tracker MagnetFields MiniTel SiliconBlock 
+foreach (test Assemblies BoxTrafos CaloEndcapReflection
+	 LheD_tracker MagnetFields MiniTel SiliconBlock 
 	 ParamVolume1D ParamVolume2D ParamVolume3D
          NestedSimple NestedDetectors MultiCollections )
   #
@@ -336,8 +337,9 @@ foreach (test Assemblies BoxTrafos CaloEndcapReflection LheD_tracker MagnetField
   if (DD4HEP_USE_GEANT4)
     dd4hep_add_test_reg( ClientTests_g4material_scan_${test}_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-      EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4MaterialScan --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
-                        "--position=0,0,0" "--direction=0,1,0"
+      EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4MaterialScan
+      		  --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
+                 "--position=0,0,0" "--direction=0,1,0"
       REGEX_PASS " Terminate Geant4 and delete associated actions." )
   endif(DD4HEP_USE_GEANT4)
 endforeach()
@@ -357,14 +359,16 @@ foreach (test BoxTrafos CaloEndcapReflection IronCylinder MiniTel SiliconBlock N
   # ROOT Geometry checks
   dd4hep_add_test_reg( ClientTests_check_geometry_${test}_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/checkGeometry --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
-                      --full=true --ntracks=10
+    EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/checkGeometry
+    	        --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
+                --full=true --ntracks=10
     REGEX_PASS " Execution finished..." )
   #
   # ROOT Geometry overlap checks
   dd4hep_add_test_reg( ClientTests_check_overlaps_${test}_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/checkOverlaps --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
+    EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/checkOverlaps
+    	        --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
                       --tolerance=0.1
     REGEX_PASS " Execution finished..." )
 endforeach()
@@ -373,7 +377,8 @@ endforeach()
 # Checksum test of the Minitel3 sub-detector
 dd4hep_add_test_reg( MiniTel_check_checksum_Minitel3
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/MiniTelGenerate.xml -plugin DD4hepDetectorChecksum -readout -detector Minitel3
+  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/MiniTelGenerate.xml
+  	      -plugin DD4hepDetectorChecksum -readout -detector Minitel3
   REGEX_PASS "Combined hash code                      36773df7c4d6cf2b  \\(52 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
@@ -381,25 +386,42 @@ dd4hep_add_test_reg( MiniTel_check_checksum_Minitel3
 # Checksum test of the full detector
 dd4hep_add_test_reg( MiniTel_check_checksum_full
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
-  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/MiniTelGenerate.xml -plugin DD4hepDetectorChecksum -readout
+  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/MiniTelGenerate.xml
+  	      -plugin DD4hepDetectorChecksum -readout
   REGEX_PASS "Combined hash code                      99b55eb7a563d587  \\(201 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
 # Test the sequential processing of two xml files
-dd4hep_add_test_reg( include_plugins_command_line
+dd4hep_add_test_reg( minitel_config_plugins_include_command_line
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/MiniTel.xml 
        	     		  -input ${ClientTestsEx_INSTALL}/compact/ExamplePlugins.xml
-  REGEX_PASS "Tested 5 numeric constants for expression evaluation"
+  REGEX_PASS "\\+\\+\\+ Tested 5 numeric constants for expression evaluation"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
 # Test the sequential processing of two xml files
-dd4hep_add_test_reg( include_plugins_command_xml
+dd4hep_add_test_reg( minitel_config_plugins_include_command_xml
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/IncludePlugins.xml 
   REGEX_PASS "Tested 5 numeric constants for expression evaluation"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR"
+)
+#
+# Test setting properties to the world volume and a single sub-detector
+dd4hep_add_test_reg( minitel_config_subdet
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/WorldSettings.xml 
+  REGEX_PASS "\\+\\+ Applied 5 settings to MyLHCBdetector5"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR"
+)
+#
+# Test setting properties to the world volume and a single sub-detector
+dd4hep_add_test_reg( minitel_config_world
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/WorldSettings.xml 
+  REGEX_PASS "\\+\\+ Applied 3 settings to /world"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
@@ -411,14 +433,15 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_test_reg( ClientTests_sim_Check_Temp_Pressure_Air
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/Check_Air.py
-    -geometry  ${ClientTestsEx_INSTALL}/compact/Check_Air.xml batch
+    	              -geometry  ${ClientTestsEx_INSTALL}/compact/Check_Air.xml batch
     REGEX_PASS "Imean:  85.538 eV   temperature: 333.33 K  pressure:   2.22 atm"
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
   #
   # Geant4 test with gdml input file (LHCb:FT)
   dd4hep_add_test_reg( ClientTests_g4_gdml_detector
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4GeometryScan --compact=${ClientTestsEx_INSTALL}/compact/GdmlDetector.xml
+    EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4GeometryScan
+    	              --compact=${ClientTestsEx_INSTALL}/compact/GdmlDetector.xml
                       --position=200,200,-2000 --direction=0,0,1
     REGEX_PASS "   122   2777.0000  5200.000  "
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
@@ -426,7 +449,8 @@ if (DD4HEP_USE_GEANT4)
   # Geant4 test with gdml input file (LHCb:MT)
   dd4hep_add_test_reg( ClientTests_g4_gdml_MT
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
-    EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4GeometryScan --compact=${ClientTestsEx_INSTALL}/compact/MT.xml
+    EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4GeometryScan
+    	              --compact=${ClientTestsEx_INSTALL}/compact/MT.xml
                       --position=200,200,7900 --direction=0,0,1
     REGEX_PASS "    15   2777.0000  4210.000   "
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
@@ -473,10 +497,28 @@ if (DD4HEP_USE_GEANT4)
     dd4hep_add_test_reg( ClientTests_sim_${script}
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MultiCollections.py 
-                        -compact ${ClientTestsEx_INSTALL}/compact/${script}.xml -batch
+                 -compact ${ClientTestsEx_INSTALL}/compact/${script}.xml -batch
       REGEX_PASS NONE
       REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
   endforeach(script)
+  #
+  # Test setting properties to a single sub-detector
+  dd4hep_add_test_reg( minitel_config_region_subdet_geant4
+    COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+    EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTel.py
+    	       -batch -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml -debug
+    REGEX_PASS "\\+ Apply REGION settings: minitel_region_5         to volume MyLHCBdetector5."
+    REGEX_FAIL "Exception;EXCEPTION;ERROR"
+  )
+  #
+  # Test setting properties to the world volume
+  dd4hep_add_test_reg( minitel_config_region_world_geant4
+    COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+    EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTel.py
+    	       -batch -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml -debug
+    REGEX_PASS "Volume world_volume Region: DefaultRegionForTheWorld. Apply user limits from world_region"
+    REGEX_FAIL "Exception;EXCEPTION;ERROR"
+  )
   #
   if(Geant4_VERSION VERSION_LESS 10.7)
     dd4hep_print("|++> Geant4 fast simulation not supported for Geant4 ${Geant4_VERSION}")

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -470,11 +470,16 @@ if (DD4HEP_USE_GEANT4)
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
   #
   # Test of an example user analysis creating an N-tuple instead of an output file with events
+  # Note: Exception: *** G4Exception : PART5107
+  #           issued by : G4IonTable::FindIon()
+  #           Isomer level 9 may be ambiguous.
+  #       *** This is just a warning message. ***
+  # This is NOT an error!
   dd4hep_add_test_reg( ClientTests_sim_UserAnalysis
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTelEnergyDeposits.py batch
     REGEX_PASS "Entries :      200 "
-    REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
+    REGEX_FAIL "EXCEPTION;ERROR;Error" )
   #
   # Test of an example user analysis creating an N-tuple instead of an output file with events
   dd4hep_add_test_reg( ClientTests_sim_TrackingRegion

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -506,7 +506,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_test_reg( minitel_config_region_subdet_geant4
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTel.py
-    	       -batch -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml -debug
+    	       -batch -debug -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml
     REGEX_PASS "\\+ Apply REGION settings: minitel_region_5         to volume MyLHCBdetector5."
     REGEX_FAIL "Exception;EXCEPTION;ERROR"
   )
@@ -515,7 +515,7 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_add_test_reg( minitel_config_region_world_geant4
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTel.py
-    	       -batch -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml -debug
+    	       -batch -debug -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml
     REGEX_PASS "Volume world_volume Region: DefaultRegionForTheWorld. Apply user limits from world_region"
     REGEX_FAIL "Exception;EXCEPTION;ERROR"
   )

--- a/examples/ClientTests/compact/WorldSettings.xml
+++ b/examples/ClientTests/compact/WorldSettings.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+<!-- #==========================================================================
+     #  AIDA Detector description implementation 
+     #==========================================================================
+     # Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+     # All rights reserved.
+     #
+     # For the licensing terms see $DD4hepINSTALL/LICENSE.
+     # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+     #
+     #==========================================================================
+     #  Check issue: https://github.com/AIDASoft/DD4hep/issues/1062
+     #==========================================================================
+-->
+
+  <debug>
+    <type name="includes" value="1"/>
+    <type name="regions"  value="1"/>
+    <type name="limits"   value="1"/>
+  </debug>
+
+  <!-- This here get parsed late, after the sub-detectors are constructed, but before closing -->
+  <includes>
+    <file ref="${DD4hepExamplesINSTALL}/examples/ClientTests/compact/MiniTel.xml"/>
+  </includes>
+
+  <display>
+    <vis name="world_vis" alpha="0.8" r="1.0" g="1.0" b="0.0" showDaughters="true"  visible="true"  drawingStyle="solid" lineStyle="solid"/>
+  </display>
+
+  <limits>
+    <limitset name="world_limits">
+      <limit name="step_length_max"  particles="*" value="5.0" unit="mm"/>
+      <limit name="track_length_max" particles="*" value="1.0" unit="mm"/>
+    </limitset>
+    <limitset name="minitel_limits_extra">
+      <limit name="step_length_max" particles="e[+-]"  value="1.0"  unit="mm"/>
+      <limit name="step_length_max" particles="mu[+-]" value="3.0"  unit="mm"/>
+      <limit name="step_length_max" particles="*"      value="5.0"  unit="mm"/>
+    </limitset>
+  </limits>
+
+  <regions>
+    <region name="world_region" eunit="MeV" lunit="mm" cut="0.001" threshold="0.001">
+      <limitsetref name="world_limits"/>
+    </region>
+    <region name="minitel_region_5" eunit="MeV" lunit="mm" cut="0.001" threshold="0.001">
+      <limitsetref name="minitel_limits_extra"/>
+    </region>
+    <region name="minitel_region_6" eunit="MeV" lunit="mm" cut="0.001" threshold="0.001">
+      <limitsetref name="minitel_limits_extra"/>
+    </region>
+  </regions>
+
+  <!-- FIRST possibily to configure the world object:
+       Use a dedicated xml child of the compact description.
+  -->
+  <world debug="true">
+    <regionref   name="world_region"/>
+    <limitsetref name="world_limits"/>
+    <visref      name="world_vis"/>
+  </world>
+
+
+  <!-- SECOND possibily to configure the world object:
+       Use a plugin to apply the options. This does NOT allow for any other shape
+       than the default box defined by the constants.
+  -->
+  <plugins>
+    <plugin type="config" name="DD4hep_DetElementConfig" path="/world" debug="true">
+      <volume>
+         <regionref   name="world_region"/>
+         <limitsetref name="world_limits"/>
+         <visref      name="world_vis"/>
+      </volume>
+    </plugin>
+  </plugins>
+
+  <!-- Use the same plugin to define any other DetElement entry  -->
+  <plugins>
+    <!-- Example to modify the world volume and assign region settings etc.  -->
+    <plugin type="config" name="DD4hep_DetElementConfig" path="/world/MyLHCBdetector5" propagate="true" debug="true">
+      <volume>
+         <regionref   name="minitel_region_5"/>
+         <limitsetref name="minitel_limits_extra"/>
+      </volume>
+    </plugin>
+
+    <plugin type="config" name="DD4hep_DetElementConfig" path="/world/MyLHCBdetector6" propagate="true">
+      <volume>
+         <regionref   name="minitel_region_6"/>
+         <limitsetref name="minitel_limits_extra"/>
+      </volume>
+    </plugin>
+  </plugins>
+
+  <!-- Example to modify a given sensitive detector and modify properties -->
+  <plugins>
+    <plugin type="config" name="DD4hep_SensitiveDetectorConfig" detector="MyLHCBdetector5" debug="true">
+      <combine_hits    value="true"/>
+      <verbose         value="true"/>
+      <type            value="tracker"/>
+      <ecut            value="5*keV"/>
+      <hits_collection value="hits_collection_5"/>
+    </plugin>
+  </plugins>
+
+</lccdd>

--- a/examples/ClientTests/scripts/DDG4TestSetup.py
+++ b/examples/ClientTests/scripts/DDG4TestSetup.py
@@ -75,11 +75,14 @@ class Setup:
     part.enableUI()
     return part
 
-  def setupPhysics(self, model='QGSP_BERT'):
+  def setupPhysics(self, model='QGSP_BERT', dump=False):
     # Now build the physics list:
     self.phys = self.kernel.physicsList()
     self.phys.extends = model
+    self.phys.decays = True
     self.phys.enableUI()
+    if dump:
+      self.phys.dump()
     return self
 
   def run(self, num_events=None):

--- a/examples/ClientTests/scripts/MiniTel.py
+++ b/examples/ClientTests/scripts/MiniTel.py
@@ -24,10 +24,27 @@ import DDG4
 
 def run():
   from MiniTelSetup import Setup
-  m = Setup()
-  if len(sys.argv) >= 2 and sys.argv[1] == "batch":
+  args = DDG4.CommandLine()
+
+  m = Setup(geometry=args.geometry)
+  cmds = []
+  if args.events:
+    cmds = ['/run/beamOn ', str(args.events)]
+
+  if args.batch:
     DDG4.setPrintLevel(DDG4.OutputLevel.WARNING)
+    cmds.append('/ddg4/UI/terminate')
     m.kernel.UI = ''
+
+  if args.debug:
+    # Configure G4 geometry setup
+    seq, act = m.geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
+    act.DebugVolumes = True
+    act.DebugRegions = True
+    act.DebugLimits  = True
+    seq, act = m.geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
+
+  m.ui.Commands = cmds
   m.configure()
   m.defineOutput()
   m.setupGun()

--- a/examples/ClientTests/scripts/MiniTel.py
+++ b/examples/ClientTests/scripts/MiniTel.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 from __future__ import absolute_import, unicode_literals
-import sys
 import DDG4
 #
 """
@@ -41,7 +40,7 @@ def run():
     seq, act = m.geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
     act.DebugVolumes = True
     act.DebugRegions = True
-    act.DebugLimits  = True
+    act.DebugLimits = True
     seq, act = m.geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
 
   m.ui.Commands = cmds

--- a/examples/ClientTests/scripts/MiniTelSetup.py
+++ b/examples/ClientTests/scripts/MiniTelSetup.py
@@ -23,8 +23,10 @@ import DDG4TestSetup
 
 
 class Setup(DDG4TestSetup.Setup):
-  def __init__(self, geometry="/examples/ClientTests/compact/MiniTel.xml", macro=None, vis=None):
+  def __init__(self, geometry=None, macro=None, vis=None):
     install_dir = os.environ['DD4hepExamplesINSTALL']
+    if geometry is None:
+      geometry = "/examples/ClientTests/compact/MiniTel.xml"
     DDG4TestSetup.Setup.__init__(self, "file:" + install_dir + geometry, macro=macro, vis=vis)
 
   def configure(self, output_level=None):


### PR DESCRIPTION

BEGINRELEASENOTES
-  Verify and enhance the possibility to import plugin definitions from an external XML file
  (See isue: https://github.com/AIDASoft/DD4hep/issues/1062).
  The corresponding examples are:
  -- minitel_config_plugins_include_command_line, which shows how to perform the task by parsing sequentially the 
     XML input files like: 
     ```
     $> geoPluginRun -input <path>/compact/MiniTel.xml  -input  <path>/compact/ExamplePlugins.xml
    ```
  -- minitel_config_plugins_include_command_xml, where the second XML file is simply included:

      <includes>
        <file ref=<path>/examples/ClientTests/compact/BoxTrafos.xml/>
        <file ref=<path>/examples/ClientTests/compact/ExamplePlugins.xml/>
      </includes>
   where `BoxTrafos` is the entire original XML containing the geometry.
-  Add plugins: configure Volume/SensitiveDetector object instances from information in XML Nodes. Given an XML tag like:
   ```
    <plugin type="config" name="DD4hep_DetElementConfig" path="/world" debug="true">
      <volume>
         <regionref   name="world_region"/>
         <limitsetref name="world_limits"/>
         <visref      name="world_vis"/>
      </volume>
    </plugin>```
Can be used directly to modify the settings of s DetElement identified by its path. Similar for sensitive detector objects:
```
    <plugin type="config" name="DD4hep_SensitiveDetectorConfig" detector="MyLHCBdetector5" debug="true">
      <combine_hits    value="true"/>
      <verbose         value="true"/>
      <type            value="tracker"/>
      <ecut            value="5*keV"/>
      <hits_collection value="hits_collection_5"/>
    </plugin>
    ```
- This construct also allows to configure the world volume as part of the resolution of issue https://github.com/AIDASoft/DD4hep/issues/1064
   ```
  <world debug="true">
    <regionref   name="world_region"/>
    <limitsetref name="world_limits"/>
    <visref      name="world_vis"/>
  </world> 
  ```
  Technically the implementation are XML utilities, which are used both by the plugin and the Compact converter.

- Propagate the changes to the world volume to Geant4, which was not possible with DDG4 before, because production cuts and region settings for the world volume belong to Geant4 and are managed by Geant4. (also https://github.com/AIDASoft/DD4hep/issues/1064)
- Side product: Add debug flags for the G4 LimitSet conversion. To enable the flags in the python setup:

  ```
    seq, act = m.geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
    act.DebugLimits = True
   ```
- Have the maps in DetectorData being named to ease debugging.
- Add some XML attribute conversions (more user friendliness)
- Add accessors to the PlacedVolume and the Volume handles to access the class name of the implementing class.
- DDDigi: Add passing event parameters to the output and from the input record to the store. Needs testing though, 
  but this requires a new release of podio.

ENDRELEASENOTES