### PR TITLE
Optimize sensitive detector callbacks in DDG4, Remove deprecated DetElement factories

### DIFF
--- a/DDDetectors/src/BoxSegment_geo.cpp
+++ b/DDDetectors/src/BoxSegment_geo.cpp
@@ -24,15 +24,26 @@ static Ref_t create_element(Detector& description, xml_h e, Ref_t sens)  {
   xml_det_t   x_det = e;
   string      name  = x_det.nameStr();
   xml_comp_t  box    (x_det.child(_U(box)));
-  xml_dim_t   pos    (x_det.child(_U(position)));
-  xml_dim_t   rot    (x_det.child(_U(rotation)));
+  xml_dim_t   pos    (x_det.child(_U(position), false));
+  xml_dim_t   rot    (x_det.child(_U(rotation), false));
   Material    mat    (description.material(x_det.materialStr()));
   DetElement  det    (name,x_det.id());
   Volume      det_vol(name+"_vol",Box(box.x(),box.y(),box.z()), mat);
   Volume      mother = description.pickMotherVolume(det);
-  Transform3D transform(Rotation3D(RotationZYX(rot.z(),rot.y(),rot.x())),Position(pos.x(),pos.y(),pos.z()));
-  PlacedVolume phv = mother.placeVolume(det_vol,transform);
+  Transform3D transform;
 
+  if ( pos && rot )   {
+    transform = Transform3D(Rotation3D(RotationZYX(rot.z(),rot.y(),rot.x())),
+			    Position(pos.x(),pos.y(),pos.z()));
+  }
+  else if ( rot )   {
+    transform = Transform3D(Rotation3D(RotationZYX(rot.z(),rot.y(),rot.x())),
+			    Position());
+  }
+  else if ( pos )   {
+    transform = Transform3D(Rotation3D(), Position(pos.x(),pos.y(),pos.z()));
+  }
+  PlacedVolume phv = mother.placeVolume(det_vol,transform);
   det_vol.setVisAttributes(description, x_det.visStr());
   det_vol.setLimitSet(description, x_det.limitsStr());
   det_vol.setRegion(description, x_det.regionStr());
@@ -51,4 +62,4 @@ static Ref_t create_element(Detector& description, xml_h e, Ref_t sens)  {
 
 // first argument is the type from the xml file
 DECLARE_DETELEMENT(DD4hep_BoxSegment,create_element)
-DECLARE_DEPRECATED_DETELEMENT(BoxSegment,create_element)
+

--- a/DDDetectors/src/CylindricalBarrelCalorimeter_geo.cpp
+++ b/DDDetectors/src/CylindricalBarrelCalorimeter_geo.cpp
@@ -77,4 +77,4 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_CylindricalBarrelCalorimeter,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(CylindricalBarrelCalorimeter,create_detector)
+

--- a/DDDetectors/src/CylindricalEndcapCalorimeter_geo.cpp
+++ b/DDDetectors/src/CylindricalEndcapCalorimeter_geo.cpp
@@ -101,4 +101,3 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_CylindricalEndcapCalorimeter,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(CylindricalEndcapCalorimeter,create_detector)

--- a/DDDetectors/src/DiskTracker_geo.cpp
+++ b/DDDetectors/src/DiskTracker_geo.cpp
@@ -85,4 +85,3 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_DiskTracker,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(DiskTracker,create_detector)

--- a/DDDetectors/src/EcalBarrel_geo.cpp
+++ b/DDDetectors/src/EcalBarrel_geo.cpp
@@ -161,4 +161,3 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_EcalBarrel,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(EcalBarrel,create_detector)

--- a/DDDetectors/src/ForwardDetector_geo.cpp
+++ b/DDDetectors/src/ForwardDetector_geo.cpp
@@ -195,4 +195,4 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_ForwardDetector,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(ForwardDetector,create_detector)
+

--- a/DDDetectors/src/MultiLayerTracker_geo.cpp
+++ b/DDDetectors/src/MultiLayerTracker_geo.cpp
@@ -78,4 +78,4 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_MultiLayerTracker,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(MultiLayerTracker,create_detector)
+

--- a/DDDetectors/src/PolyconeSupport_geo.cpp
+++ b/DDDetectors/src/PolyconeSupport_geo.cpp
@@ -60,4 +60,3 @@ static Ref_t create_detector(Detector& description, xml_h e, Ref_t sens)  {
 }
 
 DECLARE_DETELEMENT(DD4hep_PolyconeSupport,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(PolyconeSupport,create_detector)

--- a/DDDetectors/src/PolyhedraBarrelCalorimeter2_geo.cpp
+++ b/DDDetectors/src/PolyhedraBarrelCalorimeter2_geo.cpp
@@ -185,4 +185,3 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_PolyhedraBarrelCalorimeter2, create_detector)
-DECLARE_DEPRECATED_DETELEMENT(PolyhedraBarrelCalorimeter2,create_detector)

--- a/DDDetectors/src/PolyhedraEndcapCalorimeter2_geo.cpp
+++ b/DDDetectors/src/PolyhedraEndcapCalorimeter2_geo.cpp
@@ -131,4 +131,4 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_PolyhedraEndcapCalorimeter2,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(PolyhedraEndcapCalorimeter2,create_detector)
+

--- a/DDDetectors/src/SiTrackerBarrel_geo.cpp
+++ b/DDDetectors/src/SiTrackerBarrel_geo.cpp
@@ -168,4 +168,4 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_SiTrackerBarrel,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(SiTrackerBarrel,create_detector)
+

--- a/DDDetectors/src/SiTrackerEndcap2_geo.cpp
+++ b/DDDetectors/src/SiTrackerEndcap2_geo.cpp
@@ -133,4 +133,4 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 }
 
 DECLARE_DETELEMENT(DD4hep_SiTrackerEndcap2,create_detector)
-DECLARE_DEPRECATED_DETELEMENT(SiTrackerEndcap2,create_detector)
+

--- a/DDDetectors/src/TubeSegment_geo.cpp
+++ b/DDDetectors/src/TubeSegment_geo.cpp
@@ -51,4 +51,4 @@ static Ref_t create_element(Detector& description, xml_h e, Ref_t sens)  {
 }
 
 DECLARE_DETELEMENT(DD4hep_TubeSegment,create_element)
-DECLARE_DEPRECATED_DETELEMENT(TubeSegment,create_element)
+

--- a/DDG4/include/DDG4/Geant4Data.h
+++ b/DDG4/include/DDG4/Geant4Data.h
@@ -270,10 +270,10 @@ namespace dd4hep {
         Direction     momentum;
         /// Length of the track segment contributing to this hit
         double        length;
-        /// Monte Carlo / Geant4 information
-        Contribution  truth;
         /// Energy deposit in the tracker hit
         double        energyDeposit;
+        /// Monte Carlo / Geant4 information
+        Contribution  truth;
       public:
         /// Default constructor
         Hit();
@@ -283,6 +283,8 @@ namespace dd4hep {
         Hit(const Hit& c) = delete;
         /// Initializing constructor
         Hit(int track_id, int pdg_id, double deposit, double time_stamp, double len=0.0, const Position& p={0.0, 0.0, 0.0}, const Direction& d={0.0, 0.0, 0.0});
+	/// Optimized constructor for sensitive detectors
+	Hit(const Geant4HitData::Contribution& contrib, const Direction& mom, double deposit);
         /// Default destructor
         virtual ~Hit();
         /// Move assignment operator

--- a/DDG4/src/Geant4Data.cpp
+++ b/DDG4/src/Geant4Data.cpp
@@ -106,7 +106,7 @@ Geant4HitData::Contribution Geant4HitData::extractContribution(const Geant4FastS
 
 /// Default constructor
 Geant4Tracker::Hit::Hit()
-: Geant4HitData(), position(), momentum(), length(0.0), truth(), energyDeposit(0.0)
+: Geant4HitData(), position(), momentum(), length(0.0), energyDeposit(0.0), truth()
 {
   InstanceCount::increment(this);
 }
@@ -114,11 +114,19 @@ Geant4Tracker::Hit::Hit()
 /// Standard initializing constructor
 Geant4Tracker::Hit::Hit(int track_id, int pdg_id, double deposit, double time_stamp,
 			double len, const Position& pos, const Direction& mom)
-  : Geant4HitData(), position(pos), momentum(mom), length(len),
-    truth(track_id, pdg_id, deposit, time_stamp, len, pos, mom),
-    energyDeposit(deposit)
+  : Geant4HitData(), position(pos), momentum(mom), length(len), energyDeposit(deposit),
+    truth(track_id, pdg_id, deposit, time_stamp, len, pos, mom)
 {
   g4ID = track_id;
+  InstanceCount::increment(this);
+}
+
+/// Optimized constructor for sensitive detectors
+Geant4Tracker::Hit::Hit(const Geant4HitData::Contribution& contrib, const Direction& mom, double depo)
+  : Geant4HitData(), position(contrib.x, contrib.y, contrib.z),
+    momentum(mom), length(contrib.length), energyDeposit(depo), truth(contrib)
+{
+  g4ID = truth.trackID;
   InstanceCount::increment(this);
 }
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Optimize sensitive detector callbacks in DDG4.
  Many operations were performed twice: once in the sensitive detector, and once again in the computation of
  the MC contribution to the hit. This MR removes multiple computations and uses the results from the MC
  contribution to create the hit.
  The change should be fully compatible and delivers numerically identical results.

- Remove deprecated DetElement factories.
  To not clutter the global namespace with factory names, factories in the DDDetectors area were declared
  deprecated many years ago. At a time these factories were replaced by identical factoris with a name prefix "DD4hep_".
  These factories are "official" and should be used instead.
  On creation such factories issued a warning message.
  It is now time to remove these factories completely.
  

ENDRELEASENOTES