### PR TITLE
Fixed buggy geant4 vertex time from HepMC

### DIFF
--- a/DDG4/hepmc/HepMC3EventReader.cpp
+++ b/DDG4/hepmc/HepMC3EventReader.cpp
@@ -109,6 +109,7 @@ HEPMC3EventReader::readParticles(int event_number, Vertices& vertices, Particles
     p->vex          = vex.get_component(0) * len_unit;
     p->vey          = vex.get_component(1) * len_unit;
     p->vez          = vex.get_component(2) * len_unit;
+    p->vet          = vex.get_component(3) * len_unit / CLHEP::c_light;
     p->process      = 0;
     p->spin[0]      = spin[0];
     p->spin[1]      = spin[1];
@@ -146,7 +147,7 @@ HEPMC3EventReader::readParticles(int event_number, Vertices& vertices, Particles
       vtx->x = p->vex;
       vtx->y = p->vey;
       vtx->z = p->vez;
-      vtx->time = p->time;
+      vtx->time = p->vet;
 
       vtx->out.insert(p->id) ;
     }

--- a/DDG4/include/DDG4/Geant4Particle.h
+++ b/DDG4/include/DDG4/Geant4Particle.h
@@ -122,8 +122,8 @@ namespace dd4hep {
       // 12 ints + 4 bytes + 3 floats should be aligned to 8 bytes....
       /// The starting vertex
       double vsx  = 0E0, vsy  = 0E0, vsz = 0E0;
-      /// The end vertex
-      double vex  = 0E0, vey  = 0E0, vez = 0E0;
+      /// The end vertex, with time as a workaround for issue 1082
+      double vex  = 0E0, vey  = 0E0, vez = 0E0, vet = 0E0;
       /// The track momentum at the start vertex
       double psx  = 0E0, psy  = 0E0, psz = 0E0;
       /// The track momentum at the end vertex

--- a/DDG4/src/Geant4Particle.cpp
+++ b/DDG4/src/Geant4Particle.cpp
@@ -84,6 +84,7 @@ Geant4Particle& Geant4Particle::get_data(Geant4Particle& c)   {
     vex         = c.vex;
     vey         = c.vey;
     vez         = c.vez;
+    vet         = c.vet;
     psx         = c.psx;
     psy         = c.psy;
     psz         = c.psz;

--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -288,6 +288,7 @@ void Geant4ParticleHandler::begin(const G4Track* track)   {
   m_currTrack.vex         = 0.0;
   m_currTrack.vey         = 0.0;
   m_currTrack.vez         = 0.0;
+  m_currTrack.vet         = 0.0;
   m_currTrack.psx         = mom.x();
   m_currTrack.psy         = mom.y();
   m_currTrack.psz         = mom.z();


### PR DESCRIPTION
https://github.com/AIDASoft/DD4hep/issues/1082

BEGINRELEASENOTES
- Vertices read from HepMC files did not get their time assigned properly. 
ENDRELEASENOTES