### PR TITLE
fix units in Geant4FastSimShowerModel::constructSensitives

### DIFF
--- a/DDG4/src/Geant4FastSimShowerModel.cpp
+++ b/DDG4/src/Geant4FastSimShowerModel.cpp
@@ -186,7 +186,7 @@ void Geant4FastSimShowerModel::constructSensitives(Geant4DetectorConstructionCon
   G4Region* region = this->getRegion(this->m_regionName);
   for(const auto& prop : this->m_eTriggerNames)    {
     G4ParticleDefinition* def = this->getParticleDefinition(prop.first);
-    double val = dd4hep::_toDouble(prop.second) * dd4hep::GeV/CLHEP::GeV;
+    double val = dd4hep::_toDouble(prop.second)/dd4hep::GeV*CLHEP::GeV;
     this->m_eTriggerCut.emplace(def, val);
     this->info("Set Energy(ModelTrigger) [%-16s] = %8.4f GeV", prop.first.c_str(), val);
   }

--- a/DDG4/src/Geant4FastSimShowerModel.cpp
+++ b/DDG4/src/Geant4FastSimShowerModel.cpp
@@ -186,7 +186,7 @@ void Geant4FastSimShowerModel::constructSensitives(Geant4DetectorConstructionCon
   G4Region* region = this->getRegion(this->m_regionName);
   for(const auto& prop : this->m_eTriggerNames)    {
     G4ParticleDefinition* def = this->getParticleDefinition(prop.first);
-    double val = dd4hep::_toDouble(prop.second) ; // allready in G4units /dd4hep::GeV*CLHEP::GeV;
+    double val = dd4hep::_toDouble(prop.second) ; // allready in G4units
     this->m_eTriggerCut.emplace(def, val);
     this->info("Set Energy(ModelTrigger) [%-16s] = %8.4f GeV", prop.first.c_str(), val);
   }

--- a/DDG4/src/Geant4FastSimShowerModel.cpp
+++ b/DDG4/src/Geant4FastSimShowerModel.cpp
@@ -186,7 +186,7 @@ void Geant4FastSimShowerModel::constructSensitives(Geant4DetectorConstructionCon
   G4Region* region = this->getRegion(this->m_regionName);
   for(const auto& prop : this->m_eTriggerNames)    {
     G4ParticleDefinition* def = this->getParticleDefinition(prop.first);
-    double val = dd4hep::_toDouble(prop.second)/dd4hep::GeV*CLHEP::GeV;
+    double val = dd4hep::_toDouble(prop.second) ; // allready in G4units /dd4hep::GeV*CLHEP::GeV;
     this->m_eTriggerCut.emplace(def, val);
     this->info("Set Energy(ModelTrigger) [%-16s] = %8.4f GeV", prop.first.c_str(), val);
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- fix units in `Geant4FastSimShowerModel::constructSensitives`
     - used for energy check in `Geant4FastSimShowerModel::check_trigger`  for fast simulation

ENDRELEASENOTES

Logically this should be correct:  `dd4hep::_toDouble(prop.second)/dd4hep::GeV*CLHEP::GeV` - we have a dd4hep property for an energy and need it in Geant4/CLHEP units for GeV. However this is a factor 1000. too large (old code was 1000. too small).  @MarkusFrankATcernch Am I missing sth. here ? What is the correct way to convert dd4hep unit to g4 ?