### PR TITLE
Fix setting of run/event number offsets from the ddsim command line.

### DIFF
--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -23,11 +23,11 @@ class Meta(ConfigHelper):
     self.eventParameters = []
     self._runNumberOffset_EXTRA = {'help': "The run number offset to write in slcio output file. "
                                            "E.g setting it to 42 will start counting runs from 42 instead of 0",
-                                   'type' : int}
+                                   'type': int}
     self.runNumberOffset = 0
     self._eventNumberOffset_EXTRA = {'help': "The event number offset to write in slcio output file."
                                              " E.g setting it to 42 will start counting events from 42 instead of 0",
-                                     'type' : int}
+                                     'type': int}
     self.eventNumberOffset = 0
 
   def parseEventParameters(self):

--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -22,10 +22,12 @@ class Meta(ConfigHelper):
                                    'nargs': '+'}
     self.eventParameters = []
     self._runNumberOffset_EXTRA = {'help': "The run number offset to write in slcio output file. "
-                                           "E.g setting it to 42 will start counting runs from 42 instead of 0"}
+                                           "E.g setting it to 42 will start counting runs from 42 instead of 0",
+                                   'type' : int}
     self.runNumberOffset = 0
     self._eventNumberOffset_EXTRA = {'help': "The event number offset to write in slcio output file."
-                                             " E.g setting it to 42 will start counting events from 42 instead of 0"}
+                                             " E.g setting it to 42 will start counting events from 42 instead of 0",
+                                     'type' : int}
     self.eventNumberOffset = 0
 
   def parseEventParameters(self):


### PR DESCRIPTION
The ddsim --meta.runNumberOffset command-line argument doesn't work correctly (and similarly for event number).

On a machine running

```
LSB Version:    :core-4.1-amd64:core-4.1-ia32:core-4.1-noarch
Distributor ID: Scientific
Description:    Scientific Linux release 7.3 (Nitrogen)
Release:        7.3
Codename:       Nitrogen
```

I do

```
. /cvmfs/sw.hsf.org/key4hep/setup.sh
```

The then command

```
ddsim  --compactFile $LCGEO/FCCee/compact/FCCee_o1_v05/FCCee_o1_v05.xml -G -N10 --outputFile out.edm4hep.root --meta.runNumberOffset 735001  2>&1|tee log
```

eventually crashes with the error

```
Geant4UI         INFO  +++ EventAction> Install Geant4 control directory:/ddg4/EventAction/
Traceback (most recent call last):
  File "/cvmfs/sw.hsf.org/spackages7/dd4hep/1.23/x86_64-centos7-gcc11.2.0-opt/q4qtg/bin/ddsim", line 25, in <module>
    RUNNER.run()
  File "/cvmfs/sw.hsf.org/spackages7/dd4hep/1.23/x86_64-centos7-gcc11.2.0-opt/q4qtg/lib/python3.10/site-packages/DDSim/DD4hepSimulation.py", line 368, in run
    e4Out.RunNumberOffset = self.meta.runNumberOffset if self.meta.runNumberOffset > 0 else 0
TypeError: '>' not supported between instances of 'str' and 'int'
 *** Break *** segmentation violation
```

The arguments are never converted from strings to integers. The change here fixes this.



BEGINRELEASENOTES
- ddsim: Fix handling of --meta.runNumberOffset and --meta.eventNumberOffset command-line switches.

ENDRELEASENOTES