### PR TITLE
CI: adding test result upload

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,7 +45,7 @@ jobs:
           ninja install
           . ../bin/thisdd4hep.sh
           echo "::group::Test"
-          ctest --output-on-failure -j4
+          ctest --output-on-failure -j4 --output-junit TestResults_1.xml
           echo "::group::CMakeExamples"
           cd ../examples/
           mkdir build
@@ -57,7 +57,21 @@ jobs:
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"
-          ctest --output-on-failure -j2
+          ctest --output-on-failure -j2 --output-junit TestResults_2.xml
+    - name: Prepare Artifact Name
+      if: success() || failure()
+      run: |
+          artifact_name="${{ matrix.LCG }}"
+          artifact_name=$(echo -n "${artifact_name}" | sed -e 's@/@@g')
+          echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_ENV
+    - name: Upload test results
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: Test Results ${{ env.ARTIFACT_NAME }}
+        path: |
+           /home/runner/work/DD4hep/DD4hep/build/TestResults_1.xml
+           /home/runner/work/DD4hep/DD4hep/examples/build/TestResults_2.xml
 
 
   key4hep:
@@ -97,7 +111,7 @@ jobs:
           ninja install
           . ../bin/thisdd4hep.sh
           echo "::group::Test"
-          ctest --output-on-failure -j4
+          ctest --output-on-failure -j4 --output-junit TestResults_1.xml
           echo "::group::CMakeExamples"
           cd ../examples/
           mkdir build
@@ -109,7 +123,21 @@ jobs:
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"
-          ctest --output-on-failure -j2
+          ctest --output-on-failure -j2 --output-junit TestResults_2.xml
+    - name: Prepare Artifact Name
+      if: success() || failure()
+      run: |
+          artifact_name="${{ matrix.LCG }}"
+          artifact_name=$(echo -n "${artifact_name}" | sed -e 's@/@@g')
+          echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_ENV
+    - name: Upload test results
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: Test Results ${{ env.ARTIFACT_NAME }}
+        path: |
+           /home/runner/work/DD4hep/DD4hep/build/TestResults_1.xml
+           /home/runner/work/DD4hep/DD4hep/examples/build/TestResults_2.xml
 
   non-shared:
     runs-on: ubuntu-latest
@@ -182,7 +210,7 @@ jobs:
           ninja install
           . ../bin/thisdd4hep.sh
           echo "::group::Test"
-          ctest --output-on-failure -j4
+          ctest --output-on-failure -j4 --output-junit TestResults_1.xml
           echo "::group::CMakeExamples"
           cd ../examples/
           mkdir build
@@ -194,4 +222,29 @@ jobs:
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"
-          ctest --output-on-failure -j2
+          ctest --output-on-failure -j2 --output-junit TestResults_2.xml
+    - name: Prepare Artifact Name
+      if: success() || failure()
+      run: |
+          artifact_name="${{ matrix.LCG }}"
+          artifact_name=$(echo -n "${artifact_name}" | sed -e 's@/@@g')
+          echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_ENV
+    - name: Upload test results
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: Test Results ${{ env.ARTIFACT_NAME }}
+        path: |
+           /home/runner/work/DD4hep/DD4hep/build/TestResults_1.xml
+           /home/runner/work/DD4hep/DD4hep/examples/build/TestResults_2.xml
+
+  event_file:
+    if: github.repository_owner == 'aidasoft' || github.event_name == 'pull_request'
+    name: "Upload Event Payload"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/test-result-comment.yml
+++ b/.github/workflows/test-result-comment.yml
@@ -1,0 +1,46 @@
+name: Test Summary PR comment
+
+on:
+  workflow_run:
+    # do NOT use quotes: https://stackoverflow.com/a/72551795/17876693
+    workflows: [linux]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  comment-test-results:
+    name: Publish Test Results
+
+    if: github.event.workflow_run.event == 'pull_request'
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api --paginate "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
This adds upload and parsing of the test results and a display of the result in a comment to the PR, which is updated when there are results from updated commits. Should make it slightly easier to see error logs for failed tests.

The "Upload Event Payload" is needed for PRs from outside forks to know which artifacts to download.

Thanks to @olemorud for the developments as part of root-project CI

Looks like this: https://github.com/andresailer/DD4hep/pull/3#issuecomment-1519076356

some cmake versions are too old and not supporting the junit output.