### PR TITLE
DDCad: test: use newer duck for newer assimp versions; geant4 11.1.1 fix

### DIFF
--- a/DDG4/examples/initAClick.C
+++ b/DDG4/examples/initAClick.C
@@ -61,7 +61,8 @@ int initAClick(const char* command=0)  {
   std::string dd4hep  = make_str(gSystem->Getenv("DD4hepINSTALL"));
   std::string clhep   = make_str(gSystem->Getenv("CLHEP_ROOT_DIR"));
   std::string defs    = "";
-  std::string libs    = " -L"+rootsys+"/lib";
+  // lib/root is used in spack (key4hep)
+  std::string libs    = " -L"+rootsys+"/lib" + " -L"+rootsys+"/lib/root";
   std::string inc     = " -I"+dd4hep+"/examples/DDG4/examples -I"+dd4hep + " -I"+dd4hep+"/include ";
   std::string ext = "so";
   if ( !geant4.empty() )  {

--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -80,7 +80,7 @@ test -r ${ROOTENV_INIT} && { cd $(dirname ${ROOTENV_INIT}); . ./$(basename ${ROO
 #
 #----Geant4 LIBRARY_PATH------------------------------------------------------
 if [ ${Geant4_DIR} ]; then
-    G4LIB_DIR=`dirname ${Geant4_DIR}`;
+    G4LIB_DIR=`dirname ${Geant4_DIR} | sed 's@/cmake\$@@'`;
     export G4INSTALL=`dirname ${G4LIB_DIR}`;
     export G4ENV_INIT=${G4INSTALL}/bin/geant4.sh
     # ---------- initialze geant4 environment

--- a/examples/DDCAD/CMakeLists.txt
+++ b/examples/DDCAD/CMakeLists.txt
@@ -52,6 +52,11 @@ set(ClientTestsEx_INSTALL ${CMAKE_INSTALL_PREFIX}/examples/ClientTests)
 # Single shape tests:
 
 #Reference for test depends on assimp version
+if(assimp_VERSION VERSION_GREATER_EQUAL 5.2.0)
+  set(assimp_duck_VERSION 5.2.0)
+else()
+  set(assimp_duck_VERSION 5.0.0)
+endif()
 configure_file(${CMAKE_CURRENT_LIST_DIR}/compact/Check_Shape_Collada_duck.xml.in
   ${CMAKE_CURRENT_LIST_DIR}/compact/Check_Shape_Collada_duck.xml @ONLY
 )

--- a/examples/DDCAD/compact/Check_Shape_Collada_duck.xml.in
+++ b/examples/DDCAD/compact/Check_Shape_Collada_duck.xml.in
@@ -20,7 +20,7 @@
       <check vis="Shape1_vis">
         <shape type="CAD_Shape" ref="${DD4hepExamplesINSTALL}/examples/DDCAD/models/Collada/duck.dae" mesh="0"/>
       </check>
-      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/DDCAD/ref/Ref_Collada_duck.txt.@assimp_VERSION@" create="CheckShape_create"/>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/DDCAD/ref/Ref_Collada_duck.txt.@assimp_duck_VERSION@" create="CheckShape_create"/>
     </detector>
   </detectors>
 </lccdd>

--- a/examples/LHeD/scripts/initAClick.C
+++ b/examples/LHeD/scripts/initAClick.C
@@ -61,7 +61,8 @@ int initAClick(const char* command=0)  {
   std::string dd4hep  = make_str(gSystem->Getenv("DD4hepINSTALL"));
   std::string clhep   = make_str(gSystem->Getenv("CLHEP_ROOT_DIR"));
   std::string defs    = "";
-  std::string libs    = " -L"+rootsys+"/lib";
+  // lib/root is used in spack (key4hep)
+  std::string libs    = " -L"+rootsys+"/lib" + " -L"+rootsys+"/lib/root";
   std::string inc     = "";
   inc += " -I" + dd4hep + "/examples/LHeD/scripts ";
   inc += " -I" + dd4hep;


### PR DESCRIPTION
BEGINRELEASENOTES

- thisdd4hep.sh: make the Geant4 path discovery compatible with Geant4 11.1.1

ENDRELEASENOTES

make the colada duck example compatible with newer assimp versions