### PR TITLE
fix: allow rotation/position transformation on entire CAD_MultiVolume

### DIFF
--- a/DDCAD/src/plugins/CADPlugins.cpp
+++ b/DDCAD/src/plugins/CADPlugins.cpp
@@ -253,7 +253,7 @@ static Handle<TObject> create_CAD_Volume(Detector& dsc, xml_h e)   {
       if ( vol.isValid() )   {
         if ( (vol.material() == dsc.air()) && default_material.isValid() )
           vol.setMaterial(default_material);
-        envelope.placeVolume(vol);
+        envelope.placeVolume(vol,env_trafo);
       }
     }
   }


### PR DESCRIPTION
This respects the specified rotation/position in xml, similar to:
```xml
  <detectors>
    <detector id="1" name="Shape_PLY_Wuson" type="DD4hep_TestShape_Creator">
      <check vis="Shape1_vis">
        <shape type="CAD_Shape" ref="${DD4hepExamplesINSTALL}/examples/DDCAD/models/PLY/Wuson.ply"/>
        <position x="30 * cm" y="30 * cm" z="30 * cm"/>
        <rotation x="0"  y="0"  z="0"/>
      </check>
      <test type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/DDCAD/ref/Ref_PLY_Wuson.txt" create="CheckShape_create"/>
    </detector>
  </detectors>
```

BEGINRELEASENOTES
- allow rotation/position transformation on entire CAD_MultiVolume
ENDRELEASENOTES