### PR TITLE
Volumes: rearrange definition of classes (c++20, gcc13,ROOT 6.28/04)

### DIFF
--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -115,54 +115,8 @@ namespace dd4hep {
       /// String representation for debugging
       std::string str()  const;
     };
-    /// Optional parameters to implement special features such as parametrization
-    /**
-     *
-     *   \author  M.Frank
-     *   \version 1.0
-     *   \ingroup DD4HEP_CORE
-     */
-    class Parameterisation   {
-    public:
-      /** Feature: Geant4 parameterised volumes  */
-      using Dimension = std::pair<Transform3D, size_t>;
-      /// Reference to the starting point of the parameterisation
-      Transform3D   start    {   };
-      /// Reference to the parameterised transformation for dimension 1
-      Dimension     trafo1D  { {}, 0UL };
-      /// Reference to the parameterised transformation for dimension 2
-      Dimension     trafo2D  { {}, 0UL };
-      /// Reference to the parameterised transformation for dimension 3
-      Dimension     trafo3D  { {}, 0UL };
-      /// Number of entries for the parameterisation in dimension 2
-      unsigned long flags    { 0 };
-      /// Number of entries for the parameterisation in dimension 2
-      unsigned long refCount { 0 };
-      /// Reference to the placements of this volume
-      std::vector<PlacedVolume> placements {  };
-      /// Bitfield from sensitive detector to encode the volume ID on the fly
-      const detail::BitFieldElement* field { nullptr };
+    class Parameterisation;
 
-    public:
-      /// Default constructor
-      Parameterisation() = default;
-      /// Default move
-      Parameterisation(Parameterisation&& copy) = default;
-      /// Copy constructor
-      Parameterisation(const Parameterisation& c) = default;
-      /// Default destructor
-      virtual ~Parameterisation() = default;
-      /// Move assignment
-      Parameterisation& operator=(Parameterisation&& copy) = default;
-      /// Assignment operator
-      Parameterisation& operator=(const Parameterisation& copy) = default;
-      /// Increase ref count
-      Parameterisation* addref();
-      /// Decrease ref count
-      void release();
-      /// Enable ROOT persistency
-      ClassDef(Parameterisation,200);
-    };
     /// Magic word to detect memory corruptions
     unsigned long magic { 0 };
     /// Reference count on object (used to implement Grab/Release)
@@ -289,6 +243,58 @@ namespace dd4hep {
     /// String dump
     std::string toString() const;
   };
+
+  // This needs full knowledge of the PlacedVolume class, at least for ROOT 6.28/04
+  // so we place it here
+  /// Optional parameters to implement special features such as parametrization
+  /**
+   *
+   *   \author  M.Frank
+   *   \version 1.0
+   *   \ingroup DD4HEP_CORE
+   */
+  class PlacedVolumeExtension::Parameterisation {
+  public:
+    /** Feature: Geant4 parameterised volumes  */
+    using Dimension = std::pair<Transform3D, size_t>;
+    /// Reference to the starting point of the parameterisation
+    Transform3D   start    {   };
+    /// Reference to the parameterised transformation for dimension 1
+    Dimension     trafo1D  { {}, 0UL };
+    /// Reference to the parameterised transformation for dimension 2
+    Dimension     trafo2D  { {}, 0UL };
+    /// Reference to the parameterised transformation for dimension 3
+    Dimension     trafo3D  { {}, 0UL };
+    /// Number of entries for the parameterisation in dimension 2
+    unsigned long flags    { 0 };
+    /// Number of entries for the parameterisation in dimension 2
+    unsigned long refCount { 0 };
+    /// Reference to the placements of this volume
+    std::vector<PlacedVolume> placements {  };
+    /// Bitfield from sensitive detector to encode the volume ID on the fly
+    const detail::BitFieldElement* field { nullptr };
+
+  public:
+    /// Default constructor
+    Parameterisation() = default;
+    /// Default move
+    Parameterisation(Parameterisation&& copy) = default;
+    /// Copy constructor
+    Parameterisation(const Parameterisation& c) = default;
+    /// Default destructor
+    virtual ~Parameterisation() = default;
+    /// Move assignment
+    Parameterisation& operator=(Parameterisation&& copy) = default;
+    /// Assignment operator
+    Parameterisation& operator=(const Parameterisation& copy) = default;
+    /// Increase ref count
+    Parameterisation* addref();
+    /// Decrease ref count
+    void release();
+    /// Enable ROOT persistency
+    ClassDef(Parameterisation,200);
+  };
+
 
   /// Implementation class extending the ROOT volume (TGeoVolume)
   /**


### PR DESCRIPTION
Parameterisation uses PlacedVolume, root cling dictionary complains about incomplete class needed for vector<PlacedVolume>

BEGINRELEASENOTES
- Volumes.h: rearrange implementation of classes, fix needed for gcc13/root 6.28/04, c++20

ENDRELEASENOTES

This was the error message

```
[ 14%] Generating G__DD4hepGeo.cxx, ../lib/G__DD4hepGeo_rdict.pcm
In file included from input_line_4:2:
In file included from /build/jenkins/workspace/lcg_nightly_pipeline/install/dev3lhcb/ROOT/HEAD/x86_64-el9-gcc13-opt/include/Rtypes.h:193:
In file included from /build/jenkins/workspace/lcg_nightly_pipeline/install/dev3lhcb/ROOT/HEAD/x86_64-el9-gcc13-opt/include/TGenericClassInfo.h:22:
In file included from /cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/bin/../lib/gcc/x86_64-pc-linux-gnu/13.1.0/../../../../include/c++/13.1.0/vector:66:
/cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/bin/../lib/gcc/x86_64-pc-linux-gnu/13.1.0/../../../../include/c++/13.1.0/bits/stl_vector.h:367:35: error: arithmetic on a pointer to an incomplete type 'dd4hep::PlacedVolume'
                      _M_impl._M_end_of_storage - _M_impl._M_start);
                      ~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/bin/../lib/gcc/x86_64-pc-linux-gnu/13.1.0/../../../../include/c++/13.1.0/bits/stl_vector.h:526:7: note: in instantiation of member function 'std::_Vector_base<dd4hep::PlacedVolume, std::allocator<dd4hep::PlacedVolume> >::~_Vector_base' requested here
      vector() = default;
      ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/Volumes.h:142:44: note: in defaulted default constructor for 'std::vector<dd4hep::PlacedVolume, std::allocator<dd4hep::PlacedVolume> >' first required here
      std::vector<PlacedVolume> placements {  };
                                           ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/Volumes.h:44:10: note: forward declaration of 'dd4hep::PlacedVolume'
  class  PlacedVolume;
         ^
In file included from input_line_4:2:
In file included from /build/jenkins/workspace/lcg_nightly_pipeline/install/dev3lhcb/ROOT/HEAD/x86_64-el9-gcc13-opt/include/Rtypes.h:193:
In file included from /build/jenkins/workspace/lcg_nightly_pipeline/install/dev3lhcb/ROOT/HEAD/x86_64-el9-gcc13-opt/include/TGenericClassInfo.h:22:
In file included from /cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/bin/../lib/gcc/x86_64-pc-linux-gnu/13.1.0/../../../../include/c++/13.1.0/vector:66:
/cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/bin/../lib/gcc/x86_64-pc-linux-gnu/13.1.0/../../../../include/c++/13.1.0/bits/stl_vector.h:367:35: error: arithmetic on a pointer to an incomplete type 'dd4hep::PlacedVolume'
                      _M_impl._M_end_of_storage - _M_impl._M_start);
                      ~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/bin/../lib/gcc/x86_64-pc-linux-gnu/13.1.0/../../../../include/c++/13.1.0/bits/stl_vector.h:526:7: note: in instantiation of member function 'std::_Vector_base<dd4hep::PlacedVolume, std::allocator<dd4hep::PlacedVolume> >::~_Vector_base' requested here
      vector() = default;
      ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/Volumes.h:142:44: note: in defaulted default constructor for 'std::vector<dd4hep::PlacedVolume, std::allocator<dd4hep::PlacedVolume> >' first required here
      std::vector<PlacedVolume> placements {  };
                                           ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/Volumes.h:44:10: note: forward declaration of 'dd4hep::PlacedVolume'
  class  PlacedVolume;
         ^
Error: /build/jenkins/workspace/lcg_nightly_pipeline/install/dev3lhcb/ROOT/HEAD/x86_64-el9-gcc13-opt/bin/rootcling: compilation failure (/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep-master-build/DDCore/../lib/G__DD4hepGeoac3244d7d3_dictUmbrella.h)
```