### PR TITLE
Make podio type name calls future string_view proof

### DIFF
--- a/DDDigi/io/DigiEdm4hepInput.cpp
+++ b/DDDigi/io/DigiEdm4hepInput.cpp
@@ -241,7 +241,7 @@ namespace dd4hep {
       data_io<edm4hep_input>()._to_digi_if(*collection, hits, predicate);
       data_io<edm4hep_input>()._to_digi(Key(nam, segment.id, mask), hits, out);
       info("%s+++ %-24s Converted %6ld Edm4hep %-14s to %6ld cell deposits",
-	   context.event->id(), nam.c_str(), len, collection->getValueTypeName().c_str(), out.size());
+	   context.event->id(), nam.c_str(), len, collection->getValueTypeName().data(), out.size());
       put_data(segment, Key(out.name, mask), std::move(out));
       if ( m_keep_raw )   {
 	put_data(segment, Key(nam+".edm4hep", mask, segment.id), std::move(hits));

--- a/DDDigi/io/DigiEdm4hepOutput.cpp
+++ b/DDDigi/io/DigiEdm4hepOutput.cpp
@@ -100,7 +100,7 @@ namespace dd4hep {
     template <typename T> T* DigiEdm4hepOutput::internals_t::register_collection(const std::string& nam, T* coll)   {
       m_collections.emplace(nam, coll);
       m_store->registerCollection(nam, coll);
-      m_parent->debug("+++ created collection %s <%s>", nam.c_str(), coll->getTypeName().c_str());
+      m_parent->debug("+++ created collection %s <%s>", nam.c_str(), coll->getTypeName().data());
       return coll;
     }
 
@@ -235,7 +235,7 @@ namespace dd4hep {
       std::size_t end = internals->m_particles->size();
       info("%s+++ %-24s added %6ld/%6ld entries from mask: %04X to %s",
            ctxt.event->id(), cont.name.c_str(), end-start, end, cont.key.mask(),
-           coll->getTypeName().c_str());
+           coll->getTypeName().data());
     }
 
     template <typename T> void
@@ -288,7 +288,7 @@ namespace dd4hep {
       std::size_t end = coll->size();
       info("%s+++ %-24s added %6ld/%6ld entries from mask: %04X to %s",
            ctxt.event->id(), cont.name.c_str(), end-start, end, cont.key.mask(),
-           coll->getTypeName().c_str());
+           coll->getTypeName().data());
     }
 
     void DigiEdm4hepOutputProcessor::convert_history(DigiContext&           ctxt,


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the `get{Value,}TypeName` calls work with the upcoming switch to `std::string_view` return types in podio.

ENDRELEASENOTES

https://github.com/AIDASoft/podio/pull/402 switches these to `constexpr static std::string_views`. Since these are viewing string literals `string_view::data` is guaranteed to be null terminated (in this case). `std::string::data` is also guaranteed to be null terminated since c++11 (it has to be equivalent to `c_str`).