### PR TITLE
Move CellID data type to uint64_t

### DIFF
--- a/DDCore/include/DD4hep/Segmentations.h
+++ b/DDCore/include/DD4hep/Segmentations.h
@@ -14,10 +14,10 @@
 #define DD4HEP_SEGMENTATIONS_H
 
 // Framework include files
-#include "DD4hep/Handle.h"
-#include "DD4hep/Objects.h"
-#include "DD4hep/BitFieldCoder.h"
-#include "DDSegmentation/Segmentation.h"
+#include <DD4hep/Handle.h>
+#include <DD4hep/Objects.h>
+#include <DD4hep/BitFieldCoder.h>
+#include <DDSegmentation/Segmentation.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -79,9 +79,9 @@ namespace dd4hep {
     /// Set the underlying decoder
     void setDecoder(const BitFieldCoder* decoder) const;
     /// determine the local position based on the cell ID
-    Position position(const long64& cellID) const;
+    Position position(const CellID& cellID) const;
     /// determine the cell ID based on the local position
-    long64 cellID(const Position& localPosition, const Position& globalPosition, const long64& volumeID) const;
+    CellID cellID(const Position& localPosition, const Position& globalPosition, const VolumeID& volumeID) const;
     /// Determine the volume ID from the full cell ID by removing all local fields
     VolumeID volumeID(const CellID& cellID) const;
     /// Calculates the neighbours of the given cell ID and adds them to the list of neighbours

--- a/DDCore/include/DDSegmentation/BitField64.h
+++ b/DDCore/include/DDSegmentation/BitField64.h
@@ -24,9 +24,6 @@
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
   
-  typedef long long int long64 ;
-  typedef unsigned long long ulong64 ;
-  
   /// DDSegmentation namespace declaration
   namespace DDSegmentation {
     
@@ -38,7 +35,7 @@ namespace dd4hep {
      */
     class BitFieldValue{
 
-      long64& _value ;
+      CellID& _value ;
       const BitFieldElement& _bv ;
     
     public :
@@ -46,18 +43,18 @@ namespace dd4hep {
       BitFieldValue() = delete ;
     
       /// only c'tor with reference to bitfield and BitFieldElement
-      BitFieldValue( long64& bitfield, const BitFieldElement& bv ) :
+      BitFieldValue( CellID& bitfield, const BitFieldElement& bv ) :
         _value( bitfield ), _bv( bv) {}
     
       /** Returns the current field value 
        */
-      long64 value() const { return _bv.value( _value ) ; }
+      FieldID value() const { return _bv.value( _value ) ; }
   
       /// Calculate Field value given an external 64 bit bitmap value
-      long64 value(long64 id) const { return _bv.value( id ) ; }
+      FieldID value(CellID id) const { return _bv.value( id ) ; }
 
       //// Assignment operator for user convenience 
-      BitFieldValue& operator=(long64 in) {
+      BitFieldValue& operator=(FieldID in) {
         _bv.set( _value, in ) ;
         return *this ;
       } 
@@ -65,7 +62,7 @@ namespace dd4hep {
       /** Conversion operator for long64 - allows to write:<br>
        *  long64 index = myBitFieldValue ;
        */
-      operator long64() const { return value() ; } 
+      operator FieldID() const { return value() ; } 
     
       /** The field's name */
       const std::string& name() const { return _bv.name() ; }
@@ -74,13 +71,13 @@ namespace dd4hep {
       unsigned offset() const { return _bv.offset() ; }
 
       /** The field's width */
-      unsigned width() const { return _bv.width() ; }
+      unsigned width() const  { return _bv.width() ; }
 
       /** True if field is interpreted as signed */
-      bool isSigned() const { return _bv.isSigned() ; }
+      bool isSigned() const   { return _bv.isSigned() ; }
 
       /** The field's mask */
-      ulong64 mask() const { return _bv.mask() ; }
+      CellID mask() const     { return _bv.mask() ; }
 
       /** Minimal value  */
       int  minValue()  const  { return _bv.minValue();  }
@@ -119,8 +116,8 @@ namespace dd4hep {
       virtual ~BitField64() {
         if( _owner)
           delete _coder ;
-      } ; 
-  
+      }; 
+
       /** No default c'tor */
       BitField64() = delete ;
 
@@ -139,7 +136,6 @@ namespace dd4hep {
        *  Example: "layer:7,system:-3,barrel:3,theta:32:11,phi:11"
        */
       BitField64( const std::string& initString ){
-      
         _coder = new BitFieldCoder( initString ) ;
       }
 
@@ -150,11 +146,11 @@ namespace dd4hep {
 
       /** Returns the current 64bit value 
        */
-      long64 getValue() const { return _value ; }
+      CellID getValue() const { return _value ; }
     
       /** Set a new 64bit value  - bits not used in description are set to 0.
        */
-      void  setValue(long64 value ) { _value = ( _coder->mask() & value ) ; }
+      void  setValue(CellID value ) { _value = ( _coder->mask() & value ) ; }
 
       /** Set a new 64bit value given as high and low 32bit words.
        */
@@ -163,7 +159,7 @@ namespace dd4hep {
       }
     
       /** Operator for setting a new value and accessing the BitField directly */
-      BitField64& operator()(long64 val) { setValue( val ) ; return *this ; }
+      BitField64& operator()(CellID val) { setValue( val ) ; return *this ; }
  
       /** Reset - same as setValue(0) - useful if the same encoder is used for many objects.
        */
@@ -196,7 +192,6 @@ namespace dd4hep {
       /** Access to field through name .
        */
       BitFieldValue operator[](const std::string& name) { 
-
         return BitFieldValue( _value,  _coder->operator[]( name ) ) ; 
       }
       // /** Const Access to field through name .
@@ -231,8 +226,8 @@ namespace dd4hep {
     protected:
 
       // -------------- data members:--------------
-      bool  _owner{true} ;
-      long64    _value{} ;
+      bool      _owner{true} ;
+      CellID    _value{} ;
       const BitFieldCoder* _coder{} ;
     
     };

--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -12,27 +12,26 @@
 #ifndef DDSEGMENTATION_BITFIELDCODER_H
 #define DDSEGMENTATION_BITFIELDCODER_H 1
 
-
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 #include <sstream>
-
+#include <cstdint>
 
 namespace dd4hep {
 
-  typedef long long int long64 ;
-  typedef unsigned long long ulong64 ;
-
   namespace DDSegmentation {
+
+    typedef int64_t  FieldID;
+    typedef uint64_t CellID;
+    typedef uint64_t VolumeID;
 
     class StringTokenizer ; 
 
     /// Helper class for BitFieldCoder that corresponds to one field value. 
-    class BitFieldElement{
+    class BitFieldElement   {
   
     public :
-  
       /// Default constructor
       BitFieldElement() = default ;
       /// Copy constructor
@@ -53,12 +52,10 @@ namespace dd4hep {
       BitFieldElement& operator=(const BitFieldElement&) = default ;
 
       /// calculate this field's value given an external 64 bit bitmap 
-      long64 value(long64 bitfield) const;
-
+      FieldID value(CellID bitfield) const;
 
       // assign the given value to the bit field
-      void set(long64& bitfield, long64 value) const ;
-
+      void set(CellID& bitfield, FieldID value) const ;
 
       /** The field's name */
       const std::string& name() const { return _name ; }
@@ -67,13 +64,13 @@ namespace dd4hep {
       unsigned offset() const { return _offset ; }
 
       /** The field's width */
-      unsigned width() const { return _width ; }
+      unsigned width() const  { return _width ; }
 
       /** True if field is interpreted as signed */
-      bool isSigned() const { return _isSigned ; }
+      bool isSigned() const   { return _isSigned ; }
 
       /** The field's mask */
-      ulong64 mask() const { return _mask ; }
+      CellID mask() const     { return _mask ; }
 
       /** Minimal value  */
       int  minValue()  const  { return _minVal;  }
@@ -83,14 +80,13 @@ namespace dd4hep {
 
     protected:
   
-      ulong64 _mask     {};
+      CellID _mask      {};
       unsigned _offset  {};
       unsigned _width   {};
       int _minVal       {};
       int _maxVal       {};
       bool _isSigned    {};
       std::string _name;
-
     };
 
 
@@ -116,11 +112,10 @@ namespace dd4hep {
      *    @date  2017-09
      */  
     class BitFieldCoder{
-    
     public :
-    
       typedef std::map<std::string, unsigned int> IndexMap ;
 
+    public :
       /// Default constructor
       BitFieldCoder() = default ;
       /// Copy constructor
@@ -148,57 +143,50 @@ namespace dd4hep {
        *  Example: "layer:7,system:-3,barrel:3,theta:32:11,phi:11"
        */
       BitFieldCoder( const std::string& initString ) : _joined(0){
-    
         init( initString ) ;
       }
 
       /** return a new 64bit value given as high and low 32bit words.
        */
-      static long64 toLong(unsigned low_Word, unsigned high_Word ) {
+      static CellID toLong(unsigned low_Word, unsigned high_Word ) {
         return (  ( low_Word & 0xffffffffULL ) |  ( ( high_Word & 0xffffffffULL ) << 32 ) ) ; 
       }
     
       /** The low  word, bits 0-31
        */
-      static unsigned lowWord(long64 bitfield) { return unsigned( bitfield &  0xffffFFFFUL )  ; } 
+      static unsigned lowWord(CellID bitfield)  { return unsigned( bitfield &  0xffffFFFFUL ); } 
 
       /** The high  word, bits 32-63
        */
-      static unsigned highWord(long64 bitfield) { return unsigned( bitfield >> 32) ; } 
-
+      static unsigned highWord(CellID bitfield) { return unsigned( bitfield >> 32); }
 
       /** get value of sub-field specified by index 
        */
-      long64 get(long64 bitfield, size_t idx) const { 
+      FieldID get(CellID bitfield, size_t idx) const { 
         return _fields.at(idx).value( bitfield )  ;
       }
     
       /** Access to field through name .
        */
-      long64 get(long64 bitfield, const std::string& name) const {
-
+      FieldID get(CellID bitfield, const std::string& name) const {
         return _fields.at( index( name ) ).value( bitfield ) ;
       }
 
       /** set value of sub-field specified by index 
        */
-      void set(long64& bitfield, size_t idx, ulong64 value) const { 
+      void set(CellID& bitfield, size_t idx, FieldID value) const { 
         _fields.at(idx).set( bitfield , value )  ;
       }
     
       /** Access to field through name .
        */
-      void set(long64& bitfield, const std::string& name, ulong64 value) const {
-
+      void set(CellID& bitfield, const std::string& name, FieldID value) const {
         _fields.at( index( name ) ).set( bitfield, value ) ;
       }
-
-
 
       /** Highest bit used in fields [0-63]
        */
       unsigned highestBit() const ;
-    
 
       /** Number of values */
       size_t size() const { return _fields.size() ; }
@@ -207,18 +195,15 @@ namespace dd4hep {
        */
       size_t index( const std::string& name) const ;
 
-
       /** Const Access to field through name .
        */
       const BitFieldElement& operator[](const std::string& name) const { 
-
         return _fields[ index( name ) ] ;
       }
 
       /** Const Access to field through index .
        */
       const BitFieldElement& operator[](unsigned idx) const { 
-
         return _fields[ idx ] ;
       }
 
@@ -228,15 +213,14 @@ namespace dd4hep {
 
       /** Return a string with a comma separated list of the current sub field values 
        */
-      std::string valueString(ulong64 bitfield) const ;
+      std::string valueString(CellID bitfield) const ;
 
       const std::vector<BitFieldElement>& fields()  const  {
         return _fields;
       }
     
-
       /** the mask of all the bits used in the description */
-      ulong64 mask() const { return _joined ; }
+      CellID mask() const { return _joined ; }
 
     protected:
 
@@ -249,16 +233,11 @@ namespace dd4hep {
        */
       void init( const std::string& initString) ;
 
-    public:
-
     protected:
-
       // -------------- data members:--------------
-
       std::vector<BitFieldElement> _fields{} ;
       IndexMap  _map{} ;
-      long64    _joined{} ;
-
+      CellID    _joined{} ;
     };
 
 
@@ -272,7 +251,6 @@ namespace dd4hep {
      *    @date  2013-06
      */
     class StringTokenizer{
-    
       std::vector< std::string >& _tokens ;
       char _del ;
       char _last ;
@@ -288,9 +266,7 @@ namespace dd4hep {
     
       /** Operator for use with algorithms, e.g. for_each */
       void operator()(const char& c) { 
-      
         if( c != _del  ) {
-	
           if( _last == _del  ) {
             _tokens.emplace_back("") ; 
           }
@@ -298,13 +274,10 @@ namespace dd4hep {
         }
         _last = c ;
       } 
-    
     };
 
   } // end namespace
-
 } // end namespace
-
 #endif
 
 

--- a/DDCore/include/DDSegmentation/Segmentation.h
+++ b/DDCore/include/DDSegmentation/Segmentation.h
@@ -44,10 +44,6 @@ namespace dd4hep {
     typedef TypedSegmentationParameter<std::vector<std::string> >* StringVecParameter;
     typedef SegmentationParameter::UnitType UnitType;
 
-    /// Useful typedefs to differentiate cell IDs and volume IDs
-    typedef long long int CellID;
-    typedef long long int VolumeID;
-
     /// Simple container for a physics vector
     struct Vector3D {
       /// Default constructor
@@ -149,12 +145,12 @@ namespace dd4hep {
                               const std::string& defaultVal);
 
       /// Helper method to convert a bin number to a 1D position
-      static double binToPosition(CellID bin, double cellSize, double offset = 0.);
+      static double binToPosition(FieldID bin, double cellSize, double offset = 0.);
       /// Helper method to convert a 1D position to a cell ID
       static int positionToBin(double position, double cellSize, double offset = 0.);
 
       /// Helper method to convert a bin number to a 1D position given a vector of binBoundaries
-      static double binToPosition(CellID bin, std::vector<double> const& cellBoundaries, double offset = 0.);
+      static double binToPosition(FieldID bin, std::vector<double> const& cellBoundaries, double offset = 0.);
       /// Helper method to convert a 1D position to a cell ID given a vector of binBoundaries
       static int positionToBin(double position, std::vector<double> const& cellBoundaries, double offset = 0.);
 

--- a/DDCore/include/Parsers/Primitives.h
+++ b/DDCore/include/Parsers/Primitives.h
@@ -41,8 +41,9 @@ namespace dd4hep {
     class BitFieldCoder;
     class BitFieldElement;
     /// Useful typedefs to differentiate cell IDs and volume IDs
-    typedef long long int CellID;
-    typedef long long int VolumeID;
+    typedef uint64_t CellID;
+    typedef uint64_t VolumeID;
+    typedef int64_t  FieldID;
   }
 
 
@@ -54,6 +55,7 @@ namespace dd4hep {
   typedef DDSegmentation::BitFieldElement BitFieldElement;
 #else
   using DDSegmentation::CellID;
+  using DDSegmentation::FieldID;
   using DDSegmentation::VolumeID;
   using DDSegmentation::BitFieldCoder;
   using DDSegmentation::BitFieldElement;

--- a/DDCore/src/Primitives.cpp
+++ b/DDCore/src/Primitives.cpp
@@ -173,7 +173,7 @@ namespace {
 /// Convert volumeID to string format (016X)
 std::string dd4hep::volumeID(VolumeID vid)   {
   char text[32];
-  ::snprintf(text,sizeof(text),"%016llx",vid);
+  ::snprintf(text,sizeof(text),"%016lx", vid);
   return text;
 }
 

--- a/DDCore/src/Segmentations.cpp
+++ b/DDCore/src/Segmentations.cpp
@@ -68,12 +68,12 @@ DDSegmentation::Parameter  Segmentation::parameter(const std::string& parameterN
 }
 
 /// determine the local position based on the cell ID
-Position Segmentation::position(const long64& cell) const {
+Position Segmentation::position(const CellID& cell) const {
   return Position(access()->segmentation->position(cell));
 }
 
 /// determine the cell ID based on the local position
-long64 Segmentation::cellID(const Position& localPosition, const Position& globalPosition, const long64& volID) const {
+CellID Segmentation::cellID(const Position& localPosition, const Position& globalPosition, const CellID & volID) const {
   return access()->segmentation->cellID(localPosition, globalPosition, volID);
 }
 

--- a/DDCore/src/segmentations/BitFieldCoder.cpp
+++ b/DDCore/src/segmentations/BitFieldCoder.cpp
@@ -42,9 +42,9 @@ namespace dd4hep{
       }
     }
   
-    long64 BitFieldElement::value(long64 id) const { 
+    FieldID BitFieldElement::value(CellID id) const { 
       if(  _isSigned   ) {
-        long64 val = ( id & _mask ) >> _offset ;
+        FieldID val = ( id & _mask ) >> _offset ;
         if( ( val  & ( 1LL << ( _width - 1 ) ) ) != 0 ) { // negative value
           val -= ( 1LL << _width );
         }
@@ -54,7 +54,7 @@ namespace dd4hep{
       }
     }
 
-    void BitFieldElement::set(long64& field, long64 in) const {
+    void BitFieldElement::set(CellID& field, FieldID in) const {
     
       // check range 
       if( in < _minVal || in > _maxVal  ) {
@@ -96,7 +96,7 @@ namespace dd4hep{
     }
 
 
-    std::string BitFieldCoder::valueString(ulong64 bitfield) const {
+    std::string BitFieldCoder::valueString(CellID bitfield) const {
 
       std::stringstream  os ;
 

--- a/DDCore/src/segmentations/Segmentation.cpp
+++ b/DDCore/src/segmentations/Segmentation.cpp
@@ -132,7 +132,7 @@ namespace dd4hep {
     }
 
     /// Helper method to convert a bin number to a 1D position
-    double Segmentation::binToPosition(long64 bin, double cellSize, double offset) {
+    double Segmentation::binToPosition(FieldID bin, double cellSize, double offset) {
       return bin * cellSize + offset;
     }
 
@@ -145,7 +145,7 @@ namespace dd4hep {
     }
 
     /// Helper method to convert a bin number to a 1D position given a vector of binBoundaries
-    double Segmentation::binToPosition(CellID bin, std::vector<double> const& cellBoundaries, double offset) {
+    double Segmentation::binToPosition(FieldID bin, std::vector<double> const& cellBoundaries, double offset) {
       return (cellBoundaries[bin+1] + cellBoundaries[bin])*0.5 + offset;
     }
     /// Helper method to convert a 1D position to a cell ID given a vector of binBoundaries

--- a/DDDetectors/src/Beampipe_o1_v01_geo.cpp
+++ b/DDDetectors/src/Beampipe_o1_v01_geo.cpp
@@ -54,7 +54,7 @@ public:
   void setHalfLength( double half_length){
     _half_length = half_length ;
   }
-  void setID( dd4hep::long64 id ) { _id = id ;
+  void setID( dd4hep::FieldID id ) { _id = id ;
   }
   // overwrite to include points inside the inner radius of the barrel
   bool insideBounds(const Vector3D& point, double epsilon) const {

--- a/DDDetectors/src/CaloFaceBarrel_surfaces.cpp
+++ b/DDDetectors/src/CaloFaceBarrel_surfaces.cpp
@@ -55,7 +55,7 @@ namespace{
       _width = width ;
     }
 
-    void setID( dd4hep::long64 id_val ) { _id = id_val ; }
+    void setID( dd4hep::CellID id_val ) { _id = id_val ; }
     
     // overwrite to include points inside the inner radius of the barrel 
     bool insideBounds(const dd4hep::rec::Vector3D& point, double epsilon) const {

--- a/DDDetectors/src/CaloFaceEndcap_surfaces.cpp
+++ b/DDDetectors/src/CaloFaceEndcap_surfaces.cpp
@@ -55,7 +55,7 @@ namespace{
       _phi0 = phi0 ;
       _sym = symmetry ;
     }
-    void setID( dd4hep::long64 id_val ) { _id = id_val; }
+    void setID( dd4hep::CellID id_val ) { _id = id_val; }
     
     // overwrite to include points inside the inner radius of the endcap 
     bool insideBounds(const dd4hep::rec::Vector3D& point, double epsilon) const {

--- a/DDDigi/include/DDDigi/DigiSegmentSplitter.h
+++ b/DDDigi/include/DDDigi/DigiSegmentSplitter.h
@@ -60,12 +60,12 @@ namespace dd4hep {
       /// Full identifier (field + id)
       std::string identifier()  const;
       /// Check a given cell id if it matches this selection
-      bool matches(uint64_t cell)  const  {
-	return this->split_id(cell) == this->predicate.id;
-      }
+      //bool matches(uint64_t cell)  const  {
+      //  return this->split_id(cell) == this->predicate.id;
+      //}
       /// Check a given cell id if it matches this selection
       bool matches(CellID cell)  const  {
-	return this->split_id(cell) == this->predicate.id;
+        return this->split_id(cell) == this->predicate.id;
       }
 
       /// Check if a deposit should be processed

--- a/DDG4/src/Geant4ReadoutVolumeFilter.cpp
+++ b/DDG4/src/Geant4ReadoutVolumeFilter.cpp
@@ -53,7 +53,7 @@ bool Geant4ReadoutVolumeFilter::operator()(const G4Step* step) const    {
   Geant4StepHandler stepH(step);
   Geant4VolumeManager volMgr = Geant4Mapping::instance().volumeManager();
   VolumeID id  = volMgr.volumeID(stepH.preTouchable());
-  long64   key = m_key->value(id);
+  FieldID  key = m_key->value(id);
   if ( m_collection->key_min <= key && m_collection->key_max >= key )
     return true;
   return false;
@@ -64,7 +64,7 @@ bool Geant4ReadoutVolumeFilter::operator()(const Geant4FastSimSpot* spot) const 
   Geant4FastSimHandler spotH(spot);
   Geant4VolumeManager volMgr = Geant4Mapping::instance().volumeManager();
   VolumeID id  = volMgr.volumeID(spotH.touchable());
-  long64   key = m_key->value(id);
+  FieldID  key = m_key->value(id);
   if ( m_collection->key_min <= key && m_collection->key_max >= key )
     return true;
   return false;

--- a/DDRec/include/DDRec/DetectorData.h
+++ b/DDRec/include/DDRec/DetectorData.h
@@ -486,13 +486,13 @@ namespace dd4hep {
     struct NeighbourSurfacesStruct {
 
       /// map of all neighbours in the same layer
-      std::map<dd4hep::long64 , std::vector<dd4hep::long64 > > sameLayer ; 
+      std::map<dd4hep::CellID , std::vector<dd4hep::CellID > > sameLayer ; 
 
       /// map of all neighbours in the previous layer
-      std::map<dd4hep::long64 , std::vector<dd4hep::long64 > > prevLayer ;
+      std::map<dd4hep::CellID , std::vector<dd4hep::CellID > > prevLayer ;
 
       /// map of all neighbours in the next layer
-      std::map<dd4hep::long64 , std::vector<dd4hep::long64 > > nextLayer ;
+      std::map<dd4hep::CellID , std::vector<dd4hep::CellID > > nextLayer ;
 
     } ;
     typedef StructExtension<NeighbourSurfacesStruct> NeighbourSurfacesData ;

--- a/DDTest/src/test_bitfield64.cc
+++ b/DDTest/src/test_bitfield64.cc
@@ -26,7 +26,7 @@ int main(int /* argc */, char** /* argv */ ){
     BitField64 bf3( bf.fieldDescription() ) ;
 
 
-    test(  bf.getValue() , long64(0x0) , " initialized with 0 " ); 
+    test(  bf.getValue() , CellID(0x0) , " initialized with 0 " ); 
 
     //    std::cout  << " bf value : " << bf << std::endl ;
     
@@ -34,10 +34,10 @@ int main(int /* argc */, char** /* argv */ ){
 
     //    std::cout  << " bf value : " << bf << std::endl ;
 
-    test(  bf.getValue() , long64( 0xbebafecacafebabeULL ) , 
+    test(  bf.getValue() , 0xbebafecacafebabeULL, 
 	   " initialized with 0xbebafecacafebabeUL - compare as signed " ); 
 
-    test(  (ulong64) bf.getValue()   , 0xbebafecacafebabeULL  , 
+    test( bf.getValue()   , 0xbebafecacafebabeULL  , 
 	   " initialized with 0xbebafecacafebabeUL - compare as unsigned " ); 
 
 

--- a/DDTest/src/test_bitfieldcoder.cc
+++ b/DDTest/src/test_bitfieldcoder.cc
@@ -26,7 +26,7 @@ int main(int /* argc */, char** /* argv */ ){
     const BitFieldCoder bf("system:5,side:-2,layer:9,module:8,sensor:8,x:32:-16,y:-16" ) ;
 
     // set some 'random' values to bf2 
-    long64 field = 0  ;
+    CellID field = 0  ;
     
     bf.set( field, "layer",  373 );
     bf.set( field, "module", 254 );
@@ -37,7 +37,7 @@ int main(int /* argc */, char** /* argv */ ){
     bf.set( field, "y",      -16710 );
 
 
-    test(  field , long64(0xbebafecacafebabeUL)  , " same value 0xbebafecacafebabeUL from individual initialization " ); 
+    test(  field , CellID(0xbebafecacafebabeUL)  , " same value 0xbebafecacafebabeUL from individual initialization " ); 
 
 
     // make a copy for testing the access

--- a/UtilityApps/src/test_cellid_position_converter.cpp
+++ b/UtilityApps/src/test_cellid_position_converter.cpp
@@ -134,10 +134,10 @@ int main_wrapper(int argc, char** argv ){
 	
         SimCalorimeterHit* sHit = (SimCalorimeterHit*) col->getElementAt(i) ;
 	
-        dd4hep::long64 id0 = sHit->getCellID0() ;
-        dd4hep::long64 id1 = sHit->getCellID1() ;
+        dd4hep::CellID id0 = sHit->getCellID0() ;
+        dd4hep::CellID id1 = sHit->getCellID1() ;
 
-	dd4hep::long64 id =  idDecoder0.toLong( id0 , id1 ) ;                                                                                                                  
+	dd4hep::CellID id =  idDecoder0.toLong( id0 , id1 ) ;                                                                                                                  
 
 	Position point( sHit->getPosition()[0]* dd4hep::mm , sHit->getPosition()[1]* dd4hep::mm ,  sHit->getPosition()[2]* dd4hep::mm ) ;
 	

--- a/UtilityApps/src/test_surfaces.cpp
+++ b/UtilityApps/src/test_surfaces.cpp
@@ -120,7 +120,7 @@ int main_wrapper(int argc, char** argv ){
 	
         EVENT::SimTrackerHit* sHit = (EVENT::SimTrackerHit*) col->getElementAt(i) ;
 	
-        dd4hep::long64 id = sHit->getCellID0() ;
+        dd4hep::FieldID id = sHit->getCellID0() ;
 	
         idDecoder.setValue( id ) ;
         //      std::cout << " simhit with cellid : " << idDecoder << std::endl ;

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -513,7 +513,7 @@ if (DD4HEP_USE_GEANT4)
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTel.py
     	       -batch -debug -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml
     REGEX_PASS "\\+ Apply REGION settings: minitel_region_5         to volume MyLHCBdetector5."
-    REGEX_FAIL "Exception;EXCEPTION;ERROR"
+    REGEX_FAIL "EXCEPTION; Exception;ERROR"
   )
   #
   # Test setting properties to the world volume
@@ -522,7 +522,7 @@ if (DD4HEP_USE_GEANT4)
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTel.py
     	       -batch -debug -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml
     REGEX_PASS "Volume world_volume Region: DefaultRegionForTheWorld. Apply user limits from world_region"
-    REGEX_FAIL "Exception;EXCEPTION;ERROR"
+    REGEX_FAIL "EXCEPTION; Exception;ERROR"
   )
   #
   if(Geant4_VERSION VERSION_LESS 10.7)
@@ -536,7 +536,7 @@ if (DD4HEP_USE_GEANT4)
         EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/${script}.py -batch -events 2
 		   -geometry ${ClientTestsEx_INSTALL}/compact/SiliconBlock.xml -batch -events 2
         REGEX_PASS "Event 1 Begin event action. Access event related information"
-        REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
+        REGEX_FAIL "EXCEPTION; Exception;ERROR;Error" )
     endforeach(script)
   endif()
   #
@@ -546,7 +546,7 @@ if (DD4HEP_USE_GEANT4)
       EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/ParamVolume.py
       		 -geometry ${script}.xml -batch -events 2
       REGEX_PASS "Event 1 Begin event action. Access event related information"
-      REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
+      REGEX_FAIL "EXCEPTION; Exception;ERROR;Error" )
   endforeach(script)
   #
   #
@@ -558,7 +558,7 @@ if (DD4HEP_USE_GEANT4)
       EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTelGenerate.py
                  -batch -events 5 -output MiniTel_ddg4_edm4hep.edm4hep.root
       REGEX_PASS "\\+\\+\\+ Finished run 0 after 5 events \\(5 events in total\\)"
-      REGEX_FAIL "Error;ERROR;Exception"
+      REGEX_FAIL "Error;ERROR; Exception"
     )
   endif()
 endif(DD4HEP_USE_GEANT4)

--- a/examples/LHeD/src/Lhe_BeamPipe_Central_geo.cpp
+++ b/examples/LHeD/src/Lhe_BeamPipe_Central_geo.cpp
@@ -49,7 +49,7 @@ public:
   void setHalfLength( double half_length){
     _half_length = half_length ;
   }
-  void setID( dd4hep::long64 id ) { _id = id ;
+  void setID( dd4hep::CellID id ) { _id = id ;
   }
   // overwrite to include points inside the inner radius of the barrel
   bool insideBounds(const rec::Vector3D& point, double epsilon) const {

--- a/examples/LHeD/src/Lhe_CaloFaceBarrel_surfaces.cpp
+++ b/examples/LHeD/src/Lhe_CaloFaceBarrel_surfaces.cpp
@@ -55,7 +55,7 @@ namespace{
       _width = width ;
     }
 
-    void setID( dd4hep::long64 id_val ) { _id = id_val ; }
+    void setID( dd4hep::CellID id_val ) { _id = id_val ; }
     
     // overwrite to include points inside the inner radius of the barrel 
     bool insideBounds(const dd4hep::rec::Vector3D& point, double epsilon) const {

--- a/examples/LHeD/src/Lhe_CaloFaceEndcap_surfaces.cpp
+++ b/examples/LHeD/src/Lhe_CaloFaceEndcap_surfaces.cpp
@@ -55,7 +55,7 @@ namespace{
       _phi0 = phi0 ;
       _sym = symmetry ;
     }
-    void setID( dd4hep::long64 id_val ) { _id = id_val; }
+    void setID( dd4hep::CellID id_val ) { _id = id_val; }
     
     // overwrite to include points inside the inner radius of the endcap 
     bool insideBounds(const dd4hep::rec::Vector3D& point, double epsilon) const {


### PR DESCRIPTION

BEGINRELEASENOTES
- Define the CellID and the VolumeID data types of segmentations as uint64_t rather than signed integers.
  Reasoning: Please see issue: 1090 (https://github.com/AIDASoft/DD4hep/issues/1090)
ENDRELEASENOTES