### PR TITLE
Allow to user-set world material. 

### DIFF
--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -410,10 +410,18 @@ dd4hep_add_test_reg( minitel_config_plugins_include_command_xml
 )
 #
 # Test setting properties to the world volume and a single sub-detector
-dd4hep_add_test_reg( minitel_config_subdet
+dd4hep_add_test_reg( minitel_config_world_volume
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
   EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/WorldSettings.xml 
   REGEX_PASS "\\+\\+ Applied 5 settings to MyLHCBdetector5"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR"
+)
+#
+# Test creation of the world volume with user specified material
+dd4hep_add_test_reg( minitel_config_world_material
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/WorldMaterial.xml -print INFO -destroy -load
+  REGEX_PASS "\\+\\+ Created world volume 'world_volume' as TGeoBBox \\(50.00, 50.00 50.00 \\[cm\\]\\) material:Steel235"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #

--- a/examples/ClientTests/compact/WorldMaterial.xml
+++ b/examples/ClientTests/compact/WorldMaterial.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+<!-- #==========================================================================
+     #  AIDA Detector description implementation 
+     #==========================================================================
+     # Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+     # All rights reserved.
+     #
+     # For the licensing terms see $DD4hepINSTALL/LICENSE.
+     # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+     #
+     #==========================================================================
+-->
+ 
+  <info name="SiliconBlock"
+	title="Test with 2 simple silicon boxes"
+	author="Markus Frank"
+	url="http://www.cern.ch/lhcb"
+	status="development"
+	version="$Id: compact.xml 513 2013-04-05 14:31:53Z gaede $">
+    <comment>Alignment test with 2 simple boxes</comment>        
+  </info>
+
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/materials.xml"/>
+  </includes>
+
+
+  <!-- Note: 
+       You can either see the world volume itself (showDaughters="false") 
+       or the children (showDaughters="true")  not both.
+  -->
+  <display>
+    <vis name="Invisible" showDaughters="false" visible="false"/>
+    <vis name="InvisibleWithChildren" showDaughters="true" visible="false"/>
+    <vis name="WorldVis"     alpha="0.8" r="1.0" g="1.0" b="0.0" showDaughters="false"  visible="true"  drawingStyle="solid" lineStyle="solid"/>
+    <vis name="VisibleGreen" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="true"  visible="true"  drawingStyle="solid" lineStyle="solid"/>
+  </display>
+
+  <define>
+    <constant name="world_side" value="50*cm"/>
+    <constant name="world_x" value="world_side"/>
+    <constant name="world_y" value="world_side"/>
+    <constant name="world_z" value="world_side"/>
+  </define>
+
+  <world material="Steel235"/>
+
+  <detectors>
+    <detector id="1" name="SiliconBlock" type="DD4hep_BoxSegment" vis="VisibleGreen">
+      <material name="Silicon"/>
+      <sensitive type="tracker"/>
+      <box      x="20*cm" y="20*cm" z="20*cm"/>
+      <position x="0"  y="0"  z="0"/>
+      <rotation x="0"  y="0"  z="0"/>
+    </detector>
+  </detectors>
+</lccdd>


### PR DESCRIPTION
BEGINRELEASENOTES
- Allow to user-set world material in compact description:
```
  <world material="Steel235">
  </world>
```
  See issue https://github.com/AIDASoft/DD4hep/issues/1116 for details.
- Add test t_minitel_config_world_material illustrating the feature.
ENDRELEASENOTES