### PR TITLE
DD4hepSimulation: exit(0) when --dumpParameter/dumpSteeringFile

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -260,11 +260,11 @@ class DD4hepSimulation(object):
       logger.info("=" * 80)
       pprint(vars(self))
       logger.info("=" * 80)
-      exit(1)
+      exit(0)
 
     if self._dumpSteeringFile:
       self.__printSteeringFile(parser)
-      exit(1)
+      exit(0)
 
   def getDetectorLists(self, detectorDescription):
     ''' get lists of trackers and calorimeters that are defined in detectorDescription (the compact xml file)'''


### PR DESCRIPTION
`ddsim --dumpParameter` and `ddsim --dumpSteeringFile` should return 0 (success) when they run their task to completion. This allows use in scripts when running inside CI environments which treat any failing command as a job failure.

I couldn't find any tests in DD4hep that rely on this, nor any discussion on exit codes in the PRs that introduced this functionality.

BEGINRELEASENOTES
- fix: exit(0) when --dumpParameter/dumpSteeringFile

ENDRELEASENOTES