### PR TITLE
Add conversion from TGeoPara to G4Para

### DIFF
--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -45,6 +45,7 @@
 #include <TGeoScaledShape.h>
 #include <TGeoCompositeShape.h>
 #include <TGeoShapeAssembly.h>
+#include <TGeoPara.h>
 #if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
 #include <TGeoTessellated.h>
 #endif

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -610,6 +610,8 @@ void* Geant4Converter::handleSolid(const string& name, const TGeoShape* shape) c
       solid = convertShape<TGeoTrap>(shape);
     else if (isa == TGeoArb8::Class()) 
       solid = convertShape<TGeoArb8>(shape);
+    else if (isa == TGeoPara::Class())
+      solid = convertShape<TGeoPara>(shape);
 #if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
     else if (isa == TGeoTessellated::Class()) 
       solid = convertShape<TGeoTessellated>(shape);

--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -31,6 +31,7 @@
 #include <G4Trap.hh>
 #include <G4Cons.hh>
 #include <G4Hype.hh>
+#include <G4Para.hh>
 #include <G4Torus.hh>
 #include <G4Sphere.hh>
 #include <G4CutTubs.hh>
@@ -138,6 +139,14 @@ namespace dd4hep {
       for ( std::size_t i=0; i<8; ++i, vtx_xy +=2 )
         vertices.emplace_back(vtx_xy[0] * CM_2_MM, vtx_xy[1] * CM_2_MM);
       return new G4GenericTrap(sh->GetName(), sh->GetDz() * CM_2_MM, vertices);
+    }
+
+    template <> G4VSolid* convertShape<TGeoPara>(const TGeoShape* shape) {
+      const auto* sh = static_cast<const TGeoPara*>(shape);
+      return new G4Para(sh->GetName(),
+                        sh->GetX() * CM_2_MM, sh->GetY() * CM_2_MM, sh->GetZ() * CM_2_MM,
+                        sh->GetAlpha() * DEGREE_2_RAD, sh->GetTheta() * DEGREE_2_RAD,
+                        sh->GetPhi() * DEGREE_2_RAD);
     }
 
     template <> G4VSolid* convertShape<TGeoXtru>(const TGeoShape* shape)  {


### PR DESCRIPTION

BEGINRELEASENOTES
- Add conversion from of `TGeoPara` to `G4Para`

ENDRELEASENOTES

Use case from LUXE GDML geometry reading. For the unit conversion I simply followed what is done for the other shapes.

From a quick glance at the git histories of Geant4 and ROOT both seem to have been present pretty much from the start, so I don't think we need version guards.