### PR TITLE
[WIP] Enable the GDML export / import tests again

### DIFF
--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -104,7 +104,7 @@ dd4hep_add_test_reg( CLICSiD_GDML_export_LONGTEST
              -plugin DD4hep_ROOTGDMLExtract -output LumiReadout_Forward.gdml   -path /world/LumiReadout_Forward
              -plugin DD4hep_ROOTGDMLExtract -output LumiReadout_Backward.gdml  -path /world/LumiReadout_Backward
              -plugin DD4hep_VolumeDump --topstat
-  REGEX_PASS "Checked 130738 physical volume placements"
+  REGEX_PASS "Checked 130882 physical volume placements"
   REGEX_FAIL "Exception;EXCEPTION;ERROR" )
 #
 # ROOT Geometry export to GDML

--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -87,7 +87,7 @@ dd4hep_add_test_reg( CLICSiD_multiple_inputs
 #
 #
 ## Always false. Good for now!
-if( "${ROOT_FIND_VERSION}" VERSION_GREATER "6.13.0" )
+if( "${ROOT_VERSION}" VERSION_GREATER "6.13.0" )
 # ROOT Geometry export to GDML
 dd4hep_add_test_reg( CLICSiD_GDML_export_LONGTEST
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"


### PR DESCRIPTION

BEGINRELEASENOTES
- Enable GDML export / import tests again

ENDRELEASENOTES

@andresailer @MarkusFrankATcernch the importing test is failing on my end due to:
```
[...]
21: Info in <TGeoManager::CloseGeometry>: 130882 nodes/ 808 volume UID's in Detector Geometry
21: Info in <TGeoManager::CloseGeometry>: ----------------modeler ready----------------
21: DD4hep           WARN  ++ STD conditions NOT defined by client. NTP defaults taken.
21: geoPluginRun: [   0.011 sec] Executed dd4hep plugin: 'DD4hep_ROOTGDMLParse' with args (6) :[ -input EcalBarrel.gdml -path /world/EcalBarrel -world world ]
21: ROOTGDMLParse    ERROR +++ Invalid DetElement path given: /world/EcalEndcap
21: RunPlugin        ERROR ++ Exception while executing plugin DD4hep_ROOTGDMLParse:
21: 		ROOTGDMLParse: +++ Invalid DetElement path given: /world/EcalEndcap
21: dd4hep: with plugin:DD4hep_ROOTGDMLParse
21: geoPluginRun: Got uncaught exception: RunPlugin: ++ Exception while executing plugin DD4hep_ROOTGDMLParse:
21: 		ROOTGDMLParse: +++ Invalid DetElement path given: /world/EcalEndcap
21: dd4hep: with plugin:DD4hep_ROOTGDMLParse
1/1 Test #21: t_CLICSiD_GDML_import_LONGTEST ...***Failed  Error regular expression found in output. Regex=[Exception]  1.27 sec
```

I haven't really started debugging that, maybe you have an idea on how to easily fix this?