### PR TITLE
feat: support TGeoTessellated volumes in DetectorChecksum

### DIFF
--- a/DDCore/src/plugins/DetectorChecksum.cpp
+++ b/DDCore/src/plugins/DetectorChecksum.cpp
@@ -554,7 +554,7 @@ const DetectorChecksum::entry_t& DetectorChecksum::handleSolid(Solid solid) cons
         log << "</tessellated>" << newline;
       }
       else {
-        log << "<tessellated></tessellated>" << newline
+        log << "<tessellated></tessellated>" << newline;
       }
     }
     else   {

--- a/DDCore/src/plugins/DetectorChecksum.cpp
+++ b/DDCore/src/plugins/DetectorChecksum.cpp
@@ -522,6 +522,7 @@ const DetectorChecksum::entry_t& DetectorChecksum::handleSolid(Solid solid) cons
         except("DetectorChecksum","+++ TGeoTessellated volume is not closed: %s", solid.name());
       }
       for (int ivertex = 0; ivertex < sh->GetNvertices(); ivertex++)  {
+        // Note: const_cast since TGeoTessellated::GetVertex not marked const in ROOT <= 6.28
         const auto& vtx = const_cast<TGeoTessellated*>(sh)->GetVertex(ivertex);
         log << "<position name\"" << nam << "_v" << ivertex
             << " lunit=\"" << m_len_unit_nam << "\""
@@ -533,6 +534,7 @@ const DetectorChecksum::entry_t& DetectorChecksum::handleSolid(Solid solid) cons
       log << "</define>" << newline;
       log << "<tessellated name=\"" << nam << "\">" << newline;
       for (int ifacet = 0; ifacet < sh->GetNfacets(); ifacet++)  {
+        // Note: const_cast since TGeoTessellated::GetFacet not marked const in ROOT <= 6.28
         const auto& facet = const_cast<TGeoTessellated*>(sh)->GetFacet(ifacet);
         if ( facet.GetNvert() == 3 ) {
           log << "<triangular";

--- a/DDCore/src/plugins/DetectorChecksum.cpp
+++ b/DDCore/src/plugins/DetectorChecksum.cpp
@@ -546,9 +546,9 @@ const DetectorChecksum::entry_t& DetectorChecksum::handleSolid(Solid solid) cons
           except("DetectorChecksum","+++ TGeoTessellated volume with unsupported number of vertices: %s", solid.name());
         }
         for (int ivertex = 0; ivertex < facet.GetNvert(); ivertex++) {
-          log << " vertex" << ivertex + 1 << "=\"" << nam << "_v" << facet.GetVertexIndex(ivertex);
+          log << " vertex" << ivertex + 1 << "=\"" << nam << "_v" << facet.GetVertexIndex(ivertex) << "\"";
         }
-        log << "type=\"ABSOLUTE\"/>" << newline;
+        log << " type=\"ABSOLUTE\"/>" << newline;
       }
       log << "</tessellated>" << newline;
     }

--- a/DDCore/src/plugins/DetectorChecksum.cpp
+++ b/DDCore/src/plugins/DetectorChecksum.cpp
@@ -516,7 +516,7 @@ const DetectorChecksum::entry_t& DetectorChecksum::handleSolid(Solid solid) cons
       log << "<shape_assembly " << nam << "\"/>";
     }
     else if ( shape->IsA() == TGeoTessellated::Class() )  {
-      if ( hash_readout )   {
+      if ( hash_meshes )   {
         const TGeoTessellated* sh  = (TGeoTessellated*)shape;
         log << "<define>" << newline;
         if ( sh->IsClosedBody() == false ) {

--- a/DDCore/src/plugins/DetectorChecksum.cpp
+++ b/DDCore/src/plugins/DetectorChecksum.cpp
@@ -526,9 +526,9 @@ const DetectorChecksum::entry_t& DetectorChecksum::handleSolid(Solid solid) cons
         const auto& vtx = const_cast<TGeoTessellated*>(sh)->GetVertex(ivertex);
         log << "<position name\"" << nam << "_v" << ivertex
             << " lunit=\"" << m_len_unit_nam << "\""
-            << " x=\"" << vtx.x() << "\""
-            << " y=\"" << vtx.y() << "\""
-            << " z=\"" << vtx.z() << "\""
+            << " x=\"" << vtx.x()/m_len_unit << "\""
+            << " y=\"" << vtx.y()/m_len_unit << "\""
+            << " z=\"" << vtx.z()/m_len_unit << "\""
             << "/>" << newline;
       }
       log << "</define>" << newline;

--- a/DDCore/src/plugins/DetectorChecksum.cpp
+++ b/DDCore/src/plugins/DetectorChecksum.cpp
@@ -1306,7 +1306,7 @@ void DetectorChecksum::dump_sensitives()   const   {
 
 static long create_checksum(Detector& description, int argc, char** argv) {
   std::vector<std::string> detectors;
-  int precision = 6, newline = 1, level = 1, readout = 0, debug = 0;
+  int precision = 6, newline = 1, level = 1, meshes = 0, readout = 0, debug = 0;
   int dump_elements = 0, dump_materials = 0, dump_solids = 0, dump_volumes = 0;
   int dump_placements = 0, dump_detelements = 0, dump_sensitives = 0;
   int dump_iddesc = 0, dump_segmentations = 0;
@@ -1333,6 +1333,8 @@ static long create_checksum(Detector& description, int argc, char** argv) {
       debug = ::atol(argv[++i]);
     else if ( 0 == ::strncmp("+newline",argv[i],5) )
       newline = 0;
+    else if ( 0 == ::strncmp("-meshes",argv[i],5) )
+      meshes = 1;
     else if ( 0 == ::strncmp("-readout",argv[i],5) )
       readout = 1;
     else if ( 0 == ::strncmp("-dump_elements",argv[i],10) )
@@ -1357,6 +1359,9 @@ static long create_checksum(Detector& description, int argc, char** argv) {
       std::cout <<
         "Usage: -plugin DD4hepDetectorChecksum -arg [-arg]                             \n\n"
         "     -detector <string>     Top level DetElement path. Default: '/world'        \n"
+	"     -meshes                also hash the detector's meshed solids              \n"
+	"                            (may be sensitive to changes due to rounding)       \n"
+	"                            default: false                                      \n"
 	"     -readout               also hash the detector's readout properties         \n"
 	"                            (sensitive det, id desc, segmentation)              \n"
 	"                            default: false                                      \n"
@@ -1396,6 +1401,7 @@ static long create_checksum(Detector& description, int argc, char** argv) {
   if ( !dens_unit.empty() ) wr.m_densunit_nam = dens_unit;
   if ( !atom_unit.empty() ) wr.m_atomunit_nam = atom_unit;
   if ( newline ) wr.newline = "\n";
+  wr.hash_meshes = meshes;
   wr.hash_readout = readout;
   wr.max_level = level;
   wr.debug = debug;

--- a/DDCore/src/plugins/DetectorChecksum.h
+++ b/DDCore/src/plugins/DetectorChecksum.h
@@ -114,6 +114,8 @@ namespace dd4hep {
 
       /// Property: precision of hashed printouts
       mutable int precision     { 6 };
+      /// Property: Include meshed solids in detector hash
+      int hash_meshes  { 0 };
       /// Property: Include readout property in detector hash
       int hash_readout  { 0 };
       /// Property: maximum depth level for printouts

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -397,7 +397,7 @@ dd4hep_add_test_reg( Check_Shape_Tessellated_check_checksum
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/Check_Shape_Tessellated.xml
   	      -plugin DD4hepDetectorChecksum -readout
-  REGEX_PASS "Combined hash code                      7fc1ef04482fc040  \\(13 sub-codes\\)"
+  REGEX_PASS "Combined hash code                      2e6b0d0c8839df5e  \\(13 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -392,6 +392,15 @@ dd4hep_add_test_reg( MiniTel_check_checksum_full
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
+# Checksum test of the full detector
+dd4hep_add_test_reg( Check_Shape_Tessellated_check_checksum
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
+  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/Check_Shape_Tessellated.xml
+  	      -plugin DD4hepDetectorChecksum -readout
+  REGEX_PASS "Combined hash code                      7fc1ef04482fc040  \\(13 sub-codes\\)"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR"
+)
+#
 # Test the sequential processing of two xml files
 dd4hep_add_test_reg( minitel_config_plugins_include_command_line
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -392,12 +392,21 @@ dd4hep_add_test_reg( MiniTel_check_checksum_full
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
-# Checksum test of the full detector
+# Checksum test of a tessellated solid (default, without meshes)
 dd4hep_add_test_reg( Check_Shape_Tessellated_check_checksum
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/Check_Shape_Tessellated.xml
-  	      -plugin DD4hepDetectorChecksum -readout
-  REGEX_PASS "Combined hash code                      2e6b0d0c8839df5e  \\(13 sub-codes\\)"
+  	      -plugin DD4hepDetectorChecksum
+  REGEX_PASS "Combined hash code                      c8eb13dd1d4d9ca1  \\(13 sub-codes\\)"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR"
+)
+#
+# Checksum test of a tessellated solid (with meshes)
+dd4hep_add_test_reg( Check_Shape_Tessellated_check_checksum_with_meshes
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
+  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/Check_Shape_Tessellated.xml
+  	      -plugin DD4hepDetectorChecksum -meshes -precision 3
+  REGEX_PASS "Combined hash code                      ada64a13764bb466  \\(13 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #


### PR DESCRIPTION
This adds support for TGeoTessellated in detector checksumming. It also (necessarily) exports them to gdml. This requires a const_cast because const access to vertices and facets was [only recently enabled](https://github.com/root-project/root/pull/12315/files#diff-8b2a14813cbf71ff6686d872c319c8590b95c48239996255c18f28909cc05b74). Also added a test on an existing TGeoTessellated shape check.

BEGINRELEASENOTES
- Support TGeoTessellated volumes in DetectorChecksum

ENDRELEASENOTES