### PR TITLE
DDSim: Change Default Output config

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -20,7 +20,7 @@ from DDSim.Helper.Geometry import Geometry
 from DDSim.Helper.Random import Random
 from DDSim.Helper.Action import Action
 from DDSim.Helper.Output import Output, outputLevel, outputLevelType
-from DDSim.Helper.OutputConfig import OutputConfig, defaultOutputFile, DD4HEP_USE_EDM4HEP, DD4HEP_USE_LCIO
+from DDSim.Helper.OutputConfig import OutputConfig, defaultOutputFile
 from DDSim.Helper.InputConfig import InputConfig
 from DDSim.Helper.ConfigHelper import ConfigHelper
 from DDSim.Helper.MagneticField import MagneticField
@@ -354,29 +354,8 @@ class DD4hepSimulation(object):
     # Configure the random seed, do it before the I/O because we might change the seed!
     self.random.initialize(DDG4, kernel, self.output.random)
 
-    # Configure I/O
-    if callable(self.outputConfig._userPlugin):
-      self.outputConfig._userPlugin(self)
-    elif self.outputFile.endswith(".slcio"):
-      if not DD4HEP_USE_LCIO:
-        raise RuntimeError("DD4HEP was not build wiht LCIO support: please change output format %s" % self.outputFile)
-      logger.info("++++ Setting up LCIO Output ++++")
-      lcOut = geant4.setupLCIOOutput('LcioOutput', self.outputFile)
-      lcOut.RunHeader = self.meta.addParametersToRunHeader(self)
-      eventPars = self.meta.parseEventParameters()
-      lcOut.EventParametersString, lcOut.EventParametersInt, lcOut.EventParametersFloat = eventPars
-      lcOut.RunNumberOffset = self.meta.runNumberOffset if self.meta.runNumberOffset > 0 else 0
-      lcOut.EventNumberOffset = self.meta.eventNumberOffset if self.meta.eventNumberOffset > 0 else 0
-    elif self.outputFile.endswith(".root") and DD4HEP_USE_EDM4HEP:
-      logger.info("++++ Setting up EDM4hep ROOT Output ++++")
-      e4Out = geant4.setupEDM4hepOutput('EDM4hepOutput', self.outputFile)
-      eventPars = self.meta.parseEventParameters()
-      e4Out.EventParametersString, e4Out.EventParametersInt, e4Out.EventParametersFloat = eventPars
-      e4Out.RunNumberOffset = self.meta.runNumberOffset if self.meta.runNumberOffset > 0 else 0
-      e4Out.EventNumberOffset = self.meta.eventNumberOffset if self.meta.eventNumberOffset > 0 else 0
-    elif self.outputFile.endswith(".root"):
-      logger.info("++++ Setting up DD4hep's ROOT Output ++++")
-      geant4.setupROOTOutput('RootOutput', self.outputFile)
+    # Configure the output file format and plugin
+    self.outputConfig.initialize(dd4hepsimulation=self, geant4=geant4)
 
     actionList = []
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -6,8 +6,6 @@ Based on M. Frank and F. Gaede runSim.py
    @version 0.1
 
 """
-from __future__ import absolute_import, unicode_literals, division, print_function
-
 import os
 import sys
 import textwrap
@@ -30,7 +28,6 @@ from DDSim.Helper.ParticleHandler import ParticleHandler
 from DDSim.Helper.Gun import Gun
 from DDSim.Helper.UI import UI
 import argparse
-import ddsix as six
 import logging
 from io import open
 
@@ -551,7 +548,7 @@ class DD4hepSimulation(object):
     """check if the fileName is allowed, note that the filenames are case
     sensitive, and in case of hepevt we depend on this to identify short and long versions of the content
     """
-    if isinstance(fileNames, six.string_types):
+    if isinstance(fileNames, str):
       fileNames = [fileNames]
     if not all(fileName.endswith(tuple(extensions)) for fileName in fileNames):
       self._errorMessages.append("ERROR: Unknown fileformat for file: %s" % fileNames)
@@ -579,7 +576,7 @@ class DD4hepSimulation(object):
   def __parseAllHelper(self, parsed):
     """ parse all the options for the helper """
     parsedDict = vars(parsed)
-    for name, obj in six.iteritems(vars(self)):
+    for name, obj in vars(self).items():
       if isinstance(obj, ConfigHelper):
         for var in obj.getOptions():
           key = "%s.%s" % (name, var)
@@ -656,14 +653,14 @@ class DD4hepSimulation(object):
         steeringFileBase += "## %s \n" % "\n## ".join(parameter.__doc__.splitlines())
         steeringFileBase += "################################################################################\n"
         options = parameter.getOptions()
-        for opt, optionsDict in sorted(six.iteritems(options), key=sortParameters):
+        for opt, optionsDict in sorted(options.items(), key=sortParameters):
           if opt.startswith("_"):
             continue
           parValue = optionsDict['default']
-          if isinstance(optionsDict.get('help'), six.string_types):
+          if isinstance(optionsDict.get('help'), str):
             steeringFileBase += "\n## %s\n" % "\n## ".join(optionsDict.get('help').splitlines())
           # add quotes if it is a string
-          if isinstance(parValue, six.string_types):
+          if isinstance(parValue, str):
             steeringFileBase += "SIM.%s.%s = \"%s\"\n" % (parName, opt, parValue)
           else:
             steeringFileBase += "SIM.%s.%s = %s\n" % (parName, opt, parValue)
@@ -673,7 +670,7 @@ class DD4hepSimulation(object):
         if isinstance(optionObj, argparse._StoreAction):
           steeringFileBase += "## %s\n" % "\n## ".join(optionObj.help.splitlines())
         # add quotes if it is a string
-        if isinstance(parameter, six.string_types):
+        if isinstance(parameter, str):
           steeringFileBase += "SIM.%s = \"%s\"" % (parName, str(parameter))
         else:
           steeringFileBase += "SIM.%s = %s" % (parName, str(parameter))

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -22,7 +22,7 @@ from DDSim.Helper.Geometry import Geometry
 from DDSim.Helper.Random import Random
 from DDSim.Helper.Action import Action
 from DDSim.Helper.Output import Output, outputLevel, outputLevelType
-from DDSim.Helper.OutputConfig import OutputConfig
+from DDSim.Helper.OutputConfig import OutputConfig, defaultOutputFile, DD4HEP_USE_EDM4HEP, DD4HEP_USE_LCIO
 from DDSim.Helper.InputConfig import InputConfig
 from DDSim.Helper.ConfigHelper import ConfigHelper
 from DDSim.Helper.MagneticField import MagneticField
@@ -61,7 +61,7 @@ class DD4hepSimulation(object):
     self.steeringFile = None
     self.compactFile = []
     self.inputFiles = []
-    self.outputFile = "dummyOutput.slcio"
+    self.outputFile = defaultOutputFile()
     self.runType = "batch"
     self.printLevel = 3
 
@@ -361,19 +361,24 @@ class DD4hepSimulation(object):
     if callable(self.outputConfig._userPlugin):
       self.outputConfig._userPlugin(self)
     elif self.outputFile.endswith(".slcio"):
+      if not DD4HEP_USE_LCIO:
+        raise RuntimeError("DD4HEP was not build wiht LCIO support: please change output format %s" % self.outputFile)
+      logger.info("++++ Setting up LCIO Output ++++")
       lcOut = geant4.setupLCIOOutput('LcioOutput', self.outputFile)
       lcOut.RunHeader = self.meta.addParametersToRunHeader(self)
       eventPars = self.meta.parseEventParameters()
       lcOut.EventParametersString, lcOut.EventParametersInt, lcOut.EventParametersFloat = eventPars
       lcOut.RunNumberOffset = self.meta.runNumberOffset if self.meta.runNumberOffset > 0 else 0
       lcOut.EventNumberOffset = self.meta.eventNumberOffset if self.meta.eventNumberOffset > 0 else 0
-    elif self.outputFile.endswith("edm4hep.root"):
+    elif self.outputFile.endswith(".root") and DD4HEP_USE_EDM4HEP:
+      logger.info("++++ Setting up EDM4hep ROOT Output ++++")
       e4Out = geant4.setupEDM4hepOutput('EDM4hepOutput', self.outputFile)
       eventPars = self.meta.parseEventParameters()
       e4Out.EventParametersString, e4Out.EventParametersInt, e4Out.EventParametersFloat = eventPars
       e4Out.RunNumberOffset = self.meta.runNumberOffset if self.meta.runNumberOffset > 0 else 0
       e4Out.EventNumberOffset = self.meta.eventNumberOffset if self.meta.eventNumberOffset > 0 else 0
     elif self.outputFile.endswith(".root"):
+      logger.info("++++ Setting up DD4hep's ROOT Output ++++")
       geant4.setupROOTOutput('RootOutput', self.outputFile)
 
     actionList = []

--- a/DDG4/python/DDSim/Helper/Action.py
+++ b/DDG4/python/DDSim/Helper/Action.py
@@ -1,10 +1,7 @@
 """Helper object for SD Actions
 """
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
-from ddsix.moves import range
-import ddsix as six
 
 
 class Action(ConfigHelper):
@@ -80,7 +77,7 @@ class Action(ConfigHelper):
       self._mapActions.update(val)
       return
 
-    if isinstance(val, six.string_types):
+    if isinstance(val, str):
       vals = val.split(" ")
     elif isinstance(val, list):
       vals = val

--- a/DDG4/python/DDSim/Helper/ConfigHelper.py
+++ b/DDG4/python/DDSim/Helper/ConfigHelper.py
@@ -121,7 +121,8 @@ class ConfigHelper(object):
     for name, obj in vars(ddsim).items():
       if isinstance(obj, ConfigHelper):
         for var, optionsDict in obj.getOptions().items():
-          optionsDict['action'] = 'store_true' if var.startswith("enable") else optionsDict.get('action', 'store')
+          optionsDict['action'] = ('store_true' if var.startswith(("enable", "force"))
+                                   else optionsDict.get('action', 'store'))
           parser.add_argument("--%s.%s" % (name, var),
                               dest="%s.%s" % (name, var),
                               **optionsDict

--- a/DDG4/python/DDSim/Helper/ConfigHelper.py
+++ b/DDG4/python/DDSim/Helper/ConfigHelper.py
@@ -12,10 +12,6 @@ call for the parser object create an additional member::
 
 """
 
-from __future__ import absolute_import, unicode_literals
-
-import ddsix as six
-
 
 class ConfigHelper(object):
   """Base class for configuration helper"""
@@ -28,7 +24,7 @@ class ConfigHelper(object):
 
     # get all direct members not starting with underscore
     allVars = vars(self)
-    for var, val in six.iteritems(allVars):
+    for var, val in allVars.items():
       if not var.startswith('_'):
         extraArgumentsName = "_%s_EXTRA" % var
         options = getattr(self, extraArgumentsName) if hasattr(self, extraArgumentsName) else None
@@ -56,7 +52,7 @@ class ConfigHelper(object):
   def printOptions(self):
     """print all parameters"""
     options = []
-    for opt, val in six.iteritems(self.getOptions()):
+    for opt, val in self.getOptions().items():
       options.append("\n\t'%s': '%s'" % (opt, val['default']))
     return "".join(options)
 
@@ -100,7 +96,7 @@ class ConfigHelper(object):
       myTuple = val
     if isinstance(val, list):
       myTuple = tuple(val)
-    if isinstance(val, six.string_types):
+    if isinstance(val, str):
       sep = ',' if ',' in val else ' '
       myTuple = tuple([_.strip("(), ") for _ in val.split(sep)])
     if myTuple is None:
@@ -112,7 +108,7 @@ class ConfigHelper(object):
     """check if val is a bool or a string of true/false, otherwise raise exception"""
     if isinstance(val, bool):
       return val
-    elif isinstance(val, six.string_types):
+    elif isinstance(val, str):
       if val.lower() == 'true':
         return True
       elif val.lower() == 'false':
@@ -122,9 +118,9 @@ class ConfigHelper(object):
   @staticmethod
   def addAllHelper(ddsim, parser):
     """all configHelper objects to commandline args"""
-    for name, obj in six.iteritems(vars(ddsim)):
+    for name, obj in vars(ddsim).items():
       if isinstance(obj, ConfigHelper):
-        for var, optionsDict in six.iteritems(obj.getOptions()):
+        for var, optionsDict in obj.getOptions().items():
           optionsDict['action'] = 'store_true' if var.startswith("enable") else optionsDict.get('action', 'store')
           parser.add_argument("--%s.%s" % (name, var),
                               dest="%s.%s" % (name, var),

--- a/DDG4/python/DDSim/Helper/Filter.py
+++ b/DDG4/python/DDSim/Helper/Filter.py
@@ -4,13 +4,9 @@ Later the parameter dictionary is used to instantiate the filter object
 The default filters are a GeantinoRejector and a 1keV minimum energy cut
 
 """
-
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
 from g4units import keV
 import logging
-from ddsix.moves import range
-import ddsix as six
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +86,7 @@ class Filter(ConfigHelper):
       self._mapDetFilter.update(val)
       return
 
-    if isinstance(val, six.string_types):
+    if isinstance(val, str):
       vals = val.split(" ")
     elif isinstance(val, list):
       vals = val
@@ -116,7 +112,7 @@ class Filter(ConfigHelper):
 
   def __makeMapDetList(self):
     """ create the values of the mapDetFilters a list of filters """
-    for pattern, filters in six.iteritems(self._mapDetFilter):
+    for pattern, filters in self._mapDetFilter.items():
       self._mapDetFilter[pattern] = ConfigHelper.makeList(filters)
 
   def setupFilters(self, kernel):
@@ -124,10 +120,10 @@ class Filter(ConfigHelper):
     import DDG4
     setOfFilters = set()
 
-    for name, filt in six.iteritems(self.filters):
+    for name, filt in self.filters.items():
       setOfFilters.add(name)
       ddFilt = DDG4.Filter(kernel, filt['name'])
-      for para, value in six.iteritems(filt['parameter']):
+      for para, value in filt['parameter'].items():
         setattr(ddFilt, para, value)
       kernel.registerGlobalFilter(ddFilt)
       filt['filter'] = ddFilt
@@ -150,7 +146,7 @@ class Filter(ConfigHelper):
     """
     self.__makeMapDetList()
     foundFilter = False
-    for pattern, filts in six.iteritems(self.mapDetFilter):
+    for pattern, filts in self.mapDetFilter.items():
       if pattern.lower() in det.lower():
         foundFilter = True
         for filt in filts:

--- a/DDG4/python/DDSim/Helper/Geometry.py
+++ b/DDG4/python/DDSim/Helper/Geometry.py
@@ -1,7 +1,5 @@
 """Helper object for Geant4 Geometry conversion."""
 
-from __future__ import absolute_import, unicode_literals
-
 from DDSim.Helper.ConfigHelper import ConfigHelper
 
 

--- a/DDG4/python/DDSim/Helper/GuineaPig.py
+++ b/DDG4/python/DDSim/Helper/GuineaPig.py
@@ -1,6 +1,5 @@
 """Helper object for GuineaPig InputFile Parameters"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.Input import Input
 
 

--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -1,11 +1,9 @@
 """Helper object for particle gun properties"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
 from g4units import GeV
 from math import atan, exp
 import logging
-import ddsix as six
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +64,7 @@ class Gun(ConfigHelper):
     if val is None:
       return
     possibleDistributions = self._distribution_EXTRA['choices']
-    if not isinstance(val, six.string_types):
+    if not isinstance(val, str):
       raise RuntimeError("malformed input '%s' for gun.distribution. Need a string : %s " %
                          (val, ",".join(possibleDistributions)))
     if val not in possibleDistributions:

--- a/DDG4/python/DDSim/Helper/HepMC3.py
+++ b/DDG4/python/DDSim/Helper/HepMC3.py
@@ -1,6 +1,5 @@
 """Helper object for hepmc3 input control"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.Input import Input
 
 

--- a/DDG4/python/DDSim/Helper/Input.py
+++ b/DDG4/python/DDSim/Helper/Input.py
@@ -1,8 +1,6 @@
 """Base class for inputfile parameters"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
-import ddsix as six
 
 
 class Input(ConfigHelper):
@@ -23,7 +21,7 @@ class Input(ConfigHelper):
   @_parameters.setter
   def _parameters(self, newParameters):
     if isinstance(newParameters, dict):
-      for par, val in six.iteritems(newParameters):
+      for par, val in newParameters.items():
         self.__parameters[par] = str(val)
 
     else:

--- a/DDG4/python/DDSim/Helper/LCIO.py
+++ b/DDG4/python/DDSim/Helper/LCIO.py
@@ -1,6 +1,5 @@
 """Helper object for files containing one or more MCParticle collections"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.Input import Input
 
 

--- a/DDG4/python/DDSim/Helper/MagneticField.py
+++ b/DDG4/python/DDSim/Helper/MagneticField.py
@@ -1,5 +1,4 @@
 """Helper object for Magnetic Field properties"""
-from __future__ import absolute_import, unicode_literals
 from g4units import mm, m
 from DDSim.Helper.ConfigHelper import ConfigHelper
 

--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -1,11 +1,9 @@
 """Helper object for configuring the LCIO output file (meta)"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
 import datetime
 import os
 import logging
-import ddsix as six
 from io import open
 
 logger = logging.getLogger(__name__)
@@ -67,10 +65,10 @@ class Meta(ConfigHelper):
     """add the parameters to the (lcio) run Header"""
     runHeader = {}
     parameters = vars(sim)
-    for parName, parameter in six.iteritems(parameters):
+    for parName, parameter in parameters.items():
       if isinstance(parameter, ConfigHelper):
         options = parameter.getOptions()
-        for opt, optionsDict in six.iteritems(options):
+        for opt, optionsDict in options.items():
           runHeader["%s.%s" % (parName, opt)] = str(optionsDict['default'])
       else:
         runHeader[parName] = str(parameter)

--- a/DDG4/python/DDSim/Helper/Output.py
+++ b/DDG4/python/DDSim/Helper/Output.py
@@ -1,6 +1,5 @@
 """Dummy helper object for particle gun properties"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
 
 OUTPUT_CHOICES = (1, 2, 3, 4, 5, 6, 7, 'VERBOSE', 'DEBUG',

--- a/DDG4/python/DDSim/Helper/OutputConfig.py
+++ b/DDG4/python/DDSim/Helper/OutputConfig.py
@@ -1,7 +1,17 @@
 """Class for output file configuration"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
+
+#: True if DD4hep was built with LCIO
+DD4HEP_USE_LCIO = "@DD4HEP_USE_LCIO@" != "OFF"
+#: True if DD4hep was built with EDM4hep
+DD4HEP_USE_EDM4HEP = "@DD4HEP_USE_EDM4HEP@" != "OFF"
+
+
+def defaultOutputFile():
+  if DD4HEP_USE_LCIO:
+    return "dummyOutput.slcio"
+  return "dummyOutput.root"
 
 
 class OutputConfig(ConfigHelper):

--- a/DDG4/python/DDSim/Helper/ParticleHandler.py
+++ b/DDG4/python/DDSim/Helper/ParticleHandler.py
@@ -1,5 +1,4 @@
 """Configuration Helper for ParticleHandler"""
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
 from g4units import MeV, mm
 import logging

--- a/DDG4/python/DDSim/Helper/Physics.py
+++ b/DDG4/python/DDSim/Helper/Physics.py
@@ -1,12 +1,10 @@
 """Helper object for physicslist properties"""
 
-from __future__ import absolute_import, unicode_literals
 import os
 
 from DDSim.Helper.ConfigHelper import ConfigHelper
 from g4units import mm
 import logging
-import ddsix as six
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +70,7 @@ class Physics(ConfigHelper):
     if val is None:
       self._rangecut = None
       return
-    if isinstance(val, six.string_types):
+    if isinstance(val, str):
       if val == "None":
         self._rangecut = None
         return

--- a/DDG4/python/DDSim/Helper/Random.py
+++ b/DDG4/python/DDSim/Helper/Random.py
@@ -1,6 +1,5 @@
 """Helper object for random number generator objects"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
 import random
 import logging

--- a/DDG4/src/Geant4UIManager.cpp
+++ b/DDG4/src/Geant4UIManager.cpp
@@ -210,7 +210,10 @@ void Geant4UIManager::start() {
   /// Execute the chained pre-run command statements
   for(const auto& c : m_preRunCommands)  {
     info("++ Executing pre-run statement: %s",c.c_str());
-    mgr->ApplyCommand(c.c_str());
+    G4int ret = mgr->ApplyCommand(c.c_str());
+    if ( ret != 0 )  {
+      except("Failed to execute command: %s",c.c_str());
+    }
     executed_statements = true;
   }
   /// Start UI session if present
@@ -219,7 +222,10 @@ void Geant4UIManager::start() {
     /// Execute the chained post-run command statements
     for(const auto& c : m_postRunCommands)  {
       info("++ Executing post-run statement: %s",c.c_str());
-      mgr->ApplyCommand(c.c_str());
+      G4int ret = mgr->ApplyCommand(c.c_str());
+      if ( ret != 0 )  {
+        except("Failed to execute command: %s",c.c_str());
+      }
       executed_statements = true;
     }
     return;
@@ -232,7 +238,10 @@ void Geant4UIManager::start() {
     /// Execute the chained post-run command statements
     for(const auto& c : m_postRunCommands)  {
       info("++ Executing post-run statement: %s",c.c_str());
-      mgr->ApplyCommand(c.c_str());
+      G4int ret = mgr->ApplyCommand(c.c_str());
+      if ( ret != 0 )  {
+        except("Failed to execute command: %s",c.c_str());
+      }
     }
     return;
   }

--- a/examples/RICH/scripts/richsim.py
+++ b/examples/RICH/scripts/richsim.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
 
     # Output file (assuming CWD)
     SIM.outputFile = "sim.root"
+    SIM.outputConfig.forceDD4HEP = True
 
     # Override with user options
     SIM.parseOptions()


### PR DESCRIPTION
BEGINRELEASENOTES
- DDSim: change the default output file name on how DD4hep was built. Fixes #1101 
   - Add outputConfig.forceLCIO, outputConfig.forceEDM4HEP, outputConfig.forceDD4HEP switches to force a particular output plugin
   - If LCIO was used, slcio is still the default
   - If EDM4hep was used but not LCIO, EDM4hep is the default and used for all root output files. 
   - If neither LCIO or EDM4hep was used, then DD4hep's root output is used. Use the outputConfig.forceDD4HEP flag to use DD4hep's root output if EDM4hep is available as well

- DDSim: remove python2 legacy shims
- Geant4UIManager: fail when pre or post run commands are not successfully executed.

ENDRELEASENOTES