### PR TITLE
feat: convert several DDRec constructors to use `const Detector&`

### DIFF
--- a/DDCore/include/DD4hep/Detector.h
+++ b/DDCore/include/DD4hep/Detector.h
@@ -194,7 +194,7 @@ namespace dd4hep {
        is not present. Otherwise an empty detector container is returned.
     */
     virtual const std::vector<DetElement>& detectors(const std::string& type,
-                                                     bool throw_exc=false) = 0;
+                                                     bool throw_exc=false) const = 0;
 
     /// Access a set of subdetectors according to several sensitive types.
     virtual std::vector<DetElement> detectors(const std::string& type1,

--- a/DDCore/include/DD4hep/DetectorImp.h
+++ b/DDCore/include/DD4hep/DetectorImp.h
@@ -320,7 +320,7 @@ namespace dd4hep {
        - If throw_exc is set to true, an exception is thrown if the type
        is not present. Otherwise an empty detector container is returned.
     */
-    virtual const std::vector<DetElement>& detectors(const std::string& type, bool throw_exc)  override;
+    virtual const std::vector<DetElement>& detectors(const std::string& type, bool throw_exc) const override;
 
     /// Access a set of subdetectors according to several sensitive types.
     virtual std::vector<DetElement> detectors(const std::string& type1,

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -540,6 +540,7 @@ Material DetectorImp::material(const string& name) const {
 
 /// Internal helper to map detector types once the geometry is closed
 void DetectorImp::mapDetectorTypes()  {
+  m_detectorTypes[""] = {};
   for( const auto& i : m_detectors )   {
     DetElement det(i.second);
     if ( det.parent().isValid() )  { // Exclude 'world'
@@ -573,13 +574,13 @@ vector<string> DetectorImp::detectorTypes() const  {
 /// Access a set of subdetectors according to the sensitive type.
 const vector<DetElement>& DetectorImp::detectors(const string& type, bool throw_exc)  {
   if ( m_manager->IsClosed() ) {
+    DetectorTypeMap::const_iterator i=m_detectorTypes.find(type);
+    if ( i != m_detectorTypes.end() ) return (*i).second;
     if ( throw_exc )  {
-      DetectorTypeMap::const_iterator i=m_detectorTypes.find(type);
-      if ( i != m_detectorTypes.end() ) return (*i).second;
       throw runtime_error("detectors("+type+"): Detectors of this type do not exist in the current setup!");
     }
     // return empty vector instead of exception
-    return m_detectorTypes[ type ] ;
+    return m_detectorTypes.at("") ;
   }
   throw runtime_error("detectors("+type+"): Detectors can only selected by type once the geometry is closed!");
 }

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -572,7 +572,7 @@ vector<string> DetectorImp::detectorTypes() const  {
 }
 
 /// Access a set of subdetectors according to the sensitive type.
-const vector<DetElement>& DetectorImp::detectors(const string& type, bool throw_exc)  {
+const vector<DetElement>& DetectorImp::detectors(const string& type, bool throw_exc) const {
   if ( m_manager->IsClosed() ) {
     DetectorTypeMap::const_iterator i=m_detectorTypes.find(type);
     if ( i != m_detectorTypes.end() ) return (*i).second;

--- a/DDRec/include/DDRec/CellIDPositionConverter.h
+++ b/DDRec/include/DDRec/CellIDPositionConverter.h
@@ -48,7 +48,7 @@ namespace dd4hep {
     public:
       
       /// The constructor - takes the main description object.
-      CellIDPositionConverter( Detector& description ) : _description( &description )  {
+      CellIDPositionConverter(const Detector& description ) : _description( &description )  {
         _volumeManager = VolumeManager::getVolumeManager(description);
       }
 

--- a/DDRec/include/DDRec/MaterialScan.h
+++ b/DDRec/include/DDRec/MaterialScan.h
@@ -53,7 +53,7 @@ namespace dd4hep {
     private:
       
       /// Reference to detector setup
-      Detector&                        m_detector;
+      const Detector&                  m_detector;
       /// Material manager
       std::unique_ptr<MaterialManager> m_materialMgr;  //!
       /// Local cache: subdetector placements
@@ -64,7 +64,7 @@ namespace dd4hep {
     public:
 
       /// Standard constructor for the master instance
-      MaterialScan(Detector& description);
+      MaterialScan(const Detector& description);
 
       /// Default destructor
       virtual ~MaterialScan();

--- a/DDRec/include/DDRec/SurfaceManager.h
+++ b/DDRec/include/DDRec/SurfaceManager.h
@@ -38,7 +38,7 @@ namespace dd4hep {
 
     public:
       /// The constructor
-      SurfaceManager(Detector& theDetector);
+      SurfaceManager(const Detector& theDetector);
 
       /// No default constructor
 #if defined(G__ROOT)
@@ -69,7 +69,7 @@ namespace dd4hep {
 
 
       /// initialize all known surface maps
-      void initialize(Detector& theDetector) ;
+      void initialize(const Detector& theDetector) ;
 
       SurfaceMapsMap _map ;
     };

--- a/DDRec/src/MaterialScan.cpp
+++ b/DDRec/src/MaterialScan.cpp
@@ -35,7 +35,7 @@ MaterialScan::MaterialScan()
 }
 
 /// Default constructor
-MaterialScan::MaterialScan(Detector& description)
+MaterialScan::MaterialScan(const Detector& description)
   : m_detector(description)
 {
   m_materialMgr.reset(new MaterialManager(m_detector.world().volume()));

--- a/DDRec/src/SurfaceManager.cpp
+++ b/DDRec/src/SurfaceManager.cpp
@@ -25,7 +25,7 @@ namespace dd4hep {
   namespace rec {
     
 
-    SurfaceManager::SurfaceManager(Detector& theDetector){
+    SurfaceManager::SurfaceManager(const Detector& theDetector){
 
       // have to make sure the volume manager is populated once in order to have
       // the volumeIDs attached to the DetElements
@@ -52,7 +52,7 @@ namespace dd4hep {
       return 0 ;
     }
 
-    void SurfaceManager::initialize(Detector& description) {
+    void SurfaceManager::initialize(const Detector& description) {
       
       const std::vector<std::string>& types = description.detectorTypes() ;
 


### PR DESCRIPTION
This started as an attempt to use a `CellIDPositionConverter` in a class that only has access to a `const Detector&`, but then turned in to figuring out a few other constructors where we can add const-ness.

The main hurdle is addressed in https://github.com/AIDASoft/DD4hep/commit/4c26c0375502cdd2bc6d94b44a7dfd8fac45eba8, where the former approach was returning the map entry `m_detectorTypes[type]` whenever `type` is not a valid key, creating a new entry in the process. This doesn't work when const.

I changed this to adding an empty key entry when `m_detectorTypes` is first filled, `m_detectorTypes[""] = {}`, and this one can be returned when `type` is not a valid key, without violating const-ness.

### Potential implications
If a sensitive detector doesn't specify a type, then `type()` returns `""` too,
```cpp
string DetElement::type() const {
  return m_element ? m_element->GetTitle() : "";
}
```
There doesn't seem to be any guards (that I could find) against someone defining a sensitive detector with an empty string as type. Feedback welcome. I'm filing this as draft first.

BEGINRELEASENOTES
- Allow several DDRec c'tors to work on `const Detector&` instead of `Detector&`

ENDRELEASENOTES