### PR TITLE
Fix two compiler warnings

### DIFF
--- a/DDCore/src/Objects.cpp
+++ b/DDCore/src/Objects.cpp
@@ -452,7 +452,7 @@ string Limit::toString() const {
   string res = name + " = " + content;
   if (!unit.empty())
     res += unit + " ";
-  res + " (" + particles + ")";
+  res += " (" + particles + ")";
   return res;
 }
 

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -89,7 +89,7 @@ template <typename T> const char* Solid_type<T>::type() const  {
 
 /// Access the dimensions of the shape: inverse of the setDimensions member function
 template <typename T> vector<double> Solid_type<T>::dimensions()  {
-  return move( get_shape_dimensions(this->access()) );
+  return get_shape_dimensions(this->access());
 }
 
 /// Set the shape dimensions. As for the TGeo shape, but angles in rad rather than degrees.


### PR DESCRIPTION
BEGINRELEASENOTES
- Limits object: fix string creation of Limit::toString, this will now also print the relevant "particles"
- Shapes: remove "move" from return of dimensions()

ENDRELEASENOTES