### PR TITLE
CI: use clang16 for header guards check

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["dev4/x86_64-centos7-clang12-opt"]
+        LCG: ["dev4/x86_64-el9-clang16-opt"]
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3


### PR DESCRIPTION
BEGINRELEASENOTES
- CI: use clang16 for header guards check

ENDRELEASENOTES