### PR TITLE
Implement correct volume transparency settings for ROOT>=6.29

### DIFF
--- a/DDCore/src/Volumes.cpp
+++ b/DDCore/src/Volumes.cpp
@@ -1155,14 +1155,17 @@ const Volume& Volume::setVisAttributes(const VisAttr& attr) const {
       if (draw_style == VisAttr::SOLID) {
         m_element->SetFillStyle(1001);   // Root: solid
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,29,0)
+        // Set directly transparency to the volume, NOT to the material as for ROOT < 6.29
+        m_element->ResetTransparency(Char_t((1.0-vis->alpha)*100));
+#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
         // As suggested by Valentin Volkl https://sft.its.cern.ch/jira/browse/DDFORHEP-20
         //
         // According to https://root.cern.ch/phpBB3/viewtopic.php?t=2309#p66013
         // a transparency>50 will make a volume invisible in the normal pad.
         // Hence: possibly restrict transparency to a maximum of 50.
         //        but let's see first how this behaves.
-        m_element->SetTransparency((1.0-vis->alpha)*100);
+        m_element->SetTransparency(Char_t((1.0-vis->alpha)*100));
 #endif
       }
       else {

--- a/examples/ClientTests/compact/visTest.xml
+++ b/examples/ClientTests/compact/visTest.xml
@@ -1,0 +1,51 @@
+<lccdd>
+  <!-- Verify transparency handling of ROOT:
+
+       For details see: examples/ClientTests/compact/visTestEx.xml
+       Also see compact/visTestEx.xml for more explanations
+
+  -->
+  <define>
+    <constant name="world_x" value="1*m"/>
+    <constant name="world_y" value="1*m"/>
+    <constant name="world_z" value="1*m"/>
+    <constant name="tracker_region_rmax" value="1*m"/>
+    <constant name="tracker_region_zmax" value="1*m"/>
+    <constant name="tracker_region_zmin" value="-1*m"/>
+  </define>
+
+  <includes>
+    <gdmlFile ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile ref="${DD4hepINSTALL}/DDDetectors/compact/materials.xml"/>
+  </includes>
+  
+  <display>
+    <vis name="green" alpha="0.2" r= "0.0" g="1.0" b="0.0" />
+    <vis name="blue"  alpha="0.6" r= "0.0" g="0.0" b="1.0" />
+    <vis name="red"   alpha="1.0" r= "1.0" g="0.0" b="0.0" />
+  </display>
+
+  <detectors>
+    <detector name="Tube1" type="DD4hep_TubeSegment" vis="green">
+      <material name="Air"/>
+      <tubs rmin="0" rmax="1*cm" zhalf="2*cm"/>
+      <position x="0*cm" y="-4*cm" z="0"/>
+      <rotation x="0" y="0" z="0"/>
+    </detector>
+
+    <detector name="Tube2" type="DD4hep_TubeSegment" vis="blue">
+      <material name="Iron"/>
+      <tubs rmin="0" rmax="1*cm" zhalf="2*cm"/>
+      <position x="0*cm" y="0*cm" z="0"/>
+      <rotation x="0" y="0" z="0"/>
+    </detector>
+
+    <detector name="Tube3" type="DD4hep_TubeSegment" vis="red">
+      <material name="Iron"/>
+      <tubs rmin="0" rmax="1*cm" zhalf="2*cm"/>
+      <position x="0*cm" y="4*cm" z="0"/>
+      <rotation x="0" y="0" z="0"/>
+    </detector>
+  </detectors>
+
+</lccdd>

--- a/examples/ClientTests/compact/visTestEx.xml
+++ b/examples/ClientTests/compact/visTestEx.xml
@@ -1,0 +1,57 @@
+<lccdd>
+  <!-- Verify transparency handling of ROOT:
+
+       For details see: examples/ClientTests/compact/visTestEx.xml
+
+       This is the same content as visTest.xml BUT:
+       The construction sequence of the tubes is inversed.
+       With ROOT >= 6.29.1 we want to see the same picture,
+       which was not the case with ROOT < 6.29.1
+
+       Also see compact/visTest.xml
+       Also see scripts/visTest.C
+ -->
+  <define>
+    <constant name="world_x" value="1*m"/>
+    <constant name="world_y" value="1*m"/>
+    <constant name="world_z" value="1*m"/>
+    <constant name="tracker_region_rmax" value="1*m"/>
+    <constant name="tracker_region_zmax" value="1*m"/>
+    <constant name="tracker_region_zmin" value="-1*m"/>
+  </define>
+
+  <includes>
+    <gdmlFile ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile ref="${DD4hepINSTALL}/DDDetectors/compact/materials.xml"/>
+  </includes>
+  
+  <display>
+    <vis name="green" alpha="0.2" r= "0.0" g="1.0" b="0.0" />
+    <vis name="blue"  alpha="0.6" r= "0.0" g="0.0" b="1.0" />
+    <vis name="red"   alpha="1.0" r= "1.0" g="0.0" b="0.0" />
+  </display>
+
+  <detectors>
+    <detector name="Tube3" type="DD4hep_TubeSegment" vis="red">
+      <material name="Iron"/>
+      <tubs rmin="0" rmax="1*cm" zhalf="2*cm"/>
+      <position x="0*cm" y="4*cm" z="0"/>
+      <rotation x="0" y="0" z="0"/>
+    </detector>
+
+    <detector name="Tube2" type="DD4hep_TubeSegment" vis="blue">
+      <material name="Iron"/>
+      <tubs rmin="0" rmax="1*cm" zhalf="2*cm"/>
+      <position x="0*cm" y="0*cm" z="0"/>
+      <rotation x="0" y="0" z="0"/>
+    </detector>
+
+    <detector name="Tube1" type="DD4hep_TubeSegment" vis="green">
+      <material name="Air"/>
+      <tubs rmin="0" rmax="1*cm" zhalf="2*cm"/>
+      <position x="0*cm" y="-4*cm" z="0"/>
+      <rotation x="0" y="0" z="0"/>
+    </detector>
+  </detectors>
+
+</lccdd>

--- a/examples/ClientTests/scripts/visTest.C
+++ b/examples/ClientTests/scripts/visTest.C
@@ -1,0 +1,110 @@
+#include "TROOT.h"
+#include "TColor.h"
+#include "TGeoCone.h"
+#include "TGeoMatrix.h"
+#include "TGeoManager.h"
+#include "TGeoElement.h"
+#include "TGeoMaterial.h"
+
+#include <cstdio>
+
+
+class Test    {
+public:
+  TGeoManager*   m_manager = nullptr;
+  TGeoMaterial*  m_vacuum  = nullptr;
+  TGeoMedium*    m_air     = nullptr;
+
+  TGeoBBox*      m_worldShape   = nullptr;
+  TGeoVolume*    m_world = nullptr;
+  
+  struct Cone   {
+    TGeoMaterial* material = nullptr;
+    TGeoMedium*  medium = nullptr;
+    TGeoConeSeg* shape = nullptr;
+    TGeoVolume* volume = nullptr;
+    TGeoNode* place = nullptr;
+    void set_color(const char* typ, Float_t alpha, Float_t red, Float_t green, Float_t blue)   {
+      Int_t col = TColor::GetColor(red, green, blue);
+      TColor* color = gROOT->GetColor(col);
+      if ( !color )    {
+        ::printf("+++ %s Failed to allocate Color: r:%02X g:%02X b:%02X\n",
+                 typ, int(red*255.), int(green*255.), int(blue*255));
+      }
+      char text[64];
+      ::snprintf(text, sizeof(text), "%p", this);
+      TColor* colortr = new TColor(gROOT->GetListOfColors()->GetLast()+1,
+                                   color->GetRed(), color->GetGreen(), color->GetBlue(), text, alpha);
+      //colortr->SetAlpha(alpha);
+
+      ::printf("Plot cone %s (col: %d) with transparency %8.3f r:%02X g:%02X b:%02X\n",
+               typ, col, (1.0-alpha)*100, int(red*255.), int(green*255.), int(blue*255));
+
+      /// Propagate values to the volume:
+      int col_num    = color->GetNumber();
+      int col_tr_num = colortr->GetNumber();
+      volume->SetVisibility(kTRUE);
+      volume->SetVisContainers(kTRUE);
+      volume->SetVisDaughters(kTRUE);
+      volume->SetLineWidth(10);
+      volume->SetFillStyle(1001);
+      volume->ResetTransparency((1.0-alpha)*100);
+      volume->SetLineStyle(1);
+
+      /// Set line color
+      volume->SetLineColor(col_num);
+      /// Set fill color
+      volume->SetFillColor(col_tr_num);
+    }
+  } cone1, cone2;
+  
+public:
+  Test()   {
+  }
+  virtual ~Test()   {
+  }
+  void build(int version);
+};
+
+void Test::build(int version)    {
+  m_manager = new TGeoManager("geom","Tube test");
+  m_vacuum = new TGeoMaterial("vacuum", 0, 0, 0);
+  m_air = new TGeoMedium("Vacuum", 0, m_vacuum);
+
+  m_worldShape = new TGeoBBox("WorldBox", 100, 100, 100);
+  m_world = new TGeoVolume("World", m_worldShape, m_air);
+
+  cone1.material = new TGeoMaterial("Fe1", 55.845, 26, 7.87);
+  cone1.medium   = new TGeoMedium("Iron1", 1, cone1.material);
+  cone1.shape    = new TGeoConeSeg("Cone1Shape", 40, 0e0, 20e0, 0e0, 20e0, 0e0, 360e0);
+  cone1.volume   = new TGeoVolume("Cone1", cone1.shape, cone1.medium);
+  cone1.set_color("Cone1",
+                  version ? 0.1 : 0.9,
+                  version ? 1e0 : 0e0,
+                  0e0,
+                  version ? 0e0 : 1e0);
+  m_world->AddNode(cone1.volume, 1, new TGeoTranslation(-30, -30, 0));
+
+  cone2.material = version ? new TGeoMaterial("Fe2", 55.845, 26, 7.87) : cone1.material;
+  cone2.medium   = version ? new TGeoMedium("Iron2", 1, cone2.material) : cone1.medium;
+  cone2.shape    = new TGeoConeSeg("Cone2Shape", 40, 0e0, 20e0, 0e0, 20e0, 0e0, 360e0);
+  cone2.volume   = new TGeoVolume("Cone2", cone2.shape, cone2.medium);
+  cone2.set_color("Cone2",
+                  version ? 0.9 : 0.1,
+                  version ? 0e0 : 0.9,
+                  0e0,
+                  version ? 0.9 : 0e0);
+  m_world->AddNode(cone2.volume, 1, new TGeoTranslation(30, 30, 0));
+
+  m_manager->SetTopVolume(m_world);
+  m_manager->SetTopVisible(0);
+
+  m_manager->GetTopVolume()->Draw("ogl");
+}
+
+
+Test* visTest(int version=0)   {
+  Test* obj = new Test();
+  obj->build(version);
+  return obj;
+}


### PR DESCRIPTION
BEGINRELEASENOTES
- Implement correct transparency handling of ROOT:
  The transparency setting was connected to the material of the volume.
  This led to the same transparency setting for all volumes of the same material.
  It was not possible to change them at the level of the volume though 
  the API  suggested so.
  See: https://github.com/AIDASoft/DD4hep/issues/1117
  See: https://github.com/root-project/root/pull/13402
- Add test examples/ClientTests/compact/visTestEx.xml and visTest.xml.
  From the inversion of tubes with the same material, for ROOT >= 6.29
  the correct transparency settings are shown, whereas for ROOT < 6.29
  the transparency settings are the same for all volumes.
  Also see scripts/visTest.C
ENDRELEASENOTES