### PR TITLE
Geant4Output2EDM4hep: allow reuse of collection names... again

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -505,7 +505,7 @@ void Geant4Output2EDM4hep::saveCollection(OutputContext<G4Event>& /*ctxt*/, G4VH
   //-------------------------------------------------------------------
   if( typeid( Geant4Tracker::Hit ) == coll->type().type()  ){
     // Create the hit container even if there are no entries!
-    auto& hits = m_trackerHits[colName] = edm4hep::SimTrackerHitCollection();
+    auto& hits = m_trackerHits[colName];
     for(unsigned i=0 ; i < nhits ; ++i){
       auto sth = hits->create();
       const Geant4Tracker::Hit* hit = coll->hit(i);
@@ -536,8 +536,7 @@ void Geant4Output2EDM4hep::saveCollection(OutputContext<G4Event>& /*ctxt*/, G4VH
     Geant4Sensitive* sd = coll->sensitive();
     int hit_creation_mode = sd->hitCreationMode();
     // Create the hit container even if there are no entries!
-    auto& hits = m_calorimeterHits[colName] =
-      std::make_pair(edm4hep::SimCalorimeterHitCollection(), edm4hep::CaloHitContributionCollection());
+    auto& hits = m_calorimeterHits[colName];
     for(unsigned i=0 ; i < nhits ; ++i){
       auto sch = hits.first->create();
       const Geant4Calorimeter::Hit* hit = coll->hit(i);


### PR DESCRIPTION
[This](https://github.com/AIDASoft/DD4hep/issues/1111) seems to have gotten broken again [here](https://github.com/AIDASoft/DD4hep/blob/b784f3899b7cae7ef1e50b1b5b4cee6bbbfe61f8/DDG4/edm4hep/Geant4Output2EDM4hep.cpp#L476). We do NOT want to assign an empty collection since it overwrites the hits that are already in the collection; we just want to ensure that the named collection exists and the map should take care of the construction if it doesn't.

The ClientTest 'framework' doesn't easily allow for a unit test to prevent this from regressing (it's mostly based on regexes on failures), but please comment on ideas for tests there.

BEGINRELEASENOTES
- Geant4Output2EDM4hep: allow use of identical collection names across multiple detectors

ENDRELEASENOTES