### PR TITLE
HepMC3FileReader.cpp: avoid double call to `HepMC3::Reader::close()`

### DIFF
--- a/DDG4/hepmc/HepMC3FileReader.cpp
+++ b/DDG4/hepmc/HepMC3FileReader.cpp
@@ -133,8 +133,8 @@ HEPMC3FileReader::HEPMC3FileReader(const std::string& nam)
   m_reader->skip(1);
   // then we get the run info (shared pointer)
   auto runInfo = m_reader->run_info();
-  // and close the reader
-  m_reader->close();
+  // and deallocate the reader
+  m_reader.reset();
   // so we can open the file again from the start
   m_reader = HepMC3::deduce_reader(nam);
   // and set the run info object now


### PR DESCRIPTION
Fixes: #1156

BEGINRELEASENOTES
- DDSim: Fix reading HepMC3 input files via xrootd, fixes #1156

ENDRELEASENOTES