### PR TITLE
Fix GFlash test

### DIFF
--- a/DDG4/include/DDG4/Geant4FastSimShowerModel.h
+++ b/DDG4/include/DDG4/Geant4FastSimShowerModel.h
@@ -68,7 +68,7 @@ namespace dd4hep  {
       ParticleConfig m_eMax           { };
       /// Property: Set maximum kinetic energy for particles to be killed
       ParticleConfig m_eKill          { };
-      /// Property: Set minmal kinetic energy for particles to trigger the model
+      /// Property: Set minimal kinetic energy for particles to trigger the model
       ParticleConfig m_eTriggerNames  { };
 
       /// Particle definitions for which this parametrization is applicable

--- a/examples/ClientTests/scripts/SiliconBlockGFlash.py
+++ b/examples/ClientTests/scripts/SiliconBlockGFlash.py
@@ -100,6 +100,7 @@ def run():
   model.Enable = True
   # Energy boundaries are optional: Units are GeV
   model.Emin = {'e+': 0.1 * GeV, 'e-': 0.1 * GeV}
+  model.Emax = {'e+': 100 * GeV, 'e-': 100 * GeV}
   model.Ekill = {'e+': 0.1 * MeV, 'e-': 0.1 * MeV}
   model.enableUI()
   seq.adopt(model)


### PR DESCRIPTION

BEGINRELEASENOTES
- SiliconBlockGFlash: add maximal energy for using parametrisation, for electron and positron, fixes #1153 

ENDRELEASENOTES