### PR TITLE
WebDisplay: RGeomViewer is no longer experimental

### DIFF
--- a/DDEve/root7/WebDisplay.cpp
+++ b/DDEve/root7/WebDisplay.cpp
@@ -19,7 +19,11 @@
 #include "ROOT/RDirectory.hxx"
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,27,00)
 #include "ROOT/RGeomViewer.hxx"
-using GEOM_VIEWER = ROOT::Experimental::RGeomViewer;
+#  if ROOT_VERSION_CODE >= ROOT_VERSION(6,29,00)
+     using GEOM_VIEWER = ROOT::RGeomViewer;
+#  else
+     using GEOM_VIEWER = ROOT::Experimental::RGeomViewer;
+#  endif
 #else
 #include "ROOT/REveGeomViewer.hxx"
 using GEOM_VIEWER = ROOT::Experimental::REveGeomViewer;


### PR DESCRIPTION
LCG nightly builds:
```
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDEve/root7/WebDisplay.cpp:22:41: error: 'RGeomViewer' in namespace 'ROOT::Experimental' does not name a type
   22 | using GEOM_VIEWER = ROOT::Experimental::RGeomViewer;
      |                                         ^~~~~~~~~~~
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDEve/root7/WebDisplay.cpp: In function 'long int webdisplay(dd4hep::Detector&, int, char**)':
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDEve/root7/WebDisplay.cpp:84:36: error: 'GEOM_VIEWER' was not declared in this scope
   84 |     auto viewer = std::make_shared<GEOM_VIEWER>(&mgr);
      |                                    ^~~~~~~~~~~
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDEve/root7/WebDisplay.cpp:84:48: error: no matching function for call to 'make_shared<<expression error> >(TGeoManager*)'
   84 |     auto viewer = std::make_shared<GEOM_VIEWER>(&mgr);
```
BEGINRELEASENOTES
- DDEve Webdisplay: fix issue with ROOT master with RGeomViewer no longer being in the experimental namespace.

ENDRELEASENOTES