### PR TITLE
HepMC3FileReader: fix loading of run info for RootTree HepMC3 input format

### DIFF
--- a/DDG4/hepmc/HepMC3FileReader.cpp
+++ b/DDG4/hepmc/HepMC3FileReader.cpp
@@ -130,7 +130,8 @@ HEPMC3FileReader::HEPMC3FileReader(const std::string& nam)
   m_reader = HepMC3::deduce_reader(nam);
 #if HEPMC3_VERSION_CODE >= 3002006
   // to get the runInfo in the Ascii reader we have to force HepMC to read the first event
-  m_reader->skip(1);
+  HepMC3::GenEvent dummy;
+  m_reader->read_event(dummy);
   // then we get the run info (shared pointer)
   auto runInfo = m_reader->run_info();
   // and deallocate the reader


### PR DESCRIPTION
This is done by actually reading an event instead of skipping one. Skipping may be sufficient for the ASCII reader, however, RootTree reader does not perform a read on skip: https://gitlab.cern.ch/hepmc/HepMC3/-/blob/master/rootIO/src/ReaderRootTree.cc#L76-80

BEGINRELEASENOTES
- Fix loading of run info for RootTree HepMC3 input format

ENDRELEASENOTES

Here are a couple files, in case you'd like to test:
- This currently works [autoTest10x100.hepmc.gz](https://github.com/AIDASoft/DD4hep/files/12479563/autoTest10x100.hepmc.gz)
- This currently doesn't [autoTest10x100.hepmc.edm4hep.root.gz](https://github.com/AIDASoft/DD4hep/files/12479560/autoTest10x100.hepmc.edm4hep.root.gz)

cc @simonge
