### PR TITLE
fix: allow for ddsim running with uid without username

### DIFF
--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -100,6 +100,9 @@ class Meta(ConfigHelper):
 
     # add User
     import getpass
-    runHeader["User"] = getpass.getuser()
+    try:
+        runHeader["User"] = getpass.getuser()
+    except KeyError:
+        runHeader["User"] = str(os.getuid())
 
     return runHeader


### PR DESCRIPTION
Since 1.26 (ab9a96e66ac1df6a7b3989b082c043932b77dd33) we are seeing `ddsim` exceptions on certain Open Science Grid nodes/sites. Those sites appear to configure the running of singularity containers in such a way that no usernames are associated with the uid.

BEGINRELEASENOTES
- ddsim: handle run header exception when the user has no username.

ENDRELEASENOTES