### PR TITLE
DetectorChecksum.cpp: fix a typo

### DIFF
--- a/DDCore/src/plugins/DetectorChecksum.cpp
+++ b/DDCore/src/plugins/DetectorChecksum.cpp
@@ -909,7 +909,7 @@ const DetectorChecksum::entry_t& DetectorChecksum::handleSegmentation(Segmentati
         log << "/>" << newline;
       }
       log << " </parameters>" << newline;
-      log << "</segmentatoin>";
+      log << "</segmentation>";
       ise = geo.emplace(seg, make_entry(log)).first;
     }
     return ise->second;


### PR DESCRIPTION
BEGINRELEASENOTES
- A typo was fixed in the string representation used for checksum calculation. Checksums reported by DD4hepDetectorChecksum plugin will change.

ENDRELEASENOTES