### PR TITLE
Kill photons as soon they enter into a OpticalTracker

### DIFF
--- a/DDG4/plugins/Geant4SDActions.cpp
+++ b/DDG4/plugins/Geant4SDActions.cpp
@@ -163,7 +163,7 @@ namespace dd4hep {
       double    hit_deposit  = contrib.deposit;
       Hit* hit = new Hit(contrib, hit_momentum, hit_deposit);
 
-      if (h.trackDef() != G4OpticalPhoton::OpticalPhotonDefinition()) {
+      if (h.trackDef() == G4OpticalPhoton::OpticalPhotonDefinition()) {
         step->GetTrack()->SetTrackStatus(fStopAndKill);
       }
       hit->cellID = cellID(step);


### PR DESCRIPTION
BEGINRELEASENOTES
- Geant4OpticalTracker: Kill optical photons (instead of all other particles) as soon they enter into a Optical Tracker sensitive detector

ENDRELEASENOTES

Hi,

Please, correct me, but I think the condition to kill the photons when they enter an Optical Tracker is  the other way around. 

I ran a simulation of optical photon transport with and without changing that condition. The default DD4hep do not kill photons when they enter the Optical Tracker sensitive detector, but that behavior happens when the condition is reversed (as in the suggested change in this PR). 

Test: I did some tests with version 1.23 of DD4hep. The geometry is simple: a box (laboratory)  made of "optical air", showed as a semitransparent, contains a sensitive detector made of  "optical silicon", showed as red. The particle gun fires photons from the right to the left. The refractive index in the laboratory and the sensor is the same. The photons are stopped when they try to jump from the "laboratory" to the "world" (because World has no optical properties)
1. This plot shows a track of a photon that crosses the sensor, the laboratory and it is only stopped when trying to cross to the world.
![photon_default](https://github.com/AIDASoft/DD4hep/assets/114166109/c2372f80-06aa-4d17-8d7b-236d2f12e63b)
2. This plot shows a track of a photon after changing the condition of killing particle in OpticalTracker SD Action
![photon_after_change](https://github.com/AIDASoft/DD4hep/assets/114166109/8491d045-ea1d-4a7d-b6e7-b337ed681a5e)
3. This plot shows a track of a proton, same direction, with default DD4hep
![proton_default](https://github.com/AIDASoft/DD4hep/assets/114166109/5cde505b-0311-420e-bf60-0b19d95ebad9)
4. This plot shows a track of a proton, same direction, after changing the condition in  OpticalTracker SD Action
![proton_after_change](https://github.com/AIDASoft/DD4hep/assets/114166109/5fb01dd9-3ff8-4525-9933-682f6d2fceb8)

The following code reproduce the plots: 
```
git clone -b optical_tracker_test https://github.com/atolosadelgado/dd4hep_cube.git
cd dd4hep_cube
cmake -B build -S . -D CMAKE_INSTALL_PREFIX=install
cmake --build build -j 6 -- install
export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
# Gun = optical photon
python3 test.py --compactFile compact/simple_detector.xml --runType qt --macroFile vis.mac --gun.energy 4*eV --gun.particle opticalphoton
# Gun = proton
python3 test.py --compactFile compact/simple_detector.xml --runType qt --macroFile vis.mac --gun.energy 4*GeV --gun.particle proton
```