### PR TITLE
Allow to load CAD files with relative path w/r to declaring xml file (Issue 1166)

### DIFF
--- a/examples/DDCAD/CMakeLists.txt
+++ b/examples/DDCAD/CMakeLists.txt
@@ -72,7 +72,7 @@ endforeach()
 #
 # Multi-shape tests
 # Not working: OBJ_spider
-list(APPEND DDCAD_Tests_MV COB_dwarf MS3D_jeep)
+list(APPEND DDCAD_Tests_MV COB_dwarf MS3D_jeep RelativePath)
 foreach (test ${DDCAD_Tests_MV})
   dd4hep_add_test_reg( DDCAD_Check_Shape_${test}
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDCAD.sh"

--- a/examples/DDCAD/compact/Check_Shape_RelativePath.xml
+++ b/examples/DDCAD/compact/Check_Shape_RelativePath.xml
@@ -1,0 +1,30 @@
+<lccdd>
+<!-- #==========================================================================
+     #  AIDA Detector description implementation 
+     #==========================================================================
+     # Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+     # All rights reserved.
+     #
+     # For the licensing terms see $DD4hepINSTALL/LICENSE.
+     # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+     #
+     #==========================================================================
+
+     Test to verify functionality of loading CAD files with pathes relative 
+     to the declaring xml file. [See Issue 1166: Allow to give CAD files with 
+     relative paths similar to importing xml files (DDCAD) ]
+
+-->
+
+  <includes>
+    <gdmlFile ref="../../ClientTests/compact/CheckShape.xml"/>
+  </includes>
+
+  <detectors>
+    <detector id="1" name="Shape_MS3D" type="DD4hep_TestShape_Creator">
+      <check vis="Shape1_vis">
+        <shape type="CAD_MultiVolume" ref="../models/MS3D/jeep1.ms3d" unit="cm"/>
+      </check>
+    </detector>
+  </detectors>
+</lccdd>


### PR DESCRIPTION

BEGINRELEASENOTES
- Handle request from issue 1166: Allow to load CAD files with relative path w/r to declaring xml file 
- Add illustrating example: t_DDCAD_Check_Shape_RelativePath
ENDRELEASENOTES