### PR TITLE
G4VTouchable: for Geant4 11.1.ref09 cannot forward declare the class …

### DIFF
--- a/DDG4/include/DDG4/Geant4SensDetAction.h
+++ b/DDG4/include/DDG4/Geant4SensDetAction.h
@@ -20,6 +20,7 @@
 
 // Geant4 include files
 #include <G4ThreeVector.hh>
+#include <G4VTouchable.hh>
 
 // C/C++ include files
 #include <vector>
@@ -28,7 +29,6 @@
 class G4HCofThisEvent;
 class G4Step;
 class G4Event;
-class G4VTouchable;
 class G4TouchableHistory;
 class G4VHitsCollection;
 class G4VReadOutGeometry;

--- a/DDG4/include/DDG4/Geant4TouchableHandler.h
+++ b/DDG4/include/DDG4/Geant4TouchableHandler.h
@@ -13,13 +13,14 @@
 #ifndef DDG4_GEANT4TOUCHABLEHANDLER_H
 #define DDG4_GEANT4TOUCHABLEHANDLER_H
 
+#include <G4VTouchable.hh>
+
 // C/C++ include files
 #include <vector>
 #include <string>
 
 // Forward declarations
 class G4VPhysicalVolume;
-class G4VTouchable;
 class G4Step;
 
 /// Namespace for the AIDA detector description toolkit

--- a/DDG4/include/DDG4/Geant4VolumeManager.h
+++ b/DDG4/include/DDG4/Geant4VolumeManager.h
@@ -18,8 +18,8 @@
 #include <DD4hep/IDDescriptor.h>
 #include <DDG4/Geant4Primitives.h>
 
+#include <G4VTouchable.hh>
 // Geant4 forward declarations
-class G4VTouchable;
 class G4VPhysicalVolume;
 
 


### PR DESCRIPTION
…any more

BEGINRELEASENOTES
- DDG4: G4VTouchable: for Geant4 11.1.ref09 cannot forward declare the class any more

ENDRELEASENOTES