### PR TITLE
Typo in printout fixed

### DIFF
--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -35,7 +35,7 @@ class Gun(ConfigHelper):
     self.momentumMin = 0 * GeV
     self._momentumMax_EXTRA = {'help': "Maximal momentum when using distribution (default = 0.0)"}
     self.momentumMax = 10 * GeV
-    self._energy_EXTRA = {'help': "The kinetic energy for the particle gun.\n\n"
+    self._energy_EXTRA = {'help': "Total energy (including mass) for the particle gun.\n\n"
                           "If not None, it will overwrite the setting of momentumMin and momentumMax"}
     self.energy = None
 

--- a/DDTest/python/userSteeringFile.PY
+++ b/DDTest/python/userSteeringFile.PY
@@ -211,7 +211,7 @@ SIM.gun.direction = (0, 0, 1)
 ##     
 SIM.gun.distribution = None
 
-## The kinetic energy for the particle gun.
+## Total energy (including mass) for the particle gun.
 ## 
 ## If not None, it will overwrite the setting of momentumMin and momentumMax
 SIM.gun.energy = None


### PR DESCRIPTION

BEGINRELEASENOTES
- Typo in help printout fixed. Energy of particle gun corresponds to total energy (including mass)
ENDRELEASENOTES