### PR TITLE
Allow for XML processing of files relative to xml tag location

### DIFF
--- a/examples/ClientTests/compact/IncludePlugins.xml
+++ b/examples/ClientTests/compact/IncludePlugins.xml
@@ -42,6 +42,10 @@
   <plugins>
      <include ref="${DD4hepExamplesINSTALL}/examples/ClientTests/compact/ExamplePlugins.xml"/>
   </plugins>
+  <!-- This here is parsed at the very end    -->
+  <plugins>
+     <include ref="ExamplePlugins.xml"/>
+  </plugins>
 
 
 </lccdd>


### PR DESCRIPTION
 BEGINRELEASENOTES
Allow for XML processing of files relative to xml tag location:
- For some tags the relative placement of include files was not possible.
  This pull request is supposed to close these missing include features.
- See issue https://github.com/AIDASoft/DD4hep/issues/1180 for details)
- See the examples ClientTests: minitel_config_plugins_include_command_xml
  with the compact file ClientTests/compact/IncludePlugins.xml for an example.

ENDRELEASENOTES