### PR TITLE
Move DECLARE_SEGMENTATIONs for CartesianGridXYStaggered and HexGrid to ReadoutSegmentations.cpp

### DIFF
--- a/DDCore/src/plugins/ReadoutSegmentations.cpp
+++ b/DDCore/src/plugins/ReadoutSegmentations.cpp
@@ -40,6 +40,9 @@ DECLARE_SEGMENTATION(CartesianGridYZ,create_segmentation<dd4hep::DDSegmentation:
 #include "DDSegmentation/CartesianGridXYZ.h"
 DECLARE_SEGMENTATION(CartesianGridXYZ,create_segmentation<dd4hep::DDSegmentation::CartesianGridXYZ>)
 
+#include "DDSegmentation/CartesianGridXYStaggered.h"
+DECLARE_SEGMENTATION(CartesianGridXYStaggered,dd4hep::create_segmentation<dd4hep::DDSegmentation::CartesianGridXYStaggered>)
+
 #include "DDSegmentation/CartesianStripX.h"
 DECLARE_SEGMENTATION(CartesianStripX,create_segmentation<dd4hep::DDSegmentation::CartesianStripX>)
 
@@ -75,3 +78,6 @@ DECLARE_SEGMENTATION(ProjectiveCylinder,create_segmentation<dd4hep::DDSegmentati
 
 #include "DDSegmentation/MultiSegmentation.h"
 DECLARE_SEGMENTATION(MultiSegmentation,create_segmentation<dd4hep::DDSegmentation::MultiSegmentation>)
+
+#include "DDSegmentation/HexGrid.h"
+DECLARE_SEGMENTATION(HexGrid,create_segmentation<dd4hep::DDSegmentation::HexGrid>)

--- a/DDCore/src/segmentations/CartesianGridXYStaggered.cpp
+++ b/DDCore/src/segmentations/CartesianGridXYStaggered.cpp
@@ -96,7 +96,3 @@ std::vector<double> CartesianGridXYStaggered::cellDimensions(const CellID& cellI
 
 } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-
-// This is done DDCore/src/plugins/ReadoutSegmentations.cpp so the plugin is not part of libDDCore
-// needs also #include "DD4hep/Factories.h"
-// DECLARE_SEGMENTATION(CartesianGridXYStaggered,dd4hep::create_segmentation<dd4hep::DDSegmentation::CartesianGridXYStaggered>)

--- a/DDCore/src/segmentations/HexGrid.cpp
+++ b/DDCore/src/segmentations/HexGrid.cpp
@@ -145,5 +145,3 @@ namespace dd4hep {
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-
-DECLARE_SEGMENTATION(HexGrid, create_segmentation<dd4hep::DDSegmentation::HexGrid>)


### PR DESCRIPTION
This fixes runtime errors like:

    libc++abi: __cxa_guard_acquire detected recursive initialization



BEGINRELEASENOTES
- Fixed runtime issues during initialization caused by incorrectly placed `DECLARE_SEGMENTATION` for CartesianGridXYStaggered and HexGrid.

ENDRELEASENOTES