### PR TITLE
fix: use TROOT::GetIconPath instead of $ROOTSYS/icons

### DIFF
--- a/DDEve/src/Display.cpp
+++ b/DDEve/src/Display.cpp
@@ -30,6 +30,7 @@
 #include "DD4hep/Printout.h"
 
 // ROOT include files
+#include "TROOT.h"
 #include "TH2.h"
 #include "TFile.h"
 #include "TSystem.h"
@@ -270,7 +271,11 @@ void Display::UnregisterEvents(View* view)   {
 
 /// Open standard message box
 void Display::MessageBox(PrintLevel level, const string& text, const string& title) const   {
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
+  string path = TString::Format("%s/", TROOT::GetIconPath().Data()).Data();
+#else
   string path = TString::Format("%s/icons/", gSystem->Getenv("ROOTSYS")).Data();
+#endif
   const TGPicture* pic = 0;
   if ( level == VERBOSE )
     pic = client().GetPicture((path+"mb_asterisk_s.xpm").c_str());

--- a/DDEve/src/EventControl.cpp
+++ b/DDEve/src/EventControl.cpp
@@ -18,6 +18,7 @@
 #include "DD4hep/InstanceCount.h"
 
 // ROOT include files
+#include <TROOT.h>
 #include <TSystem.h>
 #include <TGTab.h>
 #include <TGLabel.h>
@@ -158,7 +159,11 @@ void EventControl::OnNewEvent(EventHandler& handler)   {
 
 /// User callback to add elements to the control
 void EventControl::OnBuild()   {
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
+  string icondir = TString::Format("%s/", TROOT::GetIconPath().Data()).Data();
+#else
   string icondir = TString::Format("%s/icons/", gSystem->Getenv("ROOTSYS")).Data();
+#endif
   TGGroupFrame* group = new TGGroupFrame(m_frame,"Event I/O Control");
   TGCompositeFrame* top = new TGHorizontalFrame(group);
   TGPictureButton* b = 0;

--- a/DDEve/src/GenericEventHandler.cpp
+++ b/DDEve/src/GenericEventHandler.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 /// ROOT include files
+#include "TROOT.h"
 #include "TGMsgBox.h"
 #include "TSystem.h"
 #include <climits>
@@ -136,7 +137,11 @@ bool GenericEventHandler::Open(const string& file_type, const string& file_name)
     err = "\nAn exception occurred \n"
       "while opening event data:\n" + string(e.what()) + "\n\n";
   }
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
+  string path = TString::Format("%s/stop_t.xpm", TROOT::GetIconPath().Data()).Data();
+#else
   string path = TString::Format("%s/icons/stop_t.xpm", gSystem->Getenv("ROOTSYS")).Data();
+#endif
   const TGPicture* pic = gClient->GetPicture(path.c_str());
   new TGMsgBox(gClient->GetRoot(),0,"Failed to open event data",err.c_str(),pic,
                kMBDismiss,0,kVerticalFrame,kTextLeft|kTextCenterY);
@@ -157,7 +162,11 @@ bool GenericEventHandler::NextEvent()   {
     throw runtime_error("+++ EventHandler::readEvent: No file open!");
   }
   catch(const exception& e)  {
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
+    string path = TString::Format("%s/stop_t.xpm", TROOT::GetIconPath().Data()).Data();
+#else
     string path = TString::Format("%s/icons/stop_t.xpm", gSystem->Getenv("ROOTSYS")).Data();
+#endif
     string err = "\nAn exception occurred \n"
       "while reading a new event:\n" + string(e.what()) + "\n\n";
     const TGPicture* pic = gClient->GetPicture(path.c_str());

--- a/UtilityApps/src/teve_display.cpp
+++ b/UtilityApps/src/teve_display.cpp
@@ -22,6 +22,7 @@
 #include "run_plugin.h"
 #include "TRint.h"
 
+#include "TROOT.h"
 #include "TEveGeoNode.h"
 #include "TEveBrowser.h"
 #include "TGNumberEntry.h"
@@ -282,7 +283,11 @@ void make_gui() {
   TGHorizontalFrame* hf = new TGHorizontalFrame(frmMain);
   {
       
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
+    TString icondir( Form("%s/", TROOT::GetIconPath().Data()) );
+#else
     TString icondir( Form("%s/icons/", gSystem->Getenv("ROOTSYS")) );
+#endif
     TGPictureButton* b = 0;
     EvNavHandler    *fh = new EvNavHandler;
 


### PR DESCRIPTION
This (almost completely) fixes #1189 by using `TROOT::GetIconPath` whenever it exists, i.e. for ROOT-6.09/02 or later. This leaves only the 6.08 versions which are allowed in DD4hep and can have the gnuinstall option, but for which the `GetIconPath` interface was not available yet.

BEGINRELEASENOTES
- Use TROOT::GetIconPath to find icons in DDEve

ENDRELEASENOTES