### PR TITLE
Add a check for the standard that Geant4 was compiled with

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,10 @@ if(DD4HEP_USE_GEANT4)
   IF(NOT Geant4_builtin_clhep_FOUND)
     SET(DD4HEP_USE_CLHEP TRUE)
   ENDIF()
+  if(Geant4_CXX_STANDARD MATCHES "[0-9]+" AND Geant4_CXX_STANDARD LESS ${CMAKE_CXX_STANDARD})
+    message(FATAL_ERROR "Geant4 was compiled with C++${Geant4_CXX_STANDARD}, but DD4hep requires C++${CMAKE_CXX_STANDARD}")
+  endif()
+
   DD4HEP_SETUP_GEANT4_TARGETS()
   # Geant4 sets the CLHEP include directory to include_directories, we undo this here
   # we don't do this inside DD4hep_SETUP_GEANT4_TARGETS, because that is also used in


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a check for the standard that Geant4 was compiled with, and fail if it's
  different from the one required for DD4hep.

ENDRELEASENOTES

I think failing is the correct behavior instead of a warning, for example. The reason is that there will be some files that will be compiled with the same flags that were used to compile Geant4, which means that it will overwrite whatever version of the standard one is requiring for DD4hep (at least with gcc, who is happy to get two different `-std=c++XX` flags).