### PR TITLE
Use std::abs, ddsim logging of sensitive detectors

### DIFF
--- a/DDCore/src/segmentations/HexGrid.cpp
+++ b/DDCore/src/segmentations/HexGrid.cpp
@@ -123,7 +123,7 @@ namespace dd4hep {
 	double a=positive_modulo(y/(std::sqrt(3)*_sideLength),1);
 	double b=positive_modulo(x/(3*_sideLength),1);
 	int ix = std::floor(x/(3*_sideLength/2.))+		
-	  (b<0.5)*(-abs(a-.5)<(b-.5)*3)+(b>0.5)*(abs(a-.5)-.5<(b-1)*3);
+	  (b<0.5)*(-std::abs(a-.5)<(b-.5)*3)+(b>0.5)*(std::abs(a-.5)-.5<(b-1)*3);
 	int iy=std::floor(y/(std::sqrt(3)*_sideLength/2.));
 	iy-=(ix+iy)&1;
 	

--- a/examples/CLICSiD/sim/field.xml
+++ b/examples/CLICSiD/sim/field.xml
@@ -24,7 +24,7 @@
 		delta_one_step="0.001*mm"
 		eps_min="5e-05*mm"
 		eps_max="0.001*mm"
-		stepper="HelixSimpleRunge"
+		stepper="ClassicalRK4"
 		equation="Mag_UsualEqRhs">
     </attributes>
   </properties>

--- a/examples/ClientTests/src/NestedBoxReflection_geo.cpp
+++ b/examples/ClientTests/src/NestedBoxReflection_geo.cpp
@@ -36,7 +36,7 @@ namespace   {
 
     constexpr double tol = 1.0e-3;       // Geant4 compatible
     double check = (x.Cross(y)).Dot(z);  // in case of a LEFT-handed orthogonal system this must be -1
-    if (abs(1. + check) > tol) {
+    if (std::abs(1. + check) > tol) {
       except("NestedBoxReflection", "+++ FAILED to construct Rotation is not LEFT-handed!");
     }
     printout(INFO, "NestedBoxReflection", "+++ Constructed LEFT-handed reflection rotation.");


### PR DESCRIPTION

BEGINRELEASENOTES
- NestedBoxReflection_geo.cpp: use std::abs instead of abs
- HexGrid: use std::abs instead of abs
- DDSim: better logging of which sensitive detector is used when defaults are used

ENDRELEASENOTES

@sebouh137 
Could you confirm that the `abs` in HexGrid is the one for floats?
As we had an issue #1192, where the `abs` changed, it is better to use `std::abs` explicitly everywhere.