### PR TITLE
Update dd4hep material scan to be unit-aware

### DIFF
--- a/DDCore/src/plugins/GeometryWalk.cpp
+++ b/DDCore/src/plugins/GeometryWalk.cpp
@@ -115,19 +115,20 @@ void GeometryWalk::walk(DetElement e, PlacedVolume::VolIDs ids)  const   {
 /// Action routine to execute the test
 long GeometryWalk::run(Detector& description,int argc,char** argv)    {
   cout << "++ Processing plugin....GeometryWalker.." << endl;
+  DetElement world = description.world();
   for(int in=1; in < argc; ++in)  {
     string name = argv[in]+1;
     if ( name == "all" || name == "All" || name == "ALL" )  {
-      const _C& children = description.world().children();
+      const _C& children = world.children();
       for (_C::const_iterator i=children.begin(); i!=children.end(); ++i)  {
         DetElement sdet = (*i).second;
         cout << "++ Processing subdetector: " << sdet.name() << endl;
-        GeometryWalk test(description,sdet);
+        GeometryWalk test(description, sdet);
       }
       return 1;
     }
     cout << "++ Processing subdetector: " << name << endl;
-    GeometryWalk test(description,description.detector(name));
+    GeometryWalk test(description, description.detector(name));
   }
   return 1;
 }

--- a/DDDetectors/src/PolyhedraEndcapCalorimeter2_surfaces.cpp
+++ b/DDDetectors/src/PolyhedraEndcapCalorimeter2_surfaces.cpp
@@ -31,7 +31,8 @@ void Installer<UserData>::install(dd4hep::DetElement component, dd4hep::PlacedVo
     }
     else if ( !handleUsingCache(component,comp_vol) )  {
       dd4hep::DetElement par = component.parent();
-      const TGeoHMatrix& m = par.nominal().worldTransformation();
+      dd4hep::Alignment  nom = par.nominal();
+      const TGeoHMatrix& m = nom.worldTransformation();
       double dz = m.GetTranslation()[2];
       const double* trans = placementTranslation(component);
       double half_mod_thickness  = (mod_shape->GetZ(1)-mod_shape->GetZ(0))/2.0;

--- a/DDDigi/src/DigiSegmentationTool.cpp
+++ b/DDDigi/src/DigiSegmentationTool.cpp
@@ -26,9 +26,10 @@ namespace  {
 		     const string& split_by,
 		     map<dd4hep::VolumeID, pair<dd4hep::DetElement, dd4hep::VolumeID> >& splits,
 		     dd4hep::DetElement de, dd4hep::VolumeID vid, dd4hep::VolumeID mask)   {
-    const auto& new_ids = de.placement().volIDs();
-    dd4hep::VolumeID    new_vid = vid;
-    dd4hep::VolumeID    new_msk = mask;
+    dd4hep::PlacedVolume plc = de.placement();
+    const auto&      new_ids = plc.volIDs();
+    dd4hep::VolumeID new_vid = vid;
+    dd4hep::VolumeID new_msk = mask;
     if ( !new_ids.empty() )   {
       new_vid |= tool.iddescriptor.encode(new_ids);
       new_msk |= tool.iddescriptor.get_mask(new_ids);
@@ -185,7 +186,8 @@ DigiSegmentationTool::split_context(const string& split_by)  const {
 /// Create full set of detector segments which can be split according to the context
 set<uint32_t> DigiSegmentationTool::split_segmentation(const string& split_by)  const  {
   map<VolumeID, pair<DetElement, VolumeID> > segmentation_splits;
-  const auto& ids = this->detector.placement().volIDs();
+  PlacedVolume     place = this->detector.placement();
+  const auto& ids = place.volIDs();
   VolumeID    vid = this->iddescriptor.encode(ids);
   VolumeID    msk = this->iddescriptor.get_mask(ids);
   const auto* fld = this->iddescriptor.field(split_by);

--- a/DDDigi/src/noise/DigiSubdetectorSequence.cpp
+++ b/DDDigi/src/noise/DigiSubdetectorSequence.cpp
@@ -57,7 +57,8 @@ void DigiSubdetectorSequence::initialize()   {
   if ( m_detector.isValid() && m_sensDet.isValid() )   {
     m_idDesc       = m_sensDet.readout().idSpec();
     m_segmentation = m_sensDet.readout().segmentation();
-    const VolIDs& ids = m_detector.placement().volIDs();
+    PlacedVolume  plc = m_detector.placement();
+    const VolIDs& ids = plc.volIDs();
     VolumeID      vid = m_idDesc.encode(ids);
     VolumeID      msk = m_idDesc.get_mask(ids);
     scan_detector(m_detector, vid, msk);
@@ -88,7 +89,8 @@ void DigiSubdetectorSequence::scan_sensitive(PlacedVolume pv, VolumeID vid, Volu
 }
 
 void DigiSubdetectorSequence::scan_detector(DetElement de, VolumeID vid, VolumeID mask)   {
-  const VolIDs& new_ids = de.placement().volIDs();
+  PlacedVolume  place   = m_detector.placement();
+  const VolIDs& new_ids = place.volIDs();
   VolumeID      new_vid = vid;
   VolumeID      new_msk = mask;
   if ( !new_ids.empty() )   {

--- a/DDEve/src/View.cpp
+++ b/DDEve/src/View.cpp
@@ -160,7 +160,8 @@ void View::ConfigureGeometry(const DisplayConfiguration::ViewConfig& config)    
   string dets;
   DisplayConfiguration::Configurations::const_iterator ic;
   float legend_y = Annotation::DefaultTextSize()+Annotation::DefaultMargin();
-  const DetElement::Children& c = m_eve->detectorDescription().world().children();
+  DetElement world = m_eve->detectorDescription().world();
+  const DetElement::Children& c = world.children();
   for( ic=config.subdetectors.begin(); ic != config.subdetectors.end(); ++ic)   {
     const DisplayConfiguration::Config& cfg = *ic;
     string nam = cfg.name;

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -983,8 +983,8 @@ void* Geant4Converter::handlePlacement(const string& name, const TGeoNode* node)
 	double width = 0e0, offset = 0e0;
 	auto flags = pv_data->params->flags;
 	auto count = pv_data->params->trafo1D.second;
-	const auto& start = pv_data->params->start.Translation().Vect();
-	const auto& delta = pv_data->params->trafo1D.first.Translation().Vect();
+	auto start = pv_data->params->start.Translation().Vect();
+	auto delta = pv_data->params->trafo1D.first.Translation().Vect();
 
 	if ( flags&Volume::X_axis )
 	  { axis = kXAxis; width = delta.X(); offset = start.X(); }

--- a/DDRec/include/DDRec/MaterialScan.h
+++ b/DDRec/include/DDRec/MaterialScan.h
@@ -53,7 +53,7 @@ namespace dd4hep {
     private:
       
       /// Reference to detector setup
-      const Detector&                  m_detector;
+      Detector&                        m_detector;
       /// Material manager
       std::unique_ptr<MaterialManager> m_materialMgr;  //!
       /// Local cache: subdetector placements
@@ -64,7 +64,7 @@ namespace dd4hep {
     public:
 
       /// Standard constructor for the master instance
-      MaterialScan(const Detector& description);
+      MaterialScan(Detector& description);
 
       /// Default destructor
       virtual ~MaterialScan();

--- a/DDRec/src/MaterialScan.cpp
+++ b/DDRec/src/MaterialScan.cpp
@@ -180,17 +180,17 @@ void MaterialScan::print(const Vector3D& p0, const Vector3D& p1, double epsilon)
   double sum_x0 = 0;
   double sum_lambda = 0;
   double path_length = 0, total_length = 0;
-  const char* fmt1 = " | %5d %-25s %3.0f %8.3f %8.4f %11.4f  %11.4f %10.3f %8.2f %11.6f %11.6f  (%7.2f,%7.2f,%7.2f)\n";
-  const char* fmt2 = " | %5d %-25s %3.0f %8.3f %8.4f %11.6g  %11.6g %10.3f %8.2f %11.6f %11.6f  (%7.2f,%7.2f,%7.2f)\n";
+  const char* fmt1 = " | %7s %-25s %3.0f %8.3f %8.4f %11.4f  %11.4f %10.3f %8.2f %11.6f %11.6f  (%7.2f,%7.2f,%7.2f)\n";
+  const char* fmt2 = " | %7s %-25s %3.0f %8.3f %8.4f %11.6g  %11.6g %10.3f %8.2f %11.6f %11.6f  (%7.2f,%7.2f,%7.2f)\n";
   const char* line = " +--------------------------------------------------------------------------------------------------------------------------------------------------\n";
 
   direction = (p1-p0).unit();
   
   ::printf("%s + Material scan between: x_0 = (%7.2f,%7.2f,%7.2f) [cm] and x_1 = (%7.2f,%7.2f,%7.2f) [cm] : \n%s",
            line,p0[0],p0[1],p0[2],p1[0],p1[1],p1[2],line);
-  ::printf(" |     \\   %-16s          Atomic               Radiation   Interaction               Path   Integrated  Integrated    Material\n","Material");
-  ::printf(" | Num. \\  %-16s   Number/Z   Mass/A  Density    Length       Length    Thickness   Length      X0        Lambda      Endpoint  \n","Name");
-  ::printf(" | Layer \\ %-16s            [g/mole]  [g/cm3]     [cm]        [cm]          [cm]      [cm]     [cm]        [cm]     (     cm,     cm,     cm)\n","");
+  ::printf(" |       \\   %-16s          Atomic               Radiation   Interaction               Path   Integrated  Integrated    Material\n","Material");
+  ::printf(" | Num.   \\  %-16s   Number/Z   Mass/A  Density    Length       Length    Thickness   Length      X0        Lambda      Endpoint/Startpoint\n","Name");
+  ::printf(" | Layer   \\ %-16s            [g/mole]  [g/cm3]     [cm]        [cm]          [cm]      [cm]     [cm]        [cm]     (     cm,     cm,     cm)\n","");
   ::printf("%s",line);
   MaterialVec materials;
   for( unsigned i=0, n=placements.size(); i<n; ++i){
@@ -223,16 +223,30 @@ void MaterialScan::print(const Vector3D& p0, const Vector3D& p1, double epsilon)
       mname += " -> ";
       mname += next_mat->GetName();
     }
-    ::printf(fmt, i+1, mname.c_str(), curr_mat->GetZ(), curr_mat->GetA(),
-             curr_mat->GetDensity(), curr_mat->GetRadLen()/dd4hep::cm, curr_mat->GetIntLen()/dd4hep::cm,
-             length/dd4hep::cm, path_length/dd4hep::cm, sum_x0, sum_lambda,
-	     end[0]/dd4hep::cm, end[1]/dd4hep::cm, end[2]/dd4hep::cm);
-    //mat->Print();
+    if ( 0 == i )  {
+      ::printf(fmt, "(start)" , curr_mat->GetName(), curr_mat->GetZ(), curr_mat->GetA(),
+	       curr_mat->GetDensity(), curr_mat->GetRadLen()/dd4hep::cm, curr_mat->GetIntLen()/dd4hep::cm,
+	       0e0, 0e0, 0e0, 0e0,
+	       p0[0]/dd4hep::cm, p0[1]/dd4hep::cm, p0[2]/dd4hep::cm);
+    }
+    // No else here!
+    if ( (n-1) == i )  {
+      ::printf(fmt, "(end)", curr_mat->GetName(), curr_mat->GetZ(), curr_mat->GetA(),
+	       curr_mat->GetDensity(), curr_mat->GetRadLen()/dd4hep::cm, curr_mat->GetIntLen()/dd4hep::cm,
+	       0e0, 0e0, 0e0, 0e0,
+	       p0[0]/dd4hep::cm, p0[1]/dd4hep::cm, p0[2]/dd4hep::cm);
+    }
+    else   {
+      ::printf(fmt, std::to_string(i+1).c_str(), mname.c_str(), next_mat->GetZ(), next_mat->GetA(),
+	       next_mat->GetDensity(), next_mat->GetRadLen()/dd4hep::cm, next_mat->GetIntLen()/dd4hep::cm,
+	       length/dd4hep::cm, path_length/dd4hep::cm, sum_x0, sum_lambda,
+	       end[0]/dd4hep::cm, end[1]/dd4hep::cm, end[2]/dd4hep::cm);
+    }
   }
   printf("%s",line);
   const MaterialData& avg = matMgr.createAveragedMaterial(materials);
   const char* fmt = avg.radiationLength() >= 1e5 ? fmt2 : fmt1;
-  ::printf(fmt,0,"Average Material",avg.Z(),avg.A(),avg.density(), 
+  ::printf(fmt,"","Average Material",avg.Z(),avg.A(),avg.density(), 
            avg.radiationLength()/dd4hep::cm, avg.interactionLength()/dd4hep::cm,
            path_length/dd4hep::cm, path_length/dd4hep::cm,
            path_length/avg.radiationLength(), 

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -721,7 +721,7 @@ namespace dd4hep {
       // first we need to find the right volume for the local surface in the DetElement's volumes
       std::list< PlacedVolume > pVList ;
       PlacedVolume pv = _det.placement() ;
-      Volume theVol = _volSurf.volume() ;
+      Volume   theVol = _volSurf.volume() ;
       
       if( ! findVolume(  pv, theVol , pVList ) ){
         theVol = _volSurf.volume() ;
@@ -730,8 +730,8 @@ namespace dd4hep {
       } 
 
       //=========== compute and cache world transform for surface ==========
-      
-      const TGeoHMatrix& wm = _det.nominal().worldTransformation() ;
+      Alignment nominal = _det.nominal();
+      const TGeoHMatrix& wm = nominal.worldTransformation() ;
       
 #if 0 // debug
       wm.Print() ;

--- a/UtilityApps/src/materialScan.cpp
+++ b/UtilityApps/src/materialScan.cpp
@@ -17,13 +17,14 @@
 //
 //==========================================================================
 
-#include "TError.h"
-#include "TInterpreter.h"
+#include <TError.h>
+#include <TInterpreter.h>
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DDRec/MaterialScan.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DDRec/MaterialScan.h>
 #include "main.h"
 
 using namespace dd4hep;
@@ -39,7 +40,8 @@ int main_wrapper(int argc, char** argv)   {
       std::cout << " usage: materialScan compact.xml x0 y0 z0 x1 y1 z1 [-interactive]" << std::endl 
                 << " or:    materialScan compact.xml -interactive" << std::endl 
                 << "        -> prints the materials on a straight line between the two given points (unit is cm) " << std::endl
-                << "        -interactive   Load geometry once, then allow for shots from the ROOT prompt"
+                << "        -interactive   Load geometry once, then allow for shots from the ROOT prompt" << std::endl
+		<< " NOTE:  ALL lengths in units of [cm]"
                 << std::endl;
       exit(EINVAL);
     }
@@ -73,7 +75,7 @@ int main_wrapper(int argc, char** argv)   {
   description.fromXML(inFile);
   MaterialScan scan(description);
   if ( do_scan )   {
-    scan.print(x0, y0, z0, x1, y1, z1);
+    scan.print(x0*dd4hep::cm, y0*dd4hep::cm, z0*dd4hep::cm, x1*dd4hep::cm, y1*dd4hep::cm, z1*dd4hep::cm);
   }
   if ( interactive )   {
     char cmd[256];

--- a/examples/DDCMS/src/DDCMS.cpp
+++ b/examples/DDCMS/src/DDCMS.cpp
@@ -335,7 +335,7 @@ xml_h AlgoArguments::raw_arg(const string& nam)  const   {
   for(xml_coll_t p(element,_U(star)); p; ++p)  {
     string n = p.attr<string>(_U(name));
     if ( n == nam )  {
-      return std::move(p);
+      return p;
     }
   }
   except("DDCMS","+++ Attempt to access non-existing algorithm option %s[%s]",name.c_str(),nam.c_str());


### PR DESCRIPTION
BEGINRELEASENOTES
- Adapt material scan to be aware of the different compilation modes for TGeo units and Geant4 units.
  See also issue https://github.com/AIDASoft/DD4hep/issues/1163.
ENDRELEASENOTES