### PR TITLE
Make the renaming of TrackerHit -> TrackerHit3D transparent

### DIFF
--- a/DDDigi/io/DigiEdm4hepOutput.cpp
+++ b/DDDigi/io/DigiEdm4hepOutput.cpp
@@ -25,7 +25,6 @@
 #include <podio/Frame.h>
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/MCParticleCollection.h>
-#include <edm4hep/TrackerHitCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/CalorimeterHitCollection.h>
 #include <edm4hep/CaloHitContributionCollection.h>
@@ -56,7 +55,7 @@ namespace dd4hep {
       /// MC particle collection
       particlecollection_t                    m_particles { };
       /// Collection of all edm4hep tracker object collections
-      std::map<std::string, std::unique_ptr<edm4hep::TrackerHitCollection> > m_tracker_collections;
+      std::map<std::string, std::unique_ptr<edm4hep::TrackerHit3DCollection> > m_tracker_collections;
       /// Collection of all edm4hep calorimeter object collections
       std::map<std::string, std::unique_ptr<edm4hep::CalorimeterHitCollection> > m_calo_collections;
       /// Output section name
@@ -114,7 +113,7 @@ namespace dd4hep {
             m_particles = std::make_pair(nam, std::make_unique<edm4hep::MCParticleCollection>());
           }
           else if ( typ == "TrackerHits" )   {
-            m_tracker_collections.emplace(nam, std::make_unique<edm4hep::TrackerHitCollection>());
+            m_tracker_collections.emplace(nam, std::make_unique<edm4hep::TrackerHit3DCollection>());
           }
           else if ( typ == "CalorimeterHits" )   {
             m_calo_collections.emplace(nam, std::make_unique<edm4hep::CalorimeterHitCollection>());
@@ -274,7 +273,7 @@ namespace dd4hep {
     template <typename T> void
     DigiEdm4hepOutputProcessor::convert_depos(const T& cont,
                                               const predicate_t& predicate,
-                                              edm4hep::TrackerHitCollection* collection)  const
+                                              edm4hep::TrackerHit3DCollection* collection)  const
     {
       std::array<float,6> covMat = {0., 0., m_pointResoutionRPhi*m_pointResoutionRPhi, 
         0., 0., m_pointResoutionZ*m_pointResoutionZ
@@ -308,7 +307,7 @@ namespace dd4hep {
       if ( !cont.empty() )   {
         switch(cont.data_type)    {
         case SegmentEntry::TRACKER_HITS:
-          convert_depos(cont, predicate, static_cast<edm4hep::TrackerHitCollection*>(coll));
+          convert_depos(cont, predicate, static_cast<edm4hep::TrackerHit3DCollection*>(coll));
           break;
         case SegmentEntry::CALORIMETER_HITS:
           convert_depos(cont, predicate, static_cast<edm4hep::CalorimeterHitCollection*>(coll));

--- a/DDDigi/io/DigiEdm4hepOutput.h
+++ b/DDDigi/io/DigiEdm4hepOutput.h
@@ -17,10 +17,17 @@
 #include <DDDigi/DigiOutputAction.h>
 
 /// C/C++ include files
+#if __has_include("edm4hep/TrackerHitCollection.h")
+#include <edm4hep/TrackerHitCollection.h>
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}
+#else
+#include <edm4hep/TrackerHit3DCollection.h>
+#endif
 
 /// Forward declarations from edm4hep
 namespace edm4hep  {
-  class TrackerHitCollection;
   class CalorimeterHitCollection;
 }
 
@@ -35,7 +42,7 @@ namespace dd4hep {
      *  Supported output containers types are:
      *  - edm4hep::MCParticles aka "MCParticles"
      *  - edm4hep::CalorimeterHitCollection  aka "CalorimeterHits"
-     *  - edm4hep::TrackerHitCollection aka "TracketHits"
+     *  - edm4hep::TrackerHit3DCollection aka "TracketHits"
      *
      *  This entity actually is only the work dispatcher:
      *  It opens files and dumps data into
@@ -103,7 +110,7 @@ namespace dd4hep {
 
       /// Convert tracker hits to edm4hep
       template <typename T> void
-      convert_depos(const T& cont, const predicate_t& predicate, edm4hep::TrackerHitCollection* collection)  const;
+      convert_depos(const T& cont, const predicate_t& predicate, edm4hep::TrackerHit3DCollection* collection)  const;
 
       /// Convert calorimeter hits to edm4hep
       template <typename T> void

--- a/DDDigi/io/DigiIO.cpp
+++ b/DDDigi/io/DigiIO.cpp
@@ -28,7 +28,14 @@
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/MCParticle.h>
 #include <edm4hep/MCParticleCollection.h>
+#if __has_include("edm4hep/TrackerHitCollection.h")
 #include <edm4hep/TrackerHitCollection.h>
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}
+#else
+#include <edm4hep/TrackerHit3DCollection.h>
+#endif
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/CalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
@@ -224,7 +231,7 @@ namespace dd4hep {
     template <> template <> 
     void data_io<edm4hep_input>::_to_edm4hep(const std::pair<const CellID, EnergyDeposit>& dep,
 					     const std::array<float, 6>& covMat,
-					     edm4hep::TrackerHitCollection& collection,
+					     edm4hep::TrackerHit3DCollection& collection,
 					     int hit_type)
 
     {


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the upcoming renaming of `edm4hep::TrackerHit` to `edm4hep::TrackerHit3D` (https://github.com/key4hep/EDM4hep/pull/252) transparent as far as DD4hep is concerned.

ENDRELEASENOTES

I am using the existence of the new header file to detect which version of the TrackerHit to use and just typedef to the new type name in case it's not yet present. In my local testing this works for current EDM4hep as well as for the version with the above PR merged.