### PR TITLE
Change ROOTFrame{Writer,Reader} to ROOT{Writer,Reader}

### DIFF
--- a/DDDigi/io/DigiEdm4hepInput.cpp
+++ b/DDDigi/io/DigiEdm4hepInput.cpp
@@ -17,7 +17,11 @@
 
 // podio/edm4hep include files
 #include <podio/Frame.h>
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include <podio/ROOTReader.h>
+#else
 #include <podio/ROOTFrameReader.h>
+#endif
 
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/SimCalorimeterHit.h>
@@ -47,7 +51,11 @@ namespace dd4hep {
       const podio::CollectionBase* get(const std::string& nam) const { return frame.get(nam); }
     };
     
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+    using reader_t = podio::ROOTReader;
+#else
     using reader_t = podio::ROOTFrameReader;
+#endif
     using frame_t  = edm4hep_read_frame_t;
 
     /// EDM4HEP Digi input reader: Collection descriptor definition

--- a/DDDigi/io/DigiEdm4hepOutput.cpp
+++ b/DDDigi/io/DigiEdm4hepOutput.cpp
@@ -21,7 +21,11 @@
 
 /// edm4hep include files
 #include <podio/CollectionBase.h>
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include <podio/ROOTWriter.h>
+#else
 #include <podio/ROOTFrameWriter.h>
+#endif
 #include <podio/Frame.h>
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/MCParticleCollection.h>
@@ -50,7 +54,11 @@ namespace dd4hep {
       using headercollection_t   = std::pair<std::string,std::unique_ptr<edm4hep::EventHeaderCollection> >;
       DigiEdm4hepOutput*                      m_parent    { nullptr };
       /// Reference to podio writer
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+      std::unique_ptr<podio::ROOTWriter>      m_writer    { };
+#else
       std::unique_ptr<podio::ROOTFrameWriter> m_writer    { };
+#endif
       /// edm4hep event header collection
       headercollection_t                      m_header    { };
       /// MC particle collection
@@ -190,7 +198,11 @@ namespace dd4hep {
       clear();
       m_writer.reset();
       std::string fname = m_parent->next_stream_name();
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+      m_writer = std::make_unique<podio::ROOTWriter>(fname);
+#else
       m_writer = std::make_unique<podio::ROOTFrameWriter>(fname);
+#endif
       m_parent->info("+++ Opened EDM4HEP output file %s", fname.c_str());
     }
 

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -27,7 +27,11 @@
 #include <edm4hep/EDM4hepVersion.h>
 /// podio include files
 #include <podio/Frame.h>
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include <podio/ROOTWriter.h>
+#else
 #include <podio/ROOTFrameWriter.h>
+#endif
 #include <podio/podioVersion.h>
 
 /// Namespace for the AIDA detector description toolkit
@@ -48,7 +52,11 @@ namespace dd4hep {
      */
     class Geant4Output2EDM4hep : public Geant4OutputAction  {
     protected:
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+      using writer_t = podio::ROOTWriter;
+#else
       using writer_t = podio::ROOTFrameWriter;
+#endif
       using stringmap_t = std::map< std::string, std::string >;
       using trackermap_t = std::map< std::string, edm4hep::SimTrackerHitCollection >;
       using calorimeterpair_t = std::pair< edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionCollection >;
@@ -238,7 +246,11 @@ void Geant4Output2EDM4hep::beginRun(const G4Run* run)  {
     }
   }
   if ( !fname.empty() )   {
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+    m_file = std::make_unique<podio::ROOTWriter>(fname);
+#else
     m_file = std::make_unique<podio::ROOTFrameWriter>(fname);
+#endif
     if ( !m_file )   {
       fatal("+++ Failed to open output file: %s", fname.c_str());
     }


### PR DESCRIPTION
BEGINRELEASENOTES
- Change ROOTFrame{Writer,Reader} to ROOT{Writer,Reader} following https://github.com/AIDASoft/podio/pull/549

ENDRELEASENOTES

When this is merged we should add to spack a requirement for newer versions to have podio 0.99 or newer