### PR TITLE
Implement CONST properties to optical sufaces. (Requires new release of ROOT)

### DIFF
--- a/DDAlign/src/AlignmentsCalib.cpp
+++ b/DDAlign/src/AlignmentsCalib.cpp
@@ -12,17 +12,14 @@
 //==========================================================================
 
 // Framework includes
-#include "DDAlign/AlignmentsCalib.h"
+#include <DDAlign/AlignmentsCalib.h>
 
-#include "DD4hep/Memory.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
+#include <DD4hep/Memory.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::align;
-typedef Condition::key_type key_type;
 
 /// Helper class to store information about alignment calibration items
 /**  Implementation details: Alignment context entry
@@ -34,12 +31,12 @@ typedef Condition::key_type key_type;
  */
 class AlignmentsCalib::Entry   {
 public:
-  Delta                  delta;
-  Delta                  original;
-  Condition              source;
-  DetElement             detector;
-  Condition::key_type    target = 0;
-  int                    dirty  = 0;
+  dd4hep::Delta                  delta;
+  dd4hep::Delta                  original;
+  dd4hep::Condition              source;
+  dd4hep::DetElement             detector;
+  dd4hep::Condition::key_type    target = 0;
+  int                            dirty  = 0;
   Entry() = default;
   Entry(const Entry& c) = delete;
   Entry& operator=(const Entry& c) = delete;
@@ -57,13 +54,13 @@ AlignmentsCalib::~AlignmentsCalib()   noexcept(false)  {
 }
 
 /// Convenience only: Access detector element by path
-DetElement AlignmentsCalib::detector(const string& path)  const   {
+dd4hep::DetElement AlignmentsCalib::detector(const std::string& path)  const   {
   DetElement det(detail::tools::findElement(description,path));
   return det;
 }
 
 /// Implementation: Add a new entry to the transaction stack.
-pair<key_type,AlignmentsCalib::Entry*>
+std::pair<dd4hep::Condition::key_type,AlignmentsCalib::Entry*>
 AlignmentsCalib::_set(DetElement detector, const Delta& delta)   {
   ConditionKey tar_key(detector.key(),Keys::alignmentKey);
   UsedConditions::iterator i = used.find(tar_key.hash);
@@ -103,14 +100,14 @@ AlignmentsCalib::_set(DetElement detector, const Delta& delta)   {
 }
 
 /// (1) Add a new entry to an existing DetElement structure.
-Condition::key_type
+dd4hep::Condition::key_type
 AlignmentsCalib::set(DetElement det, const Delta& delta)   {
   return _set(det.access(), delta).first;
 }
 
 /// (2) Add a new entry to an existing DetElement structure.
-Condition::key_type
-AlignmentsCalib::set(const string& path, const Delta& delta)   {
+dd4hep::Condition::key_type
+AlignmentsCalib::set(const std::string& path, const Delta& delta)   {
   return _set(detector(path).access(), delta).first;
 }
 

--- a/DDAlign/src/GlobalAlignmentCache.cpp
+++ b/DDAlign/src/GlobalAlignmentCache.cpp
@@ -12,35 +12,33 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DDAlign/GlobalAlignmentCache.h"
-#include "DDAlign/GlobalAlignmentOperators.h"
-#include "DD4hep/detail/DetectorInterna.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DDAlign/GlobalAlignmentCache.h>
+#include <DDAlign/GlobalAlignmentOperators.h>
+#include <DD4hep/detail/DetectorInterna.h>
 
 // ROOT include files
-#include "TGeoManager.h"
+#include <TGeoManager.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::align;
-using namespace dd4hep::align::DDAlign_standard_operations;
-typedef GlobalAlignmentStack::StackEntry Entry;
+using Entry = GlobalAlignmentStack::StackEntry;
 
-DetElement _detector(DetElement child)   {
+dd4hep::DetElement _detector(dd4hep::DetElement child)   {
   if ( child.isValid() )   {
-    DetElement p(child.parent());
+    dd4hep::DetElement p(child.parent());
     if ( p.isValid() && !p.parent().isValid() )
       return child;
     else if ( !p.isValid() )  // World detector element...
       return child;
     return _detector(p);
   }
-  throw runtime_error("dd4hep: DetElement cannot determine detector parent [Invalid handle]");
+  dd4hep::except("GlobalAlignmentCache", "DetElement cannot determine detector parent [Invalid handle]");
+  return {};
 }
 
 /// Default constructor
-GlobalAlignmentCache::GlobalAlignmentCache(Detector& description, const string& sdPath, bool top)
+GlobalAlignmentCache::GlobalAlignmentCache(Detector& description, const std::string& sdPath, bool top)
   : m_detDesc(description), m_sdPath(sdPath), m_sdPathLen(sdPath.length()), m_refCount(1), m_top(top)
 {
 }
@@ -48,7 +46,7 @@ GlobalAlignmentCache::GlobalAlignmentCache(Detector& description, const string& 
 /// Default destructor
 GlobalAlignmentCache::~GlobalAlignmentCache()   {
   int nentries = (int)m_cache.size();
-  int nsect = (int)m_detectors.size();
+  int nsect    = (int)m_detectors.size();
   detail::releaseObjects(m_detectors);
   m_cache.clear();
   printout(INFO,"GlobalAlignmentCache",
@@ -103,26 +101,26 @@ bool GlobalAlignmentCache::insert(GlobalAlignment alignment)  {
 }
 
 /// Retrieve the cache section corresponding to the path of an entry.
-GlobalAlignmentCache* GlobalAlignmentCache::section(const string& path_name) const   {
-  size_t idx, idq;
+GlobalAlignmentCache* GlobalAlignmentCache::section(const std::string& path_name) const   {
+  std::size_t idx, idq;
   if ( path_name[0] != '/' )   {
     return section(m_detDesc.world().placementPath()+'/'+path_name);
   }
-  else if ( (idx=path_name.find('/',1)) == string::npos )  {
+  else if ( (idx=path_name.find('/',1)) == std::string::npos )  {
     return (m_sdPath == path_name.c_str()+1) ? (GlobalAlignmentCache*)this : 0;
   }
   else if ( m_detectors.empty() )  {
     return 0;
   }
-  if ( (idq=path_name.find('/',idx+1)) != string::npos ) --idq;
-  string path = path_name.substr(idx+1,idq-idx);
+  if ( (idq=path_name.find('/',idx+1)) != std::string::npos ) --idq;
+  std::string path = path_name.substr(idx+1,idq-idx);
   SubdetectorAlignments::const_iterator j = m_detectors.find(path);
   return (j==m_detectors.end()) ? 0 : (*j).second;
 }
 
 /// Retrieve an alignment entry by its placement path
-GlobalAlignment GlobalAlignmentCache::get(const string& path_name) const   {
-  size_t idx, idq;
+GlobalAlignment GlobalAlignmentCache::get(const std::string& path_name) const   {
+  std::size_t idx, idq;
   unsigned int index = detail::hash32(path_name.c_str()+m_sdPathLen);
   Cache::const_iterator i = m_cache.find(index);
   if ( i != m_cache.end() )  {
@@ -134,23 +132,24 @@ GlobalAlignment GlobalAlignmentCache::get(const string& path_name) const   {
   else if ( path_name[0] != '/' )   {
     return get(m_detDesc.world().placementPath()+'/'+path_name);
   }
-  else if ( (idx=path_name.find('/',1)) == string::npos )  {
+  else if ( (idx=path_name.find('/',1)) == std::string::npos )  {
     // Escape: World volume and not found in cache --> not present
     return GlobalAlignment(0);
   }
-  if ( (idq=path_name.find('/',idx+1)) != string::npos ) --idq;
-  string path = path_name.substr(idx+1,idq-idx);
+  if ( (idq=path_name.find('/',idx+1)) != std::string::npos ) --idq;
+  std::string path = path_name.substr(idx+1, idq-idx);
   SubdetectorAlignments::const_iterator j = m_detectors.find(path);
   if ( j != m_detectors.end() ) return (*j).second->get(path_name);
   return GlobalAlignment(0);
 }
 
 /// Return all entries matching a given path.
-vector<GlobalAlignment> GlobalAlignmentCache::matches(const string& match, bool exclude_exact) const   {
-  vector<GlobalAlignment> result;
+std::vector<GlobalAlignment>
+GlobalAlignmentCache::matches(const std::string& match, bool exclude_exact) const   {
+  std::vector<GlobalAlignment> result;
   GlobalAlignmentCache* c = section(match);
   if ( c )  {
-    size_t len = match.length();
+    std::size_t len = match.length();
     result.reserve(c->m_cache.size());
     for(Cache::const_iterator i=c->m_cache.begin(); i!=c->m_cache.end();++i)  {
       const Cache::value_type& v = *i;
@@ -173,7 +172,7 @@ void GlobalAlignmentCache::commit(GlobalAlignmentStack& stack)   {
 }
 
 /// Retrieve branch cache by name. If not present it will be created
-GlobalAlignmentCache* GlobalAlignmentCache::subdetectorAlignments(const string& nam)    {
+GlobalAlignmentCache* GlobalAlignmentCache::subdetectorAlignments(const std::string& nam)    {
   SubdetectorAlignments::const_iterator i = m_detectors.find(nam);
   if ( i == m_detectors.end() )   {
     GlobalAlignmentCache* ptr = new GlobalAlignmentCache(m_detDesc,nam,false);
@@ -185,8 +184,8 @@ GlobalAlignmentCache* GlobalAlignmentCache::subdetectorAlignments(const string& 
 
 /// Apply a complete stack of ordered alignments to the geometry structure
 void GlobalAlignmentCache::apply(GlobalAlignmentStack& stack)    {
-  typedef map<string,DetElement> DetElementUpdates;
-  typedef map<DetElement,vector<Entry*> > sd_entries_t;
+  typedef std::map<std::string,DetElement> DetElementUpdates;
+  typedef std::map<DetElement,std::vector<Entry*> > sd_entries_t;
   TGeoManager& mgr = m_detDesc.manager();
   DetElementUpdates detelt_updates;
   sd_entries_t all;
@@ -218,10 +217,10 @@ void GlobalAlignmentCache::apply(GlobalAlignmentStack& stack)    {
     elt->update(DetElement::PLACEMENT_CHANGED|DetElement::PLACEMENT_ELEMENT,elt.ptr());
   }
   // Provide update callback for the highest detector element
-  string last_path = "?????";
+  std::string last_path = "?????";
   for(DetElementUpdates::iterator i=detelt_updates.begin(); i!=detelt_updates.end(); ++i)  {
-    const string& path = (*i).first;
-    if ( path.find(last_path) == string::npos )  {
+    const std::string& path = (*i).first;
+    if ( path.find(last_path) == std::string::npos )  {
       DetElement elt((*i).second);
       printout(DEBUG,"GlobalAlignmentCache","+++ Trigger placement update for %s [1]",elt.path().c_str());
       elt->update(DetElement::PLACEMENT_CHANGED|DetElement::PLACEMENT_HIGHEST,elt.ptr());
@@ -237,15 +236,16 @@ void GlobalAlignmentCache::apply(GlobalAlignmentStack& stack)    {
 }
 
 /// Apply a vector of SD entries of ordered alignments to the geometry structure
-void GlobalAlignmentCache::apply(const vector<Entry*>& changes)   {
-  typedef map<string,pair<TGeoPhysicalNode*,Entry*> > Nodes;
-  Nodes nodes;
+void GlobalAlignmentCache::apply(const std::vector<Entry*>& changes)   {
+  std::map<std::string,std::pair<TGeoPhysicalNode*,Entry*> > nodes;
+  namespace ops = dd4hep::align::DDAlign_standard_operations;
   GlobalAlignmentSelector selector(*this,nodes,changes);
+
   for_each(m_cache.begin(),m_cache.end(),selector.reset());
-  for_each(nodes.begin(),nodes.end(),GlobalAlignmentActor<node_print>(*this,nodes));
-  for_each(nodes.begin(),nodes.end(),GlobalAlignmentActor<node_reset>(*this,nodes));
+  for_each(nodes.begin(),nodes.end(),GlobalAlignmentActor<ops::node_print>(*this,nodes));
+  for_each(nodes.begin(),nodes.end(),GlobalAlignmentActor<ops::node_reset>(*this,nodes));
 
   for_each(changes.begin(),changes.end(),selector.reset());
-  for_each(nodes.begin(),nodes.end(),GlobalAlignmentActor<node_align>(*this,nodes));
-  for_each(nodes.begin(),nodes.end(),GlobalAlignmentActor<node_delete>(*this,nodes));
+  for_each(nodes.begin(),nodes.end(),GlobalAlignmentActor<ops::node_align>(*this,nodes));
+  for_each(nodes.begin(),nodes.end(),GlobalAlignmentActor<ops::node_delete>(*this,nodes));
 }

--- a/DDAlign/src/GlobalAlignmentOperators.cpp
+++ b/DDAlign/src/GlobalAlignmentOperators.cpp
@@ -12,17 +12,15 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DDAlign/GlobalAlignmentOperators.h"
-#include "DDAlign/GlobalDetectorAlignment.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/detail/DetectorInterna.h>
+#include <DDAlign/GlobalAlignmentOperators.h>
+#include <DDAlign/GlobalDetectorAlignment.h>
 
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::align;
 
 void GlobalAlignmentOperator::insert(GlobalAlignment alignment)  const   {
@@ -33,7 +31,7 @@ void GlobalAlignmentOperator::insert(GlobalAlignment alignment)  const   {
 
 void GlobalAlignmentSelector::operator()(Entries::value_type e)  const {
   TGeoPhysicalNode* pn = 0;
-  nodes.emplace(e->path,make_pair(pn,e));
+  nodes.emplace(e->path,std::make_pair(pn,e));
 }
 
 void GlobalAlignmentSelector::operator()(const Cache::value_type& entry)  const {
@@ -44,11 +42,11 @@ void GlobalAlignmentSelector::operator()(const Cache::value_type& entry)  const 
       const char* p = pn->GetName();
       bool reset_children = GlobalAlignmentStack::resetChildren(*e);
       if ( reset_children && ::strstr(p,e->path.c_str()) == p )   {
-        nodes.emplace(p,make_pair(pn,e));
+        nodes.emplace(p,std::make_pair(pn,e));
         break;
       }
       else if ( e->path == p )  {
-        nodes.emplace(p,make_pair(pn,e));
+        nodes.emplace(p,std::make_pair(pn,e));
         break;
       }
     }
@@ -75,12 +73,12 @@ template <> void GlobalAlignmentActor<DDAlign_standard_operations::node_delete>:
 
 template <> void GlobalAlignmentActor<DDAlign_standard_operations::node_reset>::operator()(Nodes::value_type& n) const  {
   TGeoPhysicalNode* p = n.second.first;
-  string np;
+  std::string np;
   if ( p->IsAligned() )   {
     for (Int_t i=0, nLvl=p->GetLevel(); i<=nLvl; i++) {
       TGeoNode* node = p->GetNode(i);
       TGeoMatrix* mat = node->GetMatrix();  // Node's relative matrix
-      np += string("/")+node->GetName();
+      np += std::string("/")+node->GetName();
       if ( !mat->IsIdentity() && i > 0 )  {    // Ignore the 'world', is identity anyhow
         GlobalAlignment a = cache.get(np);
         if ( a.isValid() )  {

--- a/DDAlign/src/GlobalAlignmentStack.cpp
+++ b/DDAlign/src/GlobalAlignmentStack.cpp
@@ -95,6 +95,7 @@ GlobalAlignmentStack::~GlobalAlignmentStack()   {
 GlobalAlignmentStack& GlobalAlignmentStack::get()  {
   if ( _stack().get() ) return *_stack();
   except("GlobalAlignmentStack", "Stack not allocated -- may not be retrieved!");
+  throw std::runtime_error("Stack not allocated");
 }
 
 /// Create an alignment stack instance. The creation of a second instance will be refused.

--- a/DDAlign/src/GlobalAlignmentStack.cpp
+++ b/DDAlign/src/GlobalAlignmentStack.cpp
@@ -12,22 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Objects.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDAlign/GlobalAlignmentStack.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Objects.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDAlign/GlobalAlignmentStack.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::align;
 
-static dd4hep_ptr<GlobalAlignmentStack>& _stack()  {
-  static dd4hep_ptr<GlobalAlignmentStack> s;
+static dd4hep::dd4hep_ptr<GlobalAlignmentStack>& _stack()  {
+  static dd4hep::dd4hep_ptr<GlobalAlignmentStack> s;
   return s;
 }
-static dd4hep_ptr<GlobalAlignmentStack>& _stack(GlobalAlignmentStack* obj)  {
-  dd4hep_ptr<GlobalAlignmentStack>& stk = _stack();
+static dd4hep::dd4hep_ptr<GlobalAlignmentStack>& _stack(GlobalAlignmentStack* obj)  {
+  dd4hep::dd4hep_ptr<GlobalAlignmentStack>& stk = _stack();
   stk.adopt(obj);
   return stk;
 }
@@ -96,13 +94,13 @@ GlobalAlignmentStack::~GlobalAlignmentStack()   {
 /// Static client accessor
 GlobalAlignmentStack& GlobalAlignmentStack::get()  {
   if ( _stack().get() ) return *_stack();
-  throw runtime_error("GlobalAlignmentStack> Stack not allocated -- may not be retrieved!");
+  except("GlobalAlignmentStack", "Stack not allocated -- may not be retrieved!");
 }
 
 /// Create an alignment stack instance. The creation of a second instance will be refused.
 void GlobalAlignmentStack::create()   {
   if ( _stack().get() )   {
-    throw runtime_error("GlobalAlignmentStack> Stack already allocated. Multiple copies are not allowed!");
+    except("GlobalAlignmentStack", "Stack already allocated. Multiple copies are not allowed!");
   }
   _stack(new GlobalAlignmentStack());
 }
@@ -118,16 +116,17 @@ void GlobalAlignmentStack::release()    {
     _stack(0);
     return;
   }
-  throw runtime_error("GlobalAlignmentStack> Attempt to delete non existing stack.");
+  except("GlobalAlignmentStack", "Attempt to delete non existing stack.");
 }
 
 /// Add a new entry to the cache. The key is the placement path
-bool GlobalAlignmentStack::insert(const string& full_path, dd4hep_ptr<StackEntry>& entry)  {
+bool GlobalAlignmentStack::insert(const std::string& full_path, dd4hep_ptr<StackEntry>& entry)  {
   if ( entry.get() && !full_path.empty() )  {
     entry->path = full_path;
     return add(entry);
   }
-  throw runtime_error("GlobalAlignmentStack> Attempt to apply an invalid alignment entry.");
+  except("GlobalAlignmentStack", "Attempt to apply an invalid alignment entry.");
+  return false;
 }
 
 /// Add a new entry to the cache. The key is the placement path
@@ -143,33 +142,35 @@ bool GlobalAlignmentStack::add(dd4hep_ptr<StackEntry>& entry)  {
       StackEntry* e = entry.get();
       // Need to make some checks BEFORE insertion
       if ( !e->detector.isValid() )   {
-        throw runtime_error("GlobalAlignmentStack> Invalid alignment entry [No such detector]");
+        except("GlobalAlignmentStack", "Invalid alignment entry [No such detector]");
       }
       printout(INFO,"GlobalAlignmentStack","Add node:%s",e->path.c_str());
       m_stack.emplace(e->path,entry.release());
       return true;
     }
-    throw runtime_error("GlobalAlignmentStack> The entry with path "+entry->path+
-                        " cannot be re-aligned twice in one transaction.");
+    except("GlobalAlignmentStack", "The entry with path "+entry->path+
+           " cannot be re-aligned twice in one transaction.");
   }
-  throw runtime_error("GlobalAlignmentStack> Attempt to apply an invalid alignment entry.");
+  except("GlobalAlignmentStack", "Attempt to apply an invalid alignment entry.");
+  return false;
 }
 
 /// Retrieve an alignment entry of the current stack
-dd4hep_ptr<GlobalAlignmentStack::StackEntry> GlobalAlignmentStack::pop()   {
+dd4hep::dd4hep_ptr<GlobalAlignmentStack::StackEntry> GlobalAlignmentStack::pop()   {
   Stack::iterator i = m_stack.begin();
   if ( i != m_stack.end() )   {
     dd4hep_ptr<StackEntry> e((*i).second);
     m_stack.erase(i);
     return e;
   }
-  throw runtime_error("GlobalAlignmentStack> Alignment stack is empty. "
-                      "Cannot pop entries - check size first!");
+  except("GlobalAlignmentStack", "Alignment stack is empty. "
+         "Cannot pop entries - check size first!");
+  return {};
 }
 
 /// Get all pathes to be aligned
-vector<const GlobalAlignmentStack::StackEntry*> GlobalAlignmentStack::entries() const    {
-  vector<const StackEntry*> result;
+std::vector<const GlobalAlignmentStack::StackEntry*> GlobalAlignmentStack::entries() const    {
+  std::vector<const StackEntry*> result;
   result.reserve(m_stack.size());
   transform(begin(m_stack),end(m_stack),back_inserter(result),detail::select2nd(m_stack));
   return result;

--- a/DDAlign/src/GlobalAlignmentWriter.cpp
+++ b/DDAlign/src/GlobalAlignmentWriter.cpp
@@ -12,25 +12,24 @@
 //==========================================================================
 
 // Framework includes
-#include "DDAlign/GlobalAlignmentWriter.h"
-#include "DDAlign/GlobalAlignmentCache.h"
-#include "DDAlign/GlobalDetectorAlignment.h"
-#include "DDAlign/AlignmentTags.h"
+#include <DDAlign/GlobalAlignmentWriter.h>
+#include <DDAlign/GlobalAlignmentCache.h>
+#include <DDAlign/GlobalDetectorAlignment.h>
+#include <DDAlign/AlignmentTags.h>
 
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "XML/DocumentHandler.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/detail/DetectorInterna.h>
+#include <XML/DocumentHandler.h>
 
-#include "TGeoMatrix.h"
+#include <TGeoMatrix.h>
 
 // C/C++ include files
 #include <stdexcept>
 
 using namespace dd4hep::align;
-using namespace dd4hep;
-using namespace std;
+namespace xml = dd4hep::xml;
 
 /// Initializing Constructor
 GlobalAlignmentWriter::GlobalAlignmentWriter(Detector& description) : m_detDesc(description)
@@ -47,19 +46,19 @@ GlobalAlignmentWriter::~GlobalAlignmentWriter()  {
 /// Create the element corresponding to one single detector element without children
 xml::Element GlobalAlignmentWriter::createElement(xml::Document doc, DetElement element)  const  {
   xml::Element e(0), placement(0), elt = xml::Element(doc,_ALU(detelement));
-  string path = element.placementPath();
+  std::string path = element.placementPath();
   GlobalAlignment a = element->global_alignment;
   GlobalDetectorAlignment det(element);
-  const vector<GlobalAlignment>& va = det.volumeAlignments();
 
   elt.setAttr(_ALU(path),element.path());
   if ( a.isValid() )  {
     addNode(elt,a);
   }
-  for(vector<GlobalAlignment>::const_iterator i=va.begin(); i!=va.end();++i)  {
+  const std::vector<GlobalAlignment>& vol_alignments = det.volumeAlignments();
+  for(const auto& alignment : vol_alignments )  {
     e = xml::Element(doc,_U(volume));
-    e.setAttr(_ALU(path),(*i)->GetName());
-    addNode(e,*i);
+    e.setAttr(_ALU(path), alignment->GetName());
+    addNode(e, alignment);
     elt.append(e);
   }
   return elt;
@@ -77,9 +76,9 @@ void GlobalAlignmentWriter::addNode(xml::Element elt, GlobalAlignment a)  const 
 
   printout(INFO,"GlobalAlignmentWriter","Write Delta constants for %s",a->GetName());
   //mat.Print();
-  if ( fabs(t[0]) > numeric_limits<double>::epsilon() ||
-       fabs(t[1]) > numeric_limits<double>::epsilon() ||
-       fabs(t[2]) > numeric_limits<double>::epsilon() ) {
+  if ( fabs(t[0]) > std::numeric_limits<double>::epsilon() ||
+       fabs(t[1]) > std::numeric_limits<double>::epsilon() ||
+       fabs(t[2]) > std::numeric_limits<double>::epsilon() ) {
     xml::Element e = xml::Element(elt.document(),_U(position));
     e.setAttr(_U(x),_toString(t[0]/dd4hep::mm,"%f*mm"));
     e.setAttr(_U(y),_toString(t[1]/dd4hep::mm,"%f*mm"));
@@ -88,9 +87,9 @@ void GlobalAlignmentWriter::addNode(xml::Element elt, GlobalAlignment a)  const 
   }
   if ( mat.IsRotation() )  {
     XYZAngles rot = detail::matrix::_xyzAngles(&mat);
-    if ( fabs(rot.X()) > numeric_limits<double>::epsilon() ||
-         fabs(rot.Y()) > numeric_limits<double>::epsilon() ||
-         fabs(rot.Z()) > numeric_limits<double>::epsilon() )    {
+    if ( fabs(rot.X()) > std::numeric_limits<double>::epsilon() ||
+         fabs(rot.Y()) > std::numeric_limits<double>::epsilon() ||
+         fabs(rot.Z()) > std::numeric_limits<double>::epsilon() )    {
 
       xml::Element e = xml::Element(elt.document(),_U(rotation));
       // Don't know why the angles have the wrong sign....
@@ -133,7 +132,7 @@ xml::Document GlobalAlignmentWriter::dump(DetElement top, bool enable_transactio
 }
 
 /// Write the XML document structure to a file.
-long GlobalAlignmentWriter::write(xml::Document doc, const string& output)   const {
+long GlobalAlignmentWriter::write(xml::Document doc, const std::string& output)   const {
   xml::DocumentHandler docH;
   return docH.output(doc, output);
 }

--- a/DDAlign/src/GlobalDetectorAlignment.cpp
+++ b/DDAlign/src/GlobalDetectorAlignment.cpp
@@ -12,17 +12,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DDAlign/GlobalDetectorAlignment.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/detail/DetectorInterna.h"
+#include <DDAlign/GlobalDetectorAlignment.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/detail/DetectorInterna.h>
 
 // ROOT include files
-#include "TGeoMatrix.h"
-#include "TGeoManager.h"
+#include <TGeoMatrix.h>
+#include <TGeoManager.h>
 
 
 #ifdef __GNUC__    // Disable some diagnostics.
@@ -56,14 +56,10 @@ namespace dd4hep {
   } /* End namespace Aligments               */
 } /* End namespace dd4hep                    */
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::align;
-
-typedef vector<pair<int,DetElement> > LevelElements;
+typedef std::vector<std::pair<int,dd4hep::DetElement> > LevelElements;
 
 DD4HEP_INSTANTIATE_HANDLE_NAMED(GlobalAlignmentData);
-
 
 namespace {
 
@@ -75,22 +71,22 @@ namespace {
       TGeoMatrix* mm = n->GetNode()->GetMatrix();
       bool dbg = GlobalDetectorAlignment::debug();
       if ( dbg )  {
-        printout(INFO,"Alignment","DELTA matrix of %s",n->GetName());
+        printout(dd4hep::INFO,"Alignment","DELTA matrix of %s",n->GetName());
         transform->Print();
-        printout(INFO,"Alignment","OLD matrix of %s",n->GetName());
+        dd4hep::printout(dd4hep::INFO,"Alignment","OLD matrix of %s",n->GetName());
         mm->Print();
       }
       transform->MultiplyLeft(mm); // orig * delta
       n->Align(transform, 0, check, overlap);
       if ( dbg )   {
-        printout(INFO,"Alignment","NEW matrix of %s",n->GetName());
+        dd4hep::printout(dd4hep::INFO,"Alignment","NEW matrix of %s",n->GetName());
         n->GetNode()->GetMatrix()->Print();
       }
       /*
-        printout(INFO,"Alignment","Apply new relative matrix  mother to daughter:");
+        printout(dd4hep::INFO,"Alignment","Apply new relative matrix  mother to daughter:");
         transform->Print();
         transform->MultiplyLeft(mm); // orig * delta
-        printout(INFO,"Alignment","With deltas %s ....",n->GetName());
+        printout(dd4hep::INFO,"Alignment","With deltas %s ....",n->GetName());
         transform->Print();
         n->Align(transform, 0, check, overlap);
 
@@ -100,31 +96,33 @@ namespace {
       */
       return GlobalAlignment(n);
     }
-    throw runtime_error("dd4hep: Cannot align non existing physical node. [Invalid Handle]");
+    dd4hep::except("GlobalDetectorAlignment", "Cannot align non existing physical node. [Invalid Handle]");
+    return { };
   }
 
   GlobalAlignment _alignment(const GlobalDetectorAlignment& det)  {
-    DetElement::Object& e = det._data();
+    dd4hep::DetElement::Object& e = det._data();
     if ( !e.global_alignment.isValid() )  {
-      string path = detail::tools::placementPath(det);
-      e.global_alignment = Ref_t(new GlobalAlignmentData(path));
+      std::string path = dd4hep::detail::tools::placementPath(det);
+      e.global_alignment = dd4hep::Ref_t(new GlobalAlignmentData(path));
     }
-    Handle<GlobalAlignmentData> h(e.global_alignment);
+    dd4hep::Handle<GlobalAlignmentData> h(e.global_alignment);
     if ( h.isValid() && h->global.isValid() )  {
       return h->global;
     }
-    throw runtime_error("dd4hep: Cannot access global alignment data. [Invalid Handle]");
+    dd4hep::except("GlobalDetectorAlignment", "Cannot access global alignment data. [Invalid Handle]");
+    return { };
   }
 
   void _dumpParentElements(GlobalDetectorAlignment& det, LevelElements& elements)   {
     int level = 0;
-    detail::tools::PlacementPath nodes;
-    detail::tools::ElementPath   det_nodes;
-    detail::tools::placementPath(det,nodes);
-    detail::tools::elementPath(det,det_nodes);
-    ///    cout << "Placement path:";
-    detail::tools::PlacementPath::const_reverse_iterator j=nodes.rbegin();
-    detail::tools::ElementPath::const_reverse_iterator   k=det_nodes.rbegin();
+    dd4hep::detail::tools::PlacementPath nodes;
+    dd4hep::detail::tools::ElementPath   det_nodes;
+    dd4hep::detail::tools::placementPath(det,nodes);
+    dd4hep::detail::tools::elementPath(det,det_nodes);
+    ///    std::cout << "Placement path:";
+    dd4hep::detail::tools::PlacementPath::const_reverse_iterator j=nodes.rbegin();
+    dd4hep::detail::tools::ElementPath::const_reverse_iterator   k=det_nodes.rbegin();
     for(; j!=nodes.rend(); ++j, ++level)  {
       //cout << "(" << level << ") " << (void*)((*j).ptr())
       //           << " " << string((*j)->GetName()) << " ";
@@ -136,9 +134,9 @@ namespace {
       else  {
         //elements.emplace_back(level,DetElement());
       }
-      //cout << " ";
+      //std::cout << " ";
     }
-    //cout << endl;
+    //std::cout << std::endl;
   }
 }
 
@@ -161,7 +159,7 @@ bool GlobalDetectorAlignment::debug(bool value)   {
 }
 
 /// Collect all placements from the detector element up to the world volume
-void GlobalDetectorAlignment::collectNodes(vector<PlacedVolume>& nodes)   {
+void GlobalDetectorAlignment::collectNodes(std::vector<PlacedVolume>& nodes)   {
   detail::tools::placementPath(*this,nodes);
 }
 
@@ -171,13 +169,13 @@ GlobalAlignment GlobalDetectorAlignment::alignment() const   {
 }
 
 /// Alignment entries for lower level volumes, which are NOT attached to daughter DetElements
-vector<GlobalAlignment>& GlobalDetectorAlignment::volumeAlignments()  {
+std::vector<GlobalAlignment>& GlobalDetectorAlignment::volumeAlignments()  {
   Handle<GlobalAlignmentData> h(_data().global_alignment);
   return h->volume_alignments;
 }
 
 /// Alignment entries for lower level volumes, which are NOT attached to daughter DetElements
-const vector<GlobalAlignment>& GlobalDetectorAlignment::volumeAlignments() const   {
+const std::vector<GlobalAlignment>& GlobalDetectorAlignment::volumeAlignments() const   {
   Handle<GlobalAlignmentData> h(_data().global_alignment);
   return h->volume_alignments;
 }
@@ -208,28 +206,28 @@ GlobalAlignment GlobalDetectorAlignment::align(TGeoHMatrix* matrix, bool chk, do
 }
 
 /// Align the PhysicalNode of the placement of the detector element (translation only)
-GlobalAlignment GlobalDetectorAlignment::align(const string& elt_path, const Position& pos, bool chk, double overlap) {
+GlobalAlignment GlobalDetectorAlignment::align(const std::string& elt_path, const Position& pos, bool chk, double overlap) {
   return align(elt_path,detail::matrix::_transform(pos),chk,overlap);
 }
 
 /// Align the PhysicalNode of the placement of the detector element (rotation only)
-GlobalAlignment GlobalDetectorAlignment::align(const string& elt_path, const RotationZYX& rot, bool chk, double overlap) {
+GlobalAlignment GlobalDetectorAlignment::align(const std::string& elt_path, const RotationZYX& rot, bool chk, double overlap) {
   return align(elt_path,detail::matrix::_transform(rot),chk,overlap);
 }
 
 /// Align the PhysicalNode of the placement of the detector element (translation + rotation)
 GlobalAlignment 
-GlobalDetectorAlignment::align(const string& elt_path, const Position& pos, const RotationZYX& rot, bool chk, double overlap) {
+GlobalDetectorAlignment::align(const std::string& elt_path, const Position& pos, const RotationZYX& rot, bool chk, double overlap) {
   return align(elt_path,detail::matrix::_transform(pos,rot),chk,overlap);
 }
 
 /// Align the physical node according to a generic Transform3D
-GlobalAlignment GlobalDetectorAlignment::align(const string& elt_path, const Transform3D& transform, bool chk, double overlap)  {
+GlobalAlignment GlobalDetectorAlignment::align(const std::string& elt_path, const Transform3D& transform, bool chk, double overlap)  {
   return align(elt_path,detail::matrix::_transform(transform),chk,overlap);
 }
 
 /// Align the physical node according to a generic TGeo matrix
-GlobalAlignment GlobalDetectorAlignment::align(const string& elt_path, TGeoHMatrix* matrix, bool chk, double overlap)  {
+GlobalAlignment GlobalDetectorAlignment::align(const std::string& elt_path, TGeoHMatrix* matrix, bool chk, double overlap)  {
   if ( elt_path.empty() )
     return _align(_alignment(*this),matrix,chk,overlap);
   else if ( elt_path == placementPath() )

--- a/DDAlign/src/plugins/AlignmentsPlugins.cpp
+++ b/DDAlign/src/plugins/AlignmentsPlugins.cpp
@@ -12,19 +12,17 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/DetFactoryHelper.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/DetFactoryHelper.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::align;
 
 // ======================================================================================
-#include "DDAlign/GlobalAlignmentWriter.h"
-long create_global_alignment_xml_file(Detector& description, int argc, char** argv)   {
-  DetElement top;
-  string output, path = "/world";
+#include <DDAlign/GlobalAlignmentWriter.h>
+long create_global_alignment_xml_file(dd4hep::Detector& description, int argc, char** argv)   {
+  dd4hep::DetElement top;
+  std::string output, path = "/world";
   bool enable_transactions = false, arg_error = false;
   for(int i=1; i<argc;++i) {
     if ( argv[i] && (argv[i][0]=='-' || argv[i][0]=='/') ) {
@@ -42,26 +40,27 @@ long create_global_alignment_xml_file(Detector& description, int argc, char** ar
 
   if ( arg_error || output.empty() || path.empty() )  {
     /// Help printout describing the basic command line interface
-    cout <<
+    std::cout <<
       "Usage: -plugin <name> -arg [-arg]                                      \n"
       "     name:   factory nameDD4hep_GlobalAlignmentWriter                \n\n"
       "     -output <string>         Path to the output file generated.       \n"
       "     -path   <string>         Path to the detector element for which   \n"
       "                              the alignment file should be written.    \n"
       "     -transactions            Enable output transactions.              \n"
-      "\tArguments given: " << arguments(argc,argv) << endl << flush;
+      "\tArguments given: " << dd4hep::arguments(argc,argv) << std::endl << std::flush;
     ::exit(EINVAL);
   }
 
-  printout(ALWAYS,"AlignmentXmlWriter",
-           "++ Writing dd4hep alignment constants of the \"%s\" DetElement tree to file \"%s\"",
-           path.c_str(), output.c_str());
-  top = detail::tools::findDaughterElement(description.world(),path);
+  dd4hep::printout(dd4hep::ALWAYS,"AlignmentXmlWriter",
+                   "++ Writing dd4hep alignment constants of the \"%s\" "
+                   "DetElement tree to file \"%s\"",
+                   path.c_str(), output.c_str());
+  top = dd4hep::detail::tools::findDaughterElement(description.world(),path);
   if ( top.isValid() )   {
     GlobalAlignmentWriter wr(description);
     return wr.write(wr.dump(top,enable_transactions), output);
   }
-  except("AlignmentXmlWriter","++ Invalid top level detector element name: %s",path.c_str());
+  dd4hep::except("AlignmentXmlWriter","++ Invalid top level detector element name: %s",path.c_str());
   return 1;
 }
 DECLARE_APPLY(DD4hep_GlobalAlignmentXmlWriter, create_global_alignment_xml_file)

--- a/DDCond/src/ConditionsContent.cpp
+++ b/DDCond/src/ConditionsContent.cpp
@@ -12,12 +12,10 @@
 //==========================================================================
 
 // Framework include files
-#include "DDCond/ConditionsContent.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Printout.h"
+#include <DDCond/ConditionsContent.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Printout.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 /// Default constructor
@@ -95,16 +93,16 @@ bool ConditionsContent::remove(Condition::key_type hash)   {
   return false;
 }
 
-pair<Condition::key_type, ConditionsLoadInfo*>
+std::pair<dd4hep::Condition::key_type, ConditionsLoadInfo*>
 ConditionsContent::insertKey(Condition::key_type hash)   {
   auto ret = m_conditions.emplace(hash,(ConditionsLoadInfo*)0);
   //printout(DEBUG,"ConditionsContent","++ Insert key: %016X",hash);
-  if ( ret.second )  return pair<Condition::key_type, ConditionsLoadInfo*>(hash,0);
-  return pair<Condition::key_type, ConditionsLoadInfo*>(0,0);
+  if ( ret.second )  return { hash, 0 };
+  return { 0,0 };
 }
 
 /// Add a new conditions key. T must inherit from class ConditionsContent::Info
-pair<Condition::key_type, ConditionsLoadInfo*>
+std::pair<dd4hep::Condition::key_type, ConditionsLoadInfo*>
 ConditionsContent::addLocationInfo(Condition::key_type hash, ConditionsLoadInfo* info)   {
   if ( info )   {
     //printout(DEBUG,"ConditionsContent","++ Add location key: %016X",hash);
@@ -115,11 +113,11 @@ ConditionsContent::addLocationInfo(Condition::key_type hash, ConditionsLoadInfo*
     }
     info->release();
   }
-  return pair<Condition::key_type, ConditionsLoadInfo*>(0,0);
+  return { 0,0 };
 }
 
 /// Add a new shared conditions dependency
-pair<Condition::key_type, ConditionDependency*>
+std::pair<dd4hep::Condition::key_type, ConditionDependency*>
 ConditionsContent::addDependency(ConditionDependency* dep)
 {
   auto ret = m_derived.emplace(dep->key(),dep);
@@ -139,11 +137,11 @@ ConditionsContent::addDependency(ConditionDependency* dep)
   except("DeConditionsRequests",
          "++ Dependency already exists: %s [%08X] [%016llX]",
          path, maker.values.item_key, maker.hash);
-  return pair<Condition::key_type, ConditionDependency*>(0,0);
+  return std::pair<Condition::key_type, ConditionDependency*>(0,0);
 }
 
 /// Add a new conditions dependency (Built internally from arguments)
-std::pair<Condition::key_type, ConditionDependency*>
+std::pair<dd4hep::Condition::key_type, ConditionDependency*>
 ConditionsContent::addDependency(DetElement de,
                                  Condition::itemkey_type item,
                                  std::shared_ptr<ConditionUpdateCall> callback)

--- a/DDCond/src/ConditionsDependencyHandler.cpp
+++ b/DDCond/src/ConditionsDependencyHandler.cpp
@@ -26,7 +26,7 @@ namespace {
     return d->target.name;
 #else
     char text[64];
-    ConditionKey::KeyMaker key(d->target.hash);
+    dd4hep::ConditionKey::KeyMaker key(d->target.hash);
     ::snprintf(text,sizeof(text),"%08X %08X",key.values.det_key, key.values.item_key);
     return text;
 #endif

--- a/DDCond/src/ConditionsDependencyHandler.cpp
+++ b/DDCond/src/ConditionsDependencyHandler.cpp
@@ -12,13 +12,12 @@
 //==========================================================================
 
 // Framework include files
-#include "DDCond/ConditionsDependencyHandler.h"
-#include "DDCond/ConditionsManagerObject.h"
-#include "DD4hep/ConditionsProcessor.h"
-#include "DD4hep/Printout.h"
-#include "TTimeStamp.h"
+#include <DDCond/ConditionsDependencyHandler.h>
+#include <DDCond/ConditionsManagerObject.h>
+#include <DD4hep/ConditionsProcessor.h>
+#include <DD4hep/Printout.h>
+#include <TTimeStamp.h>
 
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 namespace {
@@ -46,7 +45,8 @@ void ConditionsDependencyHandler::Work::do_intersection(const IOV* iov_ptr)   {
   }
 }
 
-Condition ConditionsDependencyHandler::Work::resolve(Work*& current)   {
+dd4hep::Condition
+ConditionsDependencyHandler::Work::resolve(Work*& current)   {
   Work* previous = current;
   current = this;
   state = RESOLVED;
@@ -86,7 +86,7 @@ ConditionsDependencyHandler::~ConditionsDependencyHandler()   {
 }
 
 /// ConditionResolver implementation: Access to the detector description instance
-Detector& ConditionsDependencyHandler::detectorDescription() const  {
+dd4hep::Detector& ConditionsDependencyHandler::detectorDescription() const  {
   return m_manager->detectorDescription();
 }
 
@@ -164,17 +164,20 @@ bool ConditionsDependencyHandler::registerOne(const IOV& iov, Condition cond)   
 }
 
 /// Handle multi-condition inserts by callbacks: block insertions of conditions with identical IOV
-size_t ConditionsDependencyHandler::registerMany(const IOV& iov, const std::vector<Condition>& values)   {
+std::size_t
+ConditionsDependencyHandler::registerMany(const IOV& iov, const std::vector<Condition>& values)   {
   return m_pool.registerMany(iov, values);
 }
 
 /// Interface to access conditions by hash value of the DetElement (only valid at resolve!)
-std::vector<Condition> ConditionsDependencyHandler::get(DetElement de)   {
+std::vector<dd4hep::Condition>
+ConditionsDependencyHandler::get(DetElement de)   {
   return this->get(de.key());
 }
 
 /// Interface to access conditions by hash value of the item (only valid at resolve!)
-std::vector<Condition> ConditionsDependencyHandler::getByItem(Condition::itemkey_type key)   {
+std::vector<dd4hep::Condition>
+ConditionsDependencyHandler::getByItem(Condition::itemkey_type key)   {
   if ( m_state == RESOLVED )   {
     struct item_selector {
       std::vector<Condition>  conditions;
@@ -197,7 +200,8 @@ std::vector<Condition> ConditionsDependencyHandler::getByItem(Condition::itemkey
 }
 
 /// Interface to access conditions by hash value of the DetElement (only valid at resolve!)
-std::vector<Condition> ConditionsDependencyHandler::get(Condition::detkey_type det_key)   {
+std::vector<dd4hep::Condition>
+ConditionsDependencyHandler::get(Condition::detkey_type det_key)   {
   if ( m_state == RESOLVED )   {
     ConditionKey::KeyMaker lower(det_key, Condition::FIRST_ITEM_KEY);
     ConditionKey::KeyMaker upper(det_key, Condition::LAST_ITEM_KEY);
@@ -211,14 +215,16 @@ std::vector<Condition> ConditionsDependencyHandler::get(Condition::detkey_type d
 }
 
 /// ConditionResolver implementation: Interface to access conditions
-Condition ConditionsDependencyHandler::get(Condition::key_type key, bool throw_if_not)  {
+dd4hep::Condition
+ConditionsDependencyHandler::get(Condition::key_type key, bool throw_if_not)  {
   return this->get(key, nullptr, throw_if_not);
 }
 
 /// ConditionResolver implementation: Interface to access conditions
-Condition ConditionsDependencyHandler::get(Condition::key_type key,
-                                           const ConditionDependency* dependency,
-                                           bool throw_if_not)
+dd4hep::Condition
+ConditionsDependencyHandler::get(Condition::key_type key,
+                                 const ConditionDependency* dependency,
+                                 bool throw_if_not)
 {
   /// If we are not already resolving here, we follow the normal procedure
   Condition c = m_pool.get(key);
@@ -324,14 +330,14 @@ void ConditionsDependencyHandler::do_callback(Work* work)   {
     }
     else   {
       printout(ERROR,"DependencyHandler",
-	       "+++ Callback handler returned invalid condition.  Key:%s %c%s%c",
-	       work->context.dependency->target.toString().c_str(),
+               "+++ Callback handler returned invalid condition.  Key:%s %c%s%c",
+               work->context.dependency->target.toString().c_str(),
 #if defined(DD4HEP_CONDITIONS_DEBUG)
-	       '[',work->context.dependency->detector.path().c_str(),']'
+               '[',work->context.dependency->detector.path().c_str(),']'
 #else
-	       ' ',"",' '
+               ' ',"",' '
 #endif
-	       );
+               );
       throw std::runtime_error("Invalid derived condition callback");
     }
     return;

--- a/DDCond/src/ConditionsIOVPool.cpp
+++ b/DDCond/src/ConditionsIOVPool.cpp
@@ -12,15 +12,14 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDCond/ConditionsIOVPool.h"
-#include "DDCond/ConditionsCleanup.h"
-#include "DDCond/ConditionsDataLoader.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDCond/ConditionsIOVPool.h>
+#include <DDCond/ConditionsCleanup.h>
+#include <DDCond/ConditionsDataLoader.h>
 
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/detail/ConditionsInterna.h>
 
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 /// Default constructor

--- a/DDCond/src/ConditionsManager.cpp
+++ b/DDCond/src/ConditionsManager.cpp
@@ -12,23 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Errors.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/PluginCreators.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Errors.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/PluginCreators.h>
 
-#include "DD4hep/ConditionsListener.h"
-#include "DDCond/ConditionsManager.h"
-#include "DDCond/ConditionsManagerObject.h"
+#include <DD4hep/ConditionsListener.h>
+#include <DDCond/ConditionsManager.h>
+#include <DDCond/ConditionsManagerObject.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 DD4HEP_INSTANTIATE_HANDLE_NAMED(ConditionsManagerObject);
-
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -94,8 +91,8 @@ void ConditionsManagerObject::onRemove(Condition condition)   {
 }
 
 /// Access the used/registered IOV types
-const vector<const IOVType*> ConditionsManagerObject::iovTypesUsed() const   {
-  vector<const IOVType*> result;
+const std::vector<const dd4hep::IOVType*> ConditionsManagerObject::iovTypesUsed() const   {
+  std::vector<const IOVType*> result;
   const auto& types = this->iovTypes();
   for ( const auto& i : types )  {
     if ( i.type != IOVType::UNKNOWN_IOV ) result.emplace_back(&i);
@@ -107,15 +104,15 @@ const vector<const IOVType*> ConditionsManagerObject::iovTypesUsed() const   {
 void ConditionsManagerObject::fromString(const std::string& data, IOV& iov)   {
   size_t id1 = data.find(',');
   size_t id2 = data.find('#');
-  if ( id2 == string::npos )  {
+  if ( id2 == std::string::npos )  {
     except("ConditionsManager","+++ Unknown IOV string representation: %s",data.c_str());
   }
-  string iov_name = data.substr(id2+1);
+  std::string iov_name = data.substr(id2+1);
   IOV::Key key;
   int nents = 0;
   /// Need assignment from long (k1,k2) for compatibility with Apple MAC
   long k1 = 0, k2 = 0;
-  if ( id1 != string::npos )   {
+  if ( id1 != std::string::npos )   {
     nents = ::sscanf(data.c_str(),"%ld,%ld#",&k1,&k2) == 2 ? 2 : 0;
     key.second = k2;
     key.first = k1;
@@ -143,7 +140,7 @@ void ConditionsManagerObject::fromString(const std::string& data, IOV& iov)   {
 }
 
 /// Register IOV using new string data
-ConditionsPool* ConditionsManagerObject::registerIOV(const string& data)   {
+ConditionsPool* ConditionsManagerObject::registerIOV(const std::string& data)   {
   IOV iov(0);
   // Convert string to IOV
   fromString(data, iov);
@@ -173,17 +170,17 @@ ConditionsManager& ConditionsManager::initialize()   {
 }
 
 /// Access the detector description
-Detector& ConditionsManager::detectorDescription()  const   {
+dd4hep::Detector& ConditionsManager::detectorDescription()  const   {
   return access()->detectorDescription();
 }
 
 /// Access to the property manager
-PropertyManager& ConditionsManager::properties()  const   {
+dd4hep::PropertyManager& ConditionsManager::properties()  const   {
   return access()->properties();
 }
 
 /// Access to properties
-Property& ConditionsManager::operator[](const std::string& property_name) const    {
+dd4hep::Property& ConditionsManager::operator[](const std::string& property_name) const    {
   return access()->properties().property(property_name);
 }
 
@@ -193,13 +190,13 @@ ConditionsDataLoader& ConditionsManager::loader()  const    {
 }
 
 /// Register new IOV type if it does not (yet) exist.
-pair<bool, const IOVType*> 
-ConditionsManager::registerIOVType(size_t iov_type, const string& iov_name)  const  {
+std::pair<bool, const dd4hep::IOVType*> 
+ConditionsManager::registerIOVType(size_t iov_type, const std::string& iov_name)  const  {
   return access()->registerIOVType(iov_type, iov_name);
 }
 
 /// Access IOV by its name
-const IOVType* ConditionsManager::iovType (const string& iov_name) const   {
+const dd4hep::IOVType* ConditionsManager::iovType (const std::string& iov_name) const   {
   return access()->iovType(iov_name);
 }
 
@@ -209,9 +206,9 @@ ConditionsIOVPool* ConditionsManager::iovPool(const IOVType& iov_type)  const {
 }
 
 /// Access the used/registered IOV types
-const vector<const IOVType*> ConditionsManager::iovTypesUsed() const  {
+const std::vector<const dd4hep::IOVType*> ConditionsManager::iovTypesUsed() const  {
   Object* obj = access();
-  vector<const IOVType*> result;
+  std::vector<const IOVType*> result;
   const auto& types = obj->iovTypes();
   result.reserve(types.size());
   for(const auto& i : types )
@@ -220,7 +217,7 @@ const vector<const IOVType*> ConditionsManager::iovTypesUsed() const  {
 }
 
 /// Register IOV with type and key
-ConditionsPool* ConditionsManager::registerIOV(const string& iov_rep)  const   {
+ConditionsPool* ConditionsManager::registerIOV(const std::string& iov_rep)  const   {
   IOV iov(0);
   Object* o = access();
   o->fromString(iov_rep, iov);
@@ -244,12 +241,12 @@ ConditionsPool* ConditionsManager::registerIOV(const IOVType& typ, IOV::Key key)
 }
 
 /// Create IOV from string
-void ConditionsManager::fromString(const string& iov_str, IOV& iov)  const  {
+void ConditionsManager::fromString(const std::string& iov_str, IOV& iov)  const  {
   access()->fromString(iov_str, iov);
 }
       
 /// Register a whole block of conditions with identical IOV.
-size_t ConditionsManager::blockRegister(ConditionsPool& pool, const std::vector<Condition>& cond) const   {
+std::size_t ConditionsManager::blockRegister(ConditionsPool& pool, const std::vector<Condition>& cond) const   {
   return access()->blockRegister(pool, cond);
 }
 

--- a/DDCond/src/ConditionsOperators.cpp
+++ b/DDCond/src/ConditionsOperators.cpp
@@ -12,18 +12,16 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/detail/ConditionsInterna.h"
-#include "DDCond/ConditionsPool.h"
-#include "DDCond/ConditionsIOVPool.h"
-#include "DDCond/ConditionsOperators.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/detail/ConditionsInterna.h>
+#include <DDCond/ConditionsPool.h>
+#include <DDCond/ConditionsIOVPool.h>
+#include <DDCond/ConditionsOperators.h>
 
 // C/C++ include files
 #include <cstring>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 /// Select all condition from the conditions manager registered at the Detector object

--- a/DDCond/src/ConditionsPool.cpp
+++ b/DDCond/src/ConditionsPool.cpp
@@ -12,16 +12,14 @@
 //==========================================================================
 
 // Framework include files
-#include "DDCond/ConditionsPool.h"
-#include "DDCond/ConditionsManagerObject.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/ConditionsPrinter.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DDCond/ConditionsPool.h>
+#include <DDCond/ConditionsManagerObject.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/ConditionsPrinter.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
-using std::string;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 DD4HEP_INSTANTIATE_HANDLE_NAMED(UpdatePool);
@@ -47,7 +45,7 @@ void ConditionsPool::print()   const  {
 }
 
 /// Print pool basics
-void ConditionsPool::print(const string& opt)   const  {
+void ConditionsPool::print(const std::string& opt)   const  {
   printout(INFO,"ConditionsPool","+++ %s Conditions for pool with IOV: %-32s age:%3d [%4d entries]",
            opt.c_str(), GetName(), age_value, size());
   if ( opt == "*" || opt == "ALL" )   {

--- a/DDCond/src/ConditionsRepository.cpp
+++ b/DDCond/src/ConditionsRepository.cpp
@@ -12,14 +12,14 @@
 //==========================================================================
 
 // Framework include files
-#include "DDCond/ConditionsRepository.h"
-#include "DDCond/ConditionsManager.h"
-#include "DDCond/ConditionsIOVPool.h"
-#include "DDCond/ConditionsTags.h"
-#include "DD4hep/detail/ConditionsInterna.h"
-#include "DD4hep/Printout.h"
-#include "XML/DocumentHandler.h"
-#include "XML/XMLTags.h"
+#include <DDCond/ConditionsRepository.h>
+#include <DDCond/ConditionsManager.h>
+#include <DDCond/ConditionsIOVPool.h>
+#include <DDCond/ConditionsTags.h>
+#include <DD4hep/detail/ConditionsInterna.h>
+#include <DD4hep/Printout.h>
+#include <XML/DocumentHandler.h>
+#include <XML/XMLTags.h>
 
 // C/C++ include files
 #include <cstring>
@@ -28,15 +28,13 @@
 #include <cerrno>
 #include <map>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::cond;
-typedef xml::Handle_t xml_h;
-typedef xml::Element xml_elt_t;
-typedef xml::Document xml_doc_t;
-typedef xml::Collection_t xml_coll_t;
+typedef dd4hep::xml::Handle_t xml_h;
+typedef dd4hep::xml::Element xml_elt_t;
+typedef dd4hep::xml::Document xml_doc_t;
+typedef dd4hep::xml::Collection_t xml_coll_t;
 
-typedef map<Condition::key_type,Condition> AllConditions;
+typedef std::map<dd4hep::Condition::key_type,dd4hep::Condition> AllConditions;
 
 /// Default constructor
 ConditionsRepository::ConditionsRepository()  {
@@ -48,7 +46,7 @@ ConditionsRepository::~ConditionsRepository()   {
 
 namespace {
 
-  int createXML(const string& output, const AllConditions& all) {
+  int createXML(const std::string& output, const AllConditions& all) {
     const char comment[] = "\n"
       "      +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n"
       "      ++++   Linear collider detector description Detector in C++  ++++\n"
@@ -62,8 +60,8 @@ namespace {
     xml_elt_t root = doc.root(), cond(0);
     for( const auto& i : all )  {
       char text[32];
-      Condition c = i.second;
-      ::snprintf(text,sizeof(text),"0x%16llX",c.key());
+      dd4hep::Condition c = i.second;
+      std::snprintf(text,sizeof(text),"0x%16llX",c.key());
       root.append(cond = xml_elt_t(doc, _U(ref)));
       cond.setAttr(_U(key), text);
 #if !defined(DD4HEP_MINIMAL_CONDITIONS)
@@ -71,7 +69,7 @@ namespace {
       cond.setAttr(_U(ref), c.address());
 #endif
     }
-    printout(ALWAYS,"ConditionsRepository","++ Handled %ld conditions.",all.size());
+    dd4hep::printout(dd4hep::ALWAYS,"ConditionsRepository","++ Handled %ld conditions.",all.size());
     if ( !output.empty() )  {
       return docH.output(doc, output);
     }
@@ -79,7 +77,7 @@ namespace {
   }
 
   /// Load the repository from file and fill user passed data structory
-  int readXML(const string& input, ConditionsRepository::Data& data)    {
+  int readXML(const std::string& input, ConditionsRepository::Data& data)    {
     struct Conv {
       /// Reference to optional user defined parameter
       ConditionsRepository::Data& data;
@@ -87,60 +85,60 @@ namespace {
       Conv(ConditionsRepository::Data& p) : data(p) {}
       /// Callback operator to be specialized depending on the element type
       void operator()(xml_h element) const   {
-        string key = element.attr<string>(_U(key));
-        size_t cap = data.capacity();
+        std::string key = element.attr<std::string>(_U(key));
+        std::size_t cap = data.capacity();
         ConditionsRepository::Entry e;
         ::sscanf(key.c_str(),"0x%16llX",&e.key);
-        e.name = element.attr<string>(_U(name));
-        e.address = element.attr<string>(_U(ref));
+        e.name = element.attr<std::string>(_U(name));
+        e.address = element.attr<std::string>(_U(ref));
         if ( data.size() == cap ) data.reserve(cap+500);
         data.emplace_back(e);
       }
     };
-    xml::DocumentHolder doc(xml::DocumentHandler().load(input));
+    dd4hep::xml::DocumentHolder doc(dd4hep::xml::DocumentHandler().load(input));
     xml_h root = doc.root();
     xml_coll_t(root, _U(ref)).for_each(Conv(data));
     return 1;
   }
   
 #if defined(DD4HEP_MINIMAL_CONDITIONS)
-  int createText(const string& output, const AllConditions&, char)
+  int createText(const std::string& output, const AllConditions&, char)
 #else
-  int createText(const string& output, const AllConditions& all, char sep)
+    int createText(const std::string& output, const AllConditions& all, char sep)
 #endif
   {
-    ofstream out(output);
+    std::ofstream out(output);
 #if !defined(DD4HEP_MINIMAL_CONDITIONS)
-    size_t siz_nam=0, siz_add=0, siz_tot=0;
+    std::size_t siz_nam=0, siz_add=0, siz_tot=0;
     char fmt[64], text[2*PATH_MAX+64];
     if ( !out.good() )  {
-      except("ConditionsRepository",
-             "++ Failed to open output file:%s [errno:%d %s]",
-             output.c_str(), errno, ::strerror(errno));
+      dd4hep::except("ConditionsRepository",
+                     "++ Failed to open output file:%s [errno:%d %s]",
+                     output.c_str(), errno, ::strerror(errno));
     }
     else if ( sep )  {
-      ::snprintf(fmt,sizeof(fmt),"%%16llX%c%%s%c%%s%c",sep,sep,sep);
+      std::snprintf(fmt,sizeof(fmt),"%%16llX%c%%s%c%%s%c",sep,sep,sep);
     }
     else   {
       for( const auto& i : all )  {
-        Condition::Object* c = i.second.ptr();
-        size_t siz_n = c->name.length();
-        size_t siz_a = c->address.length();
+        dd4hep::Condition::Object* c = i.second.ptr();
+        std::size_t siz_n = c->name.length();
+        std::size_t siz_a = c->address.length();
         if ( siz_nam < siz_n ) siz_nam = siz_n;
         if ( siz_add < siz_a ) siz_add = siz_a;
         if ( siz_tot < (siz_n+siz_a) ) siz_tot = siz_n+siz_a;
       }
       siz_tot += 8+2+1;
-      ::snprintf(fmt,sizeof(fmt),"%%16llX %%-%lds %%-%lds",long(siz_nam),long(siz_add));
+      std::snprintf(fmt,sizeof(fmt),"%%16llX %%-%lds %%-%lds",long(siz_nam),long(siz_add));
     }
     out << "dd4hep." << char(sep ? sep : '-')
         << "." << long(siz_nam)
         << "." << long(siz_add)
-        << "." << long(siz_tot) << endl;
+        << "." << long(siz_tot) << std::endl;
     for( const auto& i : all )  {
-      Condition c = i.second;
-      ::snprintf(text, sizeof(text), fmt, c.key(), c.name(), c.address().c_str());
-      out << text << endl;
+      dd4hep::Condition c = i.second;
+      std::snprintf(text, sizeof(text), fmt, c.key(), c.name(), c.address().c_str());
+      out << text << std::endl;
     }
 #endif
     out.close();
@@ -148,11 +146,11 @@ namespace {
   }
 
   /// Load the repository from file and fill user passed data structory
-  int readText(const string& input, ConditionsRepository::Data& data)    {
-    size_t   idx, siz_nam, siz_add, siz_tot;
+  int readText(const std::string& input, ConditionsRepository::Data& data)    {
+    std::size_t   idx, siz_nam, siz_add, siz_tot;
     char     sep, c, text[2*PATH_MAX];
     ConditionsRepository::Entry e;
-    ifstream in(input);
+    std::ifstream in(input);
 
     in >> c >> c >> c >> c >> c >> c >> c >> sep 
        >> c >> siz_nam
@@ -167,34 +165,34 @@ namespace {
       text[0] = 0;
       in.getline(text,sizeof(text),'\n');
       if ( in.good() )  {
-	text[sizeof(text)-1] = 0;
+        text[sizeof(text)-1] = 0;
         if ( siz_tot )  {
-	  text[8] = 0;
+          text[8] = 0;
           // Direct access mode with fixed record size
           if ( 9+siz_nam < sizeof(text) )  {
             text[9+siz_nam] = 0;
             e.name = text+9;
-	  }
+          }
           if ( 10+siz_nam+siz_add < (long)sizeof(text) )  {
             text[10+siz_nam+siz_add] = 0;
             e.address = text+10+siz_nam;  
-            if ( (idx=e.name.find(' ')) != string::npos && idx < e.name.length() )
+            if ( (idx=e.name.find(' ')) != std::string::npos && idx < e.name.length() )
               e.name[idx] = 0;
-            if ( (idx=e.address.find(' ')) != string::npos && idx < e.address.length() )
+            if ( (idx=e.address.find(' ')) != std::string::npos && idx < e.address.length() )
               e.address[idx] = 0;
           }
           else  {
-            except("ConditionsRepository","+++ Invalid record encountered. [Sever error]");
+            dd4hep::except("ConditionsRepository","+++ Invalid record encountered. [Sever error]");
           }
         }
         else  {
           // Variable record size
           e.name=text+9;
-          if ( (idx=e.name.find(sep)) != string::npos && idx < sizeof(text)-10 )
+          if ( (idx=e.name.find(sep)) != std::string::npos && idx < sizeof(text)-10 )
             text[9+idx] = 0, e.address=text+idx+10, e.name=text+9;
-          if ( (idx=e.address.find(sep)) != string::npos && idx < e.address.length() )
+          if ( (idx=e.address.find(sep)) != std::string::npos && idx < e.address.length() )
             e.address[idx] = 0;
-          else if ( (idx=e.address.find('\n')) != string::npos && idx < e.address.length() )
+          else if ( (idx=e.address.find('\n')) != std::string::npos && idx < e.address.length() )
             e.address[idx] = 0;
         }
         size_t cap = data.capacity();
@@ -209,7 +207,7 @@ namespace {
 }
 
 /// Save the repository to file
-int ConditionsRepository::save(ConditionsManager manager, const string& output)  const  {
+int ConditionsRepository::save(ConditionsManager manager, const std::string& output)  const  {
   AllConditions all;
   const auto types = manager.iovTypesUsed();
   for( const IOVType* type : types )  {
@@ -226,19 +224,19 @@ int ConditionsRepository::save(ConditionsManager manager, const string& output) 
     }
   }
 
-  if ( output.find(".xml") != string::npos )   {
+  if ( output.find(".xml") != std::string::npos )   {
     /// Write XML file with conditions addresses
     return createXML(output, all);
   }
-  else if ( output.find(".txt") != string::npos )   {
+  else if ( output.find(".txt") != std::string::npos )   {
     /// Write fixed records with conditions addresses
     return createText(output, all, 0);
   }
-  else if ( output.find(".daf") != string::npos )   {
+  else if ( output.find(".daf") != std::string::npos )   {
     /// Write fixed records with conditions addresses
     return createText(output, all, 0);
   }
-  else if ( output.find(".csv") != string::npos )   {
+  else if ( output.find(".csv") != std::string::npos )   {
     /// Write records separated by ';' with conditions addresses
     return createText(output, all, ';');
   }
@@ -246,17 +244,17 @@ int ConditionsRepository::save(ConditionsManager manager, const string& output) 
 }
 
 /// Load the repository from file and fill user passed data structory
-int ConditionsRepository::load(const string& input, Data& data)  const  {
-  if ( input.find(".xml") != string::npos )   {
+int ConditionsRepository::load(const std::string& input, Data& data)  const  {
+  if ( input.find(".xml") != std::string::npos )   {
     return readXML(input, data);
   }
-  else if ( input.find(".txt") != string::npos )   {
+  else if ( input.find(".txt") != std::string::npos )   {
     return readText(input, data);
   }
-  else if ( input.find(".daf") != string::npos )   {
+  else if ( input.find(".daf") != std::string::npos )   {
     return readText(input, data);
   }
-  else if ( input.find(".csv") != string::npos )   {
+  else if ( input.find(".csv") != std::string::npos )   {
     return readText(input, data);
   }
   return 0;

--- a/DDCond/src/ConditionsRootPersistency.cpp
+++ b/DDCond/src/ConditionsRootPersistency.cpp
@@ -12,22 +12,19 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DDCond/ConditionsSlice.h"
-#include "DDCond/ConditionsIOVPool.h"
-#include "DDCond/ConditionsRootPersistency.h"
+#include <DD4hep/Printout.h>
+#include <DDCond/ConditionsSlice.h>
+#include <DDCond/ConditionsIOVPool.h>
+#include <DDCond/ConditionsRootPersistency.h>
 
-#include "TFile.h"
-#include "TTimeStamp.h"
+#include <TFile.h>
+#include <TTimeStamp.h>
 
 typedef dd4hep::cond::ConditionsRootPersistency __ConditionsRootPersistency;
 
 /// ROOT Class implementation directive
 ClassImp(__ConditionsRootPersistency)
 
-
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 // Local namespace for anonymous stuff
@@ -39,12 +36,12 @@ namespace  {
    *  \version 1.0
    *  \ingroup DD4HEP_CONDITIONS
    */
-  struct Scanner : public Condition::Processor   {
+  struct Scanner : public dd4hep::Condition::Processor   {
     ConditionsRootPersistency::pool_type& pool;
     /// Constructor
     Scanner(ConditionsRootPersistency::pool_type& p) : pool(p) {}
     /// Conditions callback for object processing
-    virtual int process(Condition c)  const override  {
+    virtual int process(dd4hep::Condition c)  const override  {
       pool.emplace_back(c.ptr());
       return 1;
     }
@@ -66,7 +63,7 @@ ConditionsRootPersistency::ConditionsRootPersistency() : TNamed()   {
 }
 
 /// Initializing constructor
-ConditionsRootPersistency::ConditionsRootPersistency(const string& name, const string& title)
+ConditionsRootPersistency::ConditionsRootPersistency(const std::string& name, const std::string& title)
   : TNamed(name.c_str(), title.c_str())
 {
 }
@@ -77,11 +74,12 @@ ConditionsRootPersistency::~ConditionsRootPersistency()    {
 }
 
 /// Add conditions content to be saved. Note, that dependent conditions shall not be saved!
-size_t ConditionsRootPersistency::add(const std::string& identifier,
-                                      const IOV& iov,
-                                      std::vector<Condition>& conditions)   {
+std::size_t ConditionsRootPersistency::add(const std::string& identifier,
+                                           const IOV& iov,
+                                           std::vector<Condition>& conditions)
+{
   DurationStamp stamp(this);
-  conditionPools.emplace_back(pair<iov_key_type, pool_type>());
+  conditionPools.emplace_back(std::pair<iov_key_type, pool_type>());
   pool_type&    ent = conditionPools.back().second;
   iov_key_type& key = conditionPools.back().first;
   key.first         = identifier;
@@ -93,9 +91,9 @@ size_t ConditionsRootPersistency::add(const std::string& identifier,
 }
 
 /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
-size_t ConditionsRootPersistency::add(const string& identifier, ConditionsPool& pool)    {
+size_t ConditionsRootPersistency::add(const std::string& identifier, ConditionsPool& pool)    {
   DurationStamp stamp(this);
-  conditionPools.emplace_back(pair<iov_key_type, pool_type>());
+  conditionPools.emplace_back(std::pair<iov_key_type, pool_type>());
   pool_type&    ent = conditionPools.back().second;
   iov_key_type& key = conditionPools.back().first;
   const IOV*    iov = pool.iov;
@@ -108,11 +106,11 @@ size_t ConditionsRootPersistency::add(const string& identifier, ConditionsPool& 
 }
 
 /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
-size_t ConditionsRootPersistency::add(const string& identifier, const ConditionsIOVPool& pool)    {
+size_t ConditionsRootPersistency::add(const std::string& identifier, const ConditionsIOVPool& pool)    {
   size_t count = 0;
   DurationStamp stamp(this);
   for( const auto& p : pool.elements )  {
-    iovPools.emplace_back(pair<iov_key_type, pool_type>());
+    iovPools.emplace_back(std::pair<iov_key_type, pool_type>());
     pool_type&    ent = iovPools.back().second;
     iov_key_type& key = iovPools.back().first;
     const IOV*    iov = p.second->iov;
@@ -127,9 +125,9 @@ size_t ConditionsRootPersistency::add(const string& identifier, const Conditions
 }
 
 /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
-size_t ConditionsRootPersistency::add(const string& identifier, const UserPool& pool)    {
+size_t ConditionsRootPersistency::add(const std::string& identifier, const UserPool& pool)    {
   DurationStamp stamp(this);
-  userPools.emplace_back(pair<iov_key_type, pool_type>());
+  userPools.emplace_back(std::pair<iov_key_type, pool_type>());
   pool_type&    ent = userPools.back().second;
   iov_key_type& key = userPools.back().first;
   const IOV&    iov = pool.validity();
@@ -142,7 +140,7 @@ size_t ConditionsRootPersistency::add(const string& identifier, const UserPool& 
 }
 
 /// Open ROOT file in read mode
-TFile* ConditionsRootPersistency::openFile(const string& fname)     {
+TFile* ConditionsRootPersistency::openFile(const std::string& fname)     {
   TDirectory::TContext context;
   TFile* file = TFile::Open(fname.c_str());
   if ( file && !file->IsZombie()) return file;
@@ -171,7 +169,7 @@ void ConditionsRootPersistency::clear()  {
 
 /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
 std::unique_ptr<ConditionsRootPersistency>
-ConditionsRootPersistency::load(TFile* file,const string& obj)   {
+ConditionsRootPersistency::load(TFile* file,const std::string& obj)   {
   std::unique_ptr<ConditionsRootPersistency> p;
   if ( file && !file->IsZombie())    {
     TTimeStamp start;
@@ -304,7 +302,7 @@ int ConditionsRootPersistency::save(TFile* file)    {
 }
 
 /// Save the data content to a root file
-int ConditionsRootPersistency::save(const string& fname)    {
+int ConditionsRootPersistency::save(const std::string& fname)    {
   DurationStamp stamp(this);
   //TDirectory::TContext context;
   TFile* file = TFile::Open(fname.c_str(),"RECREATE");

--- a/DDCond/src/ConditionsSlice.cpp
+++ b/DDCond/src/ConditionsSlice.cpp
@@ -12,13 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DDCond/ConditionsSlice.h"
-#include "DDCond/ConditionsIOVPool.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Printout.h"
+#include <DDCond/ConditionsSlice.h>
+#include <DDCond/ConditionsIOVPool.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Printout.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 /// Initializing constructor
@@ -29,7 +27,7 @@ ConditionsSlice::ConditionsSlice(ConditionsManager mgr) : manager(mgr)
 
 /// Initializing constructor
 ConditionsSlice::ConditionsSlice(ConditionsManager mgr,
-                                 const shared_ptr<ConditionsContent>& cont)
+                                 const std::shared_ptr<ConditionsContent>& cont)
   : manager(mgr), content(cont)
 {
   InstanceCount::increment(this);  
@@ -55,10 +53,10 @@ void ConditionsSlice::derefPools()     {
 }
 
 /// Access the combined IOV of the slice from the pool
-const IOV& ConditionsSlice::iov()  const    {
+const dd4hep::IOV& ConditionsSlice::iov()  const    {
   if ( pool.get() ) return pool->validity();
-  dd4hep::except("ConditionsSlice",
-                 "pool-iov: Failed to access validity of non-existing pool.");
+  except("ConditionsSlice",
+         "pool-iov: Failed to access validity of non-existing pool.");
   return pool->validity();
 }
 
@@ -74,29 +72,29 @@ bool ConditionsSlice::manage(ConditionsPool* p, Condition condition, ManageFlag 
     bool ret = false;
     if ( flg&REGISTER_MANAGER )  {
       if ( !p )   {
-        dd4hep::except("ConditionsSlice",
-                       "manage_condition: Cannot access conditions pool according to IOV:%s.",
-                       pool->validity().str().c_str());
+        except("ConditionsSlice",
+               "manage_condition: Cannot access conditions pool according to IOV:%s.",
+               pool->validity().str().c_str());
       }
       ret = manager.registerUnlocked(*p,condition);
       if ( !ret )  {
-        dd4hep::except("ConditionsSlice",
-                       "manage_condition: Failed to register condition %016llx according to IOV:%s.",
-                       condition->hash, pool->validity().str().c_str());
+        except("ConditionsSlice",
+               "manage_condition: Failed to register condition %016llx according to IOV:%s.",
+               condition->hash, pool->validity().str().c_str());
       }
     }
     if ( flg&REGISTER_POOL )  {
       ret = pool->insert(condition);
       if ( !ret )  {
-        dd4hep::except("ConditionsSlice",
-                       "manage_condition: Failed to register condition %016llx to user pool with IOV:%s.",
-                       condition->hash, pool->validity().str().c_str());
+        except("ConditionsSlice",
+               "manage_condition: Failed to register condition %016llx to user pool with IOV:%s.",
+               condition->hash, pool->validity().str().c_str());
       }
     }
     return ret;
   }
-  dd4hep::except("ConditionsSlice",
-                 "manage_condition: Cannot manage invalid condition!");
+  except("ConditionsSlice",
+         "manage_condition: Cannot manage invalid condition!");
   return false;
 }
 
@@ -107,14 +105,14 @@ bool ConditionsSlice::manage(Condition condition, ManageFlag flg)    {
 }
 
 /// Access all conditions from a given detector element
-vector<Condition> ConditionsSlice::get(DetElement detector)  const  {
+std::vector<dd4hep::Condition> ConditionsSlice::get(DetElement detector)  const  {
   return pool->get(detector,FIRST_ITEM,LAST_ITEM);
 }
 
 /// No ConditionsMap overload: Access all conditions within a key range in the interval [lower,upper]
-vector<Condition> ConditionsSlice::get(DetElement detector,
-                                       Condition::itemkey_type lower,
-                                       Condition::itemkey_type upper)  const  {
+std::vector<dd4hep::Condition> ConditionsSlice::get(DetElement detector,
+                                                    Condition::itemkey_type lower,
+                                                    Condition::itemkey_type upper)  const  {
   return pool->get(detector, lower, upper);
 }
 
@@ -123,25 +121,25 @@ bool ConditionsSlice::insert(DetElement detector, Condition::itemkey_type key, C
   if ( condition.isValid() )  {
     ConditionsPool* p = manager.registerIOV(pool->validity());
     if ( !p )   {
-      dd4hep::except("ConditionsSlice",
-                     "manage_condition: Cannot access conditions pool according to IOV:%s.",
-                     pool->validity().str().c_str());
+      except("ConditionsSlice",
+             "manage_condition: Cannot access conditions pool according to IOV:%s.",
+             pool->validity().str().c_str());
     }
     bool ret = manager.registerUnlocked(*p,condition);
     if ( !ret )  {
-      dd4hep::except("ConditionsSlice",
-                     "manage_condition: Failed to register condition %016llx according to IOV:%s.",
-                     condition->hash, pool->validity().str().c_str());
+      except("ConditionsSlice",
+             "manage_condition: Failed to register condition %016llx according to IOV:%s.",
+             condition->hash, pool->validity().str().c_str());
     }
     return pool->insert(detector, key, condition);
   }
-  dd4hep::except("ConditionsSlice",
-                 "insert_condition: Cannot insert invalid condition to the user pool!");
+  except("ConditionsSlice",
+         "insert_condition: Cannot insert invalid condition to the user pool!");
   return false;
 }
 
 /// ConditionsMap overload: Access a condition
-Condition ConditionsSlice::get(DetElement detector, Condition::itemkey_type key)  const   {
+dd4hep::Condition ConditionsSlice::get(DetElement detector, Condition::itemkey_type key)  const   {
   return pool->get(detector, key);
 }
 
@@ -160,14 +158,14 @@ void ConditionsSlice::scan(DetElement         detector,
 
 namespace  {
   
-  struct SliceOper  : public ConditionsSelect  {
+  struct SliceOper  : public dd4hep::ConditionsSelect  {
     ConditionsContent& content;
     SliceOper(ConditionsContent& c) : content(c) {}
     void operator()(const ConditionsIOVPool::Elements::value_type& v)    {
       v.second->select_all(*this);
     }
-    bool operator()(Condition::Object* c)  const  {
-      if ( 0 == (c->flags&Condition::DERIVED) )   {
+    bool operator()(dd4hep::Condition::Object* c)  const  {
+      if ( 0 == (c->flags&dd4hep::Condition::DERIVED) )   {
 #if !defined(DD4HEP_MINIMAL_CONDITIONS)
         content.addLocation(c->hash,c->address);
 #endif

--- a/DDCond/src/ConditionsTreePersistency.cpp
+++ b/DDCond/src/ConditionsTreePersistency.cpp
@@ -12,21 +12,18 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DDCond/ConditionsSlice.h"
-#include "DDCond/ConditionsIOVPool.h"
-#include "DDCond/ConditionsTreePersistency.h"
+#include <DD4hep/Printout.h>
+#include <DDCond/ConditionsSlice.h>
+#include <DDCond/ConditionsIOVPool.h>
+#include <DDCond/ConditionsTreePersistency.h>
 
-#include "TFile.h"
-#include "TTimeStamp.h"
+#include <TFile.h>
+#include <TTimeStamp.h>
 
 typedef dd4hep::cond::ConditionsTreePersistency __ConditionsTreePersistency;
 /// ROOT Class implementation directive
 ClassImp(__ConditionsTreePersistency)
 
-
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 // Local namespace for anonymous stuff
@@ -38,12 +35,12 @@ namespace  {
    *  \version 1.0
    *  \ingroup DD4HEP_CONDITIONS
    */
-  struct Scanner : public Condition::Processor   {
+  struct Scanner : public dd4hep::Condition::Processor   {
     ConditionsTreePersistency::pool_type& pool;
     /// Constructor
     Scanner(ConditionsTreePersistency::pool_type& p) : pool(p) {}
     /// Conditions callback for object processing
-    virtual int process(Condition c)  const override  {
+    virtual int process(dd4hep::Condition c)  const override  {
       pool.emplace_back(c.ptr());
       return 1;
     }
@@ -65,7 +62,7 @@ ConditionsTreePersistency::ConditionsTreePersistency() : TNamed()   {
 }
 
 /// Initializing constructor
-ConditionsTreePersistency::ConditionsTreePersistency(const string& name, const string& title)
+ConditionsTreePersistency::ConditionsTreePersistency(const std::string& name, const std::string& title)
   : TNamed(name.c_str(), title.c_str())
 {
 }
@@ -76,11 +73,12 @@ ConditionsTreePersistency::~ConditionsTreePersistency()    {
 }
 
 /// Add conditions content to be saved. Note, that dependent conditions shall not be saved!
-size_t ConditionsTreePersistency::add(const std::string& identifier,
-                                      const IOV& iov,
-                                      std::vector<Condition>& conditions)   {
+std::size_t ConditionsTreePersistency::add(const std::string& identifier,
+                                           const IOV& iov,
+                                           std::vector<Condition>& conditions)
+{
   DurationStamp stamp(this);
-  conditionPools.emplace_back(pair<iov_key_type, pool_type>());
+  conditionPools.emplace_back(std::pair<iov_key_type, pool_type>());
   pool_type&    ent = conditionPools.back().second;
   iov_key_type& key = conditionPools.back().first;
   key.first         = identifier;
@@ -92,9 +90,9 @@ size_t ConditionsTreePersistency::add(const std::string& identifier,
 }
 
 /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
-size_t ConditionsTreePersistency::add(const string& identifier, ConditionsPool& pool)    {
+std::size_t ConditionsTreePersistency::add(const std::string& identifier, ConditionsPool& pool)    {
   DurationStamp stamp(this);
-  conditionPools.emplace_back(pair<iov_key_type, pool_type>());
+  conditionPools.emplace_back(std::pair<iov_key_type, pool_type>());
   pool_type&    ent = conditionPools.back().second;
   iov_key_type& key = conditionPools.back().first;
   const IOV*    iov = pool.iov;
@@ -107,11 +105,11 @@ size_t ConditionsTreePersistency::add(const string& identifier, ConditionsPool& 
 }
 
 /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
-size_t ConditionsTreePersistency::add(const string& identifier, const ConditionsIOVPool& pool)    {
-  size_t count = 0;
+std::size_t ConditionsTreePersistency::add(const std::string& identifier, const ConditionsIOVPool& pool)    {
+  std::size_t count = 0;
   DurationStamp stamp(this);
   for( const auto& p : pool.elements )  {
-    iovPools.emplace_back(pair<iov_key_type, pool_type>());
+    iovPools.emplace_back(std::pair<iov_key_type, pool_type>());
     pool_type&    ent = iovPools.back().second;
     iov_key_type& key = iovPools.back().first;
     const IOV*    iov = p.second->iov;
@@ -126,7 +124,7 @@ size_t ConditionsTreePersistency::add(const string& identifier, const Conditions
 }
 
 /// Open ROOT file in read mode
-TFile* ConditionsTreePersistency::openFile(const string& fname)     {
+TFile* ConditionsTreePersistency::openFile(const std::string& fname)     {
   TDirectory::TContext context;
   TFile* file = TFile::Open(fname.c_str());
   if ( file && !file->IsZombie()) return file;
@@ -154,7 +152,7 @@ void ConditionsTreePersistency::clear()  {
 
 /// Add conditions content to the saved. Note, that dependent conditions shall not be saved!
 std::unique_ptr<ConditionsTreePersistency>
-ConditionsTreePersistency::load(TFile* file,const string& obj)   {
+ConditionsTreePersistency::load(TFile* file,const std::string& obj)   {
   std::unique_ptr<ConditionsTreePersistency> p;
   if ( file && !file->IsZombie())    {
     TTimeStamp start;
@@ -174,13 +172,14 @@ ConditionsTreePersistency::load(TFile* file,const string& obj)   {
 }
 
 /// Load ConditionsPool(s) and populate conditions manager
-size_t ConditionsTreePersistency::_import(ImportStrategy     strategy,
-                                          persistent_type&   persistent_pools,
-                                          const std::string& id,
-                                          const std::string& iov_type,
-                                          const IOV::Key&    iov_key,
-                                          ConditionsManager  mgr)   {
-  size_t count = 0;
+std::size_t ConditionsTreePersistency::_import(ImportStrategy     strategy,
+                                               persistent_type&   persistent_pools,
+                                               const std::string& id,
+                                               const std::string& iov_type,
+                                               const IOV::Key&    iov_key,
+                                               ConditionsManager  mgr)
+{
+  std::size_t count = 0;
   std::pair<bool,const IOVType*> iovTyp(false,0);
   for (auto& iovp : persistent_pools )   {
     bool use = false;
@@ -243,29 +242,29 @@ size_t ConditionsTreePersistency::_import(ImportStrategy     strategy,
 }
 
 /// Load ConditionsIOVPool and populate conditions manager
-size_t ConditionsTreePersistency::importIOVPool(const std::string& identifier,
-                                                const std::string& iov_type,
-                                                ConditionsManager  mgr)
+std::size_t ConditionsTreePersistency::importIOVPool(const std::string& identifier,
+                                                     const std::string& iov_type,
+                                                     ConditionsManager  mgr)
 {
   DurationStamp stamp(this);
   return _import(IMPORT_ALL,iovPools,identifier,iov_type,IOV::Key(),mgr);
 }
 
 /// Load ConditionsIOVPool and populate conditions manager
-size_t ConditionsTreePersistency::importConditionsPool(const std::string& identifier,
-                                                       const std::string& iov_type,
-                                                       ConditionsManager  mgr)
+std::size_t ConditionsTreePersistency::importConditionsPool(const std::string& identifier,
+                                                            const std::string& iov_type,
+                                                            ConditionsManager  mgr)
 {
   DurationStamp stamp(this);
   return _import(IMPORT_ALL,conditionPools,identifier,iov_type,IOV::Key(),mgr);
 }
 
 /// Load conditions pool and populate conditions manager. Allow tro be selective also for the key
-size_t ConditionsTreePersistency::importConditionsPool(ImportStrategy     strategy,
-                                                       const std::string& identifier,
-                                                       const std::string& iov_type,
-                                                       const IOV::Key&    iov_key,
-                                                       ConditionsManager  mgr)   {
+std::size_t ConditionsTreePersistency::importConditionsPool(ImportStrategy     strategy,
+                                                            const std::string& identifier,
+                                                            const std::string& iov_type,
+                                                            const IOV::Key&    iov_key,
+                                                            ConditionsManager  mgr)   {
   return _import(strategy,conditionPools,identifier,iov_type,iov_key,mgr);
 }
 
@@ -278,7 +277,7 @@ int ConditionsTreePersistency::save(TFile* file)    {
 }
 
 /// Save the data content to a root file
-int ConditionsTreePersistency::save(const string& fname)    {
+int ConditionsTreePersistency::save(const std::string& fname)    {
   DurationStamp stamp(this);
   //TDirectory::TContext context;
   TFile* file = TFile::Open(fname.c_str(),"RECREATE");

--- a/DDCond/src/plugins/ConditionsLinearPool.cpp
+++ b/DDCond/src/plugins/ConditionsLinearPool.cpp
@@ -14,11 +14,11 @@
 #define DDCOND_CONDITIONSLINEARPOOL_H
 
 // Framework include files
-#include "DDCond/ConditionsPool.h"
-#include "DDCond/ConditionsManager.h"
-#include "DDCond/ConditionsSelectors.h"
+#include <DDCond/ConditionsPool.h>
+#include <DDCond/ConditionsManager.h>
+#include <DDCond/ConditionsSelectors.h>
 
-#include "DD4hep/Printout.h"
+#include <DD4hep/Printout.h>
 
 // C/C++ include files
 #include <list>
@@ -185,10 +185,9 @@ namespace dd4hep {
 //==========================================================================
 
 // Framework include files
-//#include "DDCond/ConditionsLinearPool.h"
-#include "DD4hep/InstanceCount.h"
+//#include <DDCond/ConditionsLinearPool.h>
+#include <DD4hep/InstanceCount.h>
 
-using dd4hep::Handle;
 using namespace dd4hep::cond;
 
 /// Default constructor
@@ -196,7 +195,6 @@ template<typename MAPPING, typename BASE>
 ConditionsLinearPool<MAPPING,BASE>::ConditionsLinearPool(ConditionsManager mgr, IOV* i)
   : BASE(mgr, i)
 {
-  
   this->BASE::SetName(i ? i->str().c_str() : "Unknown IOV");
   this->BASE::SetTitle("ConditionsLinearPool");
   InstanceCount::increment(this);
@@ -219,10 +217,8 @@ namespace dd4hep {
   } /* End namespace cond             */
 } /* End namespace dd4hep                   */
 
-#include "DD4hep/Factories.h"
+#include <DD4hep/Factories.h>
 namespace {
-  using namespace dd4hep;
-  
   ConditionsManager _mgr(int argc, char** argv)  {
     if ( argc > 0 )  {
       ConditionsManager::Object* m = (ConditionsManager::Object*)argv[0];
@@ -231,9 +227,9 @@ namespace {
     dd4hep::except("ConditionsLinearPool","++ Insufficient arguments: arg[0] = ConditionManager!");
     return ConditionsManager(0);
   }
-  IOV* _iov(int argc, char** argv)  {
+  dd4hep::IOV* _iov(int argc, char** argv)  {
     if ( argc > 1 )  {
-      IOV* i = (IOV*)argv[1];
+      dd4hep::IOV* i = (dd4hep::IOV*)argv[1];
       return i;
     }
     dd4hep::except("ConditionsLinearPool","++ Insufficient arguments: arg[1] = IOV!");
@@ -241,7 +237,7 @@ namespace {
   }
 
 #define _CR(fun,x,b,y) void* fun(dd4hep::Detector&, int argc, char** argv) \
-  {  return new b<x<Condition::Object*>,y>(_mgr(argc,argv), _iov(argc,argv));  }
+  {  return new b<x<dd4hep::Condition::Object*>,y>(_mgr(argc,argv), _iov(argc,argv));  }
   /// Create a conditions pool based on STL vectors
   _CR(create_vector_pool,std::vector,ConditionsLinearPool,ConditionsPool)
   /// Create a conditions pool based on STL lists

--- a/DDCond/src/plugins/ConditionsMappedPool.cpp
+++ b/DDCond/src/plugins/ConditionsMappedPool.cpp
@@ -14,11 +14,11 @@
 #define DDCOND_CONDITIONSMAPPEDPOOL_H
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
-#include "DDCond/ConditionsPool.h"
-#include "DDCond/ConditionsSelectors.h"
+#include <DDCond/ConditionsPool.h>
+#include <DDCond/ConditionsSelectors.h>
 
 // C/C++ include files
 #include <map>
@@ -54,7 +54,7 @@ namespace dd4hep {
       Mapping          m_entries;
       
       /// Helper function to loop over the conditions container and apply a functor
-      template <typename R,typename T> size_t loop(R& result, T functor) {
+      template <typename R,typename T> std::size_t loop(R& result, T functor) {
         size_t len = result.size();
         for_each(m_entries.begin(),m_entries.end(),functor);
         return result.size() - len;
@@ -198,8 +198,8 @@ namespace dd4hep {
 //==========================================================================
 
 // Framework include files
-//#include "DDCond/ConditionsMappedPool.h"
-#include "DD4hep/InstanceCount.h"
+//#include <DDCond/ConditionsMappedPool.h>
+#include <DD4hep/InstanceCount.h>
 
 using dd4hep::Handle;
 using namespace dd4hep::cond;
@@ -219,9 +219,8 @@ ConditionsMappedPool<MAPPING,BASE>::~ConditionsMappedPool()  {
   InstanceCount::decrement(this);
 }
 
-#include "DD4hep/Factories.h"
+#include <DD4hep/Factories.h>
 namespace {
-  using namespace dd4hep;
   ConditionsManager _mgr(int argc, char** argv)  {
     if ( argc > 0 )  {
       ConditionsManagerObject* m = (ConditionsManagerObject*)argv[0];
@@ -231,7 +230,7 @@ namespace {
     return ConditionsManager(0);
   }
 #define _CR(fun,x,b,y) void* fun(dd4hep::Detector&, int argc, char** argv) \
-  {  return new b<x<Condition::key_type,Condition::Object*>,y>(_mgr(argc,argv));  }
+  {  return new b<x<dd4hep::Condition::key_type,dd4hep::Condition::Object*>,y>(_mgr(argc,argv));  }
 
   /// Create a conditions pool based on STL maps
   _CR(create_map_pool,std::map,ConditionsMappedPool,ConditionsPool)

--- a/DDCond/src/plugins/ConditionsMultiLoader.cpp
+++ b/DDCond/src/plugins/ConditionsMultiLoader.cpp
@@ -16,8 +16,8 @@
 #define DD4HEP_CONDITIONS_MULTICONDITONSLOADER_H
 
 // Framework include files
-#include "DDCond/ConditionsDataLoader.h"
-#include "DD4hep/Printout.h"
+#include <DDCond/ConditionsDataLoader.h>
+#include <DD4hep/Printout.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -86,14 +86,13 @@ namespace dd4hep {
 //==========================================================================
 
 // Framework include files
-//#include "ConditionsMultiLoader.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Factories.h"
-#include "DD4hep/PluginCreators.h"
-#include "DDCond/ConditionsManager.h"
+//#include <ConditionsMultiLoader.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Factories.h>
+#include <DD4hep/PluginCreators.h>
+#include <DDCond/ConditionsManager.h>
 
 // Forward declartions
-using std::string;
 using namespace dd4hep::cond;
 
 namespace {
@@ -106,7 +105,7 @@ namespace {
 DECLARE_DD4HEP_CONSTRUCTOR(DD4hep_Conditions_multi_Loader,create_loader)
 
 /// Standard constructor, initializes variables
-ConditionsMultiLoader::ConditionsMultiLoader(Detector& description, ConditionsManager mgr, const string& nam) 
+ConditionsMultiLoader::ConditionsMultiLoader(Detector& description, ConditionsManager mgr, const std::string& nam) 
 : ConditionsDataLoader(description, mgr, nam)
 {
 }
@@ -122,15 +121,15 @@ ConditionsMultiLoader::load_source(const std::string& nam,
   OpenSources::iterator iop = m_openSources.find(nam);
   if ( iop == m_openSources.end() )  {
     size_t idx = nam.find(':');
-    if ( idx == string::npos )   {
+    if ( idx == std::string::npos )   {
       except("ConditionsMultiLoader","Invalid data source specification: "+nam);
     }
-    string ident = nam.substr(0,idx);
+    std::string ident = nam.substr(0,idx);
     Loaders::iterator ild = m_loaders.find(ident);
     ConditionsDataLoader* loader = 0;
     if ( ild == m_loaders.end() )  {
-      string typ = "DD4hep_Conditions_"+ident+"_Loader";
-      string fac = ident+"_ConditionsDataLoader";
+      std::string typ = "DD4hep_Conditions_"+ident+"_Loader";
+      std::string fac = ident+"_ConditionsDataLoader";
       const void* argv[] = {fac.c_str(), m_mgr.ptr(), 0};
       loader = createPlugin<ConditionsDataLoader>(typ,m_detector,2,argv);
       if ( !loader )  {
@@ -160,7 +159,7 @@ size_t ConditionsMultiLoader::load_range(key_type key,
     const IOV& iov = (*i).second;
     if ( iov.type == req_validity.type )  {
       if ( IOV::key_partially_contained(iov.keyData,req_validity.keyData) )  { 
-        const string& nam = (*i).first;
+        const std::string& nam = (*i).first;
         ConditionsDataLoader* loader = load_source(nam, req_validity);
         loader->load_range(key, req_validity, conditions);
       }
@@ -180,7 +179,7 @@ size_t ConditionsMultiLoader::load_single(key_type key,
     const IOV& iov = (*i).second;
     if ( iov.type == req_validity.type )  {
       if ( IOV::key_partially_contained(iov.keyData,req_validity.keyData) )  {
-        const string& nam = (*i).first;
+        const std::string& nam = (*i).first;
         ConditionsDataLoader* loader = load_source(nam, req_validity);
         loader->load_single(key, req_validity, conditions);
       }

--- a/DDCond/src/plugins/ConditionsParser.cpp
+++ b/DDCond/src/plugins/ConditionsParser.cpp
@@ -12,22 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "XML/Conversions.h"
-#include "XML/XMLElements.h"
-#include "XML/DocumentHandler.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/DetFactoryHelper.h"
+#include <DD4hep/Detector.h>
+#include <XML/Conversions.h>
+#include <XML/XMLElements.h>
+#include <XML/DocumentHandler.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/DetFactoryHelper.h>
 
-#include "DDCond/ConditionsTags.h"
-#include "DDCond/ConditionsEntry.h"
-#include "DDCond/ConditionsManager.h"
-#include "DDCond/ConditionsDataLoader.h"
+#include <DDCond/ConditionsTags.h>
+#include <DDCond/ConditionsEntry.h>
+#include <DDCond/ConditionsManager.h>
+#include <DDCond/ConditionsDataLoader.h>
 
-/*
- *   dd4hep namespace declaration
- */
+/// Namespace for the AIDA detector description toolkit
 namespace dd4hep  {
 
   namespace {
@@ -57,8 +55,6 @@ namespace dd4hep  {
   template <> void Converter<conditions>::operator()(xml_h seq)  const;
 }
   
-using std::string;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 /// Namespace for the AIDA detector description toolkit
@@ -75,19 +71,19 @@ namespace dd4hep {
   };
 
   /// Helper: Extract the validity from the xml element
-  string _getValidity(xml_h elt)  {
+  std::string _getValidity(xml_h elt)  {
     if ( !elt.ptr() )
       return "Infinite";
     else if ( !elt.hasAttr(_UC(validity)) )
       return _getValidity(elt.parent());
-    return elt.attr<string>(_UC(validity));
+    return elt.attr<std::string>(_UC(validity));
   }
 
   /// Helper: Extract the required detector element from the parsing information
   DetElement _getDetector(void* param, xml_h e)  {
     ConversionArg* arg  = static_cast<ConversionArg*>(param);
     DetElement detector = arg ? arg->detector : DetElement();
-    string     subpath  = e.hasAttr(_U(path)) ? e.attr<string>(_U(path)) : string();
+    std::string     subpath  = e.hasAttr(_U(path)) ? e.attr<std::string>(_U(path)) : std::string();
     return subpath.empty() ? detector : detail::tools::findDaughterElement(detector,subpath);
   }
 
@@ -95,7 +91,7 @@ namespace dd4hep {
   Entry* _createStackEntry(void* param, xml_h element)  {
     xml_comp_t e(element);
     DetElement elt = _getDetector(param, element);
-    string name = e.hasAttr(_U(name)) ? e.nameStr() : e.tag();
+    std::string name = e.hasAttr(_U(name)) ? e.nameStr() : e.tag();
     return new Entry(elt,name,e.tag(),_getValidity(element),detail::hash32(name));
   }
 
@@ -133,7 +129,7 @@ namespace dd4hep {
    */
   template <> void Converter<arbitrary>::operator()(xml_h e) const {
     xml_comp_t elt(e);
-    string tag = elt.tag();
+    std::string tag = elt.tag();
     ConversionArg* arg  = _param<ConversionArg>();
     if ( !arg )
       except("ConditionsParser","++ Invalid parser argument [Internal Error]");
@@ -153,7 +149,7 @@ namespace dd4hep {
       xml_coll_t(e,_U(star)).for_each(Converter<conditions>(description,param,optional));
     else if ( tag == "alignment" )   {
       dd4hep_ptr<Entry> val(_createStackEntry(param,e));
-      val->value = elt.attr<string>(_U(ref));
+      val->value = elt.attr<std::string>(_U(ref));
       if ( !arg->stack )
         except("ConditionsParser","Non-existing Conditions stack:%s %d",__FILE__, __LINE__);
       else
@@ -210,15 +206,15 @@ namespace dd4hep {
  *  @version 1.0
  *  @date    01/04/2014
  */
-static void* setup_global_Conditions(Detector& description, int argc, char** argv)  {
+static void* setup_global_Conditions(dd4hep::Detector& description, int argc, char** argv)  {
   if ( argc == 2 )  {
     xml_h e = xml_h::Elt_t(argv[0]);
     ConditionsStack* stack = (ConditionsStack*)argv[1];
-    ConversionArg args(description.world(), stack);
-    (dd4hep::Converter<conditions>(description,&args))(e);
+    dd4hep::ConversionArg args(description.world(), stack);
+    (dd4hep::Converter<dd4hep::conditions>(description,&args))(e);
     return &description;
   }
-  except("XML_DOC_READER","Invalid number of arguments to interprete conditions: %d != %d.",argc,2);
+  dd4hep::except("XML_DOC_READER","Invalid number of arguments to interprete conditions: %d != %d.",argc,2);
   return 0;
 }
 DECLARE_DD4HEP_CONSTRUCTOR(XMLConditionsParser,setup_global_Conditions)

--- a/DDCond/src/plugins/ConditionsRepositoryWriter.cpp
+++ b/DDCond/src/plugins/ConditionsRepositoryWriter.cpp
@@ -14,9 +14,9 @@
 #define DD4HEP_DDCOND_CONDITIONSREPOSITORYWRITER_H
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "XML/XMLElements.h"
-#include "DDCond/ConditionsManager.h"
+#include <DD4hep/Detector.h>
+#include <XML/XMLElements.h>
+#include <DDCond/ConditionsManager.h>
 
 // C/C++ include files
 
@@ -90,20 +90,20 @@ namespace dd4hep {
 //==========================================================================
 
 // Framework include files
-#include "XML/XMLElements.h"
-#include "XML/DocumentHandler.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Alignments.h"
-#include "DD4hep/AlignmentData.h"
-#include "DD4hep/OpaqueDataBinder.h"
-#include "DD4hep/ConditionsProcessor.h"
-#include "DD4hep/DetFactoryHelper.h"
-#include "DD4hep/detail/ConditionsInterna.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
+#include <XML/XMLElements.h>
+#include <XML/DocumentHandler.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Alignments.h>
+#include <DD4hep/AlignmentData.h>
+#include <DD4hep/OpaqueDataBinder.h>
+#include <DD4hep/ConditionsProcessor.h>
+#include <DD4hep/DetFactoryHelper.h>
+#include <DD4hep/detail/ConditionsInterna.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
 
-#include "DDCond/ConditionsTags.h"
-#include "DDCond/ConditionsSlice.h"
-#include "DDCond/ConditionsManagerObject.h"
+#include <DDCond/ConditionsTags.h>
+#include <DDCond/ConditionsSlice.h>
+#include <DDCond/ConditionsManagerObject.h>
 
 // C/C++ include files
 #include <stdexcept>
@@ -112,18 +112,17 @@ namespace dd4hep {
 #include <list>
 #include <set>
 
-using std::string;
-using std::shared_ptr;
-using std::stringstream;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 namespace units = dd4hep;
+namespace xml = dd4hep::xml;
+using dd4hep::printout;
+using dd4hep::_toString;
 
 /// Anonymous local stuff only used in this module
 namespace {
 
   /// Module print level
-  static PrintLevel s_printLevel = INFO;
+  static dd4hep::PrintLevel s_printLevel = dd4hep::INFO;
 
   class pressure;
   class temperature;
@@ -134,9 +133,9 @@ namespace {
     xml::Element root;
   public:
     PropertyDumper(xml::Element p) : root(p)  {}
-    void operator()(const std::pair<string,Property>& p)  const  {
+    void operator()(const std::pair<std::string, dd4hep::Property>& p)  const  {
       xml::Element e = xml::Element(root.document(),_UC(property));
-      string val = p.second.str();
+      std::string val = p.second.str();
       if ( val[0] == '\'' ) val = p.second.str().c_str()+1;
       if ( !val.empty() && val[val.length()-1] == '\'' ) val[val.length()-1] = 0;
       e.setAttr(_U(name), p.first);
@@ -145,9 +144,9 @@ namespace {
     }
   };
   
-  template <typename T> xml::Element _convert(xml::Element par, Condition c);
+  template <typename T> xml::Element _convert(xml::Element par, dd4hep::Condition c);
   
-  xml::Element make(xml::Element e, Condition c)  {
+  xml::Element make(xml::Element e, dd4hep::Condition c)  {
     char hash[64];
     std::string nam = c.name();
     std::string cn = nam.substr(nam.find('#')+1);
@@ -156,22 +155,22 @@ namespace {
     e.setAttr(_U(key),hash);
     return e;
   }
-  xml::Element _convert(xml::Element par, const Translation3D& tr)  {
+  xml::Element _convert(xml::Element par, const dd4hep::Translation3D& tr)  {
     xml::Element e = xml::Element(par.document(),_U(pivot));
-    const Translation3D::Vector& v = tr.Vect();
+    const dd4hep::Translation3D::Vector& v = tr.Vect();
     e.setAttr(_U(x),_toString(v.X()/dd4hep::mm,"%f*mm"));
     e.setAttr(_U(y),_toString(v.Y()/dd4hep::mm,"%f*mm"));
     e.setAttr(_U(z),_toString(v.Z()/dd4hep::mm,"%f*mm"));
     return e;
   }
-  xml::Element _convert(xml::Element par, const Position& pos)  {
+  xml::Element _convert(xml::Element par, const dd4hep::Position& pos)  {
     xml::Element e = xml::Element(par.document(),_U(position));
     e.setAttr(_U(x),_toString(pos.X()/dd4hep::mm,"%f*mm"));
     e.setAttr(_U(y),_toString(pos.Y()/dd4hep::mm,"%f*mm"));
     e.setAttr(_U(z),_toString(pos.Z()/dd4hep::mm,"%f*mm"));
     return e;
   }
-  xml::Element _convert(xml::Element par, const RotationZYX& rot)  {
+  xml::Element _convert(xml::Element par, const dd4hep::RotationZYX& rot)  {
     xml::Element e = xml::Element(par.document(),_U(rotation));
     double z, y, x;
     rot.GetComponents(z,y,x);
@@ -180,80 +179,80 @@ namespace {
     e.setAttr(_U(z),_toString(z/dd4hep::rad,"%f*rad"));
     return e;
   }
-  template <> xml::Element _convert<value>(xml::Element par, Condition c)  {
+  template <> xml::Element _convert<value>(xml::Element par, dd4hep::Condition c)  {
     xml::Element v = make(xml::Element(par.document(),_U(value)),c);
-    OpaqueData& data = c.data();
+    dd4hep::OpaqueData& data = c.data();
     v.setAttr(_U(type),data.dataType());
     v.setAttr(_U(value),data.str());
     return v;
   }
-  template <> xml::Element _convert<pressure>(xml::Element par, Condition c)  {
+  template <> xml::Element _convert<pressure>(xml::Element par, dd4hep::Condition c)  {
     xml::Element press = make(xml::Element(par.document(),_UC(pressure)),c);
     press.setAttr(_U(value),c.get<double>()/(100e0*units::pascal));
     press.setAttr(_U(unit),"hPa");
     return press;
   }
-  template <> xml::Element _convert<temperature>(xml::Element par, Condition c)  {
+  template <> xml::Element _convert<temperature>(xml::Element par, dd4hep::Condition c)  {
     xml::Element temp = make(xml::Element(par.document(),_UC(temperature)),c);
     temp.setAttr(_U(value),c.get<double>()/units::kelvin);
     temp.setAttr(_U(unit),"kelvin");
     return temp;
   }
-  template <> xml::Element _convert<Delta>(xml::Element par, Condition c)  {
-    xml::Element       align = make(xml::Element(par.document(),_UC(alignment_delta)),c);
-    const Delta&       delta = c.get<Delta>();
-    if ( delta.flags&Delta::HAVE_TRANSLATION )
+  template <> xml::Element _convert<dd4hep::Delta>(xml::Element par, dd4hep::Condition c)  {
+    xml::Element         align = make(xml::Element(par.document(),_UC(alignment_delta)),c);
+    const dd4hep::Delta& delta = c.get<dd4hep::Delta>();
+    if ( delta.flags&dd4hep::Delta::HAVE_TRANSLATION )
       align.append(_convert(align,delta.translation));
-    if ( delta.flags&Delta::HAVE_ROTATION )
+    if ( delta.flags&dd4hep::Delta::HAVE_ROTATION )
       align.append(_convert(align,delta.rotation));
-    if ( delta.flags&Delta::HAVE_PIVOT )
+    if ( delta.flags&dd4hep::Delta::HAVE_PIVOT )
       align.append(_convert(align,delta.pivot));
     return align;
   }
-  template <> xml::Element _convert<Alignment>(xml::Element par, Condition c)  {
+  template <> xml::Element _convert<dd4hep::Alignment>(xml::Element par, dd4hep::Condition c)  {
     char hash[64];
-    typedef ConditionKey::KeyMaker KM;
-    AlignmentCondition  acond = c;
-    KM                  km(c.key());
-    const Delta&        delta = acond.data().delta;
-    xml::Element        align(xml::Element(par.document(),_UC(alignment_delta)));
-    Condition::key_type key = KM(km.values.det_key,align::Keys::deltaKey).hash;
+    typedef dd4hep::ConditionKey::KeyMaker KM;
+    dd4hep::AlignmentCondition   acond = c;
+    KM                           km(c.key());
+    const dd4hep::Delta&         delta = acond.data().delta;
+    xml::Element                 align(xml::Element(par.document(),_UC(alignment_delta)));
+    dd4hep::Condition::key_type  key = KM(km.values.det_key,dd4hep::align::Keys::deltaKey).hash;
     ::snprintf(hash,sizeof(hash),"%llX",key);
-    align.setAttr(_U(name),align::Keys::deltaName);
+    align.setAttr(_U(name), dd4hep::align::Keys::deltaName);
     align.setAttr(_U(key),hash);
-    if ( delta.flags&Delta::HAVE_TRANSLATION )
+    if ( delta.flags&dd4hep::Delta::HAVE_TRANSLATION )
       align.append(_convert(align,delta.translation));
-    if ( delta.flags&Delta::HAVE_ROTATION )
+    if ( delta.flags&dd4hep::Delta::HAVE_ROTATION )
       align.append(_convert(align,delta.rotation));
-    if ( delta.flags&Delta::HAVE_PIVOT )
+    if ( delta.flags&dd4hep::Delta::HAVE_PIVOT )
       align.append(_convert(align,delta.pivot));
     return align;
   }
-  xml::Element _seq(xml::Element v, Condition c, const char* tag, const char* match)  {
-    OpaqueData& data = c.data();
-    string typ = data.dataType();
+  xml::Element _seq(xml::Element v, dd4hep::Condition c, const char* tag, const char* match)  {
+    dd4hep::OpaqueData& data = c.data();
+    std::string typ = data.dataType();
     size_t len = ::strlen(match);
     size_t idx = typ.find(match);
     size_t idq = typ.find(',',idx+len);
-    if ( idx != string::npos && idq != string::npos )   {
-      string subtyp = tag;
+    if ( idx != std::string::npos && idq != std::string::npos )   {
+      std::string subtyp = tag;
       subtyp += "["+typ.substr(idx+len,idq-idx-len)+"]";
       v.setAttr(_U(type),subtyp);
       xml::Handle_t(v.ptr()).setText(data.str());
       return v;
     }
-    except("Writer","++ Unknwon XML conversion to type: %s",typ.c_str());
+    dd4hep::except("Writer","++ Unknwon XML conversion to type: %s",typ.c_str());
     return v;
   }
-  template <> xml::Element _convert<std::vector<void*> >(xml::Element par, Condition c)  {
+  template <> xml::Element _convert<std::vector<void*> >(xml::Element par, dd4hep::Condition c)  {
     xml::Element v = make(xml::Element(par.document(),_UC(sequence)),c);
     return _seq(v,c,"vector","::vector<");
   }
-  template <> xml::Element _convert<std::list<void*> >(xml::Element par, Condition c)  {
+  template <> xml::Element _convert<std::list<void*> >(xml::Element par, dd4hep::Condition c)  {
     xml::Element v = make(xml::Element(par.document(),_UC(sequence)),c);
     return _seq(v,c,"list","::list<");
   }
-  template <> xml::Element _convert<std::set<void*> >(xml::Element par, Condition c)  {
+  template <> xml::Element _convert<std::set<void*> >(xml::Element par, dd4hep::Condition c)  {
     xml::Element v = make(xml::Element(par.document(),_UC(sequence)),c);
     return _seq(v,c,"set","::set<");
   }
@@ -291,9 +290,9 @@ size_t ConditionsXMLRepositoryWriter::collect(xml::Element root, ConditionsSlice
 
   root.append(repo);
   repo.append(iov);
-  ::snprintf(text,sizeof(text),"%ld,%ld#%s",
-             long(validity.keyData.first), long(validity.keyData.second),
-             validity.iovType->name.c_str());
+  std::snprintf(text,sizeof(text),"%ld,%ld#%s",
+                long(validity.keyData.first), long(validity.keyData.second),
+                validity.iovType->name.c_str());
   iov.setAttr(_UC(validity),text);
   return collect(iov,slice,slice.manager->detectorDescription().world());
 }
@@ -334,7 +333,7 @@ size_t ConditionsXMLRepositoryWriter::collect(xml::Element root,
     std::vector<Condition> conds;
     conditionsCollector(slice,conds)(detector);
     if ( !conds.empty() )   {
-      stringstream comment;
+      std::stringstream comment;
       Condition cond_align, cond_delta;
       xml::Element conditions = xml::Element(root.document(),_UC(detelement));
       conditions.setAttr(_U(path),detector.path());
@@ -366,7 +365,7 @@ size_t ConditionsXMLRepositoryWriter::collect(xml::Element root,
           cond_delta = c;
         }
         else {
-          const OpaqueData&    data = c.data();
+          const dd4hep::OpaqueData& data = c.data();
           const std::type_info& typ = data.typeInfo();
 #if defined(DD4HEP_HAVE_ALL_PARSERS)
           if ( typ == typeid(char)   || typ == typeid(unsigned char)  ||
@@ -374,11 +373,11 @@ size_t ConditionsXMLRepositoryWriter::collect(xml::Element root,
                typ == typeid(int)    || typ == typeid(unsigned int)   ||
                typ == typeid(long)   || typ == typeid(unsigned long)  ||
                typ == typeid(float)  || typ == typeid(double)         ||
-               typ == typeid(bool)   || typ == typeid(string) )
+               typ == typeid(bool)   || typ == typeid(std::string) )
 #else
             if ( typ == typeid(int)    || typ == typeid(long)           ||
                  typ == typeid(float)  || typ == typeid(double)         ||
-                 typ == typeid(bool)   || typ == typeid(string) )
+                 typ == typeid(bool)   || typ == typeid(std::string) )
 #endif
             {
               conditions.append(_convert<value>(conditions,c));
@@ -416,7 +415,7 @@ size_t ConditionsXMLRepositoryWriter::collect(xml::Element root,
         ++m_numConverted;
       }
       else if ( cond_delta.isValid() )   {
-        conditions.append(_convert<Delta>(conditions,cond_delta));
+        conditions.append(_convert<dd4hep::Delta>(conditions,cond_delta));
         ++m_numConverted;
       }
     }
@@ -428,8 +427,8 @@ size_t ConditionsXMLRepositoryWriter::collect(xml::Element root,
 // ======================================================================================
 
 /// Write the XML document structure to a file.
-long ConditionsXMLRepositoryWriter::write(xml::Document doc, const string& output)   const {
-  xml::DocumentHandler docH;
+long ConditionsXMLRepositoryWriter::write(xml::Document doc, const std::string& output)   const {
+  xml_handler_t docH;
   long ret = docH.output(doc, output);
   if ( !output.empty() )  {
     printout(INFO,"Writer","++ Successfully wrote %ld conditions (%ld unconverted) to file: %s",
@@ -444,12 +443,12 @@ long ConditionsXMLRepositoryWriter::write(xml::Document doc, const string& outpu
  *  \version 1.0
  *  \date    01/04/2014
  */
-static long write_repository_conditions(Detector& description, int argc, char** argv)  {
+static long write_repository_conditions(dd4hep::Detector& description, int argc, char** argv)  {
   ConditionsManager manager  =  ConditionsManager::from(description);
-  const IOVType*    iovtype  =  0;
-  long              iovvalue = -1;
-  long              mgr_prop = 0;
-  string            output;
+  const dd4hep::IOVType* iovtype  =  0;
+  long                   iovvalue = -1;
+  long                   mgr_prop = 0;
+  std::string            output;
 
   for(int i=0; i<argc; ++i)  {
     if ( ::strncmp(argv[i],"-iov_type",7) == 0 )
@@ -461,26 +460,26 @@ static long write_repository_conditions(Detector& description, int argc, char** 
     else if ( ::strncmp(argv[i],"-manager",4) == 0 )
       mgr_prop = 1;
     else if ( ::strncmp(argv[i],"-help",2) == 0 )  {
-      printout(ALWAYS,"Plugin-Help","Usage: dd4hep_XMLConditionsRepositoryWriter --opt [--opt]           ");
-      printout(ALWAYS,"Plugin-Help","  -output    <string>   Output file name. Default: stdout           ");
-      printout(ALWAYS,"Plugin-Help","  -manager   <string>   Add manager properties to the output.       ");
-      printout(ALWAYS,"Plugin-Help","  -iov_type  <string>   IOV type to be selected.                    ");
-      printout(ALWAYS,"Plugin-Help","  -iov_value <string>   IOV value to create the conditions snapshot.");
+      printout(dd4hep::ALWAYS,"Plugin-Help","Usage: dd4hep_XMLConditionsRepositoryWriter --opt [--opt]           ");
+      printout(dd4hep::ALWAYS,"Plugin-Help","  -output    <string>   Output file name. Default: stdout           ");
+      printout(dd4hep::ALWAYS,"Plugin-Help","  -manager   <string>   Add manager properties to the output.       ");
+      printout(dd4hep::ALWAYS,"Plugin-Help","  -iov_type  <string>   IOV type to be selected.                    ");
+      printout(dd4hep::ALWAYS,"Plugin-Help","  -iov_value <string>   IOV value to create the conditions snapshot.");
       ::exit(EINVAL);
     }
   }
   if ( 0 == iovtype )
-    except("ConditionsPrepare","++ Unknown IOV type supplied.");
+    dd4hep::except("ConditionsPrepare","++ Unknown IOV type supplied.");
   if ( 0 > iovvalue )
-    except("ConditionsPrepare",
-           "++ Unknown IOV value supplied for iov type %s.",iovtype->str().c_str());
+    dd4hep::except("ConditionsPrepare",
+                   "++ Unknown IOV value supplied for iov type %s.",iovtype->str().c_str());
 
-  IOV iov(iovtype,iovvalue);
-  shared_ptr<ConditionsContent> content(new ConditionsContent());
-  shared_ptr<ConditionsSlice>   slice(new ConditionsSlice(manager,content));
-  cond::fill_content(manager,*content,*iovtype);
+  dd4hep::IOV iov(iovtype,iovvalue);
+  std::shared_ptr<ConditionsContent> content(new ConditionsContent());
+  std::shared_ptr<ConditionsSlice>   slice(new ConditionsSlice(manager,content));
+  dd4hep::cond::fill_content(manager,*content,*iovtype);
   ConditionsManager::Result cres = manager.prepare(iov, *slice);
-  printout(INFO,"Conditions",
+  printout(dd4hep::INFO, "Conditions",
            "++ Selected conditions: %7ld conditions (S:%ld,L:%ld,C:%ld,M:%ld) for IOV:%-12s",
            cres.total(), cres.selected, cres.loaded, cres.computed, cres.missing,
            iovtype ? iov.str().c_str() : "???");
@@ -507,16 +506,16 @@ DECLARE_APPLY(DD4hep_ConditionsXMLRepositoryWriter,write_repository_conditions)
  *  \version 1.0
  *  \date    01/04/2014
  */
-static long write_repository_manager(Detector& description, int argc, char** argv)  {
+static long write_repository_manager(dd4hep::Detector& description, int argc, char** argv)  {
   ConditionsManager manager  =  ConditionsManager::from(description);
-  string            output;
+  std::string       output;
 
   for(int i=0; i<argc; ++i)  {
     if ( ::strncmp(argv[i],"-output",4) == 0 && argc>i+1)
       output = argv[++i];
     else if ( ::strncmp(argv[i],"-help",2) == 0 )  {
-      printout(ALWAYS,"Plugin-Help","Usage: dd4hep_XMLConditionsManagerWriter --opt [--opt]           ");
-      printout(ALWAYS,"Plugin-Help","  -output    <string>   Output file name. Default: stdout        ");
+      printout(dd4hep::ALWAYS,"Plugin-Help","Usage: dd4hep_XMLConditionsManagerWriter --opt [--opt]           ");
+      printout(dd4hep::ALWAYS,"Plugin-Help","  -output    <string>   Output file name. Default: stdout        ");
       ::exit(EINVAL);
     }
   }

--- a/DDCond/src/plugins/ConditionsSnapshotRootLoader.cpp
+++ b/DDCond/src/plugins/ConditionsSnapshotRootLoader.cpp
@@ -15,9 +15,9 @@
 #define DD4HEP_CONDITIONS_CONDIITONSSNAPSHOTROOTLOADER_H
 
 // Framework include files
-#include "DDCond/ConditionsDataLoader.h"
-#include "DDCond/ConditionsRootPersistency.h"
-#include "DD4hep/Printout.h"
+#include <DDCond/ConditionsDataLoader.h>
+#include <DDCond/ConditionsRootPersistency.h>
+#include <DD4hep/Printout.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -61,24 +61,22 @@ namespace dd4hep {
 }      /* End namespace dd4hep                            */
 #endif /* DD4HEP_CONDITIONS_CONDIITONSSNAPSHOTROOTLOADER_H  */
 
-//#include "ConditionsSnapshotRootLoader.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Factories.h"
-#include "DD4hep/PluginCreators.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+//#include <ConditionsSnapshotRootLoader.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Factories.h>
+#include <DD4hep/PluginCreators.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
-#include "TFile.h"
+#include <TFile.h>
 
 // C/C++ include files
 #include <string>
 
 // Forward declartions
-using std::string;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 namespace {
-  void* create_loader(Detector& description, int argc, char** argv)   {
+  void* create_loader(dd4hep::Detector& description, int argc, char** argv)   {
     const char* name = argc>0 ? argv[0] : "XMLLoader";
     ConditionsManagerObject* mgr = (ConditionsManagerObject*)(argc>0 ? argv[1] : 0);
     return new ConditionsSnapshotRootLoader(description,ConditionsManager(mgr),name);

--- a/DDCond/src/plugins/ConditionsUserPool.cpp
+++ b/DDCond/src/plugins/ConditionsUserPool.cpp
@@ -14,8 +14,8 @@
 #define DDCOND_CONDITIONSMAPPEDUSERPOOL_H
 
 // Framework include files
-#include "DDCond/ConditionsPool.h"
-#include "DD4hep/ConditionsMap.h"
+#include <DDCond/ConditionsPool.h>
+#include <DD4hep/ConditionsMap.h>
 
 // C/C++ include files
 #include <map>
@@ -151,41 +151,40 @@ namespace dd4hep {
 //==========================================================================
 
 // Framework include files
-//#include "DDCond/ConditionsMappedPool.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Factories.h"
-#include "DD4hep/InstanceCount.h"
+//#include <DDCond/ConditionsMappedPool.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Factories.h>
+#include <DD4hep/InstanceCount.h>
 
-#include "DDCond/ConditionsIOVPool.h"
-#include "DDCond/ConditionsSelectors.h"
-#include "DDCond/ConditionsDataLoader.h"
-#include "DDCond/ConditionsManagerObject.h"
-#include "DDCond/ConditionsDependencyHandler.h"
+#include <DDCond/ConditionsIOVPool.h>
+#include <DDCond/ConditionsSelectors.h>
+#include <DDCond/ConditionsDataLoader.h>
+#include <DDCond/ConditionsManagerObject.h>
+#include <DDCond/ConditionsDependencyHandler.h>
 
+// C/C++ include files
 #include <mutex>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 namespace {
 
-  class SimplePrint : public Condition::Processor {
+  class SimplePrint : public dd4hep::Condition::Processor {
     /// Conditions callback for object processing
-    virtual int process(Condition)  const override    { return 1; }
+    virtual int process(dd4hep::Condition)  const override    { return 1; }
     /// Conditions callback for object processing
-    virtual int operator()(Condition)  const override { return 1; }
+    virtual int operator()(dd4hep::Condition)  const override { return 1; }
     /// Conditions callback for object processing in maps
-    virtual int operator()(const pair<Condition::key_type,Condition>& i)  const override  {
-      Condition c = i.second;
-      printout(INFO,"UserPool","++ %16llX/%16llX Val:%s %s",i.first, c->hash, c->value.c_str(), c.str().c_str());
+    virtual int operator()(const std::pair<dd4hep::Condition::key_type,dd4hep::Condition>& i)  const override  {
+      dd4hep::Condition c = i.second;
+      dd4hep::printout(dd4hep::INFO,"UserPool","++ %16llX/%16llX Val:%s %s",i.first, c->hash, c->value.c_str(), c.str().c_str());
       return 1;
     }
   };
-  template <typename T> struct MapSelector : public ConditionsSelect {
+  template <typename T> struct MapSelector : public dd4hep::ConditionsSelect {
     T& m;
     MapSelector(T& o) : m(o) {}
-    bool operator()(Condition::Object* o)  const
+    bool operator()(dd4hep::Condition::Object* o)  const
     { return m.emplace(o->hash,o).second;    }
   };
   template <typename T> MapSelector<T> mapSelector(T& container)
@@ -193,14 +192,14 @@ namespace {
 
   template <typename T> struct Inserter {
     T& m;
-    IOV* iov;
-    Inserter(T& o, IOV* i=0) : m(o), iov(i) {}
-    void operator()(const Condition& c)  {
-      Condition::Object* o = c.ptr();
+    dd4hep::IOV* iov;
+    Inserter(T& o, dd4hep::IOV* i=0) : m(o), iov(i) {}
+    void operator()(const dd4hep::Condition& c)  {
+      dd4hep::Condition::Object* o = c.ptr();
       m.emplace(o->hash,o);
       if ( iov ) iov->iov_intersection(o->iov->key());
     }
-    void operator()(const pair<Condition::key_type,Condition>& e) { (*this)(e.second);  }
+    void operator()(const std::pair<dd4hep::Condition::key_type,dd4hep::Condition>& e) { (*this)(e.second);  }
   };
 }
 
@@ -229,7 +228,7 @@ ConditionsMappedUserPool<MAPPING>::~ConditionsMappedUserPool()  {
   InstanceCount::decrement(this);
 }
 
-template<typename MAPPING> inline Condition::Object* 
+template<typename MAPPING> inline dd4hep::Condition::Object* 
 ConditionsMappedUserPool<MAPPING>::i_findCondition(Condition::key_type key)  const {
   typename MAPPING::const_iterator i=m_conditions.find(key);
 #if 0
@@ -263,7 +262,7 @@ size_t ConditionsMappedUserPool<MAPPING>::size()  const  {
 
 /// Print pool content
 template<typename MAPPING>
-void ConditionsMappedUserPool<MAPPING>::print(const string& opt)   const  {
+void ConditionsMappedUserPool<MAPPING>::print(const std::string& opt)   const  {
   const IOV* iov = &m_iov;
   printout(INFO,"UserPool","+++ %s Conditions for USER pool with IOV: %-32s [%4d entries]",
            opt.c_str(), iov->str().c_str(), size());
@@ -297,13 +296,13 @@ bool ConditionsMappedUserPool<MAPPING>::exists(const ConditionKey& key)  const  
 
 /// Check if a condition exists in the pool and return it to the caller
 template<typename MAPPING>
-Condition ConditionsMappedUserPool<MAPPING>::get(Condition::key_type hash)  const   {
+dd4hep::Condition ConditionsMappedUserPool<MAPPING>::get(Condition::key_type hash)  const   {
   return i_findCondition(hash);
 }
 
 /// Check if a condition exists in the pool and return it to the caller     
 template<typename MAPPING>
-Condition ConditionsMappedUserPool<MAPPING>::get(const ConditionKey& key)  const   {
+dd4hep::Condition ConditionsMappedUserPool<MAPPING>::get(const ConditionKey& key)  const   {
   return i_findCondition(key.hash);
 }
 
@@ -323,13 +322,13 @@ ConditionsMappedUserPool<MAPPING>::registerOne(const IOV& iov,
 }
 
 /// Do block insertions of conditions with identical IOV including registration to the manager
-template<typename MAPPING> size_t
+template<typename MAPPING> std::size_t
 ConditionsMappedUserPool<MAPPING>::registerMany(const IOV& iov,
-                                                const vector<Condition>& conds)   {
+                                                const std::vector<Condition>& conds)   {
   if ( iov.iovType )   {
     ConditionsPool* pool = m_manager.registerIOV(*iov.iovType,iov.keyData);
     if ( pool )   {
-      size_t result = m_manager.blockRegister(*pool, conds);
+      std::size_t result = m_manager.blockRegister(*pool, conds);
       if ( result == conds.size() )   {
         for(auto c : conds) i_insert(c.ptr());
         return result;
@@ -364,12 +363,12 @@ bool ConditionsMappedUserPool<MAPPING>::insert(DetElement detector,
 
 /// ConditionsMap overload: Access a condition
 template<typename MAPPING>
-Condition ConditionsMappedUserPool<MAPPING>::get(DetElement detector, unsigned int item_key)  const  {
+dd4hep::Condition ConditionsMappedUserPool<MAPPING>::get(DetElement detector, unsigned int item_key)  const  {
   return get(ConditionKey::KeyMaker(detector.key(), item_key).hash);
 }
   
 /// No ConditionsMap overload: Access all conditions within a key range in the interval [lower,upper]
-template<typename MAPPING> std::vector<Condition>
+template<typename MAPPING> std::vector<dd4hep::Condition>
 ConditionsMappedUserPool<MAPPING>::get(DetElement detector,
                                        Condition::itemkey_type lower,
                                        Condition::itemkey_type upper)  const {
@@ -379,9 +378,9 @@ ConditionsMappedUserPool<MAPPING>::get(DetElement detector,
 }
 
 /// Specialization for std::map: Access all conditions within a given key range
-template<typename MAPPING> std::vector<Condition>
+template<typename MAPPING> std::vector<dd4hep::Condition>
 ConditionsMappedUserPool<MAPPING>::get(Condition::key_type lower, Condition::key_type upper)   const  {
-  vector<Condition> result;
+  std::vector<Condition> result;
   if ( !m_conditions.empty() )   {
     typename MAPPING::const_iterator first = m_conditions.lower_bound(lower);
     for(; first != m_conditions.end(); ++first )  {
@@ -442,9 +441,9 @@ bool ConditionsMappedUserPool<MAPPING>::remove(Condition::key_type hash_key)    
 
 /// Evaluate and register all derived conditions from the dependency list
 template<typename MAPPING>
-size_t ConditionsMappedUserPool<MAPPING>::compute(const Dependencies& deps,
-                                                  ConditionUpdateUserContext* user_param,
-                                                  bool force)
+std::size_t ConditionsMappedUserPool<MAPPING>::compute(const Dependencies& deps,
+                                                       ConditionUpdateUserContext* user_param,
+                                                       bool force)
 {
   if ( !deps.empty() )  {
     Dependencies missing;
@@ -484,10 +483,10 @@ size_t ConditionsMappedUserPool<MAPPING>::compute(const Dependencies& deps,
 
 namespace {
   struct COMP {
-    typedef pair<Condition::key_type,const ConditionDependency*>     Dep;
-    typedef pair<const Condition::key_type,detail::ConditionObject*> Cond;
-    typedef pair<const Condition::key_type,ConditionsLoadInfo* >     Info;
-    typedef pair<const Condition::key_type,Condition>                Cond2;
+    typedef std::pair<dd4hep::Condition::key_type,const ConditionDependency*>             Dep;
+    typedef std::pair<const dd4hep::Condition::key_type,dd4hep::detail::ConditionObject*> Cond;
+    typedef std::pair<const dd4hep::Condition::key_type,ConditionsLoadInfo* >             Info;
+    typedef std::pair<const dd4hep::Condition::key_type,dd4hep::Condition>                Cond2;
     
     bool operator()(const Dep& a,const Cond& b) const   { return a.first < b.first; }
     bool operator()(const Cond& a,const Dep& b) const   { return a.first < b.first; }
@@ -505,8 +504,8 @@ ConditionsMappedUserPool<MAPPING>::prepare(const IOV&                  required,
                                            ConditionsSlice&            slice,
                                            ConditionUpdateUserContext* user_param)
 {
-  typedef vector<pair<Condition::key_type,ConditionDependency*> > CalcMissing;
-  typedef vector<pair<Condition::key_type,ConditionsLoadInfo*> >  CondMissing;
+  typedef std::vector<std::pair<Condition::key_type,ConditionDependency*> > CalcMissing;
+  typedef std::vector<std::pair<Condition::key_type,ConditionsLoadInfo*> >  CondMissing;
   const auto& slice_cond = slice.content->conditions();
   const auto& slice_calc = slice.content->derived();
   auto&  slice_miss_cond = slice.missingConditions();
@@ -519,8 +518,8 @@ ConditionsMappedUserPool<MAPPING>::prepare(const IOV&                  required,
   // This is a critical operation, because we have to ensure the
   // IOV pools are ONLY manipulated by the current thread.
   // Otherwise the selection and the population are unsafe!
-  static mutex lock;
-  lock_guard<mutex> guard(lock);
+  static std::mutex lock;
+  std::lock_guard<std::mutex> guard(lock);
 
   m_conditions.clear();
   slice_miss_cond.clear();
@@ -598,7 +597,7 @@ ConditionsMappedUserPool<MAPPING>::prepare(const IOV&                  required,
   //
   if ( num_calc_miss > 0 )  {
     if ( do_load )  {
-      map<Condition::key_type,const ConditionDependency*> deps(calc_missing.begin(),last_calc);
+      std::map<Condition::key_type,const ConditionDependency*> deps(calc_missing.begin(),last_calc);
       ConditionsDependencyHandler handler(m_manager, *this, deps, user_param);
       /// 1rst pass: Compute/create the missing condiions
       handler.compute();
@@ -633,7 +632,7 @@ ConditionsMappedUserPool<MAPPING>::load(const IOV&                  required,
                                         ConditionsSlice&            slice,
                                         ConditionUpdateUserContext* /* user_param */)
 {
-  typedef vector<pair<Condition::key_type,ConditionsLoadInfo*> >  CondMissing;
+  typedef std::vector<std::pair<Condition::key_type,ConditionsLoadInfo*> >  CondMissing;
   const auto& slice_cond = slice.content->conditions();
   auto&  slice_miss_cond = slice.missingConditions();
   bool   do_load         = m_manager->doLoadConditions();
@@ -644,8 +643,8 @@ ConditionsMappedUserPool<MAPPING>::load(const IOV&                  required,
   // This is a critical operation, because we have to ensure the
   // IOV pools are ONLY manipulated by the current thread.
   // Otherwise the selection and the population are unsafe!
-  static mutex lock;
-  lock_guard<mutex> guard(lock);
+  static std::mutex lock;
+  std::lock_guard<std::mutex> guard(lock);
 
   m_conditions.clear();
   slice_miss_cond.clear();
@@ -707,7 +706,7 @@ ConditionsMappedUserPool<MAPPING>::compute(const IOV&                  required,
                                            ConditionsSlice&            slice,
                                            ConditionUpdateUserContext* user_param)
 {
-  typedef vector<pair<Condition::key_type,ConditionDependency*> > CalcMissing;
+  typedef std::vector<std::pair<Condition::key_type,ConditionDependency*> > CalcMissing;
   const auto& slice_calc = slice.content->derived();
   auto&  slice_miss_calc = slice.missingDerivations();
   bool   do_load         = m_manager->doLoadConditions();
@@ -718,8 +717,8 @@ ConditionsMappedUserPool<MAPPING>::compute(const IOV&                  required,
   // This is a critical operation, because we have to ensure the
   // IOV pools are ONLY manipulated by the current thread.
   // Otherwise the selection and the population are unsafe!
-  static mutex lock;
-  lock_guard<mutex> guard(lock);
+  static std::mutex lock;
+  std::lock_guard<std::mutex> guard(lock);
 
   slice_miss_calc.clear();
   CalcMissing calc_missing(slice_calc.size()+m_conditions.size());
@@ -741,7 +740,7 @@ ConditionsMappedUserPool<MAPPING>::compute(const IOV&                  required,
   //
   if ( num_calc_miss > 0 )  {
     if ( do_load )  {
-      map<Condition::key_type,const ConditionDependency*> deps(calc_missing.begin(),last_calc);
+      std::map<Condition::key_type,const ConditionDependency*> deps(calc_missing.begin(),last_calc);
       ConditionsDependencyHandler handler(m_manager, *this, deps, user_param);
 
       /// 1rst pass: Compute/create the missing condiions
@@ -778,7 +777,7 @@ namespace dd4hep {
   /// Namespace for implementation details of the AIDA detector description toolkit
   namespace cond {
 
-    typedef unordered_map<Condition::key_type,Condition::Object*> umap_t;
+    typedef std::unordered_map<Condition::key_type,Condition::Object*> umap_t;
 
     /// Access all conditions within a given key range
     /** Specialization necessary, since unordered maps have no lower bound.
@@ -796,7 +795,7 @@ namespace dd4hep {
      */
     template<> std::vector<Condition>
     ConditionsMappedUserPool<umap_t>::get(Condition::key_type lower, Condition::key_type upper)   const  {
-      vector<Condition> result;
+      std::vector<Condition> result;
       for( const auto& e : m_conditions )  {
         if ( e.second->hash >= lower && e.second->hash <= upper )
           result.emplace_back(e.second);
@@ -808,24 +807,24 @@ namespace dd4hep {
 
 namespace {
   template <typename MAPPING>
-  void* create_pool(Detector&, int argc, char** argv)  {
+  void* create_pool(dd4hep::Detector&, int argc, char** argv)  {
     if ( argc > 1 )  {
       ConditionsManagerObject* m = (ConditionsManagerObject*)argv[0];
       ConditionsIOVPool* p = (ConditionsIOVPool*)argv[1];
       UserPool* pool = new ConditionsMappedUserPool<MAPPING>(m, p);
       return pool;
     }
-    except("ConditionsMappedUserPool","++ Insufficient arguments: arg[0] = ConditionManager!");
+    dd4hep::except("ConditionsMappedUserPool","++ Insufficient arguments: arg[0] = ConditionManager!");
     return 0;
   }
 }
 
 // Factory for the user pool using a binary tree map
-void* create_map_user_pool(Detector& description, int argc, char** argv)
-{  return create_pool<map<Condition::key_type,Condition::Object*> >(description, argc, argv);  }
+void* create_map_user_pool(dd4hep::Detector& description, int argc, char** argv)
+{  return create_pool<std::map<dd4hep::Condition::key_type,dd4hep::Condition::Object*> >(description, argc, argv);  }
 DECLARE_DD4HEP_CONSTRUCTOR(DD4hep_ConditionsMapUserPool, create_map_user_pool)
 
 // Factory for the user pool using a binary tree map
-void* create_unordered_map_user_pool(Detector& description, int argc, char** argv)
-{  return create_pool<unordered_map<Condition::key_type,Condition::Object*> >(description, argc, argv);  }
+void* create_unordered_map_user_pool(dd4hep::Detector& description, int argc, char** argv)
+{  return create_pool<std::unordered_map<dd4hep::Condition::key_type,dd4hep::Condition::Object*> >(description, argc, argv);  }
 DECLARE_DD4HEP_CONSTRUCTOR(DD4hep_ConditionsUnorderedMapUserPool, create_map_user_pool)

--- a/DDCond/src/plugins/ConditionsXmlLoader.cpp
+++ b/DDCond/src/plugins/ConditionsXmlLoader.cpp
@@ -15,8 +15,8 @@
 #define DD4HEP_CONDITIONS_XMLCONDITONSLOADER_H
 
 // Framework include files
-#include "DDCond/ConditionsDataLoader.h"
-#include "DD4hep/Printout.h"
+#include <DDCond/ConditionsDataLoader.h>
+#include <DD4hep/Printout.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -44,18 +44,18 @@ namespace dd4hep {
       /// Default destructor
       virtual ~ConditionsXmlLoader();
       /// Load  a condition set given a Detector Element and the conditions name according to their validity
-      virtual size_t load_single(key_type key,
-                                 const IOV& req_validity,
-                                 RangeConditions& conditions);
+      virtual std::size_t load_single(key_type key,
+                                      const IOV& req_validity,
+                                      RangeConditions& conditions);
       /// Load  a condition set given a Detector Element and the conditions name according to their validity
-      virtual size_t load_range( key_type key,
-                                 const IOV& req_validity,
-                                 RangeConditions& conditions);
+      virtual std::size_t load_range( key_type key,
+                                      const IOV& req_validity,
+                                      RangeConditions& conditions);
       /// Optimized update using conditions slice data
-      virtual size_t load_many(  const IOV& /* req_validity */,
-                                 RequiredItems&  /* work         */,
-                                 LoadedItems&    /* loaded       */,
-                                 IOV&       /* conditions_validity */)
+      virtual std::size_t load_many(  const IOV& /* req_validity */,
+                                      RequiredItems&  /* work         */,
+                                      LoadedItems&    /* loaded       */,
+                                      IOV&       /* conditions_validity */)
       {
         except("ConditionsLoader","+++ update: Invalid call!");
         return 0;
@@ -65,26 +65,24 @@ namespace dd4hep {
 }      /* End namespace dd4hep                    */
 #endif /* DD4HEP_CONDITIONS_XMLCONDITONSLOADER_H  */
 
-//#include "ConditionsXmlLoader.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Factories.h"
-#include "DD4hep/PluginCreators.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+// #include <ConditionsXmlLoader.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Factories.h>
+#include <DD4hep/PluginCreators.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
-#include "XML/XMLElements.h"
-#include "XML/DocumentHandler.h"
-#include "DDCond/ConditionsEntry.h"
+#include <XML/XMLElements.h>
+#include <XML/DocumentHandler.h>
+#include <DDCond/ConditionsEntry.h>
 
 // C/C++ include files
 #include <string>
 
 // Forward declartions
-using std::string;
-using namespace dd4hep;
 using namespace dd4hep::cond;
 
 namespace {
-  void* create_loader(Detector& description, int argc, char** argv)   {
+  void* create_loader(dd4hep::Detector& description, int argc, char** argv)   {
     const char* name = argc>0 ? argv[0] : "XMLLoader";
     ConditionsManagerObject* mgr = (ConditionsManagerObject*)(argc>0 ? argv[1] : 0);
     return new ConditionsXmlLoader(description,ConditionsManager(mgr),name);
@@ -107,8 +105,8 @@ size_t ConditionsXmlLoader::load_source(const std::string& nam,
                                         const IOV& req_validity,
                                         RangeConditions& conditions)
 {
-  size_t len = conditions.size();
-  string fac = "XMLConditionsParser";
+  std::size_t len = conditions.size();
+  std::string fac = "XMLConditionsParser";
   xml::DocumentHolder doc(xml::DocumentHandler().load(nam));
   xml::Handle_t       handle = doc.root();
   ConditionsStack     stack;
@@ -136,11 +134,11 @@ size_t ConditionsXmlLoader::load_source(const std::string& nam,
   return conditions.size()-len;
 }
 
-size_t ConditionsXmlLoader::load_single(key_type key,
-                                        const IOV& req_validity,
-                                        RangeConditions& conditions)
+std::size_t ConditionsXmlLoader::load_single(key_type key,
+                                             const IOV& req_validity,
+                                             RangeConditions& conditions)
 {
-  size_t len = conditions.size();
+  std::size_t len = conditions.size();
   if ( m_buffer.empty() && !m_sources.empty() )  {
     return load_source(m_sources.begin()->first, key, req_validity, conditions);
   }
@@ -158,11 +156,11 @@ size_t ConditionsXmlLoader::load_single(key_type key,
   return conditions.size()-len;
 }
 
-size_t ConditionsXmlLoader::load_range(key_type key,
-                                       const IOV& req_validity,
-                                       RangeConditions& conditions)
+std::size_t ConditionsXmlLoader::load_range(key_type key,
+                                            const IOV& req_validity,
+                                            RangeConditions& conditions)
 {
-  size_t len = conditions.size();
+  std::size_t len = conditions.size();
   while ( !m_sources.empty() )  {
     load_source(m_sources.begin()->first, key, req_validity, conditions);
   }
@@ -180,4 +178,3 @@ size_t ConditionsXmlLoader::load_range(key_type key,
   m_buffer = keep;
   return conditions.size()-len;
 }
-

--- a/DDCore/include/DD4hep/Objects.h
+++ b/DDCore/include/DD4hep/Objects.h
@@ -14,8 +14,8 @@
 #define DD4HEP_OBJECTS_H
 
 // Framework include files
-#include "DD4hep/Handle.h"
-#include "DD4hep/NamedObject.h"
+#include <DD4hep/Handle.h>
+#include <DD4hep/NamedObject.h>
 
 // Forward declarations
 class TMap;
@@ -33,23 +33,22 @@ class TGeoIdentity;
 #pragma GCC diagnostic ignored "-Wdeprecated" // Code that causes warning goes here
 #endif
 // ROOT include files
-#include "Math/Vector3D.h"
-#include "Math/Transform3D.h"
-#include "Math/Translation3D.h"
-#include "Math/RotationX.h"
-#include "Math/RotationY.h"
-#include "Math/RotationZ.h"
-#include "Math/Rotation3D.h"
-#include "Math/RotationZYX.h"
-#include "Math/EulerAngles.h"
-#include "Math/VectorUtil.h"
+#include <Math/Vector3D.h>
+#include <Math/Transform3D.h>
+#include <Math/Translation3D.h>
+#include <Math/RotationX.h>
+#include <Math/RotationY.h>
+#include <Math/RotationZ.h>
+#include <Math/Rotation3D.h>
+#include <Math/RotationZYX.h>
+#include <Math/EulerAngles.h>
+#include <Math/VectorUtil.h>
 #include <TGeoElement.h>
 #include <TGeoMaterial.h>
 #include <TGeoMedium.h>
-#include "TGeoPhysicalNode.h"
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
-#include "TGDMLMatrix.h"
-#endif
+#include <TGeoPhysicalNode.h>
+#include <TGDMLMatrix.h>
+
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
@@ -272,9 +271,8 @@ namespace dd4hep {
    */
   class Material: public Handle<TGeoMedium> {
   public:
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
     typedef const TGDMLMatrix* Property;
-#endif
+
   public:
     /// Default constructor
     Material() = default;
@@ -304,7 +302,6 @@ namespace dd4hep {
     double intLength() const;
     /// Access the fraction of an element within the material
     double fraction(Atom atom) const;
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
     /// Access to tabular properties of the material
     Property property(const char* name)  const;
     /// Access to tabular properties of the material
@@ -315,7 +312,6 @@ namespace dd4hep {
     double constProperty(const std::string& name)  const;
     /// Access string property value from the material table
     std::string constPropertyRef(const std::string& name, const std::string& default_value="");
-#endif
   };
 
   /// Handle class describing visualization attributes
@@ -506,8 +502,8 @@ namespace dd4hep {
 
 }   /* End namespace dd4hep             */
 
-#include "Math/Vector4D.h"
-#include "Math/Point3D.h"
+#include <Math/Vector4D.h>
+#include <Math/Point3D.h>
 
 namespace ROOT {
   namespace Math {

--- a/DDCore/include/DD4hep/OpticalSurfaceManager.h
+++ b/DDCore/include/DD4hep/OpticalSurfaceManager.h
@@ -14,10 +14,10 @@
 #define DD4HEP_OPTICALSURFACEMANAGER_H
 
 // Framework include files
-#include "DD4hep/OpticalSurfaces.h"
+#include <DD4hep/OpticalSurfaces.h>
 
 // ROOT include files
-#include "TGeoManager.h"
+#include <TGeoManager.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -58,7 +58,6 @@ namespace dd4hep {
     /// static accessor calling DD4hepOpticalSurfaceManagerPlugin if necessary
     static OpticalSurfaceManager getOpticalSurfaceManager(Detector& description);
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
     /// Access skin surface by its full name
     SkinSurface    skinSurface(const std::string& full_name)  const;
     /// Access skin surface by its identifier tuple (DetElement, name)
@@ -80,7 +79,6 @@ namespace dd4hep {
 
     /// Register the temporary surface objects with the TGeoManager
     void registerSurfaces(DetElement subdetector);
-#endif
   };
 }         /* End namespace dd4hep                  */
 #endif // DD4HEP_OPTICALSURFACEMANAGER_H

--- a/DDCore/include/DD4hep/OpticalSurfaces.h
+++ b/DDCore/include/DD4hep/OpticalSurfaces.h
@@ -14,13 +14,11 @@
 #define DD4HEP_OPTICALSURFACES_H
 
 // Framework include files
-#include "DD4hep/Volumes.h"
-#include "DD4hep/DetElement.h"
-
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
+#include <DD4hep/Volumes.h>
+#include <DD4hep/DetElement.h>
 
 // ROOT include files
-#include "TGeoOpticalSurface.h"
+#include <TGeoOpticalSurface.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -192,8 +190,5 @@ namespace dd4hep {
     /// Access the right node of the border surface
     PlacedVolume   right()  const;
   };
-
-
-}         /* End namespace dd4hep              */
-#endif    /* ROOT_VERSION                      */
+}      /* End namespace dd4hep              */
 #endif // DD4HEP_OPTICALSURFACES_H

--- a/DDCore/include/DD4hep/PropertyTable.h
+++ b/DDCore/include/DD4hep/PropertyTable.h
@@ -13,14 +13,11 @@
 #ifndef DD4HEP_PROPERTYTABLE_H
 #define DD4HEP_PROPERTYTABLE_H
 
-#include "RVersion.h"
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
-
 // Framework include files
-#include "DD4hep/Handle.h"
+#include <DD4hep/Handle.h>
 
 // ROOT include files
-#include "TGDMLMatrix.h"
+#include <TGDMLMatrix.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -59,6 +56,5 @@ namespace dd4hep {
     PropertyTable& operator=(const PropertyTable& m) = default;
   };
 
-}         /* End namespace dd4hep              */
-#endif    /* ROOT_VERSION                      */
+}      // End namespace dd4hep
 #endif // DD4HEP_PROPERTYTABLE_H

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -46,9 +46,7 @@
 #include <TGeoCompositeShape.h>
 #include <TGeoShapeAssembly.h>
 #include <TGeoPara.h>
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
 #include <TGeoTessellated.h>
-#endif
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
@@ -1762,7 +1760,6 @@ namespace dd4hep {
     }
   };
 
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
   /// Class describing a tessellated shape
   /**
    *   For any further documentation please see the following ROOT documentation:
@@ -1833,7 +1830,6 @@ namespace dd4hep {
     /// Access a single vertex from the shape
     const Vertex& vertex(int index)    const;
   };
-#endif
   
   /// Base class describing boolean (=union,intersection,subtraction) solids
   /**
@@ -2012,6 +2008,5 @@ namespace dd4hep {
     /// Copy Assignment operator
     IntersectionSolid& operator=(const IntersectionSolid& copy) = default;
   };
-
-}         /* End namespace dd4hep             */
+}      /* End namespace dd4hep             */
 #endif // DD4HEP_SHAPES_H

--- a/DDCore/include/DD4hep/detail/OpticalSurfaceManagerInterna.h
+++ b/DDCore/include/DD4hep/detail/OpticalSurfaceManagerInterna.h
@@ -22,7 +22,7 @@
 #define DD4HEP_DETAIL_OPTICALSURFACEMANAGERINTERNA_H
 
 /// Framework include files
-#include "DD4hep/Detector.h"
+#include <DD4hep/Detector.h>
 
 /// C/C++ include files
 #include <map>
@@ -46,11 +46,9 @@ namespace dd4hep {
 
       /// Reference to the main detector description object
       Detector& detector;
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
       std::map<LocalKey,    SkinSurface>    skinSurfaces;
       std::map<LocalKey,    BorderSurface>  borderSurfaces;
       std::map<std::string, OpticalSurface> opticalSurfaces;
-#endif
       
     public:
       /// Default constructor

--- a/DDCore/include/DD4hep/detail/Plugins.inl
+++ b/DDCore/include/DD4hep/detail/Plugins.inl
@@ -14,7 +14,7 @@
 #ifndef DD4HEP_PLUGINS_INL
 #define DD4HEP_PLUGINS_INL
 
-#include "DD4hep/Plugins.h"
+#include <DD4hep/Plugins.h>
 
 #if !defined(DD4HEP_PARSERS_NO_ROOT) && ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 #include <set>

--- a/DDCore/include/XML/Layering.h
+++ b/DDCore/include/XML/Layering.h
@@ -15,7 +15,7 @@
 #define XML_LAYERING_H
 
 // Framework include files
-#include "XML/XMLElements.h"
+#include <XML/XMLElements.h>
 
 // C/C++ include files
 #include <vector>

--- a/DDCore/src/AlignmentData.cpp
+++ b/DDCore/src/AlignmentData.cpp
@@ -12,18 +12,19 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/AlignmentData.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/DetElement.h"
-#include "DD4hep/OpaqueData.h"
-#include "DD4hep/Primitives.h"
+#include <DD4hep/AlignmentData.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/DetElement.h>
+#include <DD4hep/OpaqueData.h>
+#include <DD4hep/Primitives.h>
 
 // ROOT include files
-#include "TGeoMatrix.h"
+#include <TGeoMatrix.h>
+
+// C/C++ include files
 #include <sstream>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Copy constructor
@@ -84,12 +85,12 @@ void Delta::computeMatrix(TGeoHMatrix& tr_delta)  const   {
 }
 
 /// print alignment delta object
-ostream& operator << (ostream& ostr, const Delta& data)   {
-  string res;
-  stringstream str;
+std::ostream& operator << (std::ostream& ostr, const Delta& data)   {
+  std::string res;
+  std::stringstream str;
   str << "[" << data.translation << "," << data.rotation << "," << data.pivot << "]";
   res = str.str();
-  for(size_t i=0; i<res.length(); ++i)
+  for(std::size_t i=0; i<res.length(); ++i)
     if ( res[i]=='\n' ) res[i] = ' ';
   return ostr << res;
 }
@@ -131,8 +132,8 @@ AlignmentData& AlignmentData::operator=(const AlignmentData& copy)  {
 }
 
 /// print Conditions object
-ostream& operator << (ostream& ostr, const AlignmentData& data)   {
-  stringstream str;
+std::ostream& operator << (std::ostream& ostr, const AlignmentData& data)   {
+  std::stringstream str;
   str << data.delta;
   return ostr << str.str();
 }
@@ -229,7 +230,7 @@ Alignment AlignmentData::nominal() const   {
   return detector.nominal();
 }
 
-#include "DD4hep/GrammarUnparsed.h"
+#include <DD4hep/GrammarUnparsed.h>
 static auto s_registry = GrammarRegistry::pre_note<Delta>(1)
               .pre_note<AlignmentData>(1)
               .pre_note<std::map<DetElement, Delta> >(1);

--- a/DDCore/src/AlignmentNominalMap.cpp
+++ b/DDCore/src/AlignmentNominalMap.cpp
@@ -12,11 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/DetectorProcessor.h"
-#include "DD4hep/AlignmentsNominalMap.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/DetectorProcessor.h>
+#include <DD4hep/AlignmentsNominalMap.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
 using namespace dd4hep;
 using align::Keys;

--- a/DDCore/src/AlignmentTools.cpp
+++ b/DDCore/src/AlignmentTools.cpp
@@ -12,16 +12,16 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/IOV.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/AlignmentTools.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
+#include <DD4hep/IOV.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/AlignmentTools.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/detail/DetectorInterna.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
 
 // ROOT include files
-#include "TGeoMatrix.h"
+#include <TGeoMatrix.h>
 
 using     dd4hep::PlacedVolume;
 using     dd4hep::Alignment;

--- a/DDCore/src/Alignments.cpp
+++ b/DDCore/src/Alignments.cpp
@@ -12,22 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/AlignmentData.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/AlignmentData.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
 // C/C++ include files
 #include <sstream>
 
-
-using namespace std;
 using namespace dd4hep;
 
-const string dd4hep::align::Keys::deltaName("alignment_delta");
+const std::string dd4hep::align::Keys::deltaName("alignment_delta");
 const dd4hep::Condition::itemkey_type  dd4hep::align::Keys::deltaKey =
   dd4hep::ConditionKey::itemCode("alignment_delta");
 
-const string dd4hep::align::Keys::alignmentName("alignment");
+const std::string dd4hep::align::Keys::alignmentName("alignment");
 const dd4hep::Condition::itemkey_type dd4hep::align::Keys::alignmentKey =
   dd4hep::ConditionKey::itemCode("alignment");
 
@@ -36,7 +34,7 @@ Alignment::Processor::Processor() {
 }
 
 /// Initializing constructor to create a new object (Specialized for AlignmentNamedObject)
-Alignment::Alignment(const string& nam)  {
+Alignment::Alignment(const std::string& nam)  {
   char*   p = (char*)::operator new(sizeof(Object)+sizeof(AlignmentData));
   Object* o = new(p) Object(nam, "alignment", p+sizeof(Object), sizeof(AlignmentData));
   assign(o, nam, "alignment");
@@ -44,7 +42,7 @@ Alignment::Alignment(const string& nam)  {
 }
 
 /// Initializing constructor to create a new object (Specialized for AlignmentObject)
-AlignmentCondition::AlignmentCondition(const string& nam)   {
+AlignmentCondition::AlignmentCondition(const std::string& nam)   {
   char*   p = (char*)::operator new(sizeof(Object)+sizeof(AlignmentData));
   Object* o = new(p) Object(nam, "alignment", p+sizeof(Object), sizeof(AlignmentData));
   assign(o, nam, "alignment");
@@ -77,7 +75,7 @@ const TGeoHMatrix& Alignment::detectorTransformation() const   {
 }
 
 /// Access to the node list
-const vector<PlacedVolume>& Alignment::nodes() const   {
+const std::vector<PlacedVolume>& Alignment::nodes() const   {
   return access()->values().nodes;
 }
 

--- a/DDCore/src/AlignmentsCalculator.cpp
+++ b/DDCore/src/AlignmentsCalculator.cpp
@@ -12,20 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/Conditions.h"
-#include "DD4hep/ConditionsMap.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/ConditionDerived.h"
-#include "DD4hep/DetectorProcessor.h"
-#include "DD4hep/AlignmentsProcessor.h"
-#include "DD4hep/AlignmentsCalculator.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Conditions.h>
+#include <DD4hep/ConditionsMap.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/ConditionDerived.h>
+#include <DD4hep/DetectorProcessor.h>
+#include <DD4hep/AlignmentsProcessor.h>
+#include <DD4hep/AlignmentsCalculator.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
 
 using namespace dd4hep;
 using namespace dd4hep::align;
-typedef AlignmentsCalculator::Result Result;
+using Result = AlignmentsCalculator::Result;
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -72,8 +72,8 @@ namespace dd4hep {
 
       class Calculator::Context  {
       public:
-        typedef std::map<DetElement,size_t,AlignmentsCalculator::PathOrdering>  DetectorMap;
-        typedef std::map<unsigned int,size_t>             Keys;
+        typedef std::map<DetElement,std::size_t,AlignmentsCalculator::PathOrdering>  DetectorMap;
+        typedef std::map<unsigned int,std::size_t>             Keys;
         typedef std::vector<Entry>                        Entries;
 
         DetectorMap    detectors;
@@ -324,5 +324,5 @@ size_t AlignmentsCalculator::extract_deltas(DetElement start,
   return deltas.size();
 }
 
-#include "DD4hep/GrammarUnparsed.h"
+#include <DD4hep/GrammarUnparsed.h>
 static auto s_registry = GrammarRegistry::pre_note<AlignmentsCalculator::OrderedDeltas>(1);

--- a/DDCore/src/AlignmentsInterna.cpp
+++ b/DDCore/src/AlignmentsInterna.cpp
@@ -12,17 +12,16 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/IOV.h"
-#include "DD4hep/World.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
+#include <DD4hep/IOV.h>
+#include <DD4hep/World.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/detail/DetectorInterna.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
+using AlignmentObject = detail::AlignmentObject;
 
 DD4HEP_INSTANTIATE_HANDLE_UNNAMED(AlignmentData);
 #if defined(DD4HEP_MINIMAL_CONDITIONS)
@@ -42,7 +41,7 @@ AlignmentObject::AlignmentObject()
 }
 
 /// Standard constructor
-AlignmentObject::AlignmentObject(const string& nam, const string& tit, void* p, size_t len)
+AlignmentObject::AlignmentObject(const std::string& nam, const std::string& tit, void* p, size_t len)
   : ConditionObject(nam, tit), alignment_data(0)
 {
   InstanceCount::increment(this);
@@ -67,5 +66,5 @@ void AlignmentObject::clear()   {
   flags = Condition::ALIGNMENT_DERIVED;
 }
 
-#include "DD4hep/GrammarUnparsed.h"
+#include <DD4hep/GrammarUnparsed.h>
 static auto s_registry = GrammarRegistry::pre_note<AlignmentObject>();

--- a/DDCore/src/AlignmentsPrinter.cpp
+++ b/DDCore/src/AlignmentsPrinter.cpp
@@ -12,22 +12,21 @@
 //==========================================================================
 
 // Framework includes
-#include "Parsers/Parsers.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/AlignmentsPrinter.h"
-#include "DD4hep/AlignmentsProcessor.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
+#include <Parsers/Parsers.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/AlignmentsPrinter.h>
+#include <DD4hep/AlignmentsProcessor.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
+#include <TClass.h>
 
 // C/C++ include files
 #include <sstream>
-#include "TClass.h"
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::align;
 
 /// Initializing constructor
-AlignmentsPrinter::AlignmentsPrinter(ConditionsMap* cond_map, const string& pref, int flg)
+AlignmentsPrinter::AlignmentsPrinter(ConditionsMap* cond_map, const std::string& pref, int flg)
   : mapping(cond_map), name("Alignment"), prefix(pref), printLevel(INFO), m_flag(flg)
 {
 }
@@ -41,7 +40,7 @@ int AlignmentsPrinter::operator()(Alignment a)  const  {
 /// Callback to output alignments information of an entire DetElement
 int AlignmentsPrinter::operator()(DetElement de, int level)  const   {
   if ( mapping )   {
-    vector<Alignment> alignments;
+    std::vector<Alignment> alignments;
     alignmentsCollector(*mapping,alignments)(de, level);
     printout(printLevel, name, "++ %s %-3ld Alignments for DE %s",
              prefix.c_str(), alignments.size(), de.path().c_str()); 
@@ -55,7 +54,7 @@ int AlignmentsPrinter::operator()(DetElement de, int level)  const   {
 }
 
 /// Initializing constructor
-AlignedVolumePrinter::AlignedVolumePrinter(ConditionsMap* cond_map, const string& pref,int flg)
+AlignedVolumePrinter::AlignedVolumePrinter(ConditionsMap* cond_map, const std::string& pref,int flg)
   : AlignmentsPrinter(cond_map, pref, flg)
 {
   name = "Alignment";
@@ -68,12 +67,12 @@ int AlignedVolumePrinter::operator()(Alignment a)  const  {
 }
 
 /// Default printout of an alignment entry
-void dd4hep::align::printAlignment(PrintLevel lvl, const string& prefix, Alignment a)   {
+void dd4hep::align::printAlignment(PrintLevel lvl, const std::string& prefix, Alignment a)   {
   if ( a.isValid() )   {
     Alignment::Object* ptr = a.ptr();
     const AlignmentData& data = a.data();
     const Delta& D = data.delta;
-    string new_prefix = prefix;
+    std::string new_prefix = prefix;
     new_prefix.assign(prefix.length(),' ');
     printout(lvl,prefix,"++ %s \t [%p] Typ:%s",
              new_prefix.c_str(), a.ptr(),
@@ -90,14 +89,14 @@ void dd4hep::align::printAlignment(PrintLevel lvl, const string& prefix, Alignme
   }
 }
 
-static string replace_all(const string& in, const string& from, const string& to)  {
-  string res = in;
-  size_t idx;
-  while( string::npos != (idx=res.find(from)) )
+static std::string replace_all(const std::string& in, const std::string& from, const std::string& to)  {
+  std::string res = in;
+  std::size_t idx;
+  while( std::string::npos != (idx=res.find(from)) )
     res.replace(idx,from.length(),to);
   return res;
 }
-static string _transformPoint2World(const AlignmentData& data, const Position& local)  {
+static std::string _transformPoint2World(const AlignmentData& data, const Position& local)  {
   char text[256];
   Position world = data.localToWorld(local);
   ::snprintf(text,sizeof(text),"Local: (%7.3f , %7.3f , %7.3f )  -- > World:  (%7.3f , %7.3f , %7.3f )",
@@ -105,7 +104,7 @@ static string _transformPoint2World(const AlignmentData& data, const Position& l
   return text;
 }
 
-static string _transformPoint2Detector(const AlignmentData& data, const Position& local)  {
+static std::string _transformPoint2Detector(const AlignmentData& data, const Position& local)  {
   char text[256];
   Position world = data.localToDetector(local);
   ::snprintf(text,sizeof(text),"Local: (%7.3f , %7.3f , %7.3f )  -- > Parent: (%7.3f , %7.3f , %7.3f )",
@@ -113,14 +112,14 @@ static string _transformPoint2Detector(const AlignmentData& data, const Position
   return text;
 }
 
-void dd4hep::align::printAlignment(PrintLevel lvl, const string& prefix,
-                                        const string& opt, DetElement de, Alignment alignment)
+void dd4hep::align::printAlignment(PrintLevel lvl, const std::string& prefix,
+                                   const std::string& opt, DetElement de, Alignment alignment)
 {
-  const string& tag = prefix;
+  const std::string& tag = prefix;
   const AlignmentData& align_data = alignment.data();
   Condition  align_cond;// = align_data.condition;
   const Delta& align_delta = align_data.delta;
-  string par = de.parent().isValid() ? de.parent().path() : string();
+  std::string par = de.parent().isValid() ? de.parent().path() : std::string();
   Box bbox = de.placement().volume().solid();
   /// The edge positions of the bounding box:
   Position p1( bbox.x(), bbox.y(), bbox.z());
@@ -148,22 +147,22 @@ void dd4hep::align::printAlignment(PrintLevel lvl, const string& prefix,
              alignment.ptr());
   }
   if ( align_delta.hasTranslation() )  {
-    stringstream str;
+    std::stringstream str;
     Position copy(align_delta.translation * (1./dd4hep::cm));
     Parsers::toStream(copy, str);
     printout(lvl,tag,"++ %s DELTA Translation: %s [cm]",
              opt.c_str(), replace_all(str.str(),"\n","").c_str());
   }
   if ( align_delta.hasPivot() )  {
-    stringstream str;
+    std::stringstream str;
     Delta::Pivot copy(align_delta.pivot.Vect() * (1./dd4hep::cm));
     Parsers::toStream(copy, str);
-    string res = replace_all(str.str(),"\n","");
+    std::string res = replace_all(str.str(),"\n","");
     res = "( "+replace_all(res,"  "," , ")+" )";
     printout(lvl,tag,"++ %s DELTA Pivot:       %s [cm]", opt.c_str(), res.c_str());
   }
   if ( align_delta.hasRotation() )  {
-    stringstream str;
+    std::stringstream str;
     Parsers::toStream(align_delta.rotation, str);
     printout(lvl,tag,"++ %s DELTA Rotation:    %s [rad]", opt.c_str(), replace_all(str.str(),"\n","").c_str());
   }
@@ -193,10 +192,10 @@ void dd4hep::align::printAlignment(PrintLevel lvl, const string& prefix,
 }
 
 /// Default printout of a detector element entry
-void dd4hep::align::printElement(PrintLevel prt_level, const string& prefix, DetElement de, ConditionsMap& pool)   {
-  string tag = prefix+"Element";
+void dd4hep::align::printElement(PrintLevel prt_level, const std::string& prefix, DetElement de, ConditionsMap& pool)   {
+  std::string tag = prefix+"Element";
   if ( de.isValid() )  {
-    vector<Alignment> alignments;
+    std::vector<Alignment> alignments;
     alignmentsCollector(pool,alignments)(de);
     printout(prt_level,tag,"++ Alignments of DE %s [%d entries]",
              de.path().c_str(), int(alignments.size()));
@@ -208,13 +207,13 @@ void dd4hep::align::printElement(PrintLevel prt_level, const string& prefix, Det
 }
 
 /// PrintElement placement with/without alignment applied
-void dd4hep::align::printElementPlacement(PrintLevel lvl, const string& prefix, DetElement de, ConditionsMap& pool)   {
-  string tag = prefix+"Element";
+void dd4hep::align::printElementPlacement(PrintLevel lvl, const std::string& prefix, DetElement de, ConditionsMap& pool)   {
+  std::string tag = prefix+"Element";
   if ( de.isValid() )  {
     char text[132];
     Alignment    nominal = de.nominal();
     Box bbox = de.placement().volume().solid();
-    vector<Alignment> alignments;
+    std::vector<Alignment> alignments;
 
     alignmentsCollector(pool,alignments)(de);
     ::memset(text,'=',sizeof(text));

--- a/DDCore/src/AlignmentsProcessor.cpp
+++ b/DDCore/src/AlignmentsProcessor.cpp
@@ -12,13 +12,12 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/AlignmentsProcessor.h"
-#include "DD4hep/ConditionsProcessor.h"
-#include "DD4hep/detail/ContainerHelpers.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/AlignmentsProcessor.h>
+#include <DD4hep/ConditionsProcessor.h>
+#include <DD4hep/detail/ContainerHelpers.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::align;
 
@@ -27,7 +26,7 @@ template <typename T>
 int DeltaCollector<T>::operator()(DetElement de, int level)  const  {
   if ( de.isValid() )  {
     int count = 0;
-    vector<Condition> conditions;
+    std::vector<Condition> conditions;
     cond::conditionsCollector(mapping,conditions)(de,level);
     for( auto cond : conditions )   {
       if ( cond->testFlag(Condition::ALIGNMENT_DELTA) )  {
@@ -46,7 +45,7 @@ template <typename T>
 int AlignmentsCollector<T>::operator()(DetElement de, int level)  const  {
   if ( de.isValid() )  {
     int count = 0;
-    vector<Condition> conditions;
+    std::vector<Condition> conditions;
     cond::conditionsCollector(mapping,conditions)(de,level);
     for( auto cond : conditions )   {
       if ( cond->testFlag(Condition::ALIGNMENT_DERIVED) )  {
@@ -68,26 +67,26 @@ namespace dd4hep {
   /// Namespace for the AIDA detector description toolkit supporting XML utilities
   namespace align {
 
-    template class DeltaCollector<list<Delta> >;
-    template class DeltaCollector<vector<Delta> >;
-    template class DeltaCollector<map<DetElement,Delta> >;
-    template class DeltaCollector<vector<pair<DetElement,Delta> > >;
-    template class DeltaCollector<vector<pair<string,Delta> > >;
+    template class DeltaCollector<std::list<Delta> >;
+    template class DeltaCollector<std::vector<Delta> >;
+    template class DeltaCollector<std::map<DetElement,Delta> >;
+    template class DeltaCollector<std::vector<std::pair<DetElement,Delta> > >;
+    template class DeltaCollector<std::vector<std::pair<std::string,Delta> > >;
 
-    template class DeltaCollector<multimap<DetElement,Delta> >;
-    template class DeltaCollector<map<string,Delta> >;
-    template class DeltaCollector<multimap<string,Delta> >;
+    template class DeltaCollector<std::multimap<DetElement,Delta> >;
+    template class DeltaCollector<std::map<std::string,Delta> >;
+    template class DeltaCollector<std::multimap<std::string,Delta> >;
 
 
-    template class AlignmentsCollector<list<Alignment> >;
-    template class AlignmentsCollector<vector<Alignment> >;
-    template class AlignmentsCollector<map<DetElement,Alignment> >;
-    template class AlignmentsCollector<vector<pair<DetElement,Alignment> > >;
-    template class AlignmentsCollector<vector<pair<string,Alignment> > >;
+    template class AlignmentsCollector<std::list<Alignment> >;
+    template class AlignmentsCollector<std::vector<Alignment> >;
+    template class AlignmentsCollector<std::map<DetElement,Alignment> >;
+    template class AlignmentsCollector<std::vector<std::pair<DetElement,Alignment> > >;
+    template class AlignmentsCollector<std::vector<std::pair<std::string,Alignment> > >;
 
-    template class AlignmentsCollector<multimap<DetElement,Alignment> >;
-    template class AlignmentsCollector<map<string,Alignment> >;
-    template class AlignmentsCollector<multimap<string,Alignment> >;
+    template class AlignmentsCollector<std::multimap<DetElement,Alignment> >;
+    template class AlignmentsCollector<std::map<std::string,Alignment> >;
+    template class AlignmentsCollector<std::multimap<std::string,Alignment> >;
 
   }    /* End namespace align  */
 }      /* End namespace dd4hep      */

--- a/DDCore/src/BuildType.cpp
+++ b/DDCore/src/BuildType.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/BuildType.h"
+#include <DD4hep/BuildType.h>
 
 // C/C++ include files
 #include <stdexcept>

--- a/DDCore/src/Callback.cpp
+++ b/DDCore/src/Callback.cpp
@@ -12,13 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Callback.h"
-#include "DD4hep/Exceptions.h"
-
-using namespace dd4hep;
+#include <DD4hep/Callback.h>
+#include <DD4hep/Exceptions.h>
 
 /// Check the compatibility of two typed objects. The test is the result of a dynamic_cast
-void CallbackSequence::checkTypes(const std::type_info& typ1, const std::type_info& typ2, void* test) {
+void dd4hep::CallbackSequence::checkTypes(const std::type_info& typ1, const std::type_info& typ2, void* test) {
   if (!test) {
     throw unrelated_type_error(typ1, typ2, "Cannot install a callback for these 2 types.");
   }

--- a/DDCore/src/CartesianGridXY.cpp
+++ b/DDCore/src/CartesianGridXY.cpp
@@ -12,12 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/CartesianGridXY.h"
-#include "DDSegmentation/CartesianGridXY.h"
+#include <DD4hep/CartesianGridXY.h>
+#include <DDSegmentation/CartesianGridXY.h>
 
-// C/C++ include files
-
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -74,12 +71,12 @@ void CartesianGridXY::setOffsetY(double offset) const   {
 }
 
 /// access the field name used for X
-const string& CartesianGridXY::fieldNameX() const {
+const std::string& CartesianGridXY::fieldNameX() const {
   return access()->implementation->fieldNameX();
 }
 
 /// access the field name used for Y
-const string& CartesianGridXY::fieldNameY() const {
+const std::string& CartesianGridXY::fieldNameY() const {
   return access()->implementation->fieldNameY();
 }
 
@@ -92,6 +89,6 @@ const string& CartesianGridXY::fieldNameY() const {
     -# size in x
     -# size in y
 */
-vector<double> CartesianGridXY::cellDimensions(const CellID& id) const  {
+std::vector<double> CartesianGridXY::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianGridXYZ.cpp
+++ b/DDCore/src/CartesianGridXYZ.cpp
@@ -12,12 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/CartesianGridXYZ.h"
-#include "DDSegmentation/CartesianGridXYZ.h"
+#include <DD4hep/CartesianGridXYZ.h>
+#include <DDSegmentation/CartesianGridXYZ.h>
 
-// C/C++ include files
-
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -94,17 +91,17 @@ void CartesianGridXYZ::setOffsetZ(double offset) const   {
 }
 
 /// access the field name used for X
-const string& CartesianGridXYZ::fieldNameX() const {
+const std::string& CartesianGridXYZ::fieldNameX() const {
   return access()->implementation->fieldNameX();
 }
 
 /// access the field name used for Y
-const string& CartesianGridXYZ::fieldNameY() const {
+const std::string& CartesianGridXYZ::fieldNameY() const {
   return access()->implementation->fieldNameY();
 }
 
 /// access the field name used for Z
-const string& CartesianGridXYZ::fieldNameZ() const {
+const std::string& CartesianGridXYZ::fieldNameZ() const {
   return access()->implementation->fieldNameZ();
 }
 
@@ -118,6 +115,6 @@ const string& CartesianGridXYZ::fieldNameZ() const {
     -# size in y
     -# size in z
 */
-vector<double> CartesianGridXYZ::cellDimensions(const CellID& id) const  {
+std::vector<double> CartesianGridXYZ::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianGridXZ.cpp
+++ b/DDCore/src/CartesianGridXZ.cpp
@@ -12,12 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/CartesianGridXZ.h"
-#include "DDSegmentation/CartesianGridXZ.h"
+#include <DD4hep/CartesianGridXZ.h>
+#include <DDSegmentation/CartesianGridXZ.h>
 
-// C/C++ include files
-
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -74,12 +71,12 @@ void CartesianGridXZ::setOffsetZ(double offset) const   {
 }
 
 /// access the field name used for X
-const string& CartesianGridXZ::fieldNameX() const {
+const std::string& CartesianGridXZ::fieldNameX() const {
   return access()->implementation->fieldNameX();
 }
 
 /// access the field name used for Z
-const string& CartesianGridXZ::fieldNameZ() const {
+const std::string& CartesianGridXZ::fieldNameZ() const {
   return access()->implementation->fieldNameZ();
 }
 
@@ -92,6 +89,6 @@ const string& CartesianGridXZ::fieldNameZ() const {
     -# size in x
     -# size in z
 */
-vector<double> CartesianGridXZ::cellDimensions(const CellID& id) const  {
+std::vector<double> CartesianGridXZ::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianGridYZ.cpp
+++ b/DDCore/src/CartesianGridYZ.cpp
@@ -12,12 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/CartesianGridYZ.h"
-#include "DDSegmentation/CartesianGridYZ.h"
+#include <DD4hep/CartesianGridYZ.h>
+#include <DDSegmentation/CartesianGridYZ.h>
 
-// C/C++ include files
-
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -74,12 +71,12 @@ void CartesianGridYZ::setOffsetZ(double offset) const   {
 }
 
 /// access the field name used for Y
-const string& CartesianGridYZ::fieldNameY() const {
+const std::string& CartesianGridYZ::fieldNameY() const {
   return access()->implementation->fieldNameY();
 }
 
 /// access the field name used for Z
-const string& CartesianGridYZ::fieldNameZ() const {
+const std::string& CartesianGridYZ::fieldNameZ() const {
   return access()->implementation->fieldNameZ();
 }
 
@@ -92,6 +89,6 @@ const string& CartesianGridYZ::fieldNameZ() const {
     -# size in y
     -# size in z
 */
-vector<double> CartesianGridYZ::cellDimensions(const CellID& id) const  {
+std::vector<double> CartesianGridYZ::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianStripX.cpp
+++ b/DDCore/src/CartesianStripX.cpp
@@ -12,10 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/CartesianStripX.h"
-#include "DDSegmentation/CartesianStripX.h"
+#include <DD4hep/CartesianStripX.h>
+#include <DDSegmentation/CartesianStripX.h>
 
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -44,7 +43,7 @@ double CartesianStripX::offsetX() const { return access()->implementation->offse
 void CartesianStripX::setOffsetX(double offset) const { access()->implementation->setOffsetX(offset); }
 
 /// access the field name used for X
-const string& CartesianStripX::fieldNameX() const { return access()->implementation->fieldNameX(); }
+const std::string& CartesianStripX::fieldNameX() const { return access()->implementation->fieldNameX(); }
 
 /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
     in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
@@ -55,6 +54,6 @@ const string& CartesianStripX::fieldNameX() const { return access()->implementat
     -# size in x
     -# size in y
 */
-vector<double> CartesianStripX::cellDimensions(const CellID& id) const {
+std::vector<double> CartesianStripX::cellDimensions(const CellID& id) const {
     return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianStripY.cpp
+++ b/DDCore/src/CartesianStripY.cpp
@@ -12,10 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/CartesianStripY.h"
-#include "DDSegmentation/CartesianStripY.h"
+#include <DD4hep/CartesianStripY.h>
+#include <DDSegmentation/CartesianStripY.h>
 
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -44,7 +43,7 @@ double CartesianStripY::offsetY() const { return access()->implementation->offse
 void CartesianStripY::setOffsetY(double offset) const { access()->implementation->setOffsetY(offset); }
 
 /// access the field name used for Y
-const string& CartesianStripY::fieldNameY() const { return access()->implementation->fieldNameY(); }
+const std::string& CartesianStripY::fieldNameY() const { return access()->implementation->fieldNameY(); }
 
 /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
     in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
@@ -55,6 +54,6 @@ const string& CartesianStripY::fieldNameY() const { return access()->implementat
     -# size in x
     -# size in y
 */
-vector<double> CartesianStripY::cellDimensions(const CellID& id) const {
+std::vector<double> CartesianStripY::cellDimensions(const CellID& id) const {
     return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianStripZ.cpp
+++ b/DDCore/src/CartesianStripZ.cpp
@@ -12,10 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/CartesianStripZ.h"
-#include "DDSegmentation/CartesianStripZ.h"
+#include <DD4hep/CartesianStripZ.h>
+#include <DDSegmentation/CartesianStripZ.h>
 
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -44,7 +43,7 @@ double CartesianStripZ::offsetZ() const { return access()->implementation->offse
 void CartesianStripZ::setOffsetZ(double offset) const { access()->implementation->setOffsetZ(offset); }
 
 /// access the field name used for Z
-const string& CartesianStripZ::fieldNameZ() const { return access()->implementation->fieldNameZ(); }
+const std::string& CartesianStripZ::fieldNameZ() const { return access()->implementation->fieldNameZ(); }
 
 /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
     in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
@@ -55,6 +54,6 @@ const string& CartesianStripZ::fieldNameZ() const { return access()->implementat
     -# size in x
     -# size in y
 */
-vector<double> CartesianStripZ::cellDimensions(const CellID& id) const {
+std::vector<double> CartesianStripZ::cellDimensions(const CellID& id) const {
     return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/ComponentProperties.cpp
+++ b/DDCore/src/ComponentProperties.cpp
@@ -12,45 +12,44 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
-#include "Parsers/Parsers.h"
-#include "DD4hep/ComponentProperties.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
+#include <Parsers/Parsers.h>
+#include <DD4hep/ComponentProperties.h>
 
 // C/C++ include files
 #include <stdexcept>
 #include <cstring>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Property type name
-string Property::type(const Property& property) {
+std::string Property::type(const Property& property) {
   return type(property.grammar().type());
 }
 
 /// Property type name
-string Property::type(const type_info& typ) {
+std::string Property::type(const std::type_info& typ) {
   return typeName(typ);
 }
 
 /// Property type name
-string Property::type() const {
+std::string Property::type() const {
   return Property::type(grammar().type());
 }
 
 const BasicGrammar& Property::grammar() const {
   if ( m_hdl )
     return *m_hdl;
-  throw runtime_error("Attempt to access property grammar from invalid object.");
+  throw std::runtime_error("Attempt to access property grammar from invalid object.");
 }
 
 /// Conversion to string value
-string Property::str() const {
+std::string Property::str() const {
   if ( m_hdl && m_par ) {
     return m_hdl->str(m_par);
   }
-  throw runtime_error("Attempt to access property grammar from invalid object.");
+  throw std::runtime_error("Attempt to access property grammar from invalid object.");
 }
 
 /// Conversion from string value
@@ -59,7 +58,7 @@ const Property& Property::str(const std::string& input)   const {
     m_hdl->fromString(m_par,input);
     return *this;
   }
-  throw runtime_error("Attempt to access property grammar from invalid object.");
+  throw std::runtime_error("Attempt to access property grammar from invalid object.");
 }
 
 /// Conversion from string value
@@ -68,16 +67,16 @@ Property& Property::str(const std::string& input)    {
     m_hdl->fromString(m_par,input);
     return *this;
   }
-  throw runtime_error("Attempt to access property grammar from invalid object.");
+  throw std::runtime_error("Attempt to access property grammar from invalid object.");
 }
 
 /// Assignment operator / set new balue
 Property& Property::operator=(const char* val) {
   if ( val ) {
-    this->set < string > (val);
+    this->set < std::string > (val);
     return *this;
   }
-  throw runtime_error("Attempt to set invalid string to property!");
+  throw std::runtime_error("Attempt to set invalid string to property!");
 }
 
 /// Default constructor
@@ -106,53 +105,53 @@ bool PropertyManager::exists(const std::string& name) const   {
 }
 
 /// Verify that this property does not exist (throw exception if the name was found)
-void PropertyManager::verifyNonExistence(const string& name) const {
+void PropertyManager::verifyNonExistence(const std::string& name) const {
   Properties::const_iterator i = m_properties.find(name);
   if (i == m_properties.end())
     return;
-  throw runtime_error("The property:" + name + " already exists for this component.");
+  throw std::runtime_error("The property:" + name + " already exists for this component.");
 }
 
 /// Verify that this property exists (throw exception if the name was not found)
 PropertyManager::Properties::const_iterator
-PropertyManager::verifyExistence(const string& name) const {
+PropertyManager::verifyExistence(const std::string& name) const {
   Properties::const_iterator i = m_properties.find(name);
   if (i != m_properties.end())
     return i;
-  throw runtime_error("PropertyManager: Unknown property:" + name);
+  throw std::runtime_error("PropertyManager: Unknown property:" + name);
 }
 
 /// Verify that this property exists (throw exception if the name was not found)
 PropertyManager::Properties::iterator
-PropertyManager::verifyExistence(const string& name) {
+PropertyManager::verifyExistence(const std::string& name) {
   Properties::iterator i = m_properties.find(name);
   if (i != m_properties.end())
     return i;
-  throw runtime_error("PropertyManager: Unknown property:" + name);
+  throw std::runtime_error("PropertyManager: Unknown property:" + name);
 }
 
 /// Access property by name (CONST)
-Property& PropertyManager::property(const string& name) {
+Property& PropertyManager::property(const std::string& name) {
   return (*verifyExistence(name)).second;
 }
 
 /// Access property by name
-const Property& PropertyManager::property(const string& name) const {
+const Property& PropertyManager::property(const std::string& name) const {
   return (*verifyExistence(name)).second;
 }
 
 /// Access property by name
-Property& PropertyManager::operator[](const string& name) {
+Property& PropertyManager::operator[](const std::string& name) {
   return (*verifyExistence(name)).second;
 }
 
 /// Access property by name
-const Property& PropertyManager::operator[](const string& name) const {
+const Property& PropertyManager::operator[](const std::string& name) const {
   return (*verifyExistence(name)).second;
 }
 
 /// Add a new property
-void PropertyManager::add(const string& name, const Property& prop) {
+void PropertyManager::add(const std::string& name, const Property& prop) {
   verifyNonExistence(name);
   m_properties.emplace(name, prop);
 }
@@ -173,16 +172,16 @@ PropertyConfigurable::~PropertyConfigurable()   {
 }
 
 /// Check property for existence
-bool PropertyConfigurable::hasProperty(const string& nam) const    {
+bool PropertyConfigurable::hasProperty(const std::string& nam) const    {
   return m_properties.exists(nam);
 }
 
 /// Access single property
-Property& PropertyConfigurable::property(const string& nam)   {
+Property& PropertyConfigurable::property(const std::string& nam)   {
   return properties()[nam];
 }
 
-#include "DD4hep/GrammarParsed.h"
+#include <DD4hep/GrammarParsed.h>
 namespace dd4hep { 
   namespace Parsers {
     template <> int parse(Property& result, const std::string& input) {

--- a/DDCore/src/ConditionAny.cpp
+++ b/DDCore/src/ConditionAny.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/ConditionAny.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/ConditionAny.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
 // C/C++ include files
 #include <iomanip>

--- a/DDCore/src/ConditionDerived.cpp
+++ b/DDCore/src/ConditionDerived.cpp
@@ -12,10 +12,10 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/Detector.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/ConditionDerived.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/ConditionDerived.h>
 
 // C/C++ include files
 

--- a/DDCore/src/Conditions.cpp
+++ b/DDCore/src/Conditions.cpp
@@ -12,25 +12,24 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
 // C/C++ include files
 #include <climits>
 #include <iomanip>
 #include <cstdio>
 
-using namespace std;
 using namespace dd4hep;
 
 namespace {
   int s_have_inventory = 0;
   struct KeyTracer    {
-    map<Condition::itemkey_type,string> item_names;
-    mutex lock;
-    void add(Condition::itemkey_type key,const string& item)   {
+    std::map<Condition::itemkey_type,std::string> item_names;
+    std::mutex lock;
+    void add(Condition::itemkey_type key,const std::string& item)   {
       if ( s_have_inventory > 0 )   {
-        std::lock_guard<mutex> protect(lock);
+        std::lock_guard<std::mutex> protect(lock);
         item_names.emplace(key, item);
       }
     }
@@ -40,7 +39,7 @@ namespace {
         return (*i).second;
       }
       char text[32];
-      ::snprintf(text,sizeof(text),"%08X",key);
+      std::snprintf(text,sizeof(text),"%08X",key);
       return text;
     }
   } s_key_tracer;
@@ -75,7 +74,7 @@ Condition::Condition(key_type hash_key) : Handle<Object>()
 }
 
 /// Initializing constructor for a pure, undecorated conditions object
-Condition::Condition(const string& nam, const string& typ) : Handle<Object>()
+Condition::Condition(const std::string& nam, const std::string& typ) : Handle<Object>()
 {
   Object* o = new Object();
   assign(o,nam,typ);
@@ -83,7 +82,7 @@ Condition::Condition(const string& nam, const string& typ) : Handle<Object>()
 }
 
 /// Initializing constructor for a pure, undecorated conditions object with payload buffer
-Condition::Condition(const string& nam,const string& typ, size_t memory)
+Condition::Condition(const std::string& nam,const std::string& typ, size_t memory)
   : Handle<Object>()
 {
   void* ptr = ::operator new(sizeof(Object)+memory);
@@ -93,12 +92,12 @@ Condition::Condition(const string& nam,const string& typ, size_t memory)
 }
 
 /// Output method
-string Condition::str(int flags)  const   {
-  stringstream output;
+std::string Condition::str(int flags)  const   {
+  std::stringstream output;
   Object* o = access(); 
 #if defined(DD4HEP_CONDITIONS_HAVE_NAME)
   if ( 0 == (flags&NO_NAME) )
-    output << setw(16) << left << o->name;
+    output << std::setw(16) << std::left << o->name;
 #endif
   if ( flags&WITH_IOV )  {
     const IOV* ptr_iov = o->iovData();
@@ -143,28 +142,28 @@ const dd4hep::IOV& Condition::iov() const   {
 
 #if !defined(DD4HEP_MINIMAL_CONDITIONS)
 /// Access the type field of the condition
-const string& Condition::type()  const   {
+const std::string& Condition::type()  const   {
   return access()->type;
 }
 
 /// Access the value field of the condition as a string
-const string& Condition::value()  const   {
+const std::string& Condition::value()  const   {
   return access()->value;
 }
 
 /// Access the comment field of the condition
-const string& Condition::comment()  const   {
+const std::string& Condition::comment()  const   {
   return access()->comment;
 }
 
 /// Access the address string [e.g. database identifier]
-const string& Condition::address()  const   {
+const std::string& Condition::address()  const   {
   return access()->address;
 }
 #endif
 
 /// Access to the type information
-const type_info& Condition::typeInfo() const   {
+const std::type_info& Condition::typeInfo() const   {
   return descriptor().type();
 }
 
@@ -210,7 +209,7 @@ const dd4hep::BasicGrammar& Condition::descriptor() const   {
     invalidHandleError<Condition>();
     // This code is never reached, since function above throws exception!
     // Needed to satisfay CppCheck
-    throw runtime_error("Null pointer in Grammar object");
+    throw std::runtime_error("Null pointer in Grammar object");
   }
   return *grammar;
 }
@@ -220,7 +219,7 @@ ConditionsSelect::~ConditionsSelect()   {
 }
 
 /// Constructor from string
-ConditionKey::KeyMaker::KeyMaker(DetElement detector, const string& value)   {
+ConditionKey::KeyMaker::KeyMaker(DetElement detector, const std::string& value)   {
   KeyMaker key_maker(detector.key(), detail::hash32(value));
   hash = key_maker.hash;
   s_key_tracer.add(key_maker.values.item_key, value);
@@ -232,14 +231,14 @@ ConditionKey::KeyMaker::KeyMaker(DetElement detector, Condition::itemkey_type it
 }
 
 /// Constructor from string
-ConditionKey::KeyMaker::KeyMaker(Condition::detkey_type det_key, const string& value)   {
+ConditionKey::KeyMaker::KeyMaker(Condition::detkey_type det_key, const std::string& value)   {
   KeyMaker key_maker(det_key, detail::hash32(value));
   hash = key_maker.hash;
   s_key_tracer.add(key_maker.values.item_key, value);
 }
 
 /// Constructor from string
-ConditionKey::ConditionKey(DetElement detector, const string& value)  {
+ConditionKey::ConditionKey(DetElement detector, const std::string& value)  {
   KeyMaker key_maker(detector.key(), value);
   hash = key_maker.hash;
   s_key_tracer.add(key_maker.values.item_key, value);
@@ -249,7 +248,7 @@ ConditionKey::ConditionKey(DetElement detector, const string& value)  {
 }
 
 /// Constructor from detector element key and item sub-key
-ConditionKey::ConditionKey(Condition::detkey_type det_key, const string& value)    {
+ConditionKey::ConditionKey(Condition::detkey_type det_key, const std::string& value)    {
   KeyMaker key_maker(det_key, value);
   s_key_tracer.add(key_maker.values.item_key, value);
   hash = key_maker.hash;
@@ -278,7 +277,7 @@ Condition::key_type ConditionKey::hashCode(DetElement detector, const char* valu
 }
 
 /// Hash code generation from input string
-Condition::key_type ConditionKey::hashCode(DetElement detector, const string& value)  {
+Condition::key_type ConditionKey::hashCode(DetElement detector, const std::string& value)  {
   KeyMaker key_maker(detector.key(), value);
   s_key_tracer.add(key_maker.values.item_key, value);
   return key_maker.hash;
@@ -292,20 +291,20 @@ Condition::itemkey_type ConditionKey::itemCode(const char* value)  {
 }
 
 /// 32 bit hashcode of the item
-Condition::itemkey_type ConditionKey::itemCode(const string& value)   {
+Condition::itemkey_type ConditionKey::itemCode(const std::string& value)   {
   Condition::itemkey_type code = detail::hash32(value);
   s_key_tracer.add(code, value);
   return code;
 }
 
 /// Conversion to string
-string ConditionKey::toString()  const    {
+std::string ConditionKey::toString()  const    {
   dd4hep::ConditionKey::KeyMaker key(hash);
   char text[64];
   ::snprintf(text,sizeof(text),"%08X-%08X",key.values.det_key, key.values.item_key);
 #if defined(DD4HEP_CONDITIONS_HAVE_NAME)
   if ( !name.empty() )   {
-    stringstream str;
+    std::stringstream str;
     str << "(" << name << ") " << text;
     return str.str();
   }

--- a/DDCore/src/ConditionsData.cpp
+++ b/DDCore/src/ConditionsData.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/ConditionsData.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/ConditionsData.h>
 
 using namespace dd4hep::cond;
 
@@ -76,5 +76,5 @@ AbstractMap& AbstractMap::operator=(const AbstractMap& c)  {
   return *this;
 }
 
-#include "DD4hep/GrammarUnparsed.h"
+#include <DD4hep/GrammarUnparsed.h>
 static auto s_registry = dd4hep::GrammarRegistry::pre_note<AbstractMap>(1);

--- a/DDCore/src/ConditionsDebug.cpp
+++ b/DDCore/src/ConditionsDebug.cpp
@@ -12,24 +12,23 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Conditions.h"
-#include "DD4hep/ConditionsDebug.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/Conditions.h>
+#include <DD4hep/ConditionsDebug.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
-using std::string;
 using namespace dd4hep::cond;
 
 std::string dd4hep::cond::cond_name(const dd4hep::Condition::Object* c)  {
 #if defined(DD4HEP_MINIMAL_CONDITIONS)
   dd4hep::ConditionKey::KeyMaker key(c->hash);
   char text[64];
-  ::snprintf(text,sizeof(text),"%08X-%08X",key.values.det_key, key.values.item_key);
+  std::snprintf(text,sizeof(text),"%08X-%08X", key.values.det_key, key.values.item_key);
   return text;
 #else
   return c->name;
 #endif
 }
 
-string dd4hep::cond::cond_name(Condition c)    {
+std::string dd4hep::cond::cond_name(Condition c)    {
   return cond_name(c.ptr());
 }

--- a/DDCore/src/ConditionsInterna.cpp
+++ b/DDCore/src/ConditionsInterna.cpp
@@ -12,12 +12,11 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/IOV.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/IOV.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/detail/ConditionsInterna.h>
 
-using namespace std;
 using namespace dd4hep;
 
 #if defined(DD4HEP_CONDITIONS_HAVE_NAME)
@@ -45,10 +44,10 @@ detail::ConditionObject::ConditionObject()
 
 /// Standard constructor
 #if defined(DD4HEP_CONDITIONS_HAVE_NAME)
-detail::ConditionObject::ConditionObject(const string& nam,const string& tit)
+detail::ConditionObject::ConditionObject(const std::string& nam,const std::string& tit)
   : NamedObject(nam, tit), data()
 #else
-detail::ConditionObject::ConditionObject(const string& ,const string& )
+detail::ConditionObject::ConditionObject(const std::string& ,const std::string& )
   : data()
 #endif
 {
@@ -68,7 +67,7 @@ void detail::ConditionObject::release()  {
 /// Data offset from the opaque data block pointer to the condition
 size_t detail::ConditionObject::offset()   {
   static _P p((void*)0x1000);
-  static size_t off = _P(&p.o->data.grammar).character - p.character + sizeof(OpaqueData::grammar);
+  static std::size_t off = _P(&p.o->data.grammar).character - p.character + sizeof(OpaqueData::grammar);
   return off;
 }
 
@@ -97,5 +96,5 @@ const dd4hep::IOVType* detail::ConditionObject::iovType() const    {
 }
 
 
-#include "DD4hep/GrammarUnparsed.h"
-static auto s_registry = GrammarRegistry::pre_note<vector<Condition> >(1);
+#include <DD4hep/GrammarUnparsed.h>
+static auto s_registry = GrammarRegistry::pre_note<std::vector<Condition> >(1);

--- a/DDCore/src/ConditionsListener.cpp
+++ b/DDCore/src/ConditionsListener.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/ConditionsListener.h"
+#include <DD4hep/ConditionsListener.h>
 
 using namespace dd4hep::cond;
 

--- a/DDCore/src/ConditionsMap.cpp
+++ b/DDCore/src/ConditionsMap.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/ConditionsMap.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/ConditionsMap.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
 using namespace dd4hep;
 

--- a/DDCore/src/ConditionsPrinter.cpp
+++ b/DDCore/src/ConditionsPrinter.cpp
@@ -12,25 +12,24 @@
 //==========================================================================
 
 // Framework includes
-#include "Parsers/Parsers.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/ConditionsData.h"
-#include "DD4hep/ConditionsPrinter.h"
-#include "DD4hep/ConditionsProcessor.h"
+#include <Parsers/Parsers.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/ConditionsData.h>
+#include <DD4hep/ConditionsPrinter.h>
+#include <DD4hep/ConditionsProcessor.h>
 
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/detail/ConditionsInterna.h>
 
 // C/C++ include files
 #include <sstream>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::cond;
 
 namespace {
   /// C++ version: replace all occurrences of a string
-  string str_replace(const std::string& str, const std::string& pattern, const std::string& replacement) {
-    string res = str;
+  std::string str_replace(const std::string& str, const std::string& pattern, const std::string& replacement) {
+    std::string res = str;
     for(size_t id=res.find(pattern); id != std::string::npos; id = res.find(pattern) )
       res.replace(id,pattern.length(),replacement);
     return res;
@@ -76,11 +75,11 @@ ConditionsPrinter::ParamPrinter::ParamPrinter(ConditionsPrinter* printer, PrintL
 
 /// Callback to output conditions information
 void ConditionsPrinter::ParamPrinter::operator()(const AbstractMap::Params::value_type& obj)  const {
-  const type_info& type = obj.second.typeInfo();
+  const std::type_info& type = obj.second.typeInfo();
   ++m_parent->numParam;
-  if ( type == typeid(string) )  {
-    string value = obj.second.get<string>().c_str();
-    size_t len = value.length();
+  if ( type == typeid(std::string) )  {
+    std::string value = obj.second.get<std::string>().c_str();
+    std::size_t len = value.length();
     if ( len > m_parent->lineLength ) {
       value.erase(m_parent->lineLength);
       value += "...";
@@ -100,8 +99,8 @@ void ConditionsPrinter::ParamPrinter::operator()(const AbstractMap::Params::valu
              obj.second.str().c_str());	
   }
   else {
-    string value = obj.second.str();
-    size_t len = value.length();
+    std::string value = obj.second.str();
+    std::size_t len = value.length();
     if ( len > m_parent->lineLength ) {
       value.erase(m_parent->lineLength);
       value += "...";
@@ -115,7 +114,7 @@ void ConditionsPrinter::ParamPrinter::operator()(const AbstractMap::Params::valu
 }
 
 /// Initializing constructor
-ConditionsPrinter::ConditionsPrinter(ConditionsMap* cond_map, const string& pref, int flg)
+ConditionsPrinter::ConditionsPrinter(ConditionsMap* cond_map, const std::string& pref, int flg)
   : mapping(cond_map), m_flag(flg), name("Condition"), prefix(pref)
 {
   m_print = new ParamPrinter(this, printLevel);
@@ -137,13 +136,13 @@ ConditionsPrinter::~ConditionsPrinter()   {
 int ConditionsPrinter::operator()(Condition cond)   const   {
   m_print->printLevel = printLevel;
   if ( cond.isValid() )   {
-    string repr = cond.str(m_flag);
-    Condition::Object* ptr    = cond.ptr();
+    std::string        repr = cond.str(m_flag);
+    Condition::Object* ptr  = cond.ptr();
 
     if ( repr.length() > lineLength )
       repr = repr.substr(0,lineLength)+"...";
     printout(this->printLevel,name, "++ %s%s", prefix.c_str(), repr.c_str());
-    string new_prefix = prefix;
+    std::string new_prefix = prefix;
     new_prefix.assign(prefix.length(),' ');
     if ( !cond.is_bound() )   {
       printout(this->printLevel,name,"++ %s \tPath:%s Key:%16llX Type:%s (%s)",
@@ -151,11 +150,11 @@ int ConditionsPrinter::operator()(Condition cond)   const   {
                typeName(typeid(*ptr)).c_str());
       return 1;
     }
-    const type_info&   type   = cond.typeInfo();
-    const OpaqueData&  opaque = cond.data();
+    const std::type_info& type   = cond.typeInfo();
+    const OpaqueData&     opaque = cond.data();
     printout(this->printLevel,name,"++ %s \tPath:%s Key:%16llX Type:%s",
              new_prefix.c_str(), cond.name(), cond.key(), opaque.dataType().c_str());
-    //string values = opaque.str();
+    //std::string values = opaque.str();
     //if ( values.length() > lineLength ) values = values.substr(0,130)+"...";
     //printout(this->printLevel,name,"++ %s \tData:%s", new_prefix.c_str(), values.c_str());
     if ( type == typeid(AbstractMap) )  {
@@ -176,18 +175,18 @@ int ConditionsPrinter::operator()(Condition cond)   const   {
       }
     }
     else if ( type == typeid(Delta) )  {
-      string piv;
-      stringstream str_tr, str_rot, str_piv;
+      std::string piv;
+      std::stringstream str_tr, str_rot, str_piv;
       const Delta& D = cond.get<Delta>();
       if ( D.hasTranslation() )  {
-	Position copy(D.translation * (1./dd4hep::cm));
-	Parsers::toStream(copy, str_tr);
+        Position copy(D.translation * (1./dd4hep::cm));
+        Parsers::toStream(copy, str_tr);
       }
       if ( D.hasRotation()    )  {
-	Parsers::toStream(D.rotation, str_rot);
+        Parsers::toStream(D.rotation, str_rot);
       }
       if ( D.hasPivot()       )  {
-	Position copy(D.pivot.Vect() * (1./dd4hep::cm));
+        Position copy(D.pivot.Vect() * (1./dd4hep::cm));
         Parsers::toStream(copy, str_piv);
         piv = str_replace(str_piv.str(),"\n","");
         piv = str_replace(piv,"  "," , ");
@@ -206,8 +205,8 @@ int ConditionsPrinter::operator()(Condition cond)   const   {
                );
     }
     else if ( type == typeid(AlignmentData) )  {
-      string piv;
-      stringstream str_tr, str_rot, str_piv;
+      std::string piv;
+      std::stringstream str_tr, str_rot, str_piv;
       const Delta& D = cond.get<AlignmentData>().delta;
       if ( D.hasTranslation() ) Parsers::toStream(D.translation, str_tr);
       if ( D.hasRotation()    ) Parsers::toStream(D.rotation, str_rot);
@@ -230,9 +229,9 @@ int ConditionsPrinter::operator()(Condition cond)   const   {
                piv.c_str()
                );
     }
-    else if ( type == typeid(string) )  {
-      string value = cond.get<string>().c_str();
-      size_t len = value.length();
+    else if ( type == typeid(std::string) )  {
+      std::string value = cond.get<std::string>().c_str();
+      std::size_t len = value.length();
       if ( len > lineLength ) {
         value = value.substr(0,lineLength);
         value += "...";
@@ -244,8 +243,8 @@ int ConditionsPrinter::operator()(Condition cond)   const   {
                value.c_str());
     }
     else {
-      string value = cond.str();
-      size_t len = value.length();
+      std::string value = cond.str();
+      std::size_t len = value.length();
       if ( len > lineLength ) {
         value = value.substr(0,lineLength);
         value += "...";
@@ -264,7 +263,7 @@ int ConditionsPrinter::operator()(Condition cond)   const   {
 /// Processing callback to print conditions
 int ConditionsPrinter::operator()(DetElement de, int level)   const {
   if ( mapping )   {
-    vector<Condition> conditions;
+    std::vector<Condition> conditions;
     conditionsCollector(*mapping,conditions)(de,level);
     printout(this->printLevel, name, "++ %s %-3ld Conditions for DE %s",
              prefix.c_str(), conditions.size(), de.path().c_str()); 

--- a/DDCore/src/ConditionsProcessor.cpp
+++ b/DDCore/src/ConditionsProcessor.cpp
@@ -12,11 +12,10 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/ConditionsProcessor.h"
-#include "DD4hep/detail/ContainerHelpers.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/ConditionsProcessor.h>
+#include <DD4hep/detail/ContainerHelpers.h>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::cond;
 
@@ -48,14 +47,14 @@ namespace dd4hep {
   namespace cond   {
 
     //template class ConditionsCollector<ConditionsMap>;
-    template class ConditionsCollector<list<Condition> >;
-    template class ConditionsCollector<vector<Condition> >;
-    template class ConditionsCollector<map<DetElement,Condition> >;
-    template class ConditionsCollector<vector<pair<DetElement,Condition> > >;
-    template class ConditionsCollector<vector<pair<string,Condition> > >;
+    template class ConditionsCollector<std::list<Condition> >;
+    template class ConditionsCollector<std::vector<Condition> >;
+    template class ConditionsCollector<std::map<DetElement,Condition> >;
+    template class ConditionsCollector<std::vector<std::pair<DetElement,Condition> > >;
+    template class ConditionsCollector<std::vector<std::pair<std::string,Condition> > >;
 
-    template class ConditionsCollector<multimap<DetElement,Condition> >;
-    template class ConditionsCollector<map<string,Condition> >;
-    template class ConditionsCollector<multimap<string,Condition> >;
+    template class ConditionsCollector<std::multimap<DetElement,Condition> >;
+    template class ConditionsCollector<std::map<std::string,Condition> >;
+    template class ConditionsCollector<std::multimap<std::string,Condition> >;
   }       /* End namespace cond               */
 }         /* End namespace dd4hep                   */

--- a/DDCore/src/DD4hepRootPersistency.cpp
+++ b/DDCore/src/DD4hepRootPersistency.cpp
@@ -12,20 +12,19 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/DD4hepRootPersistency.h"
-#include "DD4hep/detail/ObjectsInterna.h"
-#include "DD4hep/detail/SegmentationsInterna.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/DD4hepRootPersistency.h>
+#include <DD4hep/detail/ObjectsInterna.h>
+#include <DD4hep/detail/SegmentationsInterna.h>
 
 // ROOT include files
-#include "TFile.h"
-#include "TTimeStamp.h"
+#include <TFile.h>
+#include <TTimeStamp.h>
 #include <memory>
 
 ClassImp(DD4hepRootPersistency)
 
 using namespace dd4hep;
-using namespace std;
 
 namespace {
   /// Ensure nominal alignments are loaded before saving
@@ -95,7 +94,7 @@ int DD4hepRootPersistency::save(Detector& description, const char* fname, const 
       DetectorData::unpatchRootStreamer(TGeoNode::Class());
       return nBytes;
     }
-    catch (const exception& e) {
+    catch (const std::exception& e) {
       DetectorData::unpatchRootStreamer(TGeoVolume::Class());
       DetectorData::unpatchRootStreamer(TGeoNode::Class());
       except("DD4hepRootPersistency","Exception %s while saving file %s",e.what(), fname);
@@ -118,7 +117,7 @@ int DD4hepRootPersistency::load(Detector& description, const char* fname, const 
   if ( f && !f->IsZombie()) {
     try  {
       TTimeStamp start;
-      unique_ptr<DD4hepRootPersistency> persist((DD4hepRootPersistency*)f->Get(instance));
+      std::unique_ptr<DD4hepRootPersistency> persist((DD4hepRootPersistency*)f->Get(instance));
       if ( persist.get() )   {
         DetectorData* source = persist->m_data;
 #if 0
@@ -189,7 +188,7 @@ int DD4hepRootPersistency::load(Detector& description, const char* fname, const 
       f->ls();
       delete f;
     }
-    catch (const exception& e) {
+    catch (const std::exception& e) {
       DetectorData::unpatchRootStreamer(TGeoVolume::Class());
       DetectorData::unpatchRootStreamer(TGeoNode::Class());
       except("DD4hepRootPersistency","Exception %s while loading file %s",e.what(), fname);
@@ -207,22 +206,20 @@ int DD4hepRootPersistency::load(Detector& description, const char* fname, const 
   return 0;
 }
 
+#include <DD4hep/detail/DetectorInterna.h>
+#include <DD4hep/detail/ConditionsInterna.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
 
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DD4hep/detail/ConditionsInterna.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
 namespace {
 
   class PersistencyChecks  {
-
   public:
-    
     size_t errors = 0;
 
     /// Default constructor
     PersistencyChecks() = default;
 
-    size_t checkConstant(const std::pair<string,Constant>& obj)  {
+    size_t checkConstant(const std::pair<std::string,Constant>& obj)  {
       if ( obj.first.empty() || obj.second->name.empty() )  {
         printout(ERROR,"chkConstant","+++ Invalid constant: key error %s <> %s [%s]",
                  obj.first.c_str(), obj.second->GetName(), obj.second->GetTitle());
@@ -238,7 +235,7 @@ namespace {
       return 1;
     }
     
-    size_t checkProperty(const std::pair<string,map<string,string> >& obj)  {
+    size_t checkProperty(const std::pair<std::string, std::map<std::string,std::string> >& obj)  {
       if ( obj.first.empty() || obj.second.empty() )  {
         printout(ERROR,"chkProperty","+++ Empty property set: %s",obj.first.c_str());
         ++errors;

--- a/DDCore/src/DD4hepUI.cpp
+++ b/DDCore/src/DD4hepUI.cpp
@@ -12,54 +12,52 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/DD4hepUI.h"
-#include "DD4hep/Printout.h"
-#include "TRint.h"
+#include <DD4hep/DD4hepUI.h>
+#include <DD4hep/Printout.h>
+#include <TRint.h>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 namespace {
-  string _visLevel(int lvl)    {
+  std::string _visLevel(int lvl)    {
     char text[32];
-    ::snprintf(text,sizeof(text),"%d",lvl);
+    std::snprintf(text,sizeof(text),"%d",lvl);
     return text;
   }
 }
 
 /// Default constructor
-DD4hepUI::DD4hepUI(Detector& instance) : m_detDesc(instance)  {
+detail::DD4hepUI::DD4hepUI(Detector& instance) : m_detDesc(instance)  {
 }
 
 /// Default destructor
-DD4hepUI::~DD4hepUI()   {
+detail::DD4hepUI::~DD4hepUI()   {
 }
 
 /// Access to the Detector instance
-Detector* DD4hepUI::instance()  const   {
+Detector* detail::DD4hepUI::instance()  const   {
   return &m_detDesc;
 }
 
 /// Access to the Detector instance
-Detector* DD4hepUI::detectorDescription()  const   {
+Detector* detail::DD4hepUI::detectorDescription()  const   {
   return &m_detDesc;
 }
 
 /// Set the printout level from the interactive prompt
-PrintLevel DD4hepUI::setPrintLevel(PrintLevel level)   const   {
+PrintLevel detail::DD4hepUI::setPrintLevel(PrintLevel level)   const   {
   return dd4hep::setPrintLevel(level);
 }
 
 /// Set the visualization level when invoking the display
-int DD4hepUI::setVisLevel(int value)     {
+int detail::DD4hepUI::setVisLevel(int value)     {
   int old_value = visLevel;
   visLevel = value;
   return old_value;
 }
 
 /// Install the dd4hep conditions manager object
-Handle<NamedObject> DD4hepUI::conditionsMgr()  const  {
+Handle<NamedObject> detail::DD4hepUI::conditionsMgr()  const  {
   if ( !m_condMgr.isValid() )  {
     const void* argv[] = {"-handle",&m_condMgr,0};
     if ( 1 != apply("DD4hep_ConditionsManagerInstaller",2,(char**)argv) )  {
@@ -73,7 +71,7 @@ Handle<NamedObject> DD4hepUI::conditionsMgr()  const  {
 }
 
 /// Load conditions from file
-long DD4hepUI::loadConditions(const std::string& fname)  const  {
+long detail::DD4hepUI::loadConditions(const std::string& fname)  const  {
   Handle<NamedObject> h = conditionsMgr();
   if ( h.isValid() )  {
     m_detDesc.fromXML(fname, BUILD_DEFAULT);
@@ -83,7 +81,7 @@ long DD4hepUI::loadConditions(const std::string& fname)  const  {
 }
 
 /// Install the dd4hep alignment manager object
-Handle<NamedObject> DD4hepUI::alignmentMgr()  const  {
+Handle<NamedObject> detail::DD4hepUI::alignmentMgr()  const  {
   if ( !m_alignMgr.isValid() )  {
     const void* argv[] = {"-handle",&m_alignMgr,0};
     if ( 1 != apply("DD4hep_AlignmentsManagerInstaller",2,(char**)argv) )  {
@@ -97,41 +95,41 @@ Handle<NamedObject> DD4hepUI::alignmentMgr()  const  {
 }
 
 /// Detector interface: Manipulate geometry using facroy converter
-long DD4hepUI::apply(const char* factory, int argc, char** argv) const   {
+long detail::DD4hepUI::apply(const char* factory, int argc, char** argv) const   {
   return m_detDesc.apply(factory, argc, argv);
 }
 
 /// Detector interface: Read any geometry description or alignment file
-void DD4hepUI::fromXML(const std::string& fname, DetectorBuildType type) const  {
+void detail::DD4hepUI::fromXML(const std::string& fname, DetectorBuildType type) const  {
   return m_detDesc.fromXML(fname, type);
 }
 
 /// Detector interface: Draw the scene on a OpenGL pane
-void DD4hepUI::draw() const   {
+void detail::DD4hepUI::draw() const   {
   drawSubtree("/world");
 }
 
 /// Detector interface: Re-draw the entire scene
-void DD4hepUI::redraw() const   {
+void detail::DD4hepUI::redraw() const   {
   redrawSubtree("/world");
 }
 
 /// Detector interface: Draw detector sub-tree the scene on a OpenGL pane
-void DD4hepUI::drawSubtree(const char* path) const    {
-  string vis = _visLevel(visLevel);
+void detail::DD4hepUI::drawSubtree(const char* path) const    {
+  std::string vis  = _visLevel(visLevel);
   const void* av[] = {"-detector", path, "-option", "ogl", "-level", vis.c_str(), 0};
   m_detDesc.apply("DD4hep_GeometryDisplay", 2, (char**)av);
 }
 
 /// Detector interface: Re-draw the entire sub-tree scene
-void DD4hepUI::redrawSubtree(const char* path) const    {
-  string vis = _visLevel(visLevel);
+void detail::DD4hepUI::redrawSubtree(const char* path) const    {
+  std::string vis  = _visLevel(visLevel);
   const void* av[] = {"-detector", path, "-option", "oglsame", "-level", vis.c_str(), 0};
   m_detDesc.apply("DD4hep_GeometryDisplay", 4, (char**)av);
 }
 
 /// Dump the volume tree
-long DD4hepUI::dumpVols(int argc, char** argv)  const   {
+long detail::DD4hepUI::dumpVols(int argc, char** argv)  const   {
   if ( argc==0 )  {
     const void* av[] = {"-positions","-pointers",0};
     return m_detDesc.apply("DD4hep_VolumeDump",2,(char**)av);
@@ -140,25 +138,25 @@ long DD4hepUI::dumpVols(int argc, char** argv)  const   {
 }
 
 /// Dump the DetElement tree with placements
-long DD4hepUI::dumpDet(const char* path)  const   {
+long detail::DD4hepUI::dumpDet(const char* path)  const   {
   const void* args[] = {"--detector", path ? path : "/world", 0};
   return m_detDesc.apply("DD4hep_DetectorVolumeDump",2,(char**)args);
 }
 
 /// Dump the DetElement tree with placements
-long DD4hepUI::dumpDetMaterials(const char* path)  const   {
+long detail::DD4hepUI::dumpDetMaterials(const char* path)  const   {
   const void* args[] = {"--detector", path ? path : "/world", "--materials", "--shapes", 0};
   return m_detDesc.apply("DD4hep_DetectorVolumeDump",4,(char**)args);
 }
 
 /// Dump the DetElement tree with placements
-long DD4hepUI::dumpStructure(const char* path)  const   {
+long detail::DD4hepUI::dumpStructure(const char* path)  const   {
   const void* args[] = {"--detector", path ? path : "/world", 0};
   return m_detDesc.apply("DD4hep_DetectorDump",2,(char**)args);
 }
 
 /// Dump the entire detector description object to a root file
-long DD4hepUI::saveROOT(const char* file_name)    const     {
+long detail::DD4hepUI::saveROOT(const char* file_name)    const     {
   if ( file_name )  {
     const void* av[] = {"-output",file_name,0};
     return m_detDesc.apply("DD4hep_Geometry2ROOT",2,(char**)av);
@@ -168,7 +166,7 @@ long DD4hepUI::saveROOT(const char* file_name)    const     {
 }
 
 /// Import the entire detector description object from a root file
-long DD4hepUI::importROOT(const char* file_name)    const    {
+long detail::DD4hepUI::importROOT(const char* file_name)    const    {
   if ( file_name )  {
     const void* av[] = {"-input",file_name,0};
     return m_detDesc.apply("DD4hep_RootLoader",2,(char**)av);
@@ -178,9 +176,9 @@ long DD4hepUI::importROOT(const char* file_name)    const    {
 }
 
 /// Create ROOT interpreter instance
-long DD4hepUI::createInterpreter(int argc, char** argv)  {
+long detail::DD4hepUI::createInterpreter(int argc, char** argv)  {
   if ( 0 == gApplication )  {
-    pair<int, char**> a(argc,argv);
+    std::pair<int, char**> a(argc,argv);
     gApplication = new TRint("DD4hepUI", &a.first, a.second);
     printout(INFO,"DD4hepUI","++ Created ROOT interpreter instance for DD4hepUI.");
     return 1;
@@ -191,7 +189,7 @@ long DD4hepUI::createInterpreter(int argc, char** argv)  {
 }
 
 /// Execute ROOT interpreter instance
-long DD4hepUI::runInterpreter()  const   {
+long detail::DD4hepUI::runInterpreter()  const   {
   if ( 0 != gApplication )  {
     if ( !gApplication->IsRunning() )  {
       gApplication->Run();

--- a/DDCore/src/DetElement.cpp
+++ b/DDCore/src/DetElement.cpp
@@ -12,21 +12,19 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DD4hep/detail/ConditionsInterna.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
-#include "DD4hep/AlignmentTools.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/World.h"
-#include "DD4hep/Detector.h"
+#include <DD4hep/detail/DetectorInterna.h>
+#include <DD4hep/detail/ConditionsInterna.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
+#include <DD4hep/AlignmentTools.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/World.h>
+#include <DD4hep/Detector.h>
 
-using namespace std;
 using namespace dd4hep;
-using dd4hep::Alignment;
     
 namespace {
-  static string s_empty_string;
+  static std::string s_empty_string;
 }
 
 /// Default constructor
@@ -38,26 +36,26 @@ DetElement::Processor::~Processor()   {
 }
 
 /// Clone constructor
-DetElement::DetElement(Object* det_data, const string& det_name, const string& det_type)
+DetElement::DetElement(Object* det_data, const std::string& det_name, const std::string& det_type)
   : Handle<DetElementObject>(det_data)
 {
   this->assign(det_data, det_name, det_type);
 }
 
 /// Constructor for a new subdetector element
-DetElement::DetElement(const string& det_name, const string& det_type, int det_id) {
+DetElement::DetElement(const std::string& det_name, const std::string& det_type, int det_id) {
   assign(new Object(det_name,det_id), det_name, det_type);
   ptr()->id = det_id;
 }
 
 /// Constructor for a new subdetector element
-DetElement::DetElement(const string& det_name, int det_id) {
+DetElement::DetElement(const std::string& det_name, int det_id) {
   assign(new Object(det_name,det_id), det_name, "");
   ptr()->id = det_id;
 }
 
 /// Constructor for a new subdetector element
-DetElement::DetElement(DetElement det_parent, const string& det_name, int det_id) {
+DetElement::DetElement(DetElement det_parent, const std::string& det_name, int det_id) {
   assign(new Object(det_name,det_id), det_name, det_parent.type());
   ptr()->id = det_id;
   det_parent.add(*this);
@@ -84,7 +82,7 @@ void DetElement::removeAtUpdate(unsigned int typ, void* pointer)  const {
 }
 
 /// Access to the full path to the placed object
-const string& DetElement::placementPath() const {
+const std::string& DetElement::placementPath() const {
   Object* o = ptr();
   if ( o ) {
     if (o->placementPath.empty()) {
@@ -96,12 +94,12 @@ const string& DetElement::placementPath() const {
 }
 
 /// Access detector type (structure, tracker, calorimeter, etc.).
-string DetElement::type() const {
+std::string DetElement::type() const {
   return m_element ? m_element->GetTitle() : "";
 }
 
 /// Set the type of the sensitive detector
-DetElement& DetElement::setType(const string& typ) {
+DetElement& DetElement::setType(const std::string& typ) {
   access()->SetTitle(typ.c_str());
   return *this;
 }
@@ -156,7 +154,7 @@ int DetElement::level()  const   {
 }
 
 /// Access the full path of the detector element
-const string& DetElement::path() const {
+const std::string& DetElement::path() const {
   Object* o = ptr();
   if ( o ) {
     if ( !o->path.empty() )
@@ -210,28 +208,28 @@ const DetElement::Children& DetElement::children() const {
 }
 
 /// Access to individual children by name
-DetElement DetElement::child(const string& child_name) const {
+DetElement DetElement::child(const std::string& child_name) const {
   if (isValid()) {
     const Children& c = ptr()->children;
     Children::const_iterator i = c.find(child_name);
     if ( i != c.end() ) return (*i).second;
-    throw runtime_error("dd4hep: DetElement::child Unknown child with name: "+child_name);
+    throw std::runtime_error("dd4hep: DetElement::child Unknown child with name: "+child_name);
   }
-  throw runtime_error("dd4hep: DetElement::child: Self is not defined [Invalid Handle]");
+  throw std::runtime_error("dd4hep: DetElement::child: Self is not defined [Invalid Handle]");
 }
 
 /// Access to individual children by name. Have option to not throw an exception
-DetElement DetElement::child(const string& child_name, bool throw_if_not_found) const {
+DetElement DetElement::child(const std::string& child_name, bool throw_if_not_found) const {
   if (isValid()) {
     const Children& c = ptr()->children;
     Children::const_iterator i = c.find(child_name);
     if ( i != c.end() ) return (*i).second;
     if ( throw_if_not_found )   {
-      throw runtime_error("dd4hep: DetElement::child Unknown child with name: "+child_name);
+      throw std::runtime_error("dd4hep: DetElement::child Unknown child with name: "+child_name);
     }
   }
   if ( throw_if_not_found )   {
-    throw runtime_error("dd4hep: DetElement::child: Self is not defined [Invalid Handle]");
+    throw std::runtime_error("dd4hep: DetElement::child: Self is not defined [Invalid Handle]");
   }
   return DetElement();
 }
@@ -249,24 +247,26 @@ DetElement DetElement::world()  const   {
 }
 
 /// Simple checking routine
-void DetElement::check(bool cond, const string& msg) const {
+void DetElement::check(bool cond, const std::string& msg) const {
   if (cond) {
-    throw runtime_error("dd4hep: " + msg);
+    throw std::runtime_error("dd4hep: " + msg);
   }
 }
 
 /// Add a new child subdetector element
 DetElement& DetElement::add(DetElement sdet) {
   if (isValid()) {
-    pair<Children::iterator, bool> r = object<Object>().children.emplace(sdet.name(), sdet);
+    auto r = object<Object>().children.emplace(sdet.name(), sdet);
     if (r.second) {
       sdet.access()->parent = *this;
       return *this;
     }
-    throw runtime_error("dd4hep: DetElement::add: Element " + string(sdet.name()) + 
-                        " is already present in path " + path() + " [Double-Insert]");
+    except("dd4hep",
+           "DetElement::add: Element %s is already present in path %s [Double-Insert]",
+           sdet.name(), this->path().c_str());
   }
-  throw runtime_error("dd4hep: DetElement::add: Self is not defined [Invalid Handle]");
+  except("dd4hep", "DetElement::add: Self is not defined [Invalid Handle]");
+  throw std::runtime_error("dd4hep: DetElement::add");
 }
 
 /// Clone (Deep copy) the DetElement structure
@@ -278,11 +278,11 @@ DetElement DetElement::clone(int flg) const   {
   return n;
 }
 
-DetElement DetElement::clone(const string& new_name) const {
+DetElement DetElement::clone(const std::string& new_name) const {
   return clone(new_name, access()->id);
 }
 
-DetElement DetElement::clone(const string& new_name, int new_id) const {
+DetElement DetElement::clone(const std::string& new_name, int new_id) const {
   Object* o = access();
   Object* n = o->clone(new_id, COPY_PLACEMENT);
   n->SetName(new_name.c_str());
@@ -290,21 +290,21 @@ DetElement DetElement::clone(const string& new_name, int new_id) const {
   return n;
 }
 
-pair<DetElement,Volume> DetElement::reflect(const string& new_name) const {
+std::pair<DetElement,Volume> DetElement::reflect(const std::string& new_name) const {
   return reflect(new_name, access()->id);
 }
 
-pair<DetElement,Volume> DetElement::reflect(const string& new_name, int new_id) const {
+std::pair<DetElement,Volume> DetElement::reflect(const std::string& new_name, int new_id) const {
   return reflect(new_name, new_id, SensitiveDetector(0));
 }
 
-pair<DetElement,Volume> DetElement::reflect(const string& new_name, int new_id, SensitiveDetector sd) const {
+std::pair<DetElement,Volume> DetElement::reflect(const std::string& new_name, int new_id, SensitiveDetector sd) const {
   if ( placement().isValid() )   {
     return m_element->reflect(new_name, new_id, sd);
   }
   except("DetElement","reflect: Only placed DetElement objects can be reflected: %s",
          path().c_str());
-  return make_pair(DetElement(),Volume());
+  return std::make_pair(DetElement(),Volume());
 }
 
 /// Access to the ideal physical volume of this detector element
@@ -335,7 +335,8 @@ DetElement& DetElement::setPlacement(const PlacedVolume& pv) {
     }
     return *this;
   }
-  throw runtime_error("dd4hep: DetElement::setPlacement: Placement is not defined [Invalid Handle]");
+  except("dd4hep", "DetElement::setPlacement: Placement is not defined [Invalid Handle]");
+  throw std::runtime_error("dd4hep: DetElement::add");
 }
 
 /// The cached VolumeID of this subdetector element
@@ -356,19 +357,19 @@ Solid DetElement::solid() const    {
   return volume()->GetShape();
 }
 
-DetElement& DetElement::setVisAttributes(const Detector& description, const string& nam, const Volume& vol) {
+DetElement& DetElement::setVisAttributes(const Detector& description, const std::string& nam, const Volume& vol) {
   vol.setVisAttributes(description, nam);
   return *this;
 }
 
-DetElement& DetElement::setRegion(const Detector& description, const string& nam, const Volume& vol) {
+DetElement& DetElement::setRegion(const Detector& description, const std::string& nam, const Volume& vol) {
   if (!nam.empty()) {
     vol.setRegion(description.region(nam));
   }
   return *this;
 }
 
-DetElement& DetElement::setLimitSet(const Detector& description, const string& nam, const Volume& vol) {
+DetElement& DetElement::setLimitSet(const Detector& description, const std::string& nam, const Volume& vol) {
   if (!nam.empty()) {
     vol.setLimitSet(description.limitSet(nam));
   }
@@ -377,15 +378,15 @@ DetElement& DetElement::setLimitSet(const Detector& description, const string& n
 
 DetElement& DetElement::setAttributes(const Detector& description,
                                       const Volume& vol,
-                                      const string& region,
-                                      const string& limits,
-                                      const string& vis)
+                                      const std::string& region,
+                                      const std::string& limits,
+                                      const std::string& vis)
 {
   return setRegion(description, region, vol).setLimitSet(description, limits, vol).setVisAttributes(description, vis, vol);
 }
 
 /// Constructor
-SensitiveDetector::SensitiveDetector(const string& nam, const string& typ) {
+SensitiveDetector::SensitiveDetector(const std::string& nam, const std::string& typ) {
   /*
     <calorimeter ecut="0" eunit="MeV" hits_collection="EcalEndcapHits" name="EcalEndcap" verbose="0">
     <global_grid_xy grid_size_x="3.5" grid_size_y="3.5"/>
@@ -398,13 +399,13 @@ SensitiveDetector::SensitiveDetector(const string& nam, const string& typ) {
 }
 
 /// Set the type of the sensitive detector
-SensitiveDetector& SensitiveDetector::setType(const string& typ) {
+SensitiveDetector& SensitiveDetector::setType(const std::string& typ) {
   access()->SetTitle(typ.c_str());
   return *this;
 }
 
 /// Access the type of the sensitive detector
-string SensitiveDetector::type() const {
+std::string SensitiveDetector::type() const {
   return m_element ? m_element->GetTitle() : s_empty_string;
 }
 
@@ -436,13 +437,13 @@ double SensitiveDetector::energyCutoff() const {
 }
 
 /// Assign the name of the hits collection
-SensitiveDetector& SensitiveDetector::setHitsCollection(const string& collection) {
+SensitiveDetector& SensitiveDetector::setHitsCollection(const std::string& collection) {
   access()->hitsCollection = collection;
   return *this;
 }
 
 /// Access the hits collection name
-const string& SensitiveDetector::hitsCollection() const {
+const std::string& SensitiveDetector::hitsCollection() const {
   return access()->hitsCollection;
 }
 

--- a/DDCore/src/DetectorData.cpp
+++ b/DDCore/src/DetectorData.cpp
@@ -26,7 +26,6 @@
 #include <TClass.h>
 #include <TROOT.h>
 
-
 namespace dd4hep {  namespace detail {    class DetectorImp;  }}
 
 using namespace dd4hep;

--- a/DDCore/src/DetectorData.cpp
+++ b/DDCore/src/DetectorData.cpp
@@ -12,24 +12,23 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Grammar.h"
-#include "DD4hep/DetectorData.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/detail/ObjectsInterna.h"
-#include "DD4hep/detail/DetectorInterna.h"
+#include <DD4hep/Grammar.h>
+#include <DD4hep/DetectorData.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/detail/ObjectsInterna.h>
+#include <DD4hep/detail/DetectorInterna.h>
 
 // ROOT include files
-#include "TGeoManager.h"
-#include "TClassStreamer.h"
-#include "TDataMember.h"
-#include "TDataType.h"
-#include "TClass.h"
-#include "TROOT.h"
+#include <TGeoManager.h>
+#include <TClassStreamer.h>
+#include <TDataMember.h>
+#include <TDataType.h>
+#include <TClass.h>
+#include <TROOT.h>
 
 
 namespace dd4hep {  namespace detail {    class DetectorImp;  }}
 
-using namespace dd4hep::detail;
 using namespace dd4hep;
 
 namespace {
@@ -212,17 +211,17 @@ void DetectorData::destroyData(bool destroy_mgr)   {
   m_extensions.clear();
   m_detectorParents.clear();
 
-  destroyHandle(m_world);
-  destroyHandle(m_field);
-  destroyHandle(m_header);
-  destroyHandles(m_readouts);
-  destroyHandles(m_idDict);
-  destroyHandles(m_limits);
-  destroyHandles(m_regions);
-  destroyHandles(m_sensitive);
-  destroyHandles(m_display);
-  destroyHandles(m_fields);
-  destroyHandles(m_define);
+  detail::destroyHandle(m_world);
+  detail::destroyHandle(m_field);
+  detail::destroyHandle(m_header);
+  detail::destroyHandles(m_readouts);
+  detail::destroyHandles(m_idDict);
+  detail::destroyHandles(m_limits);
+  detail::destroyHandles(m_regions);
+  detail::destroyHandles(m_sensitive);
+  detail::destroyHandles(m_display);
+  detail::destroyHandles(m_fields);
+  detail::destroyHandles(m_define);
 #if 0
   for(const auto& def : m_define)   {
     auto c = def;
@@ -231,7 +230,7 @@ void DetectorData::destroyData(bool destroy_mgr)   {
     delete def.second.ptr();
   }
 #endif  
-  destroyHandle(m_volManager);
+  detail::destroyHandle(m_volManager);
   m_properties.clear();
   m_trackers.clear();
   m_trackingVol.clear();
@@ -243,7 +242,7 @@ void DetectorData::destroyData(bool destroy_mgr)   {
   m_inhibitConstants = false;
   if ( destroy_mgr )  {
     gGeoManager = m_manager;
-    deletePtr(m_manager);
+    detail::deletePtr(m_manager);
     gGeoManager = 0;
   }
   else  {

--- a/DDCore/src/DetectorHelper.cpp
+++ b/DDCore/src/DetectorHelper.cpp
@@ -12,17 +12,16 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/DetectorHelper.h"
+#include <DD4hep/DetectorHelper.h>
 
 // ROOT include files
-#include "TGeoManager.h"
+#include <TGeoManager.h>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Access the sensitive detector of a given subdetector (if the sub-detector is sensitive!)
 SensitiveDetector DetectorHelper::sensitiveDetector(const std::string& detector) const    {
-  const string& det_name = detector;
+  const std::string& det_name = detector;
   SensitiveDetector sensitive = ptr()->sensitiveDetector(det_name);
   return sensitive;
 }
@@ -61,7 +60,7 @@ Atom DetectorHelper::element(const std::string& nam)  const   {
   TGeoElementTable* tab = mgr.GetElementTable();
   TGeoElement*      elt = tab->FindElement(nam.c_str());
   if ( !elt )    {
-    string n = nam;
+    std::string n = nam;
     transform(n.begin(), n.end(), n.begin(), ::toupper);
     elt = tab->FindElement(n.c_str());     // Check for IRON
     if ( !elt )    {
@@ -81,7 +80,7 @@ Material DetectorHelper::material(const std::string& nam)  const   {
   TGeoManager& mgr = access()->manager();
   TGeoMedium*  med = mgr.GetMedium(nam.c_str());
   if ( !med )    {
-    string n = nam;
+    std::string n = nam;
     transform(n.begin(), n.end(), n.begin(), ::toupper);
     med = mgr.GetMedium(n.c_str());     // Check for IRON
     if ( !med )    {

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -14,19 +14,19 @@
 #define DD4HEP_MUST_USE_DETECTORIMP_H 1
 
 // Framework include files
-#include "DD4hep/Plugins.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/GeoHandler.h"
-#include "DD4hep/DetectorHelper.h"
-#include "DD4hep/DetectorTools.h"
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/GeoHandler.h>
+#include <DD4hep/DetectorHelper.h>
+#include <DD4hep/DetectorTools.h>
 
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/detail/ObjectsInterna.h"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DD4hep/detail/VolumeManagerInterna.h"
-#include "DD4hep/detail/OpticalSurfaceManagerInterna.h"
-#include "DD4hep/DetectorImp.h"
-#include "DD4hep/DD4hepUnits.h"
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/detail/ObjectsInterna.h>
+#include <DD4hep/detail/DetectorInterna.h>
+#include <DD4hep/detail/VolumeManagerInterna.h>
+#include <DD4hep/detail/OpticalSurfaceManagerInterna.h>
+#include <DD4hep/DetectorImp.h>
+#include <DD4hep/DD4hepUnits.h>
 
 // C/C++ include files
 #include <iostream>
@@ -35,21 +35,19 @@
 #include <mutex>
 
 // ROOT inlcude files
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,12,0)
-#include "TGeoSystemOfUnits.h"
-#endif
-#include "TGeoCompositeShape.h"
-#include "TGeoBoolNode.h"
-#include "TGeoManager.h"
-#include "TGeoMatrix.h"
-#include "TGeoVolume.h"
-#include "TGeoShape.h"
-#include "TClass.h"
+#include <TGeoSystemOfUnits.h>
+#include <TGeoCompositeShape.h>
+#include <TGeoBoolNode.h>
+#include <TGeoManager.h>
+#include <TGeoMatrix.h>
+#include <TGeoVolume.h>
+#include <TGeoShape.h>
+#include <TClass.h>
 
-#include "XML/DocumentHandler.h"
+#include <XML/DocumentHandler.h>
 
 #ifndef __TIXML__
-#include "xercesc/dom/DOMException.hpp"
+#include <xercesc/dom/DOMException.hpp>
 namespace dd4hep {
   namespace xml {
     typedef xercesc::DOMException XmlException;
@@ -58,12 +56,12 @@ namespace dd4hep {
 #endif
 
 using namespace dd4hep;
-using namespace std;
 
 ClassImp(DetectorImp)
 
 namespace {
-  recursive_mutex  s_detector_apply_lock;
+
+  std::recursive_mutex  s_detector_apply_lock;
 
   struct TypePreserve {
     DetectorBuildType& m_t;
@@ -76,16 +74,16 @@ namespace {
   };
 
   struct Instances  {
-    recursive_mutex  lock;
-    map<string, Detector*> detectors;
+    std::recursive_mutex  lock;
+    std::map<std::string, Detector*> detectors;
     Instances() = default;
     ~Instances()  {
     }
-    Detector* get(const string& name)   {
+    Detector* get(const std::string& name)   {
       auto i = detectors.find(name);
       return i == detectors.end() ? 0 : (*i).second;
     }
-    void insert(const string& name, Detector* detector)   {
+    void insert(const std::string& name, Detector* detector)   {
       auto i = detectors.find(name);
       if ( i == detectors.end() )   {
         detectors.emplace(name,detector);
@@ -93,7 +91,7 @@ namespace {
       }
       except("DD4hep","Cannot insert detector instance %s [Already present]",name.c_str());
     }
-    Detector* remove(const string& name)   {
+    Detector* remove(const std::string& name)   {
       auto i = detectors.find(name);
       if ( i != detectors.end() )  {
         Detector* det = (*i).second;
@@ -106,8 +104,8 @@ namespace {
   
   class DetectorGuard  final  {
   protected:
-    static pair<recursive_mutex, map<DetectorImp*, TGeoManager*> >& detector_lock()   {
-      static pair<recursive_mutex, map<DetectorImp*, TGeoManager*> > s_inst;
+    static std::pair<std::recursive_mutex, std::map<DetectorImp*, TGeoManager*> >& detector_lock()   {
+      static std::pair<std::recursive_mutex, std::map<DetectorImp*, TGeoManager*> > s_inst;
       return s_inst;
     }
     DetectorImp* detector {nullptr};
@@ -124,8 +122,8 @@ namespace {
       auto& lock = detector_lock();
       auto i = lock.second.find(detector);
       if ( i != lock.second.end() )   {
-	mgr = (*i).second;
-	lock.second.erase(i);
+        mgr = (*i).second;
+        lock.second.erase(i);
       }
       lock.first.unlock();
       return mgr;
@@ -138,19 +136,19 @@ namespace {
   }
 }
 
-string dd4hep::versionString(){
-  string vs("vXX-YY") ;
-  sprintf( &vs[0] , "v%2.2d-%2.2d", DD4HEP_MAJOR_VERSION, DD4HEP_MINOR_VERSION  ) ;
+std::string dd4hep::versionString(){
+  std::string vs("vXX-YY") ;
+  std::sprintf( &vs[0] , "v%2.2d-%2.2d", DD4HEP_MAJOR_VERSION, DD4HEP_MINOR_VERSION  ) ;
   return vs;
 }
 
-unique_ptr<Detector> Detector::make_unique(const std::string& name)   {
+std::unique_ptr<Detector> Detector::make_unique(const std::string& name)   {
   Detector* description = new DetectorImp(name);
-  return unique_ptr<Detector>(description);
+  return std::unique_ptr<Detector>(description);
 }
 
 Detector& Detector::getInstance(const std::string& name)   {
-  lock_guard<recursive_mutex> lock(detector_instances().lock);
+  std::lock_guard<std::recursive_mutex> lock(detector_instances().lock);
   Detector* description = detector_instances().get(name);
   if ( 0 == description )   {
     gGeoManager = 0;
@@ -162,7 +160,7 @@ Detector& Detector::getInstance(const std::string& name)   {
 
 /// Destroy the instance
 void Detector::destroyInstance(const std::string& name) {
-  lock_guard<recursive_mutex> lock(detector_instances().lock);
+  std::lock_guard<std::recursive_mutex> lock(detector_instances().lock);
   Detector* description = detector_instances().remove(name);
   if (description)
     delete description;
@@ -179,34 +177,21 @@ DetectorImp::DetectorImp()
 }
 
 /// Initializing constructor
-DetectorImp::DetectorImp(const string& name)
+DetectorImp::DetectorImp(const std::string& name)
   : TNamed(), DetectorData(), DetectorLoad(this), m_buildType(BUILD_NONE)
 {
-#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,22,7)
-    printout(INFO,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
-    if ( TGeoManager::GetDefaultUnits() != TGeoManager::kG4Units )  {
-      TGeoManager::LockDefaultUnits(kFALSE);
-      TGeoManager::SetDefaultUnits(TGeoManager::kG4Units);
-      TGeoManager::LockDefaultUnits(kTRUE);
-    }
-#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,22,7)
-    if ( TGeoManager::GetDefaultUnits() != TGeoManager::kRootUnits )  {
-      TGeoManager::LockDefaultUnits(kFALSE);
-      TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
-      TGeoManager::LockDefaultUnits(kTRUE);
-    }
+#if defined(DD4HEP_USE_GEANT4_UNITS)
+  printout(INFO,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
+  if ( TGeoManager::GetDefaultUnits() != TGeoManager::kG4Units )  {
+    TGeoManager::LockDefaultUnits(kFALSE);
+    TGeoManager::SetDefaultUnits(TGeoManager::kG4Units);
+    TGeoManager::LockDefaultUnits(kTRUE);
+  }
 #else
-  static bool first = true;
-  if ( first )    {
-    first = false;
-#if defined(DD4HEP_USE_GEANT4_UNITS) && ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
-    printout(INFO,"DD4hep","++ Using globally Geant4 unit system (mm,ns,MeV)");
-    TGeoManager::SetDefaultG4Units();
-    TGeoUnit::setUnitType(TGeoUnit::kTGeant4Units);
-#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
-    TGeoManager::SetDefaultRootUnits();
-    TGeoUnit::setUnitType(TGeoUnit::kTGeoUnits);
-#endif
+  if ( TGeoManager::GetDefaultUnits() != TGeoManager::kRootUnits )  {
+    TGeoManager::LockDefaultUnits(kFALSE);
+    TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+    TGeoManager::LockDefaultUnits(kTRUE);
   }
 #endif
 
@@ -251,7 +236,7 @@ DetectorImp::DetectorImp(const string& name)
 DetectorImp::~DetectorImp() {
   DetectorGuard(this).lock(gGeoManager);
   if ( m_manager )  {
-    lock_guard<recursive_mutex> lock(detector_instances().lock);
+    std::lock_guard<std::recursive_mutex> lock(detector_instances().lock);
     if ( m_manager == gGeoManager ) gGeoManager = 0;
     Detector* description = detector_instances().get(GetName());
     if ( 0 != description )   {
@@ -280,10 +265,10 @@ Int_t DetectorImp::saveObject(const char *name, Int_t option, Int_t bufsize) con
     DetectorData::unpatchRootStreamer(TGeoNode::Class());
     return nbytes;
   }
-  catch (const exception& e) {
+  catch (const std::exception& e) {
     DetectorData::unpatchRootStreamer(TGeoVolume::Class());
     DetectorData::unpatchRootStreamer(TGeoNode::Class());
-    except("Detector","Exception %s while saving dd4hep::Detector object",e.what());
+    except("Detector","Exception %s while saving dd4hep::Detector object", e.what());
   }
   catch (...) {
     DetectorData::unpatchRootStreamer(TGeoVolume::Class());
@@ -315,7 +300,7 @@ void* DetectorImp::userExtension(unsigned long long int key, bool alert) const {
 }
 
 /// Register new mother volume using the detector name.
-void DetectorImp::declareParent(const string& detector_name, const DetElement& parent)  {
+void DetectorImp::declareParent(const std::string& detector_name, const DetElement& parent)  {
   if ( !detector_name.empty() )  {
     if ( parent.isValid() )  {
       auto i = m_detectorParents.find(detector_name);
@@ -343,7 +328,7 @@ void DetectorImp::declareParent(const string& detector_name, const DetElement& p
 /// Access mother volume by detector element
 Volume DetectorImp::pickMotherVolume(const DetElement& de) const {
   if ( de.isValid() )   {
-    string de_name = de.name();
+    std::string de_name = de.name();
     auto i = m_detectorParents.find(de_name);
     if (i == m_detectorParents.end())   {
       if ( m_worldVol.isValid() )  {
@@ -422,14 +407,14 @@ DetElement DetectorImp::detector(const std::string& name) const  {
 }
 
 Detector& DetectorImp::addDetector(const Handle<NamedObject>& ref_det) {
-  DetElement det_element(ref_det);
+  DetElement     det_element(ref_det);
   DetectorHelper helper(this);
-  DetElement existing_det = helper.detectorByID(det_element.id());
+  DetElement     existing_det = helper.detectorByID(det_element.id());
 
   if ( existing_det.isValid() )   {
     SensitiveDetector sd = helper.sensitiveDetector(existing_det);
     if ( sd.isValid() )   {
-      stringstream str;
+      std::stringstream str;
       str << "Detector: The sensitive sub-detectors " << det_element.name() << " and "
           << existing_det.name() << " have the identical ID:" << det_element.id() << ".";
       except("DD4hep",str.str());
@@ -439,9 +424,9 @@ Detector& DetectorImp::addDetector(const Handle<NamedObject>& ref_det) {
   det_element->flag |= DetElement::Object::IS_TOP_LEVEL_DETECTOR;
   PlacedVolume pv = det_element.placement();
   if ( !pv.isValid() )   {
-    stringstream str;
+    std::stringstream str;
     str << "Detector: Adding subdetectors with no valid placement is not allowed: "
-	<< det_element.name() << " ID:" << det_element.id() << ".";
+        << det_element.name() << " ID:" << det_element.id() << ".";
     except("DD4hep",str.str());
   }
   Volume volume = pv->GetMotherVolume();
@@ -464,7 +449,7 @@ Detector& DetectorImp::addDetector(const Handle<NamedObject>& ref_det) {
   // The detector's placement must be one of the existing detectors
   for(HandleMap::iterator idet = m_detectors.begin(); idet != m_detectors.end(); ++idet)  {
     DetElement parent((*idet).second);
-    Volume vol = parent.placement().volume();
+    Volume     vol = parent.placement().volume();
     if ( vol == volume )  {
       printout(INFO,"DD4hep","+++ Detector: Added detector %s to the parent:%s.",
                det_element.name(),parent.name());
@@ -473,7 +458,7 @@ Detector& DetectorImp::addDetector(const Handle<NamedObject>& ref_det) {
     }
   }
   except("DD4hep","+++ Detector: The detector %s has no known parent.", det_element.name());
-  throw runtime_error("Detector-Error"); // Never called....
+  throw std::runtime_error("Detector-Error"); // Never called....
 }
 
 /// Add a new constant by named reference to the detector description
@@ -488,38 +473,38 @@ Detector& DetectorImp::addConstant(const Handle<NamedObject>& x) {
 }
 
 /// Retrieve a constant by its name from the detector description
-Constant DetectorImp::constant(const string& name) const {
+Constant DetectorImp::constant(const std::string& name) const {
   if ( !m_inhibitConstants )   {
     return getRefChild(m_define, name);
   }
-  throw runtime_error("Detector:constant("+name+"): Access to global constants is inhibited.");
+  throw std::runtime_error("Detector:constant("+name+"): Access to global constants is inhibited.");
 }
 
 /// Typed access to constants: access string values
-string DetectorImp::constantAsString(const string& name) const {
+std::string DetectorImp::constantAsString(const std::string& name) const {
   if ( !m_inhibitConstants )   {
     Handle<NamedObject> c = constant(name);
     if (c.isValid())
       return c->GetTitle();
-    throw runtime_error("Detector:constantAsString: The constant " + name + " is not known to the system.");
+    throw std::runtime_error("Detector:constantAsString: The constant " + name + " is not known to the system.");
   }
-  throw runtime_error("Detector:constantAsString("+name+"):: Access to global constants is inhibited.");
+  throw std::runtime_error("Detector:constantAsString("+name+"):: Access to global constants is inhibited.");
 }
 
 /// Typed access to constants: long values
-long DetectorImp::constantAsLong(const string& name) const {
+long DetectorImp::constantAsLong(const std::string& name) const {
   if ( !m_inhibitConstants )   {
     return _toLong(constantAsString(name));
   }
-  throw runtime_error("Detector:constantAsLong("+name+"): Access to global constants is inhibited.");
+  throw std::runtime_error("Detector:constantAsLong("+name+"): Access to global constants is inhibited.");
 }
 
 /// Typed access to constants: double values
-double DetectorImp::constantAsDouble(const string& name) const {
+double DetectorImp::constantAsDouble(const std::string& name) const {
   if ( !m_inhibitConstants )   {
     return _toDouble(constantAsString(name));
   }
-  throw runtime_error("Detector:constantAsDouble("+name+"): Access to global constants is inhibited.");
+  throw std::runtime_error("Detector:constantAsDouble("+name+"): Access to global constants is inhibited.");
 }
 
 /// Add a field component by named reference to the detector description
@@ -530,12 +515,12 @@ Detector& DetectorImp::addField(const Handle<NamedObject>& x) {
 }
 
 /// Retrieve a matrial by its name from the detector description
-Material DetectorImp::material(const string& name) const {
+Material DetectorImp::material(const std::string& name) const {
   TGeoMedium* mat = m_manager->GetMedium(name.c_str());
   if (mat) {
     return Material(mat);
   }
-  throw runtime_error("Cannot find a material referenced by name:" + name);
+  throw std::runtime_error("Cannot find a material referenced by name:" + name);
 }
 
 /// Internal helper to map detector types once the geometry is closed
@@ -560,36 +545,36 @@ void DetectorImp::mapDetectorTypes()  {
 }
 
 /// Access the availible detector types
-vector<string> DetectorImp::detectorTypes() const  {
+std::vector<std::string> DetectorImp::detectorTypes() const  {
   if ( m_manager->IsClosed() ) {
-    vector<string> v;
+    std::vector<std::string> v;
     v.reserve(m_detectorTypes.size());
     for(const auto& t : m_detectorTypes )
       v.emplace_back(t.first);
     return v;
   }
-  throw runtime_error("detectorTypes: Call only available once the geometry is closed!");
+  throw std::runtime_error("detectorTypes: Call only available once the geometry is closed!");
 }
 
 /// Access a set of subdetectors according to the sensitive type.
-const vector<DetElement>& DetectorImp::detectors(const string& type, bool throw_exc) const {
+const std::vector<DetElement>& DetectorImp::detectors(const std::string& type, bool throw_exc) const {
   if ( m_manager->IsClosed() ) {
     DetectorTypeMap::const_iterator i=m_detectorTypes.find(type);
     if ( i != m_detectorTypes.end() ) return (*i).second;
     if ( throw_exc )  {
-      throw runtime_error("detectors("+type+"): Detectors of this type do not exist in the current setup!");
+      throw std::runtime_error("detectors("+type+"): Detectors of this type do not exist in the current setup!");
     }
     // return empty vector instead of exception
     return m_detectorTypes.at("") ;
   }
-  throw runtime_error("detectors("+type+"): Detectors can only selected by type once the geometry is closed!");
+  throw std::runtime_error("detectors("+type+"): Detectors can only selected by type once the geometry is closed!");
 }
 
-vector<DetElement> DetectorImp::detectors(unsigned int includeFlag, unsigned int excludeFlag ) const  {
+std::vector<DetElement> DetectorImp::detectors(unsigned int includeFlag, unsigned int excludeFlag ) const  {
   if( ! m_manager->IsClosed() ) {
-    throw runtime_error("detectors(typeFlag): Detectors can only selected by typeFlag once the geometry is closed!");
+    throw std::runtime_error("detectors(typeFlag): Detectors can only selected by typeFlag once the geometry is closed!");
   }
-  vector<DetElement> dets ;
+  std::vector<DetElement> dets ;
   dets.reserve( m_detectors.size() ) ;
   
   for(HandleMap::const_iterator i=m_detectors.begin(); i!=m_detectors.end(); ++i)   {
@@ -608,13 +593,13 @@ vector<DetElement> DetectorImp::detectors(unsigned int includeFlag, unsigned int
 }
 
 /// Access a set of subdetectors according to several sensitive types.
-vector<DetElement> DetectorImp::detectors(const string& type1,
-                                          const string& type2,
-                                          const string& type3,
-                                          const string& type4,
-                                          const string& type5 )  {
+std::vector<DetElement> DetectorImp::detectors(const std::string& type1,
+                                               const std::string& type2,
+                                               const std::string& type3,
+                                               const std::string& type4,
+                                               const std::string& type5 )  {
   if ( m_manager->IsClosed() ) {
-    vector<DetElement> v;
+    std::vector<DetElement> v;
     DetectorTypeMap::const_iterator i, end=m_detectorTypes.end();
     if ( !type1.empty() && (i=m_detectorTypes.find(type1)) != end )
       v.insert(v.end(),(*i).second.begin(),(*i).second.end());
@@ -628,10 +613,10 @@ vector<DetElement> DetectorImp::detectors(const string& type1,
       v.insert(v.end(),(*i).second.begin(),(*i).second.end());
     return v;
   }
-  throw runtime_error("detectors("+type1+","+type2+",...): Detectors can only selected by type once the geometry is closed!");
+  throw std::runtime_error("detectors("+type1+","+type2+",...): Detectors can only selected by type once the geometry is closed!");
 }
 
-Handle<NamedObject> DetectorImp::getRefChild(const HandleMap& e, const string& name, bool do_throw) const {
+Handle<NamedObject> DetectorImp::getRefChild(const HandleMap& e, const std::string& name, bool do_throw) const {
   HandleMap::const_iterator it = e.find(name);
   if (it != e.end()) {
     return it->second;
@@ -658,7 +643,7 @@ Handle<NamedObject> DetectorImp::getRefChild(const HandleMap& e, const string& n
       err << it->first;
     }
     err << "}";
-    throw runtime_error(err.str());
+    throw std::runtime_error(err.str());
   }
   return 0;
 }
@@ -673,7 +658,7 @@ namespace {
     void patchShapes() {
       auto&  data = *m_data;
       char   text[32];
-      string nam;
+      std::string nam;
       printout(INFO,"Detector","+++ Patching names of anonymous shapes....");
       for (auto i = data.rbegin(); i != data.rend(); ++i) {
         for( const TGeoNode* n : (*i).second )  {
@@ -693,7 +678,7 @@ namespace {
           }
           else {
             nam = sn;
-            if (nam.find("_shape") == string::npos)
+            if (nam.find("_shape") == std::string::npos)
               nam += text;
             s->SetName(nam.c_str());
           }
@@ -726,7 +711,7 @@ namespace {
 /// Finalize/close the geometry
 void DetectorImp::endDocument(bool close_geometry)    {
   TGeoManager* mgr = m_manager;
-  lock_guard<recursive_mutex> lock(s_detector_apply_lock);
+  std::lock_guard<std::recursive_mutex> lock(s_detector_apply_lock);
   if ( close_geometry && !mgr->IsClosed() )  {
 #if 0
     Region trackingRegion("TrackingRegion");
@@ -758,7 +743,7 @@ void DetectorImp::endDocument(bool close_geometry)    {
 void DetectorImp::init() {
   if (!m_world.isValid()) {
     TGeoManager* mgr = m_manager;
-    lock_guard<recursive_mutex> lock(s_detector_apply_lock);
+    std::lock_guard<std::recursive_mutex> lock(s_detector_apply_lock);
     Constant     air_const = getRefChild(m_define, "Air", false);
     Constant     vac_const = getRefChild(m_define, "Vacuum", false);
     Box          worldSolid;
@@ -817,16 +802,16 @@ void DetectorImp::init() {
 }
 
 /// Read any geometry description or alignment file
-void DetectorImp::fromXML(const string& xmlfile, DetectorBuildType build_type) {
+void DetectorImp::fromXML(const std::string& xmlfile, DetectorBuildType build_type) {
   TypePreserve build_type_preserve(m_buildType = build_type);
-  lock_guard<recursive_mutex> lock(s_detector_apply_lock);
+  std::lock_guard<std::recursive_mutex> lock(s_detector_apply_lock);
   processXML(xmlfile,0);
 }
 
 /// Read any geometry description or alignment file with external XML entity resolution
-void DetectorImp::fromXML(const string& fname, xml::UriReader* entity_resolver, DetectorBuildType build_type)  {
+void DetectorImp::fromXML(const std::string& fname, xml::UriReader* entity_resolver, DetectorBuildType build_type)  {
   TypePreserve build_type_preserve(m_buildType = build_type);
-  lock_guard<recursive_mutex> lock(s_detector_apply_lock);
+  std::lock_guard<std::recursive_mutex> lock(s_detector_apply_lock);
   processXML(fname,entity_resolver);
 }
 
@@ -839,8 +824,8 @@ void DetectorImp::dump() const {
 
 /// Manipulate geometry using facroy converter
 long DetectorImp::apply(const char* factory_type, int argc, char** argv)   const   {
-  lock_guard<recursive_mutex> lock(s_detector_apply_lock);
-  string fac = factory_type;
+  std::lock_guard<std::recursive_mutex> lock(s_detector_apply_lock);
+  std::string fac = factory_type;
   try {
     Detector* thisPtr = const_cast<DetectorImp*>(this);
     long result = PluginService::Create<long>(fac, thisPtr, argc, argv);
@@ -848,24 +833,24 @@ long DetectorImp::apply(const char* factory_type, int argc, char** argv)   const
       PluginDebug dbg;
       result = PluginService::Create<long>(fac, thisPtr, argc, argv);
       if ( 0 == result )  {
-        throw runtime_error("dd4hep: apply-plugin: Failed to locate plugin " +
-                            fac + ". " + dbg.missingFactory(fac));
+        throw std::runtime_error("dd4hep: apply-plugin: Failed to locate plugin " +
+                                 fac + ". " + dbg.missingFactory(fac));
       }
     }
     result = *(long*) result;
     if (result != 1) {
-      throw runtime_error("dd4hep: apply-plugin: Failed to execute plugin " + fac);
+      throw std::runtime_error("dd4hep: apply-plugin: Failed to execute plugin " + fac);
     }
     return result;
   }
   catch (const xml::XmlException& e) {
-    throw runtime_error(xml::_toString(e.msg) + "\ndd4hep: XML-DOM Exception with plugin:" + fac);
+    throw std::runtime_error(xml::_toString(e.msg) + "\ndd4hep: XML-DOM Exception with plugin:" + fac);
   }
-  catch (const exception& e) {
-    throw runtime_error(string(e.what()) + "\ndd4hep: with plugin:" + fac);
+  catch (const std::exception& e) {
+    throw std::runtime_error(std::string(e.what()) + "\ndd4hep: with plugin:" + fac);
   }
   catch (...) {
-    throw runtime_error("UNKNOWN exception from plugin:" + fac);
+    throw std::runtime_error("UNKNOWN exception from plugin:" + fac);
   }
   return EINVAL;
 }

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -730,6 +730,13 @@ void DetectorImp::endDocument(bool close_geometry)    {
     // Since we allow now for anonymous shapes,
     // we will rename them to use the name of the volume they are assigned to
     mgr->CloseGeometry();
+    PlacedVolume pv = mgr->GetTopNode();
+    auto* extension = pv->GetUserExtension();
+    if ( nullptr == extension )   {
+      extension = new PlacedVolume::Object();
+      pv->SetUserExtension(extension);
+    }
+    m_world.setPlacement(pv);
   }
   // Patching shape names of anaonymous shapes
   ShapePatcher patcher(m_volManager, m_world);

--- a/DDCore/src/DetectorInterna.cpp
+++ b/DDCore/src/DetectorInterna.cpp
@@ -12,22 +12,22 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DD4hep/detail/ConditionsInterna.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/Printout.h"
-#include "TGeoVolume.h"
-#include "TGeoMatrix.h"
-#include "TGeoManager.h"
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/detail/DetectorInterna.h>
+#include <DD4hep/detail/ConditionsInterna.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/Printout.h>
 
-using namespace std;
+#include <TGeoVolume.h>
+#include <TGeoMatrix.h>
+#include <TGeoManager.h>
+
 using namespace dd4hep;
-using namespace dd4hep::detail;
-typedef detail::tools::PlacementPath PlacementPath;
-typedef detail::tools::ElementPath   ElementPath;
+
+using PlacementPath = detail::tools::PlacementPath;
+using ElementPath   =  detail::tools::ElementPath;
 
 DD4HEP_INSTANTIATE_HANDLE_NAMED(DetElementObject);
 DD4HEP_INSTANTIATE_HANDLE_NAMED(SensitiveDetectorObject);
@@ -84,9 +84,9 @@ DetElementObject::DetElementObject(const std::string& nam, int ident)
 
 /// Internal object destructor: release extension object(s)
 DetElementObject::~DetElementObject() {
-  destroyHandles(children);
-  destroyHandle (nominal);
-  destroyHandle (survey);
+  detail::destroyHandles(children);
+  detail::destroyHandle (nominal);
+  detail::destroyHandle (survey);
   placement.clear();
   idealPlace.clear();
   parent.clear();
@@ -135,7 +135,7 @@ DetElementObject* DetElementObject::clone(int new_id, int flg) const {
 }
 
 /// Reflect all volumes in a DetElement sub-tree and re-attach the placements
-pair<DetElement,Volume> DetElementObject::reflect(const std::string& new_name, int new_id, SensitiveDetector sd)   {
+std::pair<DetElement,Volume> DetElementObject::reflect(const std::string& new_name, int new_id, SensitiveDetector sd)   {
   struct ChildMapper  {
     std::map<TGeoNode*,TGeoNode*> nodes;
     void match(DetElement de_det, DetElement de_ref)  const  {
@@ -154,7 +154,7 @@ pair<DetElement,Volume> DetElementObject::reflect(const std::string& new_name, i
       if ( nodes.find(n1) == nodes.end() )   {
         TGeoVolume* v1 = n1->GetVolume();
         TGeoVolume* v2 = n2->GetVolume();
-        nodes.insert(make_pair(n1,n2));
+        nodes.insert(std::make_pair(n1,n2));
         printout(DEBUG,"DetElement","reflect: Map  %p  --- %p ",n1,n2);
         for(Int_t i=0; i<v1->GetNdaughters(); ++i)
           map(v1->GetNode(i), v2->GetNode(i));
@@ -173,7 +173,7 @@ pair<DetElement,Volume> DetElementObject::reflect(const std::string& new_name, i
     mapper.map(vol_det->GetNode(i), vol_ref->GetNode(i));
   for(auto i=childrens_det.begin(), j=childrens_ref.begin(); i!=childrens_det.end(); ++i, ++j)
     mapper.match((*i).second, (*j).second);
-  return make_pair(det_ref,vol_ref);
+  return std::make_pair(det_ref,vol_ref);
 }
 
 /// Access to the world object. Only possible once the geometry is closed.
@@ -195,7 +195,7 @@ void DetElementObject::revalidate()  {
   DetElement    det(this);
   DetElement    par(det.parent());
   DetElement    wrld  = world();
-  string        place = det.placementPath();
+  std::string   place = det.placementPath();
 
   detail::tools::placementPath(par, this, par_path);
   PlacedVolume node = detail::tools::findNode(wrld.placement(),place);
@@ -251,7 +251,7 @@ void DetElementObject::update(unsigned int tags, void* param)   {
 }
 
 /// Initializing constructor
-WorldObject::WorldObject(Detector& _description, const string& nam) 
+WorldObject::WorldObject(Detector& _description, const std::string& nam) 
   : DetElementObject(nam,0), description(&_description)
 {
 }

--- a/DDCore/src/DetectorLoad.cpp
+++ b/DDCore/src/DetectorLoad.cpp
@@ -12,18 +12,18 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/DetectorLoad.h"
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Plugins.h"
-#include "XML/XMLElements.h"
-#include "XML/DocumentHandler.h"
+#include <DD4hep/DetectorLoad.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Plugins.h>
+#include <XML/XMLElements.h>
+#include <XML/DocumentHandler.h>
 
 // C/C++ include files
 #include <stdexcept>
 
 #ifndef __TIXML__
-#include "xercesc/dom/DOMException.hpp"
+#include <xercesc/dom/DOMException.hpp>
 namespace dd4hep {
   namespace xml {
     typedef xercesc::DOMException XmlException;
@@ -32,7 +32,6 @@ namespace dd4hep {
 #endif
 
 using namespace dd4hep;
-using namespace std;
 
 /// Default constructor (protected, for sub-classes)
 DetectorLoad::DetectorLoad(Detector* description) : m_detDesc(description)  {
@@ -47,7 +46,7 @@ DetectorLoad::~DetectorLoad() {
 }
 
 /// Process XML unit and adopt all data from source structure.
-void DetectorLoad::processXML(const string& xmlfile, xml::UriReader* entity_resolver) {
+void DetectorLoad::processXML(const std::string& xmlfile, xml::UriReader* entity_resolver) {
   try {
     xml::DocumentHolder doc(xml::DocumentHandler().load(xmlfile,entity_resolver));
     if ( doc )   {
@@ -57,21 +56,21 @@ void DetectorLoad::processXML(const string& xmlfile, xml::UriReader* entity_reso
         return;
       }
     }
-    throw runtime_error("dd4hep: Failed to parse the XML file " + xmlfile + " [Invalid XML ROOT handle]");
+    throw std::runtime_error("dd4hep: Failed to parse the XML file " + xmlfile + " [Invalid XML ROOT handle]");
   }
   catch (const xml::XmlException& e) {
-    throw runtime_error(xml::_toString(e.msg) + "\ndd4hep: XML-DOM Exception while parsing " + xmlfile);
+    throw std::runtime_error(xml::_toString(e.msg) + "\ndd4hep: XML-DOM Exception while parsing " + xmlfile);
   }
-  catch (const exception& e) {
-    throw runtime_error(string(e.what()) + "\ndd4hep: while parsing " + xmlfile);
+  catch (const std::exception& e) {
+    throw std::runtime_error(std::string(e.what()) + "\ndd4hep: while parsing " + xmlfile);
   }
   catch (...) {
-    throw runtime_error("dd4hep: UNKNOWN exception while parsing " + xmlfile);
+    throw std::runtime_error("dd4hep: UNKNOWN exception while parsing " + xmlfile);
   }
 }
 
 /// Process XML unit and adopt all data from source structure.
-void DetectorLoad::processXML(const xml::Handle_t& base, const string& xmlfile, xml::UriReader* entity_resolver) {
+void DetectorLoad::processXML(const xml::Handle_t& base, const std::string& xmlfile, xml::UriReader* entity_resolver) {
   try {
     xml::Strng_t xml(xmlfile);
     xml::DocumentHolder doc(xml::DocumentHandler().load(base,xml,entity_resolver));
@@ -82,16 +81,16 @@ void DetectorLoad::processXML(const xml::Handle_t& base, const string& xmlfile, 
         return;
       }
     }
-    throw runtime_error("dd4hep: Failed to parse the XML file " + xmlfile + " [Invalid XML ROOT handle]");
+    throw std::runtime_error("dd4hep: Failed to parse the XML file " + xmlfile + " [Invalid XML ROOT handle]");
   }
   catch (const xml::XmlException& e) {
-    throw runtime_error(xml::_toString(e.msg) + "\ndd4hep: XML-DOM Exception while parsing " + xmlfile);
+    throw std::runtime_error(xml::_toString(e.msg) + "\ndd4hep: XML-DOM Exception while parsing " + xmlfile);
   }
-  catch (const exception& e) {
-    throw runtime_error(string(e.what()) + "\ndd4hep: while parsing " + xmlfile);
+  catch (const std::exception& e) {
+    throw std::runtime_error(std::string(e.what()) + "\ndd4hep: while parsing " + xmlfile);
   }
   catch (...) {
-    throw runtime_error("dd4hep: UNKNOWN exception while parsing " + xmlfile);
+    throw std::runtime_error("dd4hep: UNKNOWN exception while parsing " + xmlfile);
   }
 }
 
@@ -113,65 +112,65 @@ void DetectorLoad::processXMLString(const char* xmldata, xml::UriReader* entity_
         }
       }
     }
-    throw runtime_error("DetectorLoad::processXMLString: Invalid XML In-memory source [NULL]");
+    throw std::runtime_error("DetectorLoad::processXMLString: Invalid XML In-memory source [NULL]");
   }
   catch (const xml::XmlException& e) {
-    throw runtime_error(xml::_toString(e.msg) + "\ndd4hep: XML-DOM Exception while parsing XML in-memory string.");
+    throw std::runtime_error(xml::_toString(e.msg) + "\ndd4hep: XML-DOM Exception while parsing XML in-memory string.");
   }
-  catch (const exception& e) {
-    throw runtime_error(string(e.what()) + "\ndd4hep: while parsing XML in-memory string.");
+  catch (const std::exception& e) {
+    throw std::runtime_error(std::string(e.what()) + "\ndd4hep: while parsing XML in-memory string.");
   }
   catch (...) {
-    throw runtime_error("dd4hep: UNKNOWN exception while parsing XML in-memory string.");
+    throw std::runtime_error("dd4hep: UNKNOWN exception while parsing XML in-memory string.");
   }
 }
 
 /// Process a given DOM (sub-) tree
 void DetectorLoad::processXMLElement(const std::string& xmlfile, const xml::Handle_t& xml_root) {
   if ( xml_root.ptr() )   {
-    string tag = xml_root.tag();
-    string type = tag + "_XML_reader";
+    std::string tag = xml_root.tag();
+    std::string type = tag + "_XML_reader";
     xml::Handle_t handle = xml_root;
     long result = PluginService::Create<long>(type, m_detDesc, &handle);
     if (0 == result) {
       PluginDebug dbg;
       result = PluginService::Create<long>(type, m_detDesc, &handle);
       if ( 0 == result )  {
-        throw runtime_error("dd4hep: Failed to locate plugin to interprete files of type"
-                            " \"" + tag + "\" - no factory:" + type + ". " + dbg.missingFactory(type));
+        throw std::runtime_error("dd4hep: Failed to locate plugin to interprete files of type"
+                                 " \"" + tag + "\" - no factory:" + type + ". " + dbg.missingFactory(type));
       }
     }
     result = *(long*) result;
     if (result != 1) {
-      throw runtime_error("dd4hep: Failed to parse the XML file " + xmlfile + " with the plugin " + type);
+      throw std::runtime_error("dd4hep: Failed to parse the XML file " + xmlfile + " with the plugin " + type);
     }
     return;
   }
-  throw runtime_error("dd4hep: Failed to parse the XML file " + xmlfile + " [Invalid XML ROOT handle]");
+  throw std::runtime_error("dd4hep: Failed to parse the XML file " + xmlfile + " [Invalid XML ROOT handle]");
 }
 
 /// Process a given DOM (sub-) tree
 void DetectorLoad::processXMLElement(const xml::Handle_t& xml_root, DetectorBuildType /* type */) {
   if ( xml_root.ptr() )   {
-    string tag = xml_root.tag();
-    string type = tag + "_XML_reader";
+    std::string tag = xml_root.tag();
+    std::string type = tag + "_XML_reader";
     xml::Handle_t handle = xml_root;
     long result = PluginService::Create<long>(type, m_detDesc, &handle);
     if (0 == result) {
       PluginDebug dbg;
       result = PluginService::Create<long>(type, m_detDesc, &handle);
       if ( 0 == result )  {
-        throw runtime_error("dd4hep: Failed to locate plugin to interprete files of type"
-                            " \"" + tag + "\" - no factory:" 
-                            + type + ". " + dbg.missingFactory(type));
+        throw std::runtime_error("dd4hep: Failed to locate plugin to interprete files of type"
+                                 " \"" + tag + "\" - no factory:" 
+                                 + type + ". " + dbg.missingFactory(type));
       }
     }
     result = *(long*) result;
     if (result != 1)   {
-      throw runtime_error("dd4hep: Failed to parse the XML element with tag " 
-                          + tag + " with the plugin " + type);
+      throw std::runtime_error("dd4hep: Failed to parse the XML element with tag " 
+                               + tag + " with the plugin " + type);
     }
     return;
   }
-  throw runtime_error("dd4hep: Failed to parse the XML file [Invalid XML ROOT handle]");
+  throw std::runtime_error("dd4hep: Failed to parse the XML file [Invalid XML ROOT handle]");
 }

--- a/DDCore/src/DetectorProcessor.cpp
+++ b/DDCore/src/DetectorProcessor.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/DetectorProcessor.h"
-#include "DD4hep/detail/ContainerHelpers.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/DetectorProcessor.h>
+#include <DD4hep/detail/ContainerHelpers.h>
 
 using namespace dd4hep;
 

--- a/DDCore/src/DetectorSelector.cpp
+++ b/DDCore/src/DetectorSelector.cpp
@@ -12,33 +12,31 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/DetectorSelector.h"
-#include "DD4hep/Detector.h"
+#include <DD4hep/DetectorSelector.h>
+#include <DD4hep/Detector.h>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Access a set of subdetectors according to the sensitive type.
-const DetectorSelector::Result& 
-DetectorSelector::detectors(const string& type)
+const DetectorSelector::Result& DetectorSelector::detectors(const std::string& type)
 {
   return description.detectors(type);
 }
 
 /// Access a set of subdetectors according to several sensitive types.
 DetectorSelector::Result
-DetectorSelector::detectors(const string& type1,
-                            const string& type2,
-                            const string& type3,
-                            const string& type4,
-                            const string& type5)  {
-  const string* types[] = { &type1, &type2, &type3, &type4, &type5 };
+DetectorSelector::detectors(const std::string& type1,
+                            const std::string& type2,
+                            const std::string& type3,
+                            const std::string& type4,
+                            const std::string& type5)  {
+  const std::string* types[] = { &type1, &type2, &type3, &type4, &type5 };
   Result result;
-  for(size_t i=0; i<sizeof(types)/sizeof(types[0]); ++i)  {
+  for( std::size_t i=0; i<sizeof(types)/sizeof(types[0]); ++i )  {
     try  {
       if ( !types[i]->empty() )  {
-        const vector<DetElement>& v = description.detectors(*(types[i]));
-        result.insert(end(result),begin(v),end(v));
+        const std::vector<DetElement>& v = description.detectors(*(types[i]));
+        result.insert(std::end(result), std::begin(v), std::end(v));
       }
     }
     catch(...)   {}
@@ -55,7 +53,7 @@ DetectorSelector::detectors(unsigned int includeFlag, unsigned int excludeFlag )
   const Detector::HandleMap& entries = description.detectors();
   result.reserve( entries.size() ) ;
   description.detectors(""); // Just to ensure the geometry is closed....
-  for(const auto& i : entries )  {
+  for( const auto& i : entries )  {
     DetElement det(i.second);
     if ( det.parent().isValid() )  { // Exclude 'world'
       //fixme: what to do with compounds - add their daughters  ?

--- a/DDCore/src/DetectorTools.cpp
+++ b/DDCore/src/DetectorTools.cpp
@@ -13,17 +13,17 @@
 
 // Framework include files
 #define DETECTORTOOLS_CPP
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Detector.h"
-#include "DD4hep/detail/DetectorInterna.h"
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/detail/DetectorInterna.h>
 
 // C/C++ include files
 #include <stdexcept>
 #include <memory>
 
 // ROOT include files
-#include "TGeoMatrix.h"
+#include <TGeoMatrix.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -51,7 +51,6 @@ namespace dd4hep {
     }}
 }
 
-using namespace std;
 using namespace dd4hep;
 
 /// Find path between the child element and the parent element
@@ -62,7 +61,7 @@ bool detail::tools::isParentElement(DetElement parent, DetElement child)   {
       if ( par.ptr() == parent.ptr() ) return true;
     }
   }
-  throw runtime_error("Search for parent detector element with invalid handles not allowed.");
+  throw std::runtime_error("Search for parent detector element with invalid handles not allowed.");
 }
 
 /// Find Child of PlacedVolume and assemble on the fly the path of PlacedVolumes
@@ -149,9 +148,9 @@ void detail::tools::elementPath(DetElement parent, DetElement child, ElementPath
         return;
       }
     }
-    throw runtime_error(string("The detector element ")+parent.name()+string(" is no parent of ")+child.name());
+    throw std::runtime_error(std::string("The detector element ")+parent.name()+std::string(" is no parent of ")+child.name());
   }
-  throw runtime_error("Search for parent detector element with invalid handles not allowed.");
+  throw std::runtime_error("Search for parent detector element with invalid handles not allowed.");
 }
 
 /// Collect detector elements placements to the top detector element (world) [fast, but may have holes!]
@@ -163,7 +162,7 @@ void detail::tools::elementPath(DetElement parent, DetElement element, Placement
     }
     if ( par.ptr() == parent.ptr() ) return;
   }
-  throw runtime_error(string("The detector element ")+parent.name()+string(" is no parent of ")+element.name());
+  throw std::runtime_error(std::string("The detector element ")+parent.name()+std::string(" is no parent of ")+element.name());
 }
 
 /// Collect detector elements placements to the top detector element (world) [fast, but may have holes!]
@@ -177,64 +176,64 @@ void detail::tools::elementPath(DetElement element, PlacementPath& det_nodes) {
 }
 
 /// Assemble the path of the PlacedVolume selection
-string detail::tools::elementPath(const PlacementPath& nodes, bool reverse)   {
-  string path = "";
+std::string detail::tools::elementPath(const PlacementPath& nodes, bool reverse)   {
+  std::string path = "";
   if ( reverse )  {
     for(auto i=nodes.rbegin(); i != nodes.rend(); ++i)
-      path += "/" + string((*i).name());
+      path += "/" + std::string((*i).name());
   }
   else  {
     for(auto i=begin(nodes); i != end(nodes); ++i)
-      path += "/" + string((*i)->GetName());
+      path += "/" + std::string((*i)->GetName());
   }
   return path;
 }
 
 /// Assemble the path of the PlacedVolume selection
-string detail::tools::elementPath(const ElementPath& nodes, bool reverse)  {
-  string path = "";
+std::string detail::tools::elementPath(const ElementPath& nodes, bool reverse)  {
+  std::string path = "";
   if ( reverse )  {
     for(ElementPath::const_reverse_iterator i=nodes.rbegin();i!=nodes.rend();++i)
-      path += "/" + string((*i)->GetName());
+      path += "/" + std::string((*i)->GetName());
   }
   else  {
     for(ElementPath::const_iterator i=nodes.begin();i!=nodes.end();++i)
-      path += "/" + string((*i)->GetName());
+      path += "/" + std::string((*i)->GetName());
   }
   return path;
 }
 
 /// Assemble the path of a particular detector element
-string detail::tools::elementPath(DetElement element)  {
+std::string detail::tools::elementPath(DetElement element)  {
   ElementPath nodes;
   elementPath(element,nodes);
   return elementPath(nodes);
 }
 
 /// Find DetElement as child of the top level volume by its absolute path
-DetElement detail::tools::findElement(const Detector& description, const string& path)   {
+DetElement detail::tools::findElement(const Detector& description, const std::string& path)   {
   return findDaughterElement(description.world(),path);
 }
 
 /// Find DetElement as child of a parent by its relative or absolute path
-DetElement detail::tools::findDaughterElement(DetElement parent, const string& subpath)  {
+DetElement detail::tools::findDaughterElement(DetElement parent, const std::string& subpath)  {
   if ( parent.isValid() )   {
     size_t idx = subpath.find('/',1);
     if ( subpath[0] == '/' )   {
       DetElement top = topElement(parent);
-      if ( idx == string::npos ) return top;
+      if ( idx == std::string::npos ) return top;
       return findDaughterElement(top,subpath.substr(idx+1));
     }
-    if ( idx == string::npos )
+    if ( idx == std::string::npos )
       return parent.child(subpath);
-    string name = subpath.substr(0,idx);
+    std::string name = subpath.substr(0,idx);
     DetElement node = parent.child(name);
     if ( node.isValid() )   {
       return findDaughterElement(node,subpath.substr(idx+1));
     }
-    throw runtime_error("dd4hep: DetElement "+parent.path()+" has no child named:"+name+" [No such child]");
+    throw std::runtime_error("dd4hep: DetElement "+parent.path()+" has no child named:"+name+" [No such child]");
   }
-  throw runtime_error("dd4hep: Cannot determine child with path "+subpath+" from invalid parent [invalid handle]");
+  throw std::runtime_error("dd4hep: Cannot determine child with path "+subpath+" from invalid parent [invalid handle]");
 }
 
 /// Determine top level element (=world) for any element walking up the detector element tree
@@ -244,14 +243,14 @@ DetElement detail::tools::topElement(DetElement child)   {
       return topElement(child.parent());
     return child;
   }
-  throw runtime_error("dd4hep: DetElement cannot determine top parent (world) [invalid handle]");
+  throw std::runtime_error("dd4hep: DetElement cannot determine top parent (world) [invalid handle]");
 }
 
 static void detail::tools::makePlacementPath(PlacementPath det_nodes, PlacementPath& all_nodes)   {
   for (size_t i = 0, n = det_nodes.size(); n > 0 && i < n-1; ++i)   {
     if (!findChildByName(det_nodes[i + 1], det_nodes[i], all_nodes))   {
-      throw runtime_error("dd4hep: DetElement cannot determine placement path of "
-                          + string(det_nodes[i].name()) + " [internal error]");
+      throw std::runtime_error("dd4hep: DetElement cannot determine placement path of "
+                               + std::string(det_nodes[i].name()) + " [internal error]");
     }
   }
   if ( det_nodes.size() > 0 )   {
@@ -274,37 +273,36 @@ void detail::tools::placementPath(DetElement parent, DetElement element, Placeme
 }
 
 /// Assemble the path of the PlacedVolume selection
-string detail::tools::placementPath(DetElement element)  {
+std::string detail::tools::placementPath(DetElement element)  {
   PlacementPath path;
   placementPath(element,path);
   return placementPath(path);
 }
 
 /// Assemble the path of the PlacedVolume selection
-string detail::tools::placementPath(const PlacementPath& nodes, bool reverse)  {
-  string path = "";
+std::string detail::tools::placementPath(const PlacementPath& nodes, bool reverse)  {
+  std::string path = "";
   if ( reverse )  {
     for(PlacementPath::const_reverse_iterator i=nodes.rbegin();i!=nodes.rend();++i)
-      path += "/" + string((*i)->GetName());
+      path += "/" + std::string((*i)->GetName());
   }
   else  {
     for(PlacementPath::const_iterator i=nodes.begin();i!=nodes.end();++i)
-      path += "/" + string((*i)->GetName());
+      path += "/" + std::string((*i)->GetName());
   }
   return path;
 }
 
 /// Assemble the path of the PlacedVolume selection
-string detail::tools::placementPath(const vector<const TGeoNode*>& nodes, bool reverse)   {
-  string path = "";
+std::string detail::tools::placementPath(const std::vector<const TGeoNode*>& nodes, bool reverse)   {
+  std::string path = "";
   if ( reverse )  {
-    for(vector<const TGeoNode*>::const_reverse_iterator i=nodes.rbegin();i!=nodes.rend();++i)
-      path += "/" + string((*i)->GetName());
+    for(std::vector<const TGeoNode*>::const_reverse_iterator i=nodes.rbegin();i!=nodes.rend();++i)
+      path += "/" + std::string((*i)->GetName());
+    return path;
   }
-  else  {
-    for(vector<const TGeoNode*>::const_iterator i=nodes.begin();i!=nodes.end();++i)
-      path += "/" + string((*i)->GetName());
-  }
+  for( const auto* n : nodes )
+    path += "/" + std::string(n->GetName());
   return path;
 }
 
@@ -327,7 +325,7 @@ void detail::tools::placementTrafo(const PlacementPath& nodes, bool inverse, TGe
 }
 
 /// Find a given node in the hierarchy starting from the top node (absolute placement!)
-PlacedVolume detail::tools::findNode(PlacedVolume top_place, const string& place)   {
+PlacedVolume detail::tools::findNode(PlacedVolume top_place, const std::string& place)   {
   TGeoNode* top = top_place.ptr();
   const char* path = place.c_str();
   // Check if a geometry path is valid without changing the state of the navigator.
@@ -377,16 +375,16 @@ PlacedVolume detail::tools::findNode(PlacedVolume top_place, const string& place
 }
 
 /// Convert VolumeID to string
-string detail::tools::toString(const PlacedVolume::VolIDs& ids)   {
-  stringstream log;
+std::string detail::tools::toString(const PlacedVolume::VolIDs& ids)   {
+  std::stringstream log;
   for( const auto& v : ids )
     log << v.first << "=" << v.second << "; ";
   return log.str();
 }
 
 /// Convert VolumeID to string
-string detail::tools::toString(const IDDescriptor& dsc, const PlacedVolume::VolIDs& ids, VolumeID code)   {
-  stringstream log;
+std::string detail::tools::toString(const IDDescriptor& dsc, const PlacedVolume::VolIDs& ids, VolumeID code)   {
+  std::stringstream log;
   for( const auto& id : ids )  {
     const BitFieldElement* f = dsc.field(id.first);
     VolumeID value = f->value(code);
@@ -396,14 +394,14 @@ string detail::tools::toString(const IDDescriptor& dsc, const PlacedVolume::VolI
 }
 
 /// Extract all the path elements from a path
-vector<string> detail::tools::pathElements(const string& path)   {
-  vector<string> result;
+std::vector<std::string> detail::tools::pathElements(const std::string& path)   {
+  std::vector<std::string> result;
   if ( !path.empty() )  {
-    string tmp = path[0]=='/' ? path.substr(1) : path;
-    for(size_t idx=tmp.find('/'); idx != string::npos; idx=tmp.find('/'))  {
-      string val = tmp.substr(0,idx);
+    std::string tmp = path[0]=='/' ? path.substr(1) : path;
+    for(size_t idx=tmp.find('/'); idx != std::string::npos; idx=tmp.find('/'))  {
+      std::string val = tmp.substr(0,idx);
       result.emplace_back(val);
-      tmp = tmp.length()>idx ? tmp.substr(idx+1) : string();
+      tmp = tmp.length()>idx ? tmp.substr(idx+1) : std::string();
     }
     if ( !tmp.empty() )  {
       result.emplace_back(tmp);

--- a/DDCore/src/Errors.cpp
+++ b/DDCore/src/Errors.cpp
@@ -13,7 +13,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Errors.h"
+#include <DD4hep/Errors.h>
 
 // C/C++ includes
 #include <cerrno>

--- a/DDCore/src/Exceptions.cpp
+++ b/DDCore/src/Exceptions.cpp
@@ -12,18 +12,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Exceptions.h"
-#include "DD4hep/Primitives.h"
+#include <DD4hep/Exceptions.h>
+#include <DD4hep/Primitives.h>
 
-using namespace std;
 using namespace dd4hep;
 
-string unrelated_type_error::msg(const type_info& typ1, const type_info& typ2, const string& text) {
-  string m = "The types " + typeName(typ1) + " and " + typeName(typ2) + " are not related. " + text;
+std::string unrelated_type_error::msg(const std::type_info& typ1, const std::type_info& typ2, const std::string& text) {
+  std::string m = "The types " + typeName(typ1) + " and " + typeName(typ2) + " are not related. " + text;
   return m;
 }
 
-string unrelated_value_error::msg(const type_info& typ, const string& text) {
-  string m = "The type " + typeName(typ) + " cannot be converted: " + text;
+std::string unrelated_value_error::msg(const std::type_info& typ, const std::string& text) {
+  std::string m = "The type " + typeName(typ) + " cannot be converted: " + text;
   return m;
 }

--- a/DDCore/src/ExtensionEntry.cpp
+++ b/DDCore/src/ExtensionEntry.cpp
@@ -12,8 +12,8 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/ExtensionEntry.h"
-#include "DD4hep/Printout.h"
+#include <DD4hep/ExtensionEntry.h>
+#include <DD4hep/Printout.h>
 
 /// Callback on invalid call invokation
 void dd4hep::ExtensionEntry::invalidCall(const char* tag)  const {

--- a/DDCore/src/FieldTypes.cpp
+++ b/DDCore/src/FieldTypes.cpp
@@ -11,11 +11,10 @@
 //
 //==========================================================================
 
-#include "DD4hep/FieldTypes.h"
-#include "DD4hep/detail/Handle.inl"
+#include <DD4hep/FieldTypes.h>
+#include <DD4hep/detail/Handle.inl>
 #include <cmath>
 
-using namespace std;
 using namespace dd4hep;
 
 #ifndef INFINITY
@@ -159,7 +158,7 @@ void MultipoleField::fieldComponents(const double* pos, double* field) {
     case 0:      // Nothing, but still valid
       break;
     default:     // Error condition
-      throw runtime_error("Invalid multipole field definition!");
+      throw std::runtime_error("Invalid multipole field definition!");
     }
     Transform3D::Point f = this->rotation * Transform3D::Point(bx, by, B_z);
     field[0] += f.X();

--- a/DDCore/src/Fields.cpp
+++ b/DDCore/src/Fields.cpp
@@ -11,12 +11,11 @@
 //
 //==========================================================================
 
-#include "DD4hep/Fields.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/detail/Handle.inl"
+#include <DD4hep/Fields.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/detail/Handle.inl>
 
-using namespace std;
 using namespace dd4hep;
 
 typedef CartesianField::Object CartesianFieldObject;
@@ -26,7 +25,7 @@ typedef OverlayedField::Object OverlayedFieldObject;
 DD4HEP_INSTANTIATE_HANDLE(OverlayedFieldObject);
 
 namespace {
-  void calculate_combined_field(vector<CartesianField>& v, const Position& pos, double* field) {
+  void calculate_combined_field(std::vector<CartesianField>& v, const Position& pos, double* field) {
     for (const auto& i : v ) i.value(pos, field);
   }
 }
@@ -90,7 +89,7 @@ OverlayedField::Object::~Object() {
 }
 
 /// Object constructor
-OverlayedField::OverlayedField(const string& nam) : Ref_t() {
+OverlayedField::OverlayedField(const std::string& nam) : Ref_t() {
   auto* obj = new Object();
   assign(obj, nam, "overlay_field");
   obj->field_type = CartesianField::OVERLAY;
@@ -116,13 +115,13 @@ void OverlayedField::add(CartesianField field) {
       bool isEle = field.ELECTRIC == (typ & field.ELECTRIC);
       bool isMag = field.MAGNETIC == (typ & field.MAGNETIC);
       if (isEle) {
-        vector < CartesianField > &v = o->electric_components;
+        std::vector < CartesianField > &v = o->electric_components;
         v.emplace_back(field);
         o->field_type |= field.ELECTRIC;
         o->electric = (v.size() == 1) ? field : CartesianField();
       }
       if (isMag) {
-        vector < CartesianField > &v = o->magnetic_components;
+        std::vector < CartesianField > &v = o->magnetic_components;
         v.emplace_back(field);
         o->field_type |= field.MAGNETIC;
         o->magnetic = (v.size() == 1) ? field : CartesianField();

--- a/DDCore/src/Filter.cpp
+++ b/DDCore/src/Filter.cpp
@@ -1,65 +1,82 @@
-#include "DD4hep/Filter.h"
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//  RootDictionary.h
+//
+//
+//  M.Frank
+//
+//==========================================================================
+// Framework include files
+#include <DD4hep/Filter.h>
+
+// C/C++ include files
 #include <functional>
 #include <regex>
 #include <iostream>
 
-using namespace std;
-
 namespace dd4hep {
+  
   namespace dd {
 
-    bool isMatch(string_view node, string_view name) {
+    bool isMatch(std::string_view node, std::string_view name) {
       if (!dd4hep::dd::isRegex(name)) {
         return (name == node);
       } else {
-        regex pattern({name.data(), name.size()});
-        return regex_match(begin(node), end(node), pattern);
+        std::regex pattern({name.data(), name.size()});
+        return std::regex_match(begin(node), end(node), pattern);
       }
     }
 
-    bool compareEqual(string_view node, string_view name) { return (name == node); }
+    bool compareEqual(std::string_view node, std::string_view name) { return (name == node); }
 
-    bool compareEqual(string_view node, regex pattern) {
-      return regex_match(std::string(node.data(), node.size()), pattern);
+    bool compareEqual(std::string_view node, std::regex pattern) {
+      return std::regex_match(std::string(node.data(), node.size()), pattern);
     }
 
     bool compareEqualName(const std::string_view selection, const std::string_view name) {
       return (!(dd4hep::dd::isRegex(selection)) ? dd4hep::dd::compareEqual(name, selection)
-	      : regex_match(name.begin(), name.end(), regex(std::string(selection))));
+              : std::regex_match(name.begin(), name.end(), std::regex(std::string(selection))));
     }
 
     bool compareEqualCopyNumber(std::string_view name, int copy) {
       auto pos = name.rfind('[');
       if (pos != name.npos) {
-	if (std::stoi(std::string(name.substr(pos + 1, name.rfind(']')))) == copy) {
-	  return true;
-	}
+        if (std::stoi(std::string(name.substr(pos + 1, name.rfind(']')))) == copy) {
+          return true;
+        }
       }
       
       return false;
     }
 
-    bool accepted(vector<std::regex> const& keys, string_view node) {
+    bool accepted(std::vector<std::regex> const& keys, std::string_view node) {
       return (find_if(begin(keys), end(keys), [&](const auto& n) -> bool { return compareEqual(node, n); }) !=
               end(keys));
     }
 
     bool accepted(const Filter* filter, std::string_view name) {
       for(unsigned int i = 0; i < filter->isRegex.size(); i++ ) {
-	if(!filter->isRegex[i]) {
-	  if(compareEqual(filter->skeys[i], name)) {
-	    return true;
-	  }
-	} else {
-	  if(compareEqual(name, filter->keys[filter->index[i]])) {
-	    return true;
-	  }
-	}
+        if(!filter->isRegex[i]) {
+          if(compareEqual(filter->skeys[i], name)) {
+            return true;
+          }
+        } else {
+          if(compareEqual(name, filter->keys[filter->index[i]])) {
+            return true;
+          }
+        }
       }
       return false;
     }
 
-    bool isRegex(string_view input) {
+    bool isRegex(std::string_view input) {
       return (input.find(".") != std::string_view::npos) || (input.find("*") != std::string_view::npos);
     }
 
@@ -67,19 +84,19 @@ namespace dd4hep {
       return (input.find(":") != std::string_view::npos);
     }
     
-    string_view realTopName(string_view input) {
-      string_view v = input;
+    std::string_view realTopName(std::string_view input) {
+      std::string_view v = input;
       auto first = v.find_first_of("//");
-      v.remove_prefix(min(first + 2, v.size()));
+      v.remove_prefix(std::min(first + 2, v.size()));
       return v;
     }
 
-    vector<string_view> split(string_view str, const char* delims) {
-      vector<string_view> ret;
+    std::vector<std::string_view> split(std::string_view str, const char* delims) {
+      std::vector<std::string_view> ret;
 
-      string_view::size_type start = 0;
+      std::string_view::size_type start = 0;
       auto pos = str.find_first_of(delims, start);
-      while (pos != string_view::npos) {
+      while (pos != std::string_view::npos) {
         if (pos != start) {
           ret.emplace_back(str.substr(start, pos - start));
         }

--- a/DDCore/src/GeoDictionary.h
+++ b/DDCore/src/GeoDictionary.h
@@ -17,10 +17,10 @@
 #define DDCORE_SRC_GEODICTIONARY_H
 
 // Framework include files
-#include "DD4hep/Volumes.h"
-#include "DD4hep/Shapes.h"
-#include "DD4hep/VolumeProcessor.h"
-#include "DD4hep/detail/ShapesInterna.h"
+#include <DD4hep/Volumes.h>
+#include <DD4hep/Shapes.h>
+#include <DD4hep/VolumeProcessor.h>
+#include <DD4hep/detail/ShapesInterna.h>
 
 // C/C++ include files
 #include <vector>

--- a/DDCore/src/GeoHandler.cpp
+++ b/DDCore/src/GeoHandler.cpp
@@ -12,28 +12,27 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/GeoHandler.h"
-#include "DD4hep/detail/ObjectsInterna.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/GeoHandler.h>
+#include <DD4hep/detail/ObjectsInterna.h>
 
 // ROOT includes
-#include "TGeoManager.h"
-#include "TGeoCompositeShape.h"
-#include "TGeoBoolNode.h"
-#include "TClass.h"
+#include <TGeoManager.h>
+#include <TGeoCompositeShape.h>
+#include <TGeoBoolNode.h>
+#include <TClass.h>
 
 // C/C++ include files
 #include <iostream>
 
-using namespace dd4hep::detail;
 using namespace dd4hep;
-using namespace std;
 
 namespace {
-  void collectSolid(GeoHandler::GeometryInfo& geo,
-		    const string& name,
-		    const string& node,
-		    TGeoShape* shape,
+
+  void collectSolid(detail::GeoHandler::GeometryInfo& geo,
+                    const std::string& name,
+                    const std::string& node,
+                    TGeoShape* shape,
                     TGeoMatrix* matrix)
   {
     if ( 0 == ::strncmp(shape->GetName(), "TGeo", 4) )  {
@@ -51,43 +50,43 @@ namespace {
 }
 
 /// Default constructor
-GeoHandler::GeoHandler() : m_propagateRegions(false)  {
-  m_data = new map<int,set<const TGeoNode*> >();
+detail::GeoHandler::GeoHandler() : m_propagateRegions(false)  {
+  m_data = new std::map<int, std::set<const TGeoNode*> >();
 }
 
 /// Initializing constructor
-GeoHandler::GeoHandler(map<int,set<const TGeoNode*> >* ptr)
+detail::GeoHandler::GeoHandler(std::map<int, std::set<const TGeoNode*> >* ptr)
   : m_propagateRegions(false), m_data(ptr) {
 }
 
 /// Default destructor
-GeoHandler::~GeoHandler() {
+detail::GeoHandler::~GeoHandler() {
   if (m_data)
     delete m_data;
   m_data = nullptr;
 }
 
-map<int,set<const TGeoNode*> >* GeoHandler::release() {
-  map<int,set<const TGeoNode*> >* d = m_data;
+std::map<int, std::set<const TGeoNode*> >* detail::GeoHandler::release() {
+  std::map<int, std::set<const TGeoNode*> >* d = m_data;
   m_data = nullptr;
   return d;
 }
 
 /// Propagate regions. Returns the previous value
-bool GeoHandler::setPropagateRegions(bool value)   {
+bool detail::GeoHandler::setPropagateRegions(bool value)   {
   bool old = m_propagateRegions;
   m_propagateRegions = value;
   return old;
 }
 
-GeoHandler& GeoHandler::collect(DetElement element) {
+detail::GeoHandler& detail::GeoHandler::collect(DetElement element) {
   DetElement par = element.parent();
-  TGeoNode* par_node = par.isValid() ? par.placement().ptr() : nullptr;
+  TGeoNode*  par_node = par.isValid() ? par.placement().ptr() : nullptr;
   m_data->clear();
   return i_collect(par_node, element.placement().ptr(), 0, Region(), LimitSet());
 }
 
-GeoHandler& GeoHandler::collect(DetElement element, GeometryInfo& info) {
+detail::GeoHandler& detail::GeoHandler::collect(DetElement element, GeometryInfo& info) {
   DetElement par = element.parent();
   TGeoNode* par_node = par.isValid() ? par.placement().ptr() : nullptr;
   m_data->clear();
@@ -125,16 +124,16 @@ GeoHandler& GeoHandler::collect(DetElement element, GeometryInfo& info) {
   return *this;
 }
 
-GeoHandler& GeoHandler::i_collect(const TGeoNode* /* parent */,
-				  const TGeoNode*    current,
-				  int level, Region rg, LimitSet ls)
+detail::GeoHandler& detail::GeoHandler::i_collect(const TGeoNode* /* parent */,
+                                                  const TGeoNode*    current,
+                                                  int level, Region rg, LimitSet ls)
 {
   TGeoVolume* volume = current->GetVolume();
-  TObjArray* nodes = volume->GetNodes();
-  int num_children = nodes ? nodes->GetEntriesFast() : 0;
-  Volume vol(volume);
-  Region   region = vol.region();
-  LimitSet limits = vol.limitSet();
+  TObjArray*  nodes = volume->GetNodes();
+  int         num_children = nodes ? nodes->GetEntriesFast() : 0;
+  Volume      vol(volume);
+  Region      region = vol.region();
+  LimitSet    limits = vol.limitSet();
 
   if ( m_propagateRegions )  {
     if ( !region.isValid() && rg.isValid() )   {
@@ -157,26 +156,26 @@ GeoHandler& GeoHandler::i_collect(const TGeoNode* /* parent */,
 }
 
 /// Initializing constructor
-GeoScan::GeoScan(DetElement e) {
+detail::GeoScan::GeoScan(DetElement e) {
   m_data = GeoHandler().collect(e).release();
 }
 
 /// Initializing constructor
-GeoScan::GeoScan(DetElement e, bool propagate) {
+detail::GeoScan::GeoScan(DetElement e, bool propagate) {
   GeoHandler h;
   h.setPropagateRegions(propagate);
   m_data = h.collect(e).release();
 }
 
 /// Default destructor
-GeoScan::~GeoScan() {
+detail::GeoScan::~GeoScan() {
   if (m_data)
     delete m_data;
   m_data = 0;
 }
 
 /// Work callback
-GeoScan& GeoScan::operator()() {
+detail::GeoScan& detail::GeoScan::operator()() {
   return *this;
 }
 

--- a/DDCore/src/GeometryTreeDump.cpp
+++ b/DDCore/src/GeometryTreeDump.cpp
@@ -12,39 +12,40 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
 #include "GeometryTreeDump.h"
+#include <DD4hep/Detector.h>
+
 // ROOT includes
-#include "TROOT.h"
-#include "TColor.h"
-#include "TGeoShape.h"
-#include "TGeoCone.h"
-#include "TGeoParaboloid.h"
-#include "TGeoPcon.h"
-#include "TGeoPgon.h"
-#include "TGeoSphere.h"
-#include "TGeoTorus.h"
-#include "TGeoTube.h"
-#include "TGeoTrd1.h"
-#include "TGeoTrd2.h"
-#include "TGeoArb8.h"
-#include "TGeoMatrix.h"
-#include "TGeoBoolNode.h"
-#include "TGeoCompositeShape.h"
-#include "TClass.h"
-#include "TGeoManager.h"
-#include "TMath.h"
+#include <TROOT.h>
+#include <TColor.h>
+#include <TGeoShape.h>
+#include <TGeoCone.h>
+#include <TGeoParaboloid.h>
+#include <TGeoPcon.h>
+#include <TGeoPgon.h>
+#include <TGeoSphere.h>
+#include <TGeoTorus.h>
+#include <TGeoTube.h>
+#include <TGeoTrd1.h>
+#include <TGeoTrd2.h>
+#include <TGeoArb8.h>
+#include <TGeoMatrix.h>
+#include <TGeoBoolNode.h>
+#include <TGeoCompositeShape.h>
+#include <TClass.h>
+#include <TGeoManager.h>
+#include <TMath.h>
+
+// C/C++ include files
 #include <iostream>
 
-using namespace dd4hep::detail;
 using namespace dd4hep;
-using namespace std;
 
 namespace {
-  string indent = "";
+  std::string indent = "";
 
   /// Reference to output stream
-  ostream& m_output = cout;
+  std::ostream& m_output = std::cout;
 
   void getAngles(const Double_t* m, Double_t &phi, Double_t &theta, Double_t &psi) {
     // Retreive Euler angles.
@@ -68,91 +69,91 @@ namespace {
 }
 
 /// Dump logical volume in GDML format to output stream
-void* GeometryTreeDump::handleVolume(const string& name, Volume vol) const {
+void* detail::GeometryTreeDump::handleVolume(const std::string& name, Volume vol) const {
   VisAttr vis = vol.visAttributes();
   TGeoShape* shape = vol->GetShape();
   TGeoMedium* medium = vol->GetMedium();
   int num = vol->GetNdaughters();
 
-  m_output << "\t\t<volume name=\"" << name << "\">" << endl;
-  m_output << "\t\t\t<solidref ref=\"" << shape->GetName() << "\"/>" << endl;
-  m_output << "\t\t\t<materialref ref=\"" << medium->GetName() << "\"/>" << endl;
+  m_output << "\t\t<volume name=\"" << name << "\">" << std::endl;
+  m_output << "\t\t\t<solidref ref=\"" << shape->GetName() << "\"/>" << std::endl;
+  m_output << "\t\t\t<materialref ref=\"" << medium->GetName() << "\"/>" << std::endl;
   if (vis.isValid()) {
-    m_output << "\t\t\t<visref ref=\"" << vis.name() << "\"/>" << endl;
+    m_output << "\t\t\t<visref ref=\"" << vis.name() << "\"/>" << std::endl;
   }
   if (num > 0) {
     for (int i = 0; i < num; ++i) {
       TGeoNode*   geo_nod = vol.ptr()->GetNode(vol->GetNode(i)->GetName());
       TGeoVolume* geo_vol = geo_nod->GetVolume();
       TGeoMatrix* geo_mat = geo_nod->GetMatrix();
-      m_output << "\t\t\t<physvol>" << endl;
-      m_output << "\t\t\t\t<volumeref ref=\"" << geo_vol->GetName() << "\"/>" << endl;
+      m_output << "\t\t\t<physvol>" << std::endl;
+      m_output << "\t\t\t\t<volumeref ref=\"" << geo_vol->GetName() << "\"/>" << std::endl;
       if (geo_mat) {
         if (geo_mat->IsTranslation()) {
-          m_output << "\t\t\t\t<positionref ref=\"" << geo_nod->GetName() << "_pos\"/>" << endl;
+          m_output << "\t\t\t\t<positionref ref=\"" << geo_nod->GetName() << "_pos\"/>" << std::endl;
         }
         if (geo_mat->IsRotation()) {
-          m_output << "\t\t\t\t<rotationref ref=\"" << geo_nod->GetName() << "_rot\"/>" << endl;
+          m_output << "\t\t\t\t<rotationref ref=\"" << geo_nod->GetName() << "_rot\"/>" << std::endl;
         }
       }
-      m_output << "\t\t\t</physvol>" << endl;
+      m_output << "\t\t\t</physvol>" << std::endl;
     }
   }
-  m_output << "\t\t</volume>" << endl;
+  m_output << "\t\t</volume>" << std::endl;
   return 0;
 }
 
 /// Dump solid in GDML format to output stream
-void* GeometryTreeDump::handleSolid(const string& name, const TGeoShape* shape) const {
+void* detail::GeometryTreeDump::handleSolid(const std::string& name, const TGeoShape* shape) const {
   if (shape) {
     if (shape->IsA() == TGeoBBox::Class()) {
       const TGeoBBox* sh = (const TGeoBBox*) shape;
       m_output << "\t\t<box name=\"" << name << "_shape\" x=\"" << sh->GetDX() << "\" y=\"" << sh->GetDY() << "\" z=\""
-               << sh->GetDZ() << "\" lunit=\"cm\"/>" << endl;
+               << sh->GetDZ() << "\" lunit=\"cm\"/>" << std::endl;
     }
     else if (shape->IsA() == TGeoTube::Class()) {
       const TGeoTube* sh = (const TGeoTube*) shape;
       m_output << "\t\t<tube name=\"" << name << "_shape\" rmin=\"" << sh->GetRmin() << "\" rmax=\"" << sh->GetRmax() << "\" z=\""
-               << sh->GetDz() << "\" startphi=\"0.0\" deltaphi=\"360.0\" aunit=\"deg\" lunit=\"cm\"/>" << endl;
+               << sh->GetDz() << "\" startphi=\"0.0\" deltaphi=\"360.0\" aunit=\"deg\" lunit=\"cm\"/>" << std::endl;
     }
     else if (shape->IsA() == TGeoTubeSeg::Class()) {
       const TGeoTubeSeg* sh = (const TGeoTubeSeg*) shape;
       m_output << "\t\t<tube name=\"" << name << "_shape\" rmin=\"" << sh->GetRmin() << "\" rmax=\"" << sh->GetRmax() << "\" z=\""
                << sh->GetDz() << "\" startphi=\"" << sh->GetPhi1() << "\" deltaphi=\"" << sh->GetPhi2()
-               << "\" aunit=\"deg\" lunit=\"cm\"/>" << endl;
+               << "\" aunit=\"deg\" lunit=\"cm\"/>" << std::endl;
     }
     else if (shape->IsA() == TGeoTrd1::Class()) {
       const TGeoTrd1* sh = (const TGeoTrd1*) shape;
       m_output << "\t\t<tube name=\"" << name << "_shape\" x1=\"" << sh->GetDx1() << "\" x2=\"" << sh->GetDx2() << "\" y1=\""
-               << sh->GetDy() << "\" y2=\"" << sh->GetDy() << "\" z=\"" << sh->GetDz() << "\" lunit=\"cm\"/>" << endl;
+               << sh->GetDy() << "\" y2=\"" << sh->GetDy() << "\" z=\"" << sh->GetDz() << "\" lunit=\"cm\"/>" << std::endl;
     }
     else if (shape->IsA() == TGeoTrd2::Class()) {
       const TGeoTrd2* sh = (const TGeoTrd2*) shape;
       m_output << "\t\t<tube name=\"" << name << "_shape\" x1=\"" << sh->GetDx1() << "\" x2=\"" << sh->GetDx2() << "\" y1=\""
-               << sh->GetDy1() << "\" y2=\"" << sh->GetDy2() << "\" z=\"" << sh->GetDz() << "\" lunit=\"cm\"/>" << endl;
+               << sh->GetDy1() << "\" y2=\"" << sh->GetDy2() << "\" z=\"" << sh->GetDz() << "\" lunit=\"cm\"/>" << std::endl;
     }
     else if (shape->IsA() == TGeoPgon::Class()) {
       const TGeoPgon* sh = (const TGeoPgon*) shape;
       m_output << "\t\t<polyhedra name=\"" << name << "_shape\" startphi=\"" << sh->GetPhi1() << "\" deltaphi=\"" << sh->GetDphi()
-               << "\" numsides=\"" << sh->GetNedges() << "\" aunit=\"deg\" lunit=\"cm\">" << endl;
+               << "\" numsides=\"" << sh->GetNedges() << "\" aunit=\"deg\" lunit=\"cm\">" << std::endl;
       for (int i = 0; i < sh->GetNz(); ++i) {
         m_output << "\t\t\t<zplane z=\"" << sh->GetZ(i) << "\" rmin=\"" << sh->GetRmin(i) << "\" rmax=\"" << sh->GetRmax(i)
-                 << "\" lunit=\"cm\"/>" << endl;
+                 << "\" lunit=\"cm\"/>" << std::endl;
       }
-      m_output << "\t\t</polyhedra>" << endl;
+      m_output << "\t\t</polyhedra>" << std::endl;
     }
     else if (shape->IsA() == TGeoPcon::Class()) {
       const TGeoPcon* sh = (const TGeoPcon*) shape;
       m_output << "\t\t<polycone name=\"" << name << "_shape\" startphi=\"" << sh->GetPhi1() << "\" deltaphi=\"" << sh->GetDphi()
-               << "\" aunit=\"deg\" lunit=\"cm\">" << endl;
+               << "\" aunit=\"deg\" lunit=\"cm\">" << std::endl;
       for (int i = 0; i < sh->GetNz(); ++i) {
         m_output << "\t\t\t<zplane z=\"" << sh->GetZ(i) << "\" rmin=\"" << sh->GetRmin(i) << "\" rmax=\"" << sh->GetRmax(i)
-                 << "\" lunit=\"cm\"/>" << endl;
+                 << "\" lunit=\"cm\"/>" << std::endl;
       }
-      m_output << "\t\t</polycone>" << endl;
+      m_output << "\t\t</polycone>" << std::endl;
     }
     else if (shape->IsA() == TGeoCompositeShape::Class()) {
-      string nn = name;
+      std::string nn = name;
       const TGeoCompositeShape* sh = (const TGeoCompositeShape*) shape;
       const TGeoBoolNode* boolean = sh->GetBoolNode();
       TGeoBoolNode::EGeoBoolType oper = boolean->GetBooleanOperator();
@@ -161,49 +162,49 @@ void* GeometryTreeDump::handleSolid(const string& name, const TGeoShape* shape) 
       handleSolid(name + "_right", boolean->GetRightShape());
 
       if (oper == TGeoBoolNode::kGeoSubtraction)
-        m_output << "\t\t<subtraction name=\"" << nn << "\">" << endl;
+        m_output << "\t\t<subtraction name=\"" << nn << "\">" << std::endl;
       else if (oper == TGeoBoolNode::kGeoUnion)
-        m_output << "\t\t<union name=\"" << nn << "\">" << endl;
+        m_output << "\t\t<union name=\"" << nn << "\">" << std::endl;
       else if (oper == TGeoBoolNode::kGeoIntersection)
-        m_output << "\t\t<intersection name=\"" << nn << "\">" << endl;
+        m_output << "\t\t<intersection name=\"" << nn << "\">" << std::endl;
 
-      m_output << "\t\t\t<first ref=\"" << nn << "_left\"/>" << endl;
-      m_output << "\t\t\t<second ref=\"" << nn << "_right\"/>" << endl;
+      m_output << "\t\t\t<first ref=\"" << nn << "_left\"/>" << std::endl;
+      m_output << "\t\t\t<second ref=\"" << nn << "_right\"/>" << std::endl;
       indent = "\t";
       handleTransformation("", boolean->GetRightMatrix());
       indent = "";
 
       if (oper == TGeoBoolNode::kGeoSubtraction)
-        m_output << "\t\t</subtraction>" << endl;
+        m_output << "\t\t</subtraction>" << std::endl;
       else if (oper == TGeoBoolNode::kGeoUnion)
-        m_output << "\t\t</union>" << endl;
+        m_output << "\t\t</union>" << std::endl;
       else if (oper == TGeoBoolNode::kGeoIntersection)
-        m_output << "\t\t</intersection>" << endl;
+        m_output << "\t\t</intersection>" << std::endl;
     }
     else {
-      cerr << "Failed to handle unknwon solid shape:" << shape->IsA()->GetName() << endl;
+      std::cerr << "Failed to handle unknwon solid shape:" << shape->IsA()->GetName() << std::endl;
     }
   }
   return 0;
 }
 
 /// Dump structure information in GDML format to output stream
-void GeometryTreeDump::handleStructure(const std::set<Volume>& volset) const {
-  m_output << "\t<structure>" << endl;
+void detail::GeometryTreeDump::handleStructure(const std::set<Volume>& volset) const {
+  m_output << "\t<structure>" << std::endl;
   for (const auto& vol : volset)
     handleVolume(vol->GetName(), vol);
-  m_output << "\t</structure>" << endl;
+  m_output << "\t</structure>" << std::endl;
 }
 
 /// Dump single volume transformation in GDML format to output stream
-void* GeometryTreeDump::handleTransformation(const string& name, const TGeoMatrix* mat) const {
+void* detail::GeometryTreeDump::handleTransformation(const std::string& name, const TGeoMatrix* mat) const {
   if (mat) {
     if (mat->IsTranslation()) {
       const Double_t* f = mat->GetTranslation();
       m_output << indent << "\t\t<position ";
       if (!name.empty())
         m_output << "name=\"" << name << "_pos\" ";
-      m_output << "x=\"" << f[0] << "\" " << "y=\"" << f[1] << "\" " << "z=\"" << f[2] << "\" unit=\"cm\"/>" << endl;
+      m_output << "x=\"" << f[0] << "\" " << "y=\"" << f[1] << "\" " << "z=\"" << f[2] << "\" unit=\"cm\"/>" << std::endl;
     }
     if (mat->IsRotation()) {
       const Double_t* matrix = mat->GetRotationMatrix();
@@ -212,42 +213,42 @@ void* GeometryTreeDump::handleTransformation(const string& name, const TGeoMatri
       m_output << indent << "\t\t<rotation ";
       if (!name.empty())
         m_output << "name=\"" << name << "_rot\" ";
-      m_output << "x=\"" << theta << "\" " << "y=\"" << psi << "\" " << "z=\"" << phi << "\" unit=\"deg\"/>" << endl;
+      m_output << "x=\"" << theta << "\" " << "y=\"" << psi << "\" " << "z=\"" << phi << "\" unit=\"deg\"/>" << std::endl;
     }
   }
   return 0;
 }
 
 /// Dump Transformations in GDML format to output stream
-void GeometryTreeDump::handleTransformations(const std::vector<std::pair<std::string, TGeoMatrix*> >& trafos) const {
-  m_output << "\t<define>" << endl;
-  for (const auto& t : trafos )
+void detail::GeometryTreeDump::handleTransformations(const std::vector<std::pair<std::string, TGeoMatrix*> >& trafos) const {
+  m_output << "\t<define>" << std::endl;
+  for ( const auto& t : trafos )
     handleTransformation(t.first, t.second);
-  m_output << "\t</define>" << endl;
+  m_output << "\t</define>" << std::endl;
 }
 
 /// Dump all solids in GDML format to output stream
-void GeometryTreeDump::handleSolids(const std::set<TGeoShape*>& solids) const {
-  m_output << "\t<solids>" << endl;
-  for (const auto sh : solids )
+void detail::GeometryTreeDump::handleSolids(const std::set<TGeoShape*>& solids) const {
+  m_output << "\t<solids>" << std::endl;
+  for ( const auto sh : solids )
     handleSolid(sh->GetName(), sh);
-  m_output << "\t</solids>" << endl;
+  m_output << "\t</solids>" << std::endl;
 }
 
 /// Dump all constants in GDML format to output stream
-void GeometryTreeDump::handleDefines(const Detector::HandleMap& defs) const {
-  m_output << "\t<define>" << endl;
-  for (const auto& def : defs )
+void detail::GeometryTreeDump::handleDefines(const Detector::HandleMap& defs) const {
+  m_output << "\t<define>" << std::endl;
+  for ( const auto& def : defs )
     m_output << "\t\t<constant name=\"" << def.second->name << "\" value=\"" << def.second->type << "\" />"
-             << endl;
-  m_output << "\t</define>" << endl;
+             << std::endl;
+  m_output << "\t</define>" << std::endl;
 }
 
 /// Dump all visualisation specs in Detector format to output stream
-void GeometryTreeDump::handleVisualisation(const Detector::HandleMap&) const {
+void detail::GeometryTreeDump::handleVisualisation(const Detector::HandleMap&) const {
 }
 
-static string _path = "";
+static std::string _path = "";
 static void dumpStructure(PlacedVolume pv, int level) {
   TGeoNode* current = pv.ptr();
   TGeoVolume* volume = current->GetVolume();
@@ -290,7 +291,7 @@ static void dumpDetectors(DetElement parent, int level) {
   _path = _path.substr(0, _path.length() - 1 - strlen(parent.name()));
 }
 
-void GeometryTreeDump::create(DetElement top) {
+void detail::GeometryTreeDump::create(DetElement top) {
   dumpDetectors(top, 0);
   dumpStructure(top.placement(), 0);
 }

--- a/DDCore/src/GeometryTreeDump.h
+++ b/DDCore/src/GeometryTreeDump.h
@@ -14,11 +14,15 @@
 #ifndef DDCORE_SRC_GEOMETRYTREEDUMP_H
 #define DDCORE_SRC_GEOMETRYTREEDUMP_H
 
-#include "DD4hep/Detector.h"
-#include "DD4hep/GeoHandler.h"
+// Framework include files
+#include <DD4hep/Detector.h>
+#include <DD4hep/GeoHandler.h>
+
+// C/C++ include files
 #include <set>
 #include <map>
 #include <vector>
+
 class TGeoVolume;
 class TGeoNode;
 

--- a/DDCore/src/GlobalAlignment.cpp
+++ b/DDCore/src/GlobalAlignment.cpp
@@ -12,17 +12,15 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/GlobalAlignment.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/Printout.h"
+#include <DD4hep/GlobalAlignment.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/Printout.h>
 
 // ROOT include files
-#include "TGeoMatrix.h"
-#include "TGeoManager.h"
+#include <TGeoMatrix.h>
+#include <TGeoManager.h>
 
-
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::align;
 
@@ -30,14 +28,14 @@ namespace  {
   struct CheckHandle  {
     CheckHandle(const GlobalAlignment& a)  {
       if ( a.isValid() ) return;
-      throw runtime_error("dd4hep: Attempt to access invalid alignment object. [Invalid Handle]");
+      except("dd4hep:GlobalAlignment", "Attempt to access invalid alignment object. [Invalid Handle]");
     }
     ~CheckHandle() {}
   };
 }
 
 /// Initializing constructor to create a new object
-GlobalAlignment::GlobalAlignment(const string& path) {
+GlobalAlignment::GlobalAlignment(const std::string& path) {
   //cout << "GlobalAlignment: path=" << path << endl;
   m_element = new TGeoPhysicalNode(path.c_str());
 }
@@ -59,8 +57,9 @@ PlacedVolume GlobalAlignment::nodePlacement(int level)   const   {
   CheckHandle verify_handle(*this);
   TGeoNode* n = ptr()->GetNode(level);
   if ( n ) return n;
-  throw runtime_error("dd4hep: The object chain of "+string(placement().name())+
-                      " is too short. [Invalid index]");
+  except("dd4hep:GlobalAlignment",
+         "The object chain of %s is too short. [Invalid index]", placement().name());
+  return {};
 }
 
 /// Access the placement of the mother of this node
@@ -70,7 +69,9 @@ PlacedVolume GlobalAlignment::motherPlacement(int level_up)   const    {
   if ( ind >= 0 )  {
     return ptr()->GetMother(level_up);
   }
-  throw runtime_error("dd4hep: This object "+string(placement().name())+" has not enough mothers. [Invalid index]");
+  except("dd4hep:GlobalAlignment",
+         "This object %s has not enough mothers. [Invalid index]", placement().name());
+  return {};
 }
 
 /// Access the currently applied alignment/placement matrix

--- a/DDCore/src/Grammar.cpp
+++ b/DDCore/src/Grammar.cpp
@@ -12,15 +12,15 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
-#include "DD4hep/Exceptions.h"
-#include "DD4hep/Grammar.h"
-#include "Evaluator/Evaluator.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
+#include <DD4hep/Exceptions.h>
+#include <DD4hep/Grammar.h>
+#include <Evaluator/Evaluator.h>
 
 // ROOT include files
-#include "TDataType.h"
-#include "TROOT.h"
+#include <TDataType.h>
+#include <TROOT.h>
 
 // C/C++ include files
 #include <algorithm>

--- a/DDCore/src/GrammarTypes.cpp
+++ b/DDCore/src/GrammarTypes.cpp
@@ -14,9 +14,9 @@
 // Framework include files
 #include <DD4hep/GrammarParsed.h>
 
-#include "Math/Point3D.h"
-#include "Math/Vector4D.h"
-#include "Math/Vector3D.h"
+#include <Math/Point3D.h>
+#include <Math/Vector4D.h>
+#include <Math/Vector3D.h>
 
 #ifndef DD4HEP_PARSERS_NO_ROOT
 

--- a/DDCore/src/GrammarTypesUnparsed.cpp
+++ b/DDCore/src/GrammarTypesUnparsed.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/GrammarUnparsed.h"
+#include <DD4hep/GrammarUnparsed.h>
 // C/C++ include files
 #include <any>
 

--- a/DDCore/src/Handle.cpp
+++ b/DDCore/src/Handle.cpp
@@ -36,7 +36,6 @@ namespace {
 }
 
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 namespace   {
 

--- a/DDCore/src/Handle.cpp
+++ b/DDCore/src/Handle.cpp
@@ -11,10 +11,10 @@
 //
 //==========================================================================
 
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Printout.h"
-#include "Evaluator/Evaluator.h"
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Printout.h>
+#include <Evaluator/Evaluator.h>
 
 /// C/C++ include files
 #include <iostream>
@@ -35,7 +35,6 @@ namespace {
   const dd4hep::tools::Evaluator& eval(dd4hep::evaluator());
 }
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::detail;
 
@@ -45,9 +44,9 @@ namespace   {
   static bool s_allow_variable_redefine = true;
 
   ///
-  void check_evaluation(const string& value, std::pair<int,double> res, stringstream& err)   {
+  void check_evaluation(const std::string& value, std::pair<int,double> res, std::stringstream& err)   {
     if ( res.first != tools::Evaluator::OK) {
-      throw runtime_error("dd4hep: "+err.str()+" : value="+value+" [Evaluation error]");
+      throw std::runtime_error("dd4hep: "+err.str()+" : value="+value+" [Evaluation error]");
     }
   }
 }
@@ -61,121 +60,121 @@ namespace dd4hep  {
     return tmp;
   }
 
-  std::pair<int, double> _toFloatingPoint(const string& value)   {
-    stringstream err;
+  std::pair<int, double> _toFloatingPoint(const std::string& value)   {
+    std::stringstream err;
     auto result = eval.evaluate(value, err);
     check_evaluation(value, result, err);
     return result;
   }
 
-  std::pair<int, double> _toInteger(const string& value)    {
-    string s(value);
+  std::pair<int, double> _toInteger(const std::string& value)    {
+    std::string s(value);
     size_t idx = s.find("(int)");
-    if (idx != string::npos)
+    if (idx != std::string::npos)
       s.erase(idx, 5);
     idx = s.find("(long)");
-    if (idx != string::npos)
+    if (idx != std::string::npos)
       s.erase(idx, 6);
     while (s[0] == ' ')
       s.erase(0, 1);
     return _toFloatingPoint(s);
   }
 
-  short _toShort(const string& value) {
+  short _toShort(const std::string& value) {
     return (short) _toInteger(value).second;
   }
 
-  unsigned short _toUShort(const string& value) {
+  unsigned short _toUShort(const std::string& value) {
     return (unsigned short) _toInteger(value).second;
   }
 
-  int _toInt(const string& value) {
+  int _toInt(const std::string& value) {
     return (int) _toInteger(value).second;
   }
 
-  unsigned int _toUInt(const string& value) {
+  unsigned int _toUInt(const std::string& value) {
     return (unsigned int) _toInteger(value).second;
   }
 
-  long _toLong(const string& value) {
+  long _toLong(const std::string& value) {
     return (long) _toInteger(value).second;
   }
 
-  unsigned long _toULong(const string& value) {
+  unsigned long _toULong(const std::string& value) {
     return (unsigned long) _toInteger(value).second;
   }
 
-  bool _toBool(const string& value) {
+  bool _toBool(const std::string& value) {
     return value == "true" || value == "yes" || value == "True";
   }
 
   /// String conversions: string to float value
-  float _toFloat(const string& value) {
+  float _toFloat(const std::string& value) {
     return (float) _toFloatingPoint(value).second;
   }
 
   /// String conversions: string to double value
-  double _toDouble(const string& value) {
+  double _toDouble(const std::string& value) {
     return _toFloatingPoint(value).second;
   }
 
   /// Generic type conversion from string to primitive value  \ingroup DD4HEP_CORE
-  template <typename T> T _toType(const string& value)    {
+  template <typename T> T _toType(const std::string& value)    {
     notImplemented("Value "+value+" cannot be converted to type "+typeName(typeid(T)));
     return T();
   }
 
   /// Generic type conversion from string to primitive value
-  template <> bool _toType<bool>(const string& value)  {
+  template <> bool _toType<bool>(const std::string& value)  {
     return _toBool(value);
   }
 
   /// Generic type conversion from string to primitive value
-  template <> short _toType<short>(const string& value)  {
+  template <> short _toType<short>(const std::string& value)  {
     return _toShort(value);
   }
 
   /// Generic type conversion from string to primitive value
-  template <> unsigned short _toType<unsigned short>(const string& value)  {
+  template <> unsigned short _toType<unsigned short>(const std::string& value)  {
     return (unsigned short)_toShort(value);
   }
 
   /// Generic type conversion from string to primitive value
-  template <> int _toType<int>(const string& value)  {
+  template <> int _toType<int>(const std::string& value)  {
     return _toInt(value);
   }
 
   /// Generic type conversion from string to primitive value
-  template <> unsigned int _toType<unsigned int>(const string& value)  {
+  template <> unsigned int _toType<unsigned int>(const std::string& value)  {
     return (unsigned int)_toInt(value);
   }
 
   /// Generic type conversion from string to primitive value
-  template <> long _toType<long>(const string& value)  {
+  template <> long _toType<long>(const std::string& value)  {
     return _toLong(value);
   }
 
   /// Generic type conversion from string to primitive value
-  template <> unsigned long _toType<unsigned long>(const string& value)  {
+  template <> unsigned long _toType<unsigned long>(const std::string& value)  {
     return (unsigned long)_toLong(value);
   }
 
   /// Generic type conversion from string to primitive value
-  template <> float _toType<float>(const string& value)  {
+  template <> float _toType<float>(const std::string& value)  {
     return _toFloat(value);
   }
 
   /// Generic type conversion from string to primitive value
-  template <> double _toType<double>(const string& value)  {
+  template <> double _toType<double>(const std::string& value)  {
     return _toDouble(value);
   }
 
   /// Generic type conversion from string to primitive value
-  template <> string _toType<string>(const string& value)  {
+  template <> std::string _toType<std::string>(const std::string& value)  {
     return value;
   }
 
-  template <> char _multiply<char>(const string& left, const string& right) {
+  template <> char _multiply<char>(const std::string& left, const std::string& right) {
     double val = _toDouble(left + "*" + right);
     if ( val >= double(SCHAR_MIN) && val <= double(SCHAR_MAX) )
       return (char) (int)val;
@@ -185,7 +184,7 @@ namespace dd4hep  {
     return 0;
   }
 
-  template <> unsigned char _multiply<unsigned char>(const string& left, const string& right) {
+  template <> unsigned char _multiply<unsigned char>(const std::string& left, const std::string& right) {
     double val = _toDouble(left + "*" + right);
     if ( val >= 0 && val <= double(UCHAR_MAX) )
       return (unsigned char) (int)val;
@@ -195,7 +194,7 @@ namespace dd4hep  {
     return 0;
   }
 
-  template <> short _multiply<short>(const string& left, const string& right) {
+  template <> short _multiply<short>(const std::string& left, const std::string& right) {
     double val = _toDouble(left + "*" + right);
     if ( val >= double(SHRT_MIN) && val <= double(SHRT_MAX) )
       return (short) val;
@@ -205,7 +204,7 @@ namespace dd4hep  {
     return 0;
   }
 
-  template <> unsigned short _multiply<unsigned short>(const string& left, const string& right) {
+  template <> unsigned short _multiply<unsigned short>(const std::string& left, const std::string& right) {
     double val = _toDouble(left + "*" + right);
     if ( val >= 0 && val <= double(USHRT_MAX) )
       return (unsigned short)val;
@@ -215,49 +214,49 @@ namespace dd4hep  {
     return 0;
   }
 
-  template <> int _multiply<int>(const string& left, const string& right) {
+  template <> int _multiply<int>(const std::string& left, const std::string& right) {
     return (int) _toDouble(left + "*" + right);
   }
 
-  template <> unsigned int _multiply<unsigned int>(const string& left, const string& right) {
+  template <> unsigned int _multiply<unsigned int>(const std::string& left, const std::string& right) {
     return (unsigned int) _toDouble(left + "*" + right);
   }
 
-  template <> long _multiply<long>(const string& left, const string& right) {
+  template <> long _multiply<long>(const std::string& left, const std::string& right) {
     return (long) _toDouble(left + "*" + right);
   }
 
-  template <> unsigned long _multiply<unsigned long>(const string& left, const string& right) {
+  template <> unsigned long _multiply<unsigned long>(const std::string& left, const std::string& right) {
     return (unsigned long) _toDouble(left + "*" + right);
   }
 
-  template <> float _multiply<float>(const string& left, const string& right) {
+  template <> float _multiply<float>(const std::string& left, const std::string& right) {
     return _toFloat(left + "*" + right);
   }
 
-  template <> double _multiply<double>(const string& left, const string& right) {
+  template <> double _multiply<double>(const std::string& left, const std::string& right) {
     return _toDouble(left + "*" + right);
   }
 
-  void _toDictionary(const string& name, const string& value) {
+  void _toDictionary(const std::string& name, const std::string& value) {
     _toDictionary(name, value, "number");
   }
 
   /// Enter name value pair to the dictionary.  \ingroup DD4HEP_CORE
-  void _toDictionary(const string& name, const string& value, const string& typ)   {
+  void _toDictionary(const std::string& name, const std::string& value, const std::string& typ)   {
     if ( typ == "string" )  {
       eval.setEnviron(name.c_str(),value.c_str());
       return;
     }
     else  {
       int status;
-      stringstream err;
-      string n = name, v = value;
+      std::stringstream err;
+      std::string n = name, v = value;
       size_t idx = v.find("(int)");
-      if (idx != string::npos)
+      if (idx != std::string::npos)
         v.erase(idx, 5);
       idx = v.find("(float)");
-      if (idx != string::npos)
+      if (idx != std::string::npos)
         v.erase(idx, 7);
       while (v[0] == ' ')
         v.erase(0, 1);
@@ -266,48 +265,47 @@ namespace dd4hep  {
       err.str("");
       status = eval.setVariable(n, result.second, err);
       if ( status != tools::Evaluator::OK )   {
-	stringstream err_msg;
-	err_msg << "name=" << name << " value=" << value
-		<< "  " << err.str() << " [setVariable error]";
-	if ( status == tools::Evaluator::WARNING_EXISTING_VARIABLE )   {
-	  if ( s_allow_variable_redefine )
-	    printout(WARNING,"Evaluator","+++ Overwriting variable: "+err_msg.str());
-	  else
-	    except("Evaluator","+++ Overwriting variable: "+err_msg.str());
-	}
+        std::stringstream err_msg;
+        err_msg << "name=" << name << " value=" << value
+                << "  " << err.str() << " [setVariable error]";
+        if ( status == tools::Evaluator::WARNING_EXISTING_VARIABLE )   {
+          if ( s_allow_variable_redefine )
+            printout(WARNING,"Evaluator","+++ Overwriting variable: "+err_msg.str());
+          else
+            except("Evaluator","+++ Overwriting variable: "+err_msg.str());
+        }
       }
     }
   }
 
   /// Evaluate string constant using environment stored in the evaluator
-  string _getEnviron(const string& env)   {    
-    // We are trying to deal with the case when several variables are being replaced in the
-    // string.   
+  std::string _getEnviron(const std::string& env)   {    
+    // We are trying to deal with the case when several variables are being replaced in the string.   
     size_t current_index = 0;
-    stringstream processed_variable;
+    std::stringstream processed_variable;
     while (true) {
       // Looking for the start of a variable use, with the syntax
       // "path1/path2/${VAR1}/path3/${VAR2}"
       size_t id1 = env.find("${", current_index);
       // variable start found, do a greedy search for the variable end 
-      if (id1 == string::npos) {
-         // In this case we did not find the ${ to indicate a start of variable,
+      if (id1 == std::string::npos) {
+        // In this case we did not find the ${ to indicate a start of variable,
         // we just copy the rest of the variable to the stringstream and exit
         processed_variable << env.substr(current_index);
         break;
       }
       size_t id2 = env.find("}", id1);
-      if (id2 == string::npos) {
-        runtime_error("dd4hep: Syntax error, bad variable syntax: " + env); 
+      if (id2 == std::string::npos) {
+        std::runtime_error("dd4hep: Syntax error, bad variable syntax: " + env); 
       }
       processed_variable << env.substr(current_index, id1 -current_index );
-      string v   = env.substr(id1, id2-id1+1);
-      stringstream err;
+      std::string v   = env.substr(id1, id2-id1+1);
+      std::stringstream err;
       auto   ret = eval.getEnviron(v, err);
       // Checking that the variable lookup worked
       if ( ret.first != tools::Evaluator::OK) {
-        cerr << v << ": " << err.str() << endl;
-        throw runtime_error("dd4hep: Severe error during environment lookup of " + v + " " + err.str());
+        std::cerr << v << ": " << err.str() << std::endl;
+        throw std::runtime_error("dd4hep: Severe error during environment lookup of " + v + " " + err.str());
       }
       // Now adding the variable
       processed_variable << ret.second;
@@ -317,8 +315,8 @@ namespace dd4hep  {
   }
 
   /// String manipulations: Remove unconditionally all white spaces
-  string remove_whitespace(const string& v)    {
-    string value;
+  std::string remove_whitespace(const std::string& v)    {
+    std::string value;
     value.reserve(v.length()+1);
     for(const char* p = v.c_str(); *p; ++p)   {
       if ( !::isspace(*p) ) value += *p;
@@ -326,37 +324,37 @@ namespace dd4hep  {
     return value;
   }
 
-  template <typename T> static inline string __to_string(T value, const char* fmt) {
+  template <typename T> static inline std::string __to_string(T value, const char* fmt) {
     char text[128];
     ::snprintf(text, sizeof(text), fmt, value);
     return text;
   }
 
-  string _toString(bool value) {
+  std::string _toString(bool value) {
     return value ? "true" : "false";
   }
 
-  string _toString(short value, const char* fmt) {
+  std::string _toString(short value, const char* fmt) {
     return __to_string((int)value, fmt);
   }
 
-  string _toString(int value, const char* fmt) {
+  std::string _toString(int value, const char* fmt) {
     return __to_string(value, fmt);
   }
 
-  string _toString(unsigned long value, const char* fmt) {
+  std::string _toString(unsigned long value, const char* fmt) {
     return __to_string(value, fmt);
   }
 
-  string _toString(float value, const char* fmt) {
+  std::string _toString(float value, const char* fmt) {
     return __to_string(value, fmt);
   }
 
-  string _toString(double value, const char* fmt) {
+  std::string _toString(double value, const char* fmt) {
     return __to_string(value, fmt);
   }
 
-  string _ptrToString(const void* value, const char* fmt) {
+  std::string _ptrToString(const void* value, const char* fmt) {
     return __to_string(value, fmt);
   }
 
@@ -371,19 +369,19 @@ namespace dd4hep  {
   }
   void warning_deprecated_xml_factory(const char* name)   {
     const char* edge = "++++++++++++++++++++++++++++++++++++++++++";
-    size_t len = ::strlen(name);
-    cerr << edge << edge << edge << endl;
-    cerr << "++  The usage of the factory: \"" << name << "\" is DEPRECATED due to naming conventions."
-         << setw(53-len) << right << "++" << endl;
-    cerr << "++  Please use \"DD4hep_" << name << "\" instead." << setw(93-len) << right << "++" << endl;
-    cerr << edge << edge << edge << endl;
+    size_t len = std::strlen(name);
+    std::cerr << edge << edge << edge << std::endl;
+    std::cerr << "++  The usage of the factory: \"" << name << "\" is DEPRECATED due to naming conventions."
+              << std::setw(53-len) << std::right << "++" << std::endl;
+    std::cerr << "++  Please use \"DD4hep_" << name << "\" instead." << std::setw(93-len) << std::right << "++" << std::endl;
+    std::cerr << edge << edge << edge << std::endl;
   }
 }
 
 #include "DDSegmentation/Segmentation.h"
 typedef DDSegmentation::Segmentation _Segmentation;
 namespace dd4hep {
-  template <> void Handle<_Segmentation>::assign(_Segmentation* s, const string& n, const string&) {
+  template <> void Handle<_Segmentation>::assign(_Segmentation* s, const std::string& n, const std::string&) {
     this->m_element = s;
     s->setName(n);
   }
@@ -393,9 +391,9 @@ namespace dd4hep {
   template class dd4hep::Handle<_Segmentation>;
 }
 
-#include "DD4hep/Detector.h"
-#include "TMap.h"
-#include "TColor.h"
+#include <DD4hep/Detector.h>
+#include <TMap.h>
+#include <TColor.h>
 
 template class dd4hep::Handle<NamedObject>;
 DD4HEP_SAFE_CAST_IMPLEMENTATION(NamedObject,NamedObject)
@@ -404,14 +402,14 @@ DD4HEP_INSTANTIATE_HANDLE_UNNAMED(Detector);
 DD4HEP_INSTANTIATE_HANDLE_CODE(RAW,TObject,NamedObject);
 DD4HEP_INSTANTIATE_HANDLE_CODE(NONE,TNamed,TObject,NamedObject);
 
-#include "TGeoMedium.h"
-#include "TGeoMaterial.h"
-#include "TGeoElement.h"
+#include <TGeoMedium.h>
+#include <TGeoMaterial.h>
+#include <TGeoElement.h>
 DD4HEP_INSTANTIATE_HANDLE(TGeoElement);
 DD4HEP_INSTANTIATE_HANDLE(TGeoMaterial);
 DD4HEP_INSTANTIATE_HANDLE(TGeoMedium);
 
-#include "TGeoMatrix.h"
+#include <TGeoMatrix.h>
 DD4HEP_INSTANTIATE_HANDLE(TGeoMatrix);
 DD4HEP_INSTANTIATE_HANDLE(TGeoRotation);
 DD4HEP_INSTANTIATE_HANDLE(TGeoTranslation);
@@ -419,7 +417,7 @@ DD4HEP_INSTANTIATE_HANDLE(TGeoIdentity);
 DD4HEP_INSTANTIATE_HANDLE(TGeoCombiTrans);
 DD4HEP_INSTANTIATE_HANDLE(TGeoGenTrans);
 
-#include "TGeoNode.h"
+#include <TGeoNode.h>
 DD4HEP_INSTANTIATE_HANDLE_CODE(RAW,TGeoAtt);
 DD4HEP_INSTANTIATE_HANDLE_CODE(RAW,TAtt3D);
 DD4HEP_INSTANTIATE_HANDLE_CODE(RAW,TAttLine);
@@ -428,23 +426,24 @@ DD4HEP_INSTANTIATE_HANDLE(TGeoNodeMatrix);
 DD4HEP_INSTANTIATE_HANDLE(TGeoNodeOffset);
 
 // Shapes (needed by "Shapes.cpp")
-#include "TGeoBBox.h"
-#include "TGeoPcon.h"
-#include "TGeoPgon.h"
-#include "TGeoTube.h"
-#include "TGeoCone.h"
-#include "TGeoArb8.h"
-#include "TGeoTrd1.h"
-#include "TGeoTrd2.h"
-#include "TGeoParaboloid.h"
-#include "TGeoSphere.h"
-#include "TGeoTorus.h"
-#include "TGeoBoolNode.h"
-#include "TGeoVolume.h"
-#include "TGeoScaledShape.h"
-#include "TGeoCompositeShape.h"
-#include "TGeoShapeAssembly.h"
-#include "DD4hep/detail/ShapesInterna.h"
+#include <TGeoBBox.h>
+#include <TGeoPcon.h>
+#include <TGeoPgon.h>
+#include <TGeoTube.h>
+#include <TGeoCone.h>
+#include <TGeoArb8.h>
+#include <TGeoTrd1.h>
+#include <TGeoTrd2.h>
+#include <TGeoParaboloid.h>
+#include <TGeoSphere.h>
+#include <TGeoTorus.h>
+#include <TGeoTessellated.h>
+#include <TGeoBoolNode.h>
+#include <TGeoVolume.h>
+#include <TGeoScaledShape.h>
+#include <TGeoCompositeShape.h>
+#include <TGeoShapeAssembly.h>
+#include <DD4hep/detail/ShapesInterna.h>
 DD4HEP_INSTANTIATE_HANDLE(TGeoVolumeAssembly,TGeoVolume,TGeoAtt);
 DD4HEP_INSTANTIATE_HANDLE(TGeoVolumeMulti,TGeoVolume,TGeoAtt);
 DD4HEP_INSTANTIATE_HANDLE(TGeoVolume,TGeoAtt,TAttLine,TAtt3D);
@@ -475,27 +474,23 @@ DD4HEP_INSTANTIATE_SHAPE_HANDLE(TGeoTrd1);
 DD4HEP_INSTANTIATE_SHAPE_HANDLE(TGeoTrd2);
 DD4HEP_INSTANTIATE_SHAPE_HANDLE(TGeoSphere);
 DD4HEP_INSTANTIATE_SHAPE_HANDLE(TGeoTorus);
-
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
-#include "TGeoTessellated.h"
 DD4HEP_INSTANTIATE_SHAPE_HANDLE(TGeoTessellated);
-#endif
 
 DD4HEP_INSTANTIATE_SHAPE_HANDLE(TGeoHalfSpace);
 DD4HEP_INSTANTIATE_SHAPE_HANDLE(TGeoShapeAssembly);
 DD4HEP_INSTANTIATE_SHAPE_HANDLE(TGeoCompositeShape);
 
 // Volume Placements (needed by "Volumes.cpp")
-#include "TGeoPhysicalNode.h"
+#include <TGeoPhysicalNode.h>
 DD4HEP_INSTANTIATE_HANDLE(TGeoPhysicalNode);
 
-#include "TGeoBoolNode.h"
+#include <TGeoBoolNode.h>
 DD4HEP_INSTANTIATE_HANDLE_UNNAMED(TGeoUnion);
 DD4HEP_INSTANTIATE_HANDLE_UNNAMED(TGeoIntersection);
 DD4HEP_INSTANTIATE_HANDLE_UNNAMED(TGeoSubtraction);
 
 // Replicated Volumes (needed by "Volumes.cpp")
-#include "TGeoPatternFinder.h"
+#include <TGeoPatternFinder.h>
 DD4HEP_INSTANTIATE_HANDLE_UNNAMED(TGeoPatternFinder);
 DD4HEP_INSTANTIATE_HANDLE_UNNAMED(TGeoPatternX);
 DD4HEP_INSTANTIATE_HANDLE_UNNAMED(TGeoPatternY);

--- a/DDCore/src/IDDescriptor.cpp
+++ b/DDCore/src/IDDescriptor.cpp
@@ -11,21 +11,23 @@
 //
 //==========================================================================
 
+// Framework include files
 #include "DD4hep/IDDescriptor.h"
 #include "DD4hep/detail/Handle.inl"
 #include "DD4hep/detail/ObjectsInterna.h"
 #include "DD4hep/InstanceCount.h"
 #include "DD4hep/Volumes.h"
 #include "DD4hep/Printout.h"
+
+// C/C++ include files
 #include <stdexcept>
 #include <cstdlib>
 #include <cmath>
-using namespace std;
+
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 namespace {
-  void _construct(IDDescriptor::Object* o, const string& dsc) {
+  void _construct(IDDescriptor::Object* o, const std::string& dsc) {
     BitFieldCoder& bf = o->decoder;
     o->fieldIDs.clear();
     o->fieldMap.clear();
@@ -39,23 +41,23 @@ namespace {
 }
 
 /// Initializing constructor
-IDDescriptor::IDDescriptor(const string& nam, const string& description) {
+IDDescriptor::IDDescriptor(const std::string& nam, const std::string& description) {
   Object* obj = new Object(description);
   assign(obj, nam, "iddescriptor");
   _construct(obj, description);
 }
 
 /// Re-build object in place
-void IDDescriptor::rebuild(const string& description)   {
+void IDDescriptor::rebuild(const std::string& description)   {
   Object* p = ptr();
-  string  dsc = description;
+  std::string  dsc = description;
   p->decoder.~BitFieldCoder();
   new(&p->decoder) BitFieldCoder(dsc);
   _construct(p, dsc);
 }
 
-/// Acces string representation
-string IDDescriptor::toString() const {
+/// Acces std::string representation
+std::string IDDescriptor::toString() const {
   if ( isValid() ) {
     return m_element->GetName();
   }
@@ -77,7 +79,8 @@ const IDDescriptor::FieldIDs& IDDescriptor::ids() const {
   if ( isValid() ) {
     return data<Object>()->fieldIDs;
   }
-  throw runtime_error("dd4hep: Attempt to access an invalid IDDescriptor object.");
+  except("IDDescriptor","dd4hep: Attempt to access an invalid IDDescriptor object.");
+  throw std::runtime_error("dd4hep");  // Never called. Simply make the compiler happy!
 }
 
 /// Access the fieldmap container
@@ -85,18 +88,19 @@ const IDDescriptor::FieldMap& IDDescriptor::fields() const {
   if ( isValid() ) {
     return data<Object>()->fieldMap;
   }
-  throw runtime_error("dd4hep: Attempt to access an invalid IDDescriptor object.");
+  except("IDDescriptor","dd4hep: Attempt to access an invalid IDDescriptor object.");
+  throw std::runtime_error("dd4hep");  // Never called. Simply make the compiler happy!
 }
 
 /// Get the field descriptor of one field by name
-const BitFieldElement* IDDescriptor::field(const string& field_name) const {
+const BitFieldElement* IDDescriptor::field(const std::string& field_name) const {
   const FieldMap& fm = fields();   // This already checks the object validity
   for (const auto& i : fm )
     if (i.first == field_name)
       return i.second;
   except("IDDescriptor","dd4hep: %s: This ID descriptor has no field with the name: %s",
          name(),field_name.c_str());
-  throw runtime_error("dd4hep");  // Never called. Simply make the compiler happy!
+  throw std::runtime_error("dd4hep");  // Never called. Simply make the compiler happy!
 }
 
 /// Get the field descriptor of one field by its identifier
@@ -106,14 +110,14 @@ const BitFieldElement* IDDescriptor::field(size_t identifier) const {
 }
 
 /// Get the field identifier of one field by name
-size_t IDDescriptor::fieldID(const string& field_name) const {
+std::size_t IDDescriptor::fieldID(const std::string& field_name) const {
   const FieldIDs& fm = ids();   // This already checks the object validity
   for (const auto& i : fm )
     if (i.second == field_name)
       return i.first;
   except("IDDescriptor","dd4hep: %s: This ID descriptor has no field with the name: %s",
          name(),field_name.c_str());
-  throw runtime_error("dd4hep");  // Never called. Simply make the compiler happy!
+  throw std::runtime_error("dd4hep");  // Never called. Simply make the compiler happy!
 }
 
 /// Compute the submask for a given set of volume IDs
@@ -158,34 +162,36 @@ VolumeID IDDescriptor::encode_reverse(const std::vector<std::pair<std::string, i
 
 /// Decode volume IDs and return filled descriptor with all fields
 void IDDescriptor::decodeFields(VolumeID vid,
-                                vector<pair<const BitFieldElement*, VolumeID> >& flds)  const
+                                std::vector<std::pair<const BitFieldElement*, VolumeID> >& flds)  const
 {
-  const vector<BitFieldElement>& v = access()->decoder.fields();
+  const std::vector<BitFieldElement>& v = access()->decoder.fields();
   flds.clear();
   for (auto& f : v )
     flds.emplace_back(&f, f.value(vid));
 }
 
 /// Decode volume IDs and return string reprensentation for debugging purposes
-string IDDescriptor::str(VolumeID vid)   const {
-  const vector<BitFieldElement>& v = access()->decoder.fields();
-  stringstream str;
+std::string IDDescriptor::str(VolumeID vid)   const {
+  const std::vector<BitFieldElement>& v = access()->decoder.fields();
+  std::stringstream str;
   for (auto& f : v )
-    str << f.name() << ":" << setw(4) << setfill('0') << hex << right << f.value(vid)
-        << left << dec << " ";
-  return str.str().substr(0,str.str().length()-1);
+    str << f.name()  << ":" << std::setw(4) << std::setfill('0')
+        << std::hex  << std::right << f.value(vid)
+        << std::left << std::dec << " ";
+  return str.str().substr(0, str.str().length()-1);
 }
 
 /// Decode volume IDs and return string reprensentation for debugging purposes
-string IDDescriptor::str(VolumeID vid, VolumeID mask)   const {
-  const vector<BitFieldElement>& v = access()->decoder.fields();
-  stringstream str;
+std::string IDDescriptor::str(VolumeID vid, VolumeID mask)   const {
+  const std::vector<BitFieldElement>& v = access()->decoder.fields();
+  std::stringstream str;
   for (auto& f : v )  {
     if ( 0 == (mask&f.mask()) ) continue;
-    str << f.name() << ":" << setw(4) << setfill('0') << hex << right << f.value(vid)
-        << left << dec << " ";
+    str << f.name()  << ":" << std::setw(4) << std::setfill('0')
+        << std::hex  << std::right << f.value(vid)
+        << std::left << std::dec << " ";
   }
-  return str.str().substr(0,str.str().length()-1);
+  return str.str().substr(0, str.str().length()-1);
 }
 
 /// Access the BitFieldCoder object

--- a/DDCore/src/IOV.cpp
+++ b/DDCore/src/IOV.cpp
@@ -12,16 +12,15 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/IOV.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
+#include <DD4hep/IOV.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
 
 // C/C++ include files
 #include <climits>
 #include <iomanip>
 #include <cstring>
 
-using namespace std;
 using namespace dd4hep;
 
 #if __cplusplus == 201402
@@ -139,7 +138,7 @@ void IOV::move(IOV& from)   {
 }
 
 /// Create string representation of the IOV
-string IOV::str()  const  {
+std::string IOV::str()  const  {
   char text[256];
   if ( iovType )  {
     /// Need the long(x) casts for compatibility with Apple MAC
@@ -152,8 +151,8 @@ string IOV::str()  const  {
       char c_since[64], c_until[64];
       static constexpr const Key_value_type nil = 0;
       static const Key_value_type max_time = detail::makeTime(2099,12,31,24,59,59);
-      time_t since = std::min(std::max(keyData.first, nil), max_time);
-      time_t until = std::min(std::max(keyData.second,nil), max_time);
+      std::time_t since = std::min(std::max(keyData.first, nil), max_time);
+      std::time_t until = std::min(std::max(keyData.second,nil), max_time);
       struct tm* tm_since = ::gmtime_r(&since,&time_buff);
       struct tm* tm_until = ::gmtime_r(&until,&time_buff);
       if ( nullptr == tm_since || nullptr == tm_until )    {
@@ -164,7 +163,7 @@ string IOV::str()  const  {
       ::strftime(c_until,sizeof(c_until),"%d-%m-%Y %H:%M:%S", tm_until);
       ::snprintf(text,sizeof(text),"%s(%u):[%s - %s]",
                  iovType->name.c_str(), iovType->type,
-		 c_since, c_until);
+                 c_since, c_until);
     }
     else   {
       ::snprintf(text,sizeof(text),"%s(%u):[%ld-%ld]",

--- a/DDCore/src/InstanceCount.cpp
+++ b/DDCore/src/InstanceCount.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 /// Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Handle.h"
-#include "DD4hep/Memory.h"
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Handle.h>
+#include <DD4hep/Memory.h>
 
 /// C/C++ include files
 #include <iostream>
@@ -32,13 +32,13 @@ namespace {
   typedef InstanceCount::Counter COUNT;
   typedef std::map<const std::type_info*, COUNT*> TypeCounter;
   typedef std::map<const std::string*, COUNT*> StringCounter;
-  static bool s_trace_instances = ::getenv("DD4HEP_TRACE") != 0;
-  static dd4hep_ptr<TypeCounter> s_typCounts(new TypeCounter());
-  static dd4hep_ptr<StringCounter> s_strCounts(new StringCounter());
-  static InstanceCount::Counter s_nullCount;
-  static InstanceCount::Counter s_thisCount;
-  static InstanceCount s_counter;
-  inline TypeCounter& types() {
+  static  bool s_trace_instances = ::getenv("DD4HEP_TRACE") != 0;
+  static  dd4hep_ptr<TypeCounter> s_typCounts(new TypeCounter());
+  static  dd4hep_ptr<StringCounter> s_strCounts(new StringCounter());
+  static  InstanceCount::Counter s_nullCount;
+  static  InstanceCount::Counter s_thisCount;
+  static  InstanceCount s_counter;
+  inline  TypeCounter& types() {
     return *(s_typCounts.get());
   }
   inline StringCounter& strings() {

--- a/DDCore/src/JSON/Detector.cpp
+++ b/DDCore/src/JSON/Detector.cpp
@@ -13,11 +13,11 @@
 #ifndef DD4HEP_NONE
 
 // Framework include files
-#include "JSON/Detector.h"
+#include <JSON/Detector.h>
 
 // Instantiate here the concrete implementations
 #define DD4HEP_DIMENSION_NS json
 using namespace dd4hep::DD4HEP_DIMENSION_NS;
 
-#include "Parsers/detail/Detector.imp"
+#include <Parsers/detail/Detector.imp>
 #endif

--- a/DDCore/src/JSON/DocumentHandler.cpp
+++ b/DDCore/src/JSON/DocumentHandler.cpp
@@ -21,7 +21,6 @@
 #include <memory>
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep::json;
 
 /// Default constructor
@@ -33,13 +32,13 @@ DocumentHandler::~DocumentHandler()   {
 }
 
 /// Load XML file and parse it.
-Document DocumentHandler::load(const string& fname) const   {
-  string fn = fname;
-  if ( fname.find("://") != string::npos ) fn = fname.substr(fname.find("://")+3);
-  //string cmd = "cat "+fn;
+Document DocumentHandler::load(const std::string& fname) const   {
+  std::string fn = fname;
+  if ( fname.find("://") != std::string::npos ) fn = fname.substr(fname.find("://")+3);
+  //std::string cmd = "cat "+fn;
   //::printf("\n\n+++++ Dump json file: %s\n\n\n",fn.c_str());
   //::system(cmd.c_str());
-  unique_ptr<JsonElement> doc(new JsonElement(fn, ptree()));
+  std::unique_ptr<JsonElement> doc(new JsonElement(fn, ptree()));
   boost::property_tree::read_json(fn,doc->second);
   return doc.release();
 }
@@ -47,5 +46,5 @@ Document DocumentHandler::load(const string& fname) const   {
 /// Parse a standalong XML string into a document.
 Document DocumentHandler::parse(const char* doc_string, size_t length) const   {
   if ( doc_string && length ) {}
-  throw runtime_error("Bla");
+  throw std::runtime_error("Bla");
 }

--- a/DDCore/src/JSON/Elements.cpp
+++ b/DDCore/src/JSON/Elements.cpp
@@ -12,8 +12,8 @@
 //==========================================================================
 
 // Framework include files
-#include "JSON/Printout.h"
-#include "JSON/Elements.h"
+#include <JSON/Printout.h>
+#include <JSON/Elements.h>
 
 // C/C++ include files
 #include <iostream>
@@ -21,21 +21,20 @@
 #include <cstdio>
 #include <map>
 
-using namespace std;
 using namespace dd4hep::json;
 static const size_t INVALID_NODE = ~0U;
 
 // Forward declarations
 namespace dd4hep {
-  std::pair<int, double> _toInteger(const string& value);
-  std::pair<int, double> _toFloatingPoint(const string& value);
-  void   _toDictionary(const string& name, const string& value, const string& typ);
-  string _getEnviron(const string& env);
+  std::pair<int, double> _toInteger(const std::string& value);
+  std::pair<int, double> _toFloatingPoint(const std::string& value);
+  void   _toDictionary(const std::string& name, const std::string& value, const std::string& typ);
+  std::string _getEnviron(const std::string& env);
 }
 // Static storage
 namespace {
-  string _checkEnviron(const string& env)  {
-    string r = dd4hep::_getEnviron(env);
+  std::string _checkEnviron(const std::string& env)  {
+    std::string r = dd4hep::_getEnviron(env);
     return r.empty() ? env : r;
   }
 }
@@ -50,7 +49,7 @@ namespace {
 
   JsonElement* node_first(JsonElement* e, const char* tag) {
     if ( e )  {
-      string t(tag);
+      std::string t(tag);
       if ( t == "*" )  {
         ptree::iterator i = e->second.begin();
         return i != e->second.end() ? &(*i) : 0;
@@ -61,7 +60,7 @@ namespace {
     return 0;
   }
 
-  size_t node_count(JsonElement* e, const string& t) {
+  size_t node_count(JsonElement* e, const std::string& t) {
     return e ? (t=="*" ? e->second.size() : e->second.count(t)) : 0;
   }
 
@@ -78,64 +77,64 @@ namespace {
   }
 }
 
-string dd4hep::json::_toString(Attribute attr) {
+std::string dd4hep::json::_toString(Attribute attr) {
   if (attr)
     return _toString(attribute_value(attr));
   return "";
 }
 
-template <typename T> static inline string __to_string(T value, const char* fmt) {
+template <typename T> static inline std::string __to_string(T value, const char* fmt) {
   char text[128];
   ::snprintf(text, sizeof(text), fmt, value);
   return text;
 }
 
 /// Do-nothing version. Present for completeness and argument interchangeability
-string dd4hep::json::_toString(const char* s) {
+std::string dd4hep::json::_toString(const char* s) {
   if ( !s || *s == 0 ) return "";
   else if ( !(*s == '$' && *(s+1) == '{') ) return s;
   return _checkEnviron(s);
 }
 
 /// Do-nothing version. Present for completeness and argument interchangeability
-string dd4hep::json::_toString(const string& s) {
+std::string dd4hep::json::_toString(const std::string& s) {
   if ( s.length() < 3 || s[0] != '$' ) return s;
   else if ( !(s[0] == '$' && s[1] == '{') ) return s;
   return _checkEnviron(s);
 }
 
 /// Format unsigned long integer to string with arbitrary format
-string dd4hep::json::_toString(unsigned long v, const char* fmt) {
+std::string dd4hep::json::_toString(unsigned long v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
 /// Format unsigned integer (32 bits) to string with arbitrary format
-string dd4hep::json::_toString(unsigned int v, const char* fmt) {
+std::string dd4hep::json::_toString(unsigned int v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
 /// Format signed integer (32 bits) to string with arbitrary format
-string dd4hep::json::_toString(int v, const char* fmt) {
+std::string dd4hep::json::_toString(int v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
 /// Format signed long integer to string with arbitrary format
-string dd4hep::json::_toString(long v, const char* fmt)   {
+std::string dd4hep::json::_toString(long v, const char* fmt)   {
   return __to_string(v, fmt);
 }
 
 /// Format single procision float number (32 bits) to string with arbitrary format
-string dd4hep::json::_toString(float v, const char* fmt) {
+std::string dd4hep::json::_toString(float v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
 /// Format double procision float number (64 bits) to string with arbitrary format
-string dd4hep::json::_toString(double v, const char* fmt) {
+std::string dd4hep::json::_toString(double v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
 /// Format pointer to string with arbitrary format
-string dd4hep::json::_ptrToString(const void* v, const char* fmt) {
+std::string dd4hep::json::_ptrToString(const void* v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
@@ -149,7 +148,7 @@ int dd4hep::json::_toInt(const char* value) {
 
 bool dd4hep::json::_toBool(const char* value) {
   if (value) {
-    string s = _toString(value);
+    std::string s = _toString(value);
     return s == "true";
   }
   return false;
@@ -171,7 +170,7 @@ template <typename T> void dd4hep::json::_toDictionary(const char* name, T value
   dd4hep::_toDictionary(name, _toString(value), "number");
 }
 
-template void dd4hep::json::_toDictionary(const char* name, const string& value);
+template void dd4hep::json::_toDictionary(const char* name, const std::string& value);
 template void dd4hep::json::_toDictionary(const char* name, unsigned long value);
 template void dd4hep::json::_toDictionary(const char* name, unsigned int value);
 template void dd4hep::json::_toDictionary(const char* name, unsigned short value);
@@ -182,7 +181,7 @@ template void dd4hep::json::_toDictionary(const char* name, float value);
 template void dd4hep::json::_toDictionary(const char* name, double value);
 
 /// Evaluate string constant using environment stored in the evaluator
-string dd4hep::json::getEnviron(const string& env)   {
+std::string dd4hep::json::getEnviron(const std::string& env)   {
   return dd4hep::_getEnviron(env);
 }
 
@@ -194,7 +193,7 @@ NodeList::NodeList(const NodeList& copy)
 }
 
 /// Initializing constructor
-NodeList::NodeList(JsonElement* node, const string& tag_value)
+NodeList::NodeList(JsonElement* node, const std::string& tag_value)
   : m_tag(tag_value), m_node(node)
 {
   reset();
@@ -207,7 +206,7 @@ NodeList::~NodeList() {
 /// Reset the nodelist
 JsonElement* NodeList::reset() {
   if ( m_tag == "*" )
-    m_ptr = make_pair(m_node->second.ordered_begin(), m_node->second.not_found());
+    m_ptr = std::make_pair(m_node->second.ordered_begin(), m_node->second.not_found());
   else
     m_ptr = m_node->second.equal_range(m_tag);
   if ( m_ptr.first != m_ptr.second )
@@ -269,8 +268,8 @@ bool Handle_t::hasAttr(const char* tag_value) const {
 }
 
 /// Retrieve a collection of all attributes of this DOM element
-vector<Attribute> Handle_t::attributes() const {
-  vector < Attribute > attrs;
+std::vector<Attribute> Handle_t::attributes() const {
+  std::vector < Attribute > attrs;
   if (m_node) {
     for(ptree::iterator i=m_node->second.begin(); i!=m_node->second.end(); ++i)  {
       Attribute a = &(*i);
@@ -286,12 +285,12 @@ size_t Handle_t::numChildren(const char* t, bool throw_exception) const {
     return 0;
   else if (n != INVALID_NODE)
     return n;
-  string msg = "Handle_t::numChildren: ";
+  std::string msg = "Handle_t::numChildren: ";
   if (m_node)
     msg += "Element [" + tag() + "] has no children of type '" + _toString(t) + "'";
   else
     msg += "Element [INVALID] has no children of type '" + _toString(t) + "'";
-  throw runtime_error(msg);
+  throw std::runtime_error(msg);
 }
 
 /// Remove a single child node identified by its handle from the tree of the element
@@ -299,12 +298,12 @@ Handle_t Handle_t::child(const char* t, bool throw_exception) const {
   Elt_t e = node_first(m_node, t);
   if (e || !throw_exception)
     return e;
-  string msg = "Handle_t::child: ";
+  std::string msg = "Handle_t::child: ";
   if (m_node)
     msg += "Element [" + tag() + "] has no child of type '" + _toString(t) + "'";
   else
     msg += "Element [INVALID]. Cannot remove child of type: '" + _toString(t) + "'";
-  throw runtime_error(msg);
+  throw std::runtime_error(msg);
 }
 
 NodeList Handle_t::children(const char* tag_value) const {
@@ -320,12 +319,12 @@ Attribute Handle_t::attr_ptr(const char* t) const {
   Attribute a = attribute_node(m_node, t);
   if (0 != a)
     return a;
-  string msg = "Handle_t::attr_ptr: ";
+  std::string msg = "Handle_t::attr_ptr: ";
   if (m_node)
     msg += "Element [" + tag() + "] has no attribute of type '" + _toString(t) + "'";
   else
     msg += "Element [INVALID] has no attribute of type '" + _toString(t) + "'";
-  throw runtime_error(msg);
+  throw std::runtime_error(msg);
 }
 
 /// Access attribute name (throws exception if not present)
@@ -333,7 +332,7 @@ const char* Handle_t::attr_name(const Attribute a) const {
   if (a) {
     return a->first.c_str();
   }
-  throw runtime_error("Attempt to access invalid XML attribute object!");
+  throw std::runtime_error("Attempt to access invalid XML attribute object!");
 }
 
 /// Access attribute value by the attribute's unicode name (throws exception if not present)
@@ -358,7 +357,7 @@ Handle_t Document::root() const   {
   if ( m_doc )   {
     return m_doc;
   }
-  throw runtime_error("Document::root: Invalid handle!");
+  throw std::runtime_error("Document::root: Invalid handle!");
 }
 
 /// Assign new document. Old document is dropped.
@@ -403,11 +402,11 @@ size_t Collection_t::size() const {
 }
 
 /// Helper function to throw an exception
-void Collection_t::throw_loop_exception(const exception& e) const {
+void Collection_t::throw_loop_exception(const std::exception& e) const {
   if (m_node) {
-    throw runtime_error(string(e.what()) + "\n" + "dd4hep: Error interpreting XML nodes of type <" + tag() + "/>");
+    throw std::runtime_error(std::string(e.what()) + "\n" + "dd4hep: Error interpreting XML nodes of type <" + tag() + "/>");
   }
-  throw runtime_error(string(e.what()) + "\n" + "dd4hep: Error interpreting collections XML nodes.");
+  throw std::runtime_error(std::string(e.what()) + "\n" + "dd4hep: Error interpreting collections XML nodes.");
 }
 
 void Collection_t::operator++() const {
@@ -444,8 +443,8 @@ void dd4hep::json::dumpTree(Element elt)   {
 
 void dd4hep::json::dumpTree(const JsonElement* elt)   {
   struct Dump {
-    void operator()(const JsonElement* e, const string& tag)   const  {
-      string t = tag+"   ";
+    void operator()(const JsonElement* e, const std::string& tag)   const  {
+      std::string t = tag+"   ";
       printout(INFO,"DumpTree","+++ %s %s: %s",tag.c_str(), e->first.c_str(), e->second.data().c_str());
       for(auto i=e->second.begin(); i!=e->second.end(); ++i)
         (*this)(&(*i), t);

--- a/DDCore/src/JSON/Helpers.cpp
+++ b/DDCore/src/JSON/Helpers.cpp
@@ -12,8 +12,8 @@
 //==========================================================================
 
 // Framework include files
-#include "JSON/Dimension.inl"
-#include "JSON/ChildValue.inl"
+#include <JSON/Dimension.inl>
+#include <JSON/ChildValue.inl>
 
 // Instantiate here the concrete implementations
 #define DD4HEP_DIMENSION_NS json

--- a/DDCore/src/MatrixHelpers.cpp
+++ b/DDCore/src/MatrixHelpers.cpp
@@ -12,8 +12,8 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/DD4hepUnits.h"
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/DD4hepUnits.h>
 
 #ifdef DD4HEP_USE_GEANT4_UNITS
 #define MM_2_CM 1.0
@@ -22,7 +22,7 @@
 #endif
 
 // ROOT includes
-#include "TGeoMatrix.h"
+#include <TGeoMatrix.h>
 
 TGeoIdentity* dd4hep::detail::matrix::_identity() {
   return gGeoIdentity;

--- a/DDCore/src/MultiSegmentation.cpp
+++ b/DDCore/src/MultiSegmentation.cpp
@@ -12,12 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/MultiSegmentation.h"
-#include "DDSegmentation/MultiSegmentation.h"
+#include <DD4hep/MultiSegmentation.h>
+#include <DDSegmentation/MultiSegmentation.h>
 
-// C/C++ include files
-
-using namespace std;
 using namespace dd4hep;
 
 /// access the field name used to discriminate sub-segmentations
@@ -43,8 +40,8 @@ Position MultiSegmentation::position(const CellID& id) const   {
 
 /// determine the cell ID based on the position
 dd4hep::CellID MultiSegmentation::cellID(const Position& local,
-                                   const Position& global,
-                                   const VolumeID& volID) const
+                                         const Position& global,
+                                         const VolumeID& volID) const
 {
   return access()->implementation->cellID(local, global, volID);
 }
@@ -58,6 +55,6 @@ dd4hep::CellID MultiSegmentation::cellID(const Position& local,
     -# size in x
     -# size in y
 */
-vector<double> MultiSegmentation::cellDimensions(const CellID& id) const  {
+std::vector<double> MultiSegmentation::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/NamedObject.cpp
+++ b/DDCore/src/NamedObject.cpp
@@ -12,26 +12,23 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/NamedObject.h"
-#include "DD4hep/detail/Handle.inl"
-#include "TNamed.h"
-
-using namespace std;
-using namespace dd4hep;
-using namespace dd4hep::detail;
+#include <DD4hep/NamedObject.h>
+#include <DD4hep/detail/Handle.inl>
+#include <TNamed.h>
 
 namespace dd4hep {
   template <> const char* Handle<NamedObject>::name() const  {
     return this->m_element ? this->m_element->name.c_str() : "";
   }
   template <> void
-  Handle<NamedObject>::assign(NamedObject* p, const string& n, const string& t){
+  Handle<NamedObject>::assign(NamedObject* p, const std::string& n, const std::string& t){
     m_element = p;
     p->name = n;
     p->type = t;
   }
 }
-template class dd4hep::Handle<NamedObject>;
+template class dd4hep::Handle<dd4hep::NamedObject>;
+using namespace dd4hep;
 
 /// Initializing constructor
 NamedObject::NamedObject(const char* nam, const char* typ)

--- a/DDCore/src/NoSegmentation.cpp
+++ b/DDCore/src/NoSegmentation.cpp
@@ -12,12 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/NoSegmentation.h"
-#include "DDSegmentation/NoSegmentation.h"
+#include <DD4hep/NoSegmentation.h>
+#include <DDSegmentation/NoSegmentation.h>
 
-// C/C++ include files
-
-using namespace std;
 using namespace dd4hep;
 
 Position NoSegmentation::position(const CellID& id) const   {
@@ -26,8 +23,8 @@ Position NoSegmentation::position(const CellID& id) const   {
 
 /// determine the cell ID based on the position
 dd4hep::CellID NoSegmentation::cellID(const Position& local,
-                                       const Position& global,
-                                       const VolumeID& volID) const
+                                      const Position& global,
+                                      const VolumeID& volID) const
 {
   return access()->implementation->cellID(local, global, volID);
 }

--- a/DDCore/src/ObjectExtensions.cpp
+++ b/DDCore/src/ObjectExtensions.cpp
@@ -17,10 +17,6 @@
 #include "DD4hep/Primitives.h"
 #include "DD4hep/Printout.h"
 
-// C/C++ include files
-#include <stdexcept>
-
-using namespace std;
 using namespace dd4hep;
 
 namespace {
@@ -31,7 +27,7 @@ namespace {
 }
 
 /// Default constructor
-ObjectExtensions::ObjectExtensions(const type_info& /* parent_type */)    {
+ObjectExtensions::ObjectExtensions(const std::type_info& /* parent_type */)    {
   InstanceCount::increment(this);
 }
 
@@ -59,7 +55,7 @@ void ObjectExtensions::clear(bool destroy) {
 }
 
 /// Copy object extensions from another object
-void ObjectExtensions::copyFrom(const map<unsigned long long int,ExtensionEntry*>& ext, void* arg)  {
+void ObjectExtensions::copyFrom(const std::map<unsigned long long int,ExtensionEntry*>& ext, void* arg)  {
   for( const auto& i : ext )  {
     extensions[i.first] = i.second->clone(arg);
   }
@@ -79,7 +75,7 @@ void* ObjectExtensions::addExtension(unsigned long long int key, ExtensionEntry*
     except("ObjectExtensions::addExtension","Invalid extension object for key %016llX!",key);
   }
   except("ObjectExtensions::addExtension","Invalid extension entry for key %016llX!",key);
-  return 0;
+  return nullptr;
 }
 
 /// Remove an existing extension object from the instance
@@ -95,7 +91,7 @@ void* ObjectExtensions::removeExtension(unsigned long long int key, bool destroy
     return ptr;
   }
   except("ObjectExtensions::removeExtension","The object of type %016llX is not present.",key);
-  return 0;
+  return nullptr;
 }
 
 /// Access an existing extension object from the detector element
@@ -104,8 +100,8 @@ void* ObjectExtensions::extension(unsigned long long int key) const {
   if (j != extensions.end()) {
     return (*j).second->object();
   }
-  string msg = format("ObjectExtensions::extension","The object has no extension of type %016llX.",key);
-  throw runtime_error(msg);
+  except("ObjectExtensions::extension","The object has no extension of type %016llX.",key);
+  return nullptr;
 }
 
 /// Access an existing extension object from the detector element
@@ -116,6 +112,6 @@ void* ObjectExtensions::extension(unsigned long long int key, bool alert) const 
   }
   else if ( !alert )
     return 0;
-  string msg = format("ObjectExtensions::extension","The object has no extension of type %016llX.",key);
-  throw runtime_error(msg);
+  except("ObjectExtensions::extension","The object has no extension of type %016llX.",key);
+  return nullptr;
 }

--- a/DDCore/src/Objects.cpp
+++ b/DDCore/src/Objects.cpp
@@ -12,26 +12,25 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/IDDescriptor.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/detail/ObjectsInterna.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/IDDescriptor.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/detail/ObjectsInterna.h>
 
-#include "TMap.h"
-#include "TROOT.h"
-#include "TColor.h"
-#include "TGeoMatrix.h"
-#include "TGeoManager.h"
-#include "TGeoElement.h"
-#include "TGeoMaterial.h"
+#include <TMap.h>
+#include <TROOT.h>
+#include <TColor.h>
+#include <TGeoMatrix.h>
+#include <TGeoManager.h>
+#include <TGeoElement.h>
+#include <TGeoMaterial.h>
 
 // C/C++ include files
 #include <cmath>
 #include <sstream>
 #include <iomanip>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Constructor to be used when creating a new DOM tree
@@ -40,122 +39,122 @@ Author::Author(Detector& /* description */) {
 }
 
 /// Access the auhor's name
-string Author::authorName() const {
+std::string Author::authorName() const {
   return m_element->GetName();
 }
 
 /// Set the author's name
-void Author::setAuthorName(const string& nam) {
+void Author::setAuthorName(const std::string& nam) {
   m_element->SetName(nam.c_str());
 }
 
 /// Access the auhor's email address
-string Author::authorEmail() const {
+std::string Author::authorEmail() const {
   return m_element->GetTitle();
 }
 
 /// Set the author's email address
-void Author::setAuthorEmail(const string& addr) {
+void Author::setAuthorEmail(const std::string& addr) {
   m_element->SetTitle(addr.c_str());
 }
 
 /// Constructor to be used when creating a new DOM tree
-Header::Header(const string& author_name, const string& descr_url) {
+Header::Header(const std::string& author_name, const std::string& descr_url) {
   Object* obj_ptr = new Object();
   assign(obj_ptr, author_name, descr_url);
 }
 
 /// Accessor to object name
-const string Header::name() const {
+const std::string Header::name() const {
   return m_element->GetName();
 }
 
 /// Accessor: set object name
-void Header::setName(const string& new_name) {
+void Header::setName(const std::string& new_name) {
   m_element->SetName(new_name.c_str());
 }
 
 /// Accessor to object title
-const string Header::title() const {
+const std::string Header::title() const {
   return m_element->GetTitle();
 }
 
 /// Accessor: set object title
-void Header::setTitle(const string& new_title) {
+void Header::setTitle(const std::string& new_title) {
   m_element->SetTitle(new_title.c_str());
 }
 
 /// Accessor to object url
-const string& Header::url() const {
+const std::string& Header::url() const {
   return data<Object>()->url;
 }
 
 /// Accessor: set object url
-void Header::setUrl(const string& new_url) {
+void Header::setUrl(const std::string& new_url) {
   data<Object>()->url = new_url;
 }
 
 /// Accessor to object author
-const string& Header::author() const {
+const std::string& Header::author() const {
   return data<Object>()->author;
 }
 
 /// Accessor: set object author
-void Header::setAuthor(const string& new_author) {
+void Header::setAuthor(const std::string& new_author) {
   data<Object>()->author = new_author;
 }
 
 /// Accessor to object status
-const string& Header::status() const {
+const std::string& Header::status() const {
   return data<Object>()->status;
 }
 
 /// Accessor: set object status
-void Header::setStatus(const string& new_status) {
+void Header::setStatus(const std::string& new_status) {
   data<Object>()->status = new_status;
 }
 
 /// Accessor to object version
-const string& Header::version() const {
+const std::string& Header::version() const {
   return data<Object>()->version;
 }
 
 /// Accessor: set object version
-void Header::setVersion(const string& new_version) {
+void Header::setVersion(const std::string& new_version) {
   data<Object>()->version = new_version;
 }
 
 /// Accessor to object comment
-const string& Header::comment() const {
+const std::string& Header::comment() const {
   return data<Object>()->comment;
 }
 
 /// Accessor: set object comment
-void Header::setComment(const string& new_comment) {
+void Header::setComment(const std::string& new_comment) {
   data<Object>()->comment = new_comment;
 }
 
 /// Constructor to be used when creating a new DOM tree
-Constant::Constant(const string& nam, const string& val, const string& typ) {
+Constant::Constant(const std::string& nam, const std::string& val, const std::string& typ) {
   m_element = new Object(nam, val, typ);
 }
 
 /// Constructor to be used when creating a new DOM tree
-Constant::Constant(const string& nam) {
+Constant::Constant(const std::string& nam) {
   m_element = new Object(nam.c_str(), "", "number");
 }
 
 /// Access the constant
-string Constant::dataType() const   {
+std::string Constant::dataType() const   {
   if ( isValid() )  {
     return m_element->dataType;
   }
-  throw runtime_error("dd4hep: Attempt to access internals from invalid Constant handle!");
+  throw std::runtime_error("dd4hep: Attempt to access internals from invalid Constant handle!");
 }
 
 /// String representation of this object
-string Constant::toString() const {
-  stringstream os;
+std::string Constant::toString() const {
+  std::stringstream os;
   os << m_element->GetName() << "  \"" << m_element->GetTitle() << "\"  ";
   if ( m_element->dataType == "string" ) os << "Value:" << m_element->GetTitle();
   else os << "Value:" << _toDouble(m_element->GetTitle());
@@ -163,7 +162,7 @@ string Constant::toString() const {
 }
 
 /// Constructor to be used when creating a new DOM tree
-Atom::Atom(const string& nam, const string& formula, int Z, int N, double density) {
+Atom::Atom(const std::string& nam, const std::string& formula, int Z, int N, double density) {
   TGeoElementTable* t = TGeoElement::GetElementTable();
   TGeoElement*      e = t->FindElement(nam.c_str());
   if (!e) {
@@ -180,9 +179,9 @@ double  Material::Z() const {
     TGeoMaterial* mat = val->GetMaterial();
     if ( mat )
       return mat->GetZ();
-    throw runtime_error("dd4hep: The medium " + string(val->GetName()) + " has an invalid material reference!");
+    throw std::runtime_error("dd4hep: The medium " + std::string(val->GetName()) + " has an invalid material reference!");
   }
-  throw runtime_error("dd4hep: Attempt to access proton number from invalid material handle!");
+  throw std::runtime_error("dd4hep: Attempt to access proton number from invalid material handle!");
 }
 
 /// atomic number of the underlying material
@@ -191,9 +190,9 @@ double  Material::A() const {
     TGeoMaterial* mat = ptr()->GetMaterial();
     if ( mat )
       return mat->GetA();
-    throw runtime_error("dd4hep: The medium " + string(ptr()->GetName()) + " has an invalid material reference!");
+    throw std::runtime_error("dd4hep: The medium " + std::string(ptr()->GetName()) + " has an invalid material reference!");
   }
-  throw runtime_error("dd4hep: Attempt to access atomic number from invalid material handle!");
+  throw std::runtime_error("dd4hep: Attempt to access atomic number from invalid material handle!");
 }
 
 /// density of the underlying material
@@ -202,9 +201,9 @@ double  Material::density() const {
     TGeoMaterial* mat = ptr()->GetMaterial();
     if ( mat )
       return mat->GetDensity();
-    throw runtime_error("dd4hep: The medium " + string(ptr()->GetName()) + " has an invalid material reference!");
+    throw std::runtime_error("dd4hep: The medium " + std::string(ptr()->GetName()) + " has an invalid material reference!");
   }
-  throw runtime_error("dd4hep: Attempt to access density from invalid material handle!");
+  throw std::runtime_error("dd4hep: Attempt to access density from invalid material handle!");
 }
 
 /// Access the radiation length of the underlying material
@@ -213,9 +212,9 @@ double Material::radLength() const {
     TGeoMaterial* mat = ptr()->GetMaterial();
     if ( mat )
       return mat->GetRadLen();
-    throw runtime_error("dd4hep: The medium " + string(ptr()->GetName()) + " has an invalid material reference!");
+    throw std::runtime_error("dd4hep: The medium " + std::string(ptr()->GetName()) + " has an invalid material reference!");
   }
-  throw runtime_error("dd4hep: Attempt to access radiation length from invalid material handle!");
+  throw std::runtime_error("dd4hep: Attempt to access radiation length from invalid material handle!");
 }
 
 /// Access the radiation length of the underlying material
@@ -224,9 +223,9 @@ double Material::intLength() const {
     TGeoMaterial* mat = ptr()->GetMaterial();
     if ( mat )
       return mat->GetIntLen();
-    throw runtime_error("The medium " + string(ptr()->GetName()) + " has an invalid material reference!");
+    throw std::runtime_error("The medium " + std::string(ptr()->GetName()) + " has an invalid material reference!");
   }
-  throw runtime_error("Attempt to access interaction length from invalid material handle!");
+  throw std::runtime_error("Attempt to access interaction length from invalid material handle!");
 }
 
 /// Access the fraction of an element within the material
@@ -256,7 +255,6 @@ double Material::fraction(Atom atom) const    {
   return tot>1e-20 ? frac/tot : 0.0;
 }
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
 /// Access to tabular properties of the optical surface
 Material::Property Material::property(const char* nam)  const    {
   return access()->GetMaterial()->GetProperty(nam);
@@ -281,7 +279,7 @@ double Material::constProperty(const std::string& nam)  const   {
   auto* o = access()->GetMaterial();
   double value = o->GetConstProperty(nam.c_str(), &err);
   if ( err != kTRUE ) return value;
-  throw runtime_error("Attempt to access non existing material const property: "+nam);
+  throw std::runtime_error("Attempt to access non existing material const property: "+nam);
 }
 
 /// Access string property value from the material table
@@ -291,23 +289,22 @@ std::string Material::constPropertyRef(const std::string& name, const std::strin
   if ( p ) return p;
   return default_value;
 }
-#endif
 
 /// String representation of this object
-string Material::toString() const {
+std::string Material::toString() const {
   if ( isValid() ) {
     TGeoMedium*  val = ptr();
-    stringstream out;
+    std::stringstream out;
     out << val->GetName() << " " << val->GetTitle()
-        << " id:" << hex << val->GetId()
+        << " id:" << std::hex << val->GetId()
         << " Pointer:" << val->GetPointerName();
     return out.str();
   }
-  throw runtime_error("Attempt to convert invalid material handle to string!");
+  throw std::runtime_error("Attempt to convert invalid material handle to string!");
 }
 
 /// Constructor to be used when creating a new entity
-VisAttr::VisAttr(const string& nam) {
+VisAttr::VisAttr(const std::string& nam) {
   Object* obj = new Object();
   assign(obj, nam, "vis");
   obj->color = gROOT->GetColor(kWhite);
@@ -390,13 +387,9 @@ void VisAttr::setColor(float alpha, float red, float green, float blue) {
     except("VisAttr","+++ %s Failed to allocate Color: r:%02X g:%02X b:%02X",
 	   this->name(), int(red*255.), int(green*255.), int(blue*255));
   }
-#if ROOT_VERSION_CODE >= ROOT_VERSION(5,34,25)
   o.colortr = new TColor(gROOT->GetListOfColors()->GetLast()+1,
 			 o.color->GetRed(), o.color->GetGreen(), o.color->GetBlue());
   o.colortr->SetAlpha(alpha);
-#else
-  o.colortr = o.color;
-#endif
 }
 
 /// Get RGB values of the color (if valid)
@@ -421,13 +414,13 @@ bool VisAttr::argb(float& alpha, float& red, float& green, float& blue) const {
 }
 
 /// String representation of this object
-string VisAttr::toString() const {
+std::string VisAttr::toString() const {
   const VisAttr::Object* obj = &object<Object>();
   TColor* c = obj->color;
   char text[256];
-  ::snprintf(text, sizeof(text), "%-20s RGB:%-8s [%d] %7.2f  Style:%d %d ShowDaughters:%3s Visible:%3s", ptr()->GetName(),
-             c->AsHexString(), c->GetNumber(), c->GetAlpha(), int(obj->drawingStyle), int(obj->lineStyle),
-             yes_no(obj->showDaughters), yes_no(obj->visible));
+  std::snprintf(text, sizeof(text), "%-20s RGB:%-8s [%d] %7.2f  Style:%d %d ShowDaughters:%3s Visible:%3s", ptr()->GetName(),
+                  c->AsHexString(), c->GetNumber(), c->GetAlpha(), int(obj->drawingStyle), int(obj->lineStyle),
+                  yes_no(obj->showDaughters), yes_no(obj->visible));
   return text;
 }
 
@@ -448,8 +441,8 @@ bool Limit::operator<(const Limit& c) const {
 }
 
 /// Conversion to a string representation
-string Limit::toString() const {
-  string res = name + " = " + content;
+std::string Limit::toString() const {
+  std::string res = name + " = " + content;
   if (!unit.empty())
     res += unit + " ";
   res += " (" + particles + ")";
@@ -457,25 +450,25 @@ string Limit::toString() const {
 }
 
 /// Constructor to be used when creating a new DOM tree
-LimitSet::LimitSet(const string& nam) {
+LimitSet::LimitSet(const std::string& nam) {
   assign(new Object(), nam, "limitset");
 }
 
 /// Add new limit. Returns true if the new limit was added, false if it already existed.
 bool LimitSet::addLimit(const Limit& limit) {
-  pair<Object::iterator, bool> ret = data<Object>()->limits.insert(limit);
+  std::pair<Object::iterator, bool> ret = data<Object>()->limits.insert(limit);
   return ret.second;
 }
 
 /// Accessor to limits container
-const set<Limit>& LimitSet::limits() const {
+const std::set<Limit>& LimitSet::limits() const {
   const Object* o = data<Object>();
   return o->limits;
 }
 
 /// Add new limit. Returns true if the new limit was added, false if it already existed.
 bool LimitSet::addCut(const Limit& cut_obj)   {
-  pair<Object::iterator, bool> ret = data<Object>()->cuts.insert(cut_obj);
+  std::pair<Object::iterator, bool> ret = data<Object>()->cuts.insert(cut_obj);
   return ret.second;
 }
 
@@ -485,7 +478,7 @@ const std::set<Limit>& LimitSet::cuts() const    {
 }
 
 /// Constructor to be used when creating a new DOM tree
-Region::Region(const string& nam) {
+Region::Region(const std::string& nam) {
   Object* p = new Object();
   assign(p, nam, "region");
   p->magic = magic_word();
@@ -514,7 +507,7 @@ Region& Region::setCut(double value) {
 }
 
 /// Access references to user limits
-vector<string>& Region::limits() const {
+std::vector<std::string>& Region::limits() const {
   return object<Object>().user_limits;
 }
 
@@ -555,28 +548,28 @@ struct IDSpec : public Ref_t {
   template <typename Q>
   IDSpec(const Handle<Q>& e) : Ref_t(e) {}
   /// Constructor to be used when creating a new DOM tree
-  IDSpec(Detector& doc, const string& name, const IDDescriptor& dsc);
-  void addField(const string& name, const pair<int,int>& field);
+  IDSpec(Detector& doc, const std::string& name, const IDDescriptor& dsc);
+  void addField(const std::string& name, const std::pair<int,int>& field);
 };
 
-IDSpec::IDSpec(Detector& description, const string& name, const IDDescriptor& dsc)
+IDSpec::IDSpec(Detector& description, const std::string& name, const IDDescriptor& dsc)
   : RefElement(doc,Tag_idspec,name)
 {
   const IDDescriptor::FieldIDs& f = dsc.ids();
   const IDDescriptor::FieldMap& m = dsc.fields();
   object<Object>().Attr_length = dsc.maxBit();
   for(const auto& i : f )  {
-    const string& nam = i.second;
+    const std::string& nam = i.second;
     const pair<int,int>& fld = m.find(nam)->second;
     addField(nam,fld);
   }
 }
 
-void IDSpec::addField(const string& name, const pair<int,int>& field) {
+void IDSpec::addField(const std::string& name, const pair<int,int>& field) {
   addField(Strng_t(name),field);
 }
 
-void IDSpec::addField(const string& name, const pair<int,int>& field) {
+void IDSpec::addField(const std::string& name, const pair<int,int>& field) {
   Element e(document(),Tag_idfield);
   e.object<Object>().Attr_signed = field.second<0;
   e.object<Object>().Attr_label = name;

--- a/DDCore/src/ObjectsInterna.cpp
+++ b/DDCore/src/ObjectsInterna.cpp
@@ -18,9 +18,8 @@
 #include <DD4hep/detail/SegmentationsInterna.h>
 
 #include <TROOT.h>
-using namespace std;
+
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 DD4HEP_INSTANTIATE_HANDLE_NAMED(VisAttrObject);
 
@@ -55,7 +54,7 @@ ConstantObject::ConstantObject()  {
 }
 
 /// Standard constructor
-ConstantObject::ConstantObject(const string& nam, const string& val, const string& typ)
+ConstantObject::ConstantObject(const std::string& nam, const std::string& val, const std::string& typ)
   : NamedObject(nam.c_str(), val.c_str()) {
   dataType = typ;
   InstanceCount::increment(this);

--- a/DDCore/src/OpaqueData.cpp
+++ b/DDCore/src/OpaqueData.cpp
@@ -12,47 +12,46 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
-#include "DD4hep/OpaqueData.h"
-#include "DD4hep/InstanceCount.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
+#include <DD4hep/OpaqueData.h>
+#include <DD4hep/InstanceCount.h>
 
 // C/C++ header files
 #include <cstring>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Create data block from string representation
-bool OpaqueData::fromString(const string& rep)   {
+bool OpaqueData::fromString(const std::string& rep)   {
   if ( pointer && grammar )  {
     return grammar->fromString(pointer,rep);
   }
-  throw runtime_error("Opaque data block is unbound. Cannot parse string representation.");
+  throw std::runtime_error("Opaque data block is unbound. Cannot parse string representation.");
 }
 
 /// Create string representation of the data block
-string OpaqueData::str()  const  {
+std::string OpaqueData::str()  const  {
   if ( pointer && grammar )  {
     return grammar->str(pointer);
   }
-  throw runtime_error("Opaque data block is unbound. Cannot create string representation.");
+  throw std::runtime_error("Opaque data block is unbound. Cannot create string representation.");
 }
 
 /// Access type id of the condition
-const type_info& OpaqueData::typeInfo() const  {
+const std::type_info& OpaqueData::typeInfo() const  {
   if ( pointer && grammar ) {
     return grammar->type();
   }
-  throw runtime_error("Opaque data block is unbound. Cannot determine type information!");
+  throw std::runtime_error("Opaque data block is unbound. Cannot determine type information!");
 }
 
 /// Access type name of the condition data block
-const string& OpaqueData::dataType() const   {
+const std::string& OpaqueData::dataType() const   {
   if ( pointer && grammar ) {
     return grammar->type_name();
   }
-  throw runtime_error("Opaque data block is unbound. Cannot determine type information!"); 
+  throw std::runtime_error("Opaque data block is unbound. Cannot determine type information!"); 
 }
 
 /// Standard initializing constructor
@@ -71,7 +70,7 @@ OpaqueDataBlock::OpaqueDataBlock(const OpaqueDataBlock& c)
   }
   else  {
     except("OpaqueDataBlock","Grammar type %s does not support object copy. Operation not allowed.",
-	   this->grammar->type_name().c_str());
+           this->grammar->type_name().c_str());
   }
   InstanceCount::increment(this);
 }
@@ -103,10 +102,10 @@ OpaqueDataBlock& OpaqueDataBlock::operator=(const OpaqueDataBlock& c)   {
       type = c.type;
       grammar = 0;
       if ( c.grammar )   {
-	if ( !c.grammar->specialization.copy )  {
-	  except("OpaqueDataBlock","Grammar type %s does not support object copy. Operation not allowed.",
-		 c.grammar->type_name().c_str());
-	}
+        if ( !c.grammar->specialization.copy )  {
+          except("OpaqueDataBlock","Grammar type %s does not support object copy. Operation not allowed.",
+                 c.grammar->type_name().c_str());
+        }
         bind(c.grammar);
         grammar->specialization.copy(pointer,c.pointer);
         return *this;
@@ -180,5 +179,5 @@ void* OpaqueDataBlock::bind(void* ptr, size_t size, const BasicGrammar* g)   {
   return 0;
 }
 
-#include "DD4hep/GrammarUnparsed.h"
+#include <DD4hep/GrammarUnparsed.h>
 static auto s_registry = GrammarRegistry::pre_note<OpaqueDataBlock>(1);

--- a/DDCore/src/OpaqueDataBinder.cpp
+++ b/DDCore/src/OpaqueDataBinder.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/OpaqueDataBinder.h"
-#include "DD4hep/Conditions.h"
-#include "DD4hep/detail/ConditionsInterna.h"
+#include <DD4hep/OpaqueDataBinder.h>
+#include <DD4hep/Conditions.h>
+#include <DD4hep/detail/ConditionsInterna.h>
 
 // C/C++ include files
 #include <set>
@@ -22,30 +22,27 @@
 #include <list>
 #include <vector>
 
-using namespace std;
-
 namespace {
-  using namespace dd4hep::detail;
-  
+
   /// Helper class to bind string values to C++ data objects (primitive or complex)
-  template <typename T, typename Q> bool __bind__(const ValueBinder&, T& object, const string& val, const Q*)
-  {  object.template bind<Q>(val);            return true;  }
+  template <typename T, typename Q> bool __bind__(const dd4hep::detail::ValueBinder&, T& object, const std::string& val, const Q*)
+  {  object.template bind<Q>(val);                 return true;  }
 
   /// Helper class to bind string values to a STL vector of data objects (primitive or complex)
-  template <typename T, typename Q> bool __bind__(const VectorBinder&, T& object, const string& val, const Q*)
-  {  object.template bind<vector<Q> >(val);   return true;  }
+  template <typename T, typename Q> bool __bind__(const dd4hep::detail::VectorBinder&, T& object, const std::string& val, const Q*)
+  {  object.template bind<std::vector<Q> >(val);   return true;  }
 
   /// Helper class to bind string values to a STL list of data objects (primitive or complex)
-  template <typename T, typename Q> bool __bind__(const ListBinder&, T& object, const string& val, const Q*)
-  {  object.template bind<list<Q> >(val);     return true;  }
+  template <typename T, typename Q> bool __bind__(const dd4hep::detail::ListBinder&, T& object, const std::string& val, const Q*)
+  {  object.template bind<std::list<Q> >(val);     return true;  }
 
   /// Helper class to bind string values to a STL set of data objects (primitive or complex)
-  template <typename T, typename Q> bool __bind__(const SetBinder&, T& object, const string& val, const Q*)
-  {  object.template bind<set<Q> >(val);      return true;  }
+  template <typename T, typename Q> bool __bind__(const dd4hep::detail::SetBinder&, T& object, const std::string& val, const Q*)
+  {  object.template bind<std::set<Q> >(val);      return true;  }
 
   /// Helper class to bind STL map objects
-  template <typename T, typename Q> bool __bind__(const MapBinder&, T& object, const Q*)
-  {  object.template bind<Q>();               return true;  }
+  template <typename T, typename Q> bool __bind__(const dd4hep::detail::MapBinder&, T& object, const Q*)
+  {  object.template bind<Q>();                    return true;  }
 
 }
 
@@ -57,7 +54,7 @@ namespace dd4hep {
 
     /// Binding function for scalar items. See the implementation function for the concrete instantiations
     template <typename BINDER, typename T> 
-    bool OpaqueDataBinder::bind(const BINDER& b, T& object, const string& typ, const string& val)  {
+    bool OpaqueDataBinder::bind(const BINDER& b, T& object, const std::string& typ, const std::string& val)  {
 #if defined(DD4HEP_HAVE_ALL_PARSERS)
       if ( typ.substr(0,4) == "char" )
         return __bind__(b,object,val,Primitive<char>::null_pointer());
@@ -87,49 +84,49 @@ namespace dd4hep {
       else if ( typ.substr(0,6) == "double" )
         return __bind__(b,object,val,Primitive<double>::null_pointer());
       else if ( typ.substr(0,6) == "string" )
-        return __bind__(b,object,val,Primitive<string>::null_pointer());
+        return __bind__(b,object,val,Primitive<std::string>::null_pointer());
       else if ( typ == "std::string" )
-        return __bind__(b,object,val,Primitive<string>::null_pointer());
+        return __bind__(b,object,val,Primitive<std::string>::null_pointer());
       else if ( typ == "Histo1D" )
-        return __bind__(b,object,val,Primitive<string>::null_pointer());
+        return __bind__(b,object,val,Primitive<std::string>::null_pointer());
       else if ( typ == "Histo2D" )
-        return __bind__(b,object,val,Primitive<string>::null_pointer());
+        return __bind__(b,object,val,Primitive<std::string>::null_pointer());
       else
         printout(INFO,"OpaqueDataBinder","++ Unknown conditions parameter type:%s val:%s",typ.c_str(),val.c_str());
-      return __bind__(b,object,val,Primitive<string>::null_pointer());
+      return __bind__(b,object,val,Primitive<std::string>::null_pointer());
     }
     template bool OpaqueDataBinder::bind<ValueBinder,OpaqueDataBlock>(        const ValueBinder& b, OpaqueDataBlock& object,
-                                                                              const string& typ, const string& val);
+                                                                              const std::string& typ, const std::string& val);
     template bool OpaqueDataBinder::bind<VectorBinder,OpaqueDataBlock>(       const VectorBinder& b, OpaqueDataBlock& object,
-                                                                              const string& typ, const string& val);
+                                                                              const std::string& typ, const std::string& val);
     template bool OpaqueDataBinder::bind<ListBinder,OpaqueDataBlock>(         const ListBinder& b, OpaqueDataBlock& object,
-                                                                              const string& typ, const string& val);
+                                                                              const std::string& typ, const std::string& val);
     template bool OpaqueDataBinder::bind<SetBinder,OpaqueDataBlock>(          const SetBinder& b, OpaqueDataBlock& object,
-                                                                              const string& typ, const string& val);
+                                                                              const std::string& typ, const std::string& val);
 
     template bool OpaqueDataBinder::bind<ValueBinder,Condition>(  const ValueBinder& b, Condition& object,
-                                                                  const string& typ, const string& val);
+                                                                  const std::string& typ, const std::string& val);
     template bool OpaqueDataBinder::bind<VectorBinder,Condition>( const VectorBinder& b, Condition& object,
-                                                                  const string& typ, const string& val);
+                                                                  const std::string& typ, const std::string& val);
     template bool OpaqueDataBinder::bind<ListBinder,Condition>(   const ListBinder& b, Condition& object,
-                                                                  const string& typ, const string& val);
+                                                                  const std::string& typ, const std::string& val);
     template bool OpaqueDataBinder::bind<SetBinder,Condition>(    const SetBinder& b, Condition& object,
-                                                                  const string& typ, const string& val);
+                                                                  const std::string& typ, const std::string& val);
   
     /// Binding function for sequences (unmapped STL containers)
     template <typename T> 
-    bool OpaqueDataBinder::bind_sequence(T& object, const string& typ, const string& val)
+    bool OpaqueDataBinder::bind_sequence(T& object, const std::string& typ, const std::string& val)
     {
-      size_t idx = typ.find('[');
-      size_t idq = typ.find(']');
-      string value_type = typ.substr(idx+1,idq-idx-1);
+      std::size_t idx = typ.find('[');
+      std::size_t idq = typ.find(']');
+      std::string value_type = typ.substr(idx+1,idq-idx-1);
       if ( typ.substr(0,6) == "vector" )
         return bind(VectorBinder(), object, value_type, val);
       else if ( typ.substr(0,4) == "list" )
         return bind(ListBinder(), object, value_type, val);
       else if ( typ.substr(0,3) == "set" )
         return bind(SetBinder(), object, value_type, val);
-      else if ( idx == string::npos && idq == string::npos )
+      else if ( idx == std::string::npos && idq == std::string::npos )
         return bind(ValueBinder(), object, value_type, val);
       return false;
     }
@@ -138,10 +135,10 @@ namespace dd4hep {
     static void emplace_map_item(const BINDER&,
                                  OBJECT& object,
                                  const KEY& k,
-                                 const string& val,
+                                 const std::string& val,
                                  const VAL*)
     {
-      typedef map<KEY,VAL> map_t;
+      typedef std::map<KEY,VAL> map_t;
       map_t& m = object.template get<map_t>();
       VAL v;
       if ( !BasicGrammar::instance<VAL>().fromString(&v, val) )  {
@@ -153,9 +150,9 @@ namespace dd4hep {
     template<typename BINDER, typename OBJECT, typename KEY> 
     static void emplace_map_key(const BINDER& b,
                                 OBJECT& object,
-                                const string& key_val,
-                                const string& val_type,
-                                const string& val,
+                                const std::string& key_val,
+                                const std::string& val_type,
+                                const std::string& val,
                                 const KEY*)
     {
       KEY key;
@@ -174,27 +171,27 @@ namespace dd4hep {
       else if ( val_type.substr(0,6) == "double" )
         emplace_map_item(b, object, key, val, (double*)0);
       else if ( val_type.substr(0,6) == "string" )
-        emplace_map_item(b, object, key, val, (string*)0);
+        emplace_map_item(b, object, key, val, (std::string*)0);
       else if ( val_type == "std::string" )
-        emplace_map_item(b, object, key, val, (string*)0);
+        emplace_map_item(b, object, key, val, (std::string*)0);
       else {
         printout(INFO,"Param","++ Unknown conditions parameter type:%s data:%s",
                  val_type.c_str(),val.c_str());
-        emplace_map_item(b, object, key, val, (string*)0);
+        emplace_map_item(b, object, key, val, (std::string*)0);
       }
     }
 
     template<typename BINDER, typename OBJECT, typename KEY, typename VAL>
     static void emplace_map_pair(const BINDER&,
                                  OBJECT& object,
-                                 const string& data,
+                                 const std::string& data,
                                  const KEY*,
                                  const VAL*)
     {
-      typedef map<KEY,VAL> map_t;
-      pair<KEY,VAL> entry;
+      typedef std::map<KEY,VAL> map_t;
+      std::pair<KEY,VAL> entry;
       map_t& m = object.template get<map_t>();
-      if ( !BasicGrammar::instance<pair<KEY,VAL> >().fromString(&entry,data) )  {
+      if ( !BasicGrammar::instance<std::pair<KEY,VAL> >().fromString(&entry,data) )  {
         except("OpaqueDataBinder","++ Failed to convert conditions map entry.");
       }
       m.emplace(entry);
@@ -203,8 +200,8 @@ namespace dd4hep {
     template<typename BINDER, typename OBJECT, typename KEY> 
     static void emplace_map_data(const BINDER& b,
                                  OBJECT& object,
-                                 const string& val_type,
-                                 const string& pair_data,
+                                 const std::string& val_type,
+                                 const std::string& pair_data,
                                  const KEY*)
     {
       // Short and char is not part of the standard dictionaries. Fall back to 'int'.
@@ -221,59 +218,59 @@ namespace dd4hep {
       else if ( val_type.substr(0,6) == "double" )
         emplace_map_pair(b, object, pair_data, (KEY*)0, (double*)0);
       else if ( val_type.substr(0,6) == "string" )
-        emplace_map_pair(b, object, pair_data, (KEY*)0, (string*)0);
+        emplace_map_pair(b, object, pair_data, (KEY*)0, (std::string*)0);
       else if ( val_type == "std::string" )
-        emplace_map_pair(b, object, pair_data, (KEY*)0, (string*)0);
+        emplace_map_pair(b, object, pair_data, (KEY*)0, (std::string*)0);
       else {
         printout(INFO,"Param","++ Unknown conditions parameter type:%s data:%s",
                  val_type.c_str(),pair_data.c_str());
-        emplace_map_pair(b, object, pair_data, (KEY*)0, (string*)0);
+        emplace_map_pair(b, object, pair_data, (KEY*)0, (std::string*)0);
       }
     }
 
     template<typename BINDER, typename OBJECT, typename KEY> 
-    static void bind_mapping(const BINDER& b, const string& val_type, OBJECT& object, const KEY*)   {
+    static void bind_mapping(const BINDER& b, const std::string& val_type, OBJECT& object, const KEY*)   {
       if ( val_type.substr(0,3) == "int" )
-        __bind__(b,object, (map<KEY,int>*)0);
+        __bind__(b,object, (std::map<KEY,int>*)0);
 #if defined(DD4HEP_HAVE_ALL_PARSERS)
       else if ( val_type.substr(0,12) == "unsigned int" )
-        __bind__(b,object, (map<KEY,unsigned int>*)0);
+        __bind__(b,object, (std::map<KEY,unsigned int>*)0);
       else if ( val_type.substr(0,4) == "char" )
-        __bind__(b,object, (map<KEY,char>*)0);
+        __bind__(b,object, (std::map<KEY,char>*)0);
       else if ( val_type.substr(0,13) == "unsigned char" )
-        __bind__(b,object, (map<KEY,unsigned char>*)0);
+        __bind__(b,object, (std::map<KEY,unsigned char>*)0);
       else if ( val_type.substr(0,5) == "short" )
-        __bind__(b,object, (map<KEY,short>*)0);
+        __bind__(b,object, (std::map<KEY,short>*)0);
       else if ( val_type.substr(0,14) == "unsigned short" )
-        __bind__(b,object, (map<KEY,unsigned short>*)0);
+        __bind__(b,object, (std::map<KEY,unsigned short>*)0);
       else if ( val_type.substr(0,13) == "unsigned long" )
-        __bind__(b,object, (map<KEY,unsigned long>*)0);
+        __bind__(b,object, (std::map<KEY,unsigned long>*)0);
 #else
       // Short and char is not part of the standard dictionaries. Fall back to 'int'.
       else if ( val_type.substr(0,4) == "char" )
-        __bind__(b,object, (map<KEY,int>*)0);
+        __bind__(b,object, (std::map<KEY,int>*)0);
       else if ( val_type.substr(0,5) == "short" )
-        __bind__(b,object, (map<KEY,int>*)0);
+        __bind__(b,object, (std::map<KEY,int>*)0);
 #endif
       else if ( val_type.substr(0,4) == "long" )
-        __bind__(b,object, (map<KEY,long>*)0);
+        __bind__(b,object, (std::map<KEY,long>*)0);
       else if ( val_type.substr(0,5) == "float" )
-        __bind__(b,object, (map<KEY,float>*)0);
+        __bind__(b,object, (std::map<KEY,float>*)0);
       else if ( val_type.substr(0,6) == "double" )
-        __bind__(b,object, (map<KEY,double>*)0);
+        __bind__(b,object, (std::map<KEY,double>*)0);
       else if ( val_type.substr(0,6) == "string" )
-        __bind__(b,object, (map<KEY,string>*)0);
+        __bind__(b,object, (std::map<KEY,std::string>*)0);
       else if ( val_type == "std::string" )
-        __bind__(b,object, (map<KEY,string>*)0);
+        __bind__(b,object, (std::map<KEY,std::string>*)0);
       else {
-        __bind__(b,object, (map<KEY,string>*)0);
+        __bind__(b,object, (std::map<KEY,std::string>*)0);
       }
     }
   
     /// Binding function for STL maps
     template <typename BINDER, typename OBJECT> 
     bool OpaqueDataBinder::bind_map(const BINDER& b, OBJECT& object,
-                                    const string& key_type, const string& val_type)   {
+                                    const std::string& key_type, const std::string& val_type)   {
       // Short and char is not part of the standard dictionaries. Fall back to 'int'.
       if ( key_type.substr(0,3) == "int" )
         bind_mapping(b, val_type, object, Primitive<int>::null_pointer());
@@ -290,12 +287,12 @@ namespace dd4hep {
         bind_mapping(b, val_type, object, Primitive<double>::null_pointer());
 #endif
       else if ( key_type.substr(0,6) == "string" )
-        bind_mapping(b, val_type, object, Primitive<string>::null_pointer());
+        bind_mapping(b, val_type, object, Primitive<std::string>::null_pointer());
       else if ( key_type == "std::string" )
-        bind_mapping(b, val_type, object, Primitive<string>::null_pointer());
+        bind_mapping(b, val_type, object, Primitive<std::string>::null_pointer());
       else {
         printout(INFO,"OpaqueDataBinder","++ Unknown MAP-conditions key-type:%s",key_type.c_str());
-        bind_mapping(b, val_type, object, Primitive<string>::null_pointer());
+        bind_mapping(b, val_type, object, Primitive<std::string>::null_pointer());
       }
       return true;
     }
@@ -303,8 +300,8 @@ namespace dd4hep {
     /// Filling function for STL maps.
     template <typename BINDER, typename OBJECT>
     bool OpaqueDataBinder::insert_map(const BINDER& b, OBJECT& object,
-                                      const string& key_type, const string& key,
-                                      const string& val_type, const string& val)
+                                      const std::string& key_type, const std::string& key,
+                                      const std::string& val_type, const std::string& val)
     {
       if ( key_type.substr(0,3) == "int" )
         emplace_map_key(b, object, key, val_type, val, Primitive<int>::null_pointer());
@@ -322,12 +319,12 @@ namespace dd4hep {
         emplace_map_key(b, object, key, val_type, val, Primitive<double>::null_pointer());
 #endif
       else if ( key_type.substr(0,6) == "string" )
-        emplace_map_key(b, object, key, val_type, val, Primitive<string>::null_pointer());
+        emplace_map_key(b, object, key, val_type, val, Primitive<std::string>::null_pointer());
       else if ( key_type == "std::string" )
-        emplace_map_key(b, object, key, val_type, val, Primitive<string>::null_pointer());
+        emplace_map_key(b, object, key, val_type, val, Primitive<std::string>::null_pointer());
       else {
         printout(INFO,"OpaqueDataBinder","++ Unknown MAP-conditions key-type:%s",key_type.c_str());
-        emplace_map_key(b, object, key, val_type, val, Primitive<string>::null_pointer());
+        emplace_map_key(b, object, key, val_type, val, Primitive<std::string>::null_pointer());
       }
       return true;
     }
@@ -354,43 +351,43 @@ namespace dd4hep {
         emplace_map_data(b, object, val_type, pair_data, Primitive<double>::null_pointer());
 #endif
       else if ( key_type.substr(0,6) == "string" )
-        emplace_map_data(b, object, val_type, pair_data, Primitive<string>::null_pointer());
+        emplace_map_data(b, object, val_type, pair_data, Primitive<std::string>::null_pointer());
       else if ( key_type == "std::string" )
-        emplace_map_data(b, object, val_type, pair_data, Primitive<string>::null_pointer());
+        emplace_map_data(b, object, val_type, pair_data, Primitive<std::string>::null_pointer());
       else {
         printout(INFO,"OpaqueDataBinder","++ Unknown MAP-conditions key-type:%s",key_type.c_str());
-        emplace_map_data(b, object, val_type, pair_data, Primitive<string>::null_pointer());
+        emplace_map_data(b, object, val_type, pair_data, Primitive<std::string>::null_pointer());
       }
       return true;
     }
 
-    template bool OpaqueDataBinder::bind_sequence<OpaqueDataBlock>(OpaqueDataBlock& object,const string& typ,const string& val);
+    template bool OpaqueDataBinder::bind_sequence<OpaqueDataBlock>(OpaqueDataBlock& object,const std::string& typ,const std::string& val);
     template bool OpaqueDataBinder::bind_map<MapBinder,OpaqueDataBlock>(    const MapBinder& b, OpaqueDataBlock& object,
-                                                                            const string& typ,const string& val);
+                                                                            const std::string& typ,const std::string& val);
     template bool OpaqueDataBinder::insert_map<MapBinder,OpaqueDataBlock>(  const MapBinder& b, OpaqueDataBlock& object,
-                                                                            const string& key_type, const string& key,
-                                                                            const string& val_type, const string& val);
+                                                                            const std::string& key_type, const std::string& key,
+                                                                            const std::string& val_type, const std::string& val);
     template bool OpaqueDataBinder::insert_map<MapBinder,OpaqueDataBlock>(  const MapBinder& b, OpaqueDataBlock& object,
-                                                                            const string& key_type, const string& val_type,
-                                                                            const string& pair_data);
+                                                                            const std::string& key_type, const std::string& val_type,
+                                                                            const std::string& pair_data);
 
     /// Instantiation for Conditions:
     template bool OpaqueDataBinder::bind_sequence<Condition>(   Condition& object,
-                                                                const string& typ,const string& val);
+                                                                const std::string& typ,const std::string& val);
     /// Conditions binding function for STL maps
     template <> bool OpaqueDataBinder::bind_map(const MapBinder& b, Condition& object,
-                                                const string& key_type, const string& val_type)
+                                                const std::string& key_type, const std::string& val_type)
     {    return bind_map(b, object->data, key_type, val_type);  }
 
     /// Conditions: Filling function for STL maps.
     template <> bool OpaqueDataBinder::insert_map(const MapBinder& b, Condition& object,
-                                                  const string& key_type, const string& key,
-                                                  const string& val_type, const string& val)
+                                                  const std::string& key_type, const std::string& key,
+                                                  const std::string& val_type, const std::string& val)
     {    return insert_map(b, object->data, key_type, key, val_type, val);    }
 
     /// Conditions: Filling function for STL maps.
     template <> bool OpaqueDataBinder::insert_map(const MapBinder& b, Condition& object,
-                                                  const string& key_type, const string& val_type, const string& pair_data)
+                                                  const std::string& key_type, const std::string& val_type, const std::string& pair_data)
     {    return insert_map(b, object->data, key_type, val_type, pair_data);   }  
   }
 }

--- a/DDCore/src/OpticalSurfaceManager.cpp
+++ b/DDCore/src/OpticalSurfaceManager.cpp
@@ -12,17 +12,16 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/OpticalSurfaceManager.h"
-#include "DD4hep/detail/OpticalSurfaceManagerInterna.h"
-#include "DD4hep/ExtensionEntry.h"
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
+#include <DD4hep/OpticalSurfaceManager.h>
+#include <DD4hep/detail/OpticalSurfaceManagerInterna.h>
+#include <DD4hep/ExtensionEntry.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
 
 // C/C++ includes
 #include <sstream>
 #include <iomanip>
 
-using namespace std;
 using namespace dd4hep;
 
 /// static accessor calling DD4hepOpticalSurfaceManagerPlugin if necessary
@@ -30,13 +29,11 @@ OpticalSurfaceManager OpticalSurfaceManager::getOpticalSurfaceManager(Detector& 
   return description.surfaceManager();
 }
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
-
 /// Access skin surface by its identifier
-SkinSurface  OpticalSurfaceManager::skinSurface(DetElement de, const string& nam)  const   {
+SkinSurface  OpticalSurfaceManager::skinSurface(DetElement de, const std::string& nam)  const   {
   if ( de.isValid() )  {
     Object* o = access();
-    string  n = de.path() + '#' + nam;
+    std::string  n = de.path() + '#' + nam;
     TGeoSkinSurface* surf = o->detector.manager().GetSkinSurface(n.c_str());
     if ( surf ) return surf;
     auto i = o->skinSurfaces.find(Object::LocalKey(de, nam));
@@ -49,15 +46,15 @@ SkinSurface  OpticalSurfaceManager::skinSurface(DetElement de, const string& nam
 }
 
 /// Access skin surface by its full name
-SkinSurface  OpticalSurfaceManager::skinSurface(const string& full_nam)  const   {
+SkinSurface  OpticalSurfaceManager::skinSurface(const std::string& full_nam)  const   {
   return access()->detector.manager().GetSkinSurface(full_nam.c_str());
 }
 
 /// Access border surface by its identifier
-BorderSurface  OpticalSurfaceManager::borderSurface(DetElement de, const string& nam)  const   {
+BorderSurface  OpticalSurfaceManager::borderSurface(DetElement de, const std::string& nam)  const   {
   if ( de.isValid() )  {
     Object* o = access();
-    string  n = de.path() + '#' + nam;
+    std::string  n = de.path() + '#' + nam;
     TGeoBorderSurface* surf = o->detector.manager().GetBorderSurface(n.c_str());
     if ( surf ) return surf;
     auto i = o->borderSurfaces.find(Object::LocalKey(de, nam));
@@ -70,15 +67,15 @@ BorderSurface  OpticalSurfaceManager::borderSurface(DetElement de, const string&
 }
 
 /// Access border surface by its full name
-BorderSurface  OpticalSurfaceManager::borderSurface(const string& full_nam)  const   {
+BorderSurface  OpticalSurfaceManager::borderSurface(const std::string& full_nam)  const   {
   return access()->detector.manager().GetBorderSurface(full_nam.c_str());
 }
 
 /// Access optical surface data by its identifier
-OpticalSurface OpticalSurfaceManager::opticalSurface(DetElement de, const string& nam)  const   {
+OpticalSurface OpticalSurfaceManager::opticalSurface(DetElement de, const std::string& nam)  const   {
   if ( de.isValid() )  {
     Object* o = access();
-    string  n = de.path() + '#' + nam;
+    std::string  n = de.path() + '#' + nam;
     TGeoOpticalSurface* surf = o->detector.manager().GetOpticalSurface(n.c_str());
     if ( surf ) return surf;
     auto i = o->opticalSurfaces.find(n);
@@ -91,13 +88,13 @@ OpticalSurface OpticalSurfaceManager::opticalSurface(DetElement de, const string
 }
 
 /// Access optical surface data by its identifier
-OpticalSurface OpticalSurfaceManager::opticalSurface(const string& full_nam)  const   {
+OpticalSurface OpticalSurfaceManager::opticalSurface(const std::string& full_nam)  const   {
   return access()->detector.manager().GetOpticalSurface(full_nam.c_str());
 }
 
 /// Add skin surface to manager
 void OpticalSurfaceManager::addSkinSurface(DetElement de, SkinSurface surf)  const   {
-  if ( access()->skinSurfaces.emplace(make_pair(de,surf->GetName()), surf).second )
+  if ( access()->skinSurfaces.emplace(std::make_pair(de,surf->GetName()), surf).second )
     return;
   except("OpticalSurfaceManager","++ Skin surface %s already present for DE:%s.",
          surf->GetName(), de.name());
@@ -105,7 +102,7 @@ void OpticalSurfaceManager::addSkinSurface(DetElement de, SkinSurface surf)  con
 
 /// Add border surface to manager
 void OpticalSurfaceManager::addBorderSurface(DetElement de, BorderSurface surf)  const   {
-  if ( access()->borderSurfaces.emplace(make_pair(de,surf->GetName()), surf).second )
+  if ( access()->borderSurfaces.emplace(std::make_pair(de,surf->GetName()), surf).second )
     return;
   except("OpticalSurfaceManager","++ Border surface %s already present for DE:%s.",
          surf->GetName(), de.name());
@@ -122,7 +119,7 @@ void OpticalSurfaceManager::addOpticalSurface(OpticalSurface surf)  const   {
 /// Register the temporary surface objects with the TGeoManager
 void OpticalSurfaceManager::registerSurfaces(DetElement subdetector)    {
   Object* o = access();
-  unique_ptr<Object> extension(new Object(o->detector));
+  std::unique_ptr<Object> extension(new Object(o->detector));
   for(auto& optical : o->opticalSurfaces)  {
     o->detector.manager().AddOpticalSurface(optical.second.ptr());
     extension->opticalSurfaces.insert(optical);
@@ -130,7 +127,7 @@ void OpticalSurfaceManager::registerSurfaces(DetElement subdetector)    {
   o->opticalSurfaces.clear();
   
   for(auto& skin : o->skinSurfaces)  {
-    string n = skin.first.first.path() + '#' + skin.first.second;
+    std::string n = skin.first.first.path() + '#' + skin.first.second;
     skin.second->SetName(n.c_str());
     o->detector.manager().AddSkinSurface(skin.second.ptr());
     extension->skinSurfaces.insert(skin);
@@ -138,7 +135,7 @@ void OpticalSurfaceManager::registerSurfaces(DetElement subdetector)    {
   o->skinSurfaces.clear();
   
   for(auto& border : o->borderSurfaces)  {
-    string n = border.first.first.path() + '#' + border.first.second;
+    std::string n = border.first.first.path() + '#' + border.first.second;
     border.second->SetName(n.c_str());
     o->detector.manager().AddBorderSurface(border.second.ptr());
     extension->borderSurfaces.insert(border);
@@ -152,4 +149,4 @@ void OpticalSurfaceManager::registerSurfaces(DetElement subdetector)    {
   }
   subdetector.addExtension(new detail::DeleteExtension<Object,Object>(extension.release()));
 }
-#endif
+

--- a/DDCore/src/OpticalSurfaceManagerInterna.cpp
+++ b/DDCore/src/OpticalSurfaceManagerInterna.cpp
@@ -12,14 +12,13 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/detail/OpticalSurfaceManagerInterna.h"
-#include "DD4hep/detail/Handle.inl"
+#include <DD4hep/detail/OpticalSurfaceManagerInterna.h>
+#include <DD4hep/detail/Handle.inl>
 
 // C/C++ includes
 #include <sstream>
 #include <iomanip>
 
-using namespace std;
 using namespace dd4hep;
 
 using detail::OpticalSurfaceManagerObject;

--- a/DDCore/src/OpticalSurfaces.cpp
+++ b/DDCore/src/OpticalSurfaces.cpp
@@ -12,22 +12,19 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/OpticalSurfaces.h"
-#include "DD4hep/NamedObject.h"
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/World.h"
+#include <DD4hep/OpticalSurfaces.h>
+#include <DD4hep/NamedObject.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/World.h>
 
-#include "DD4hep/detail/Handle.inl"
+#include <DD4hep/detail/Handle.inl>
 
 // C/C++ includes
 #include <sstream>
 #include <iomanip>
 
-using namespace std;
 using namespace dd4hep;
-
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
 
 DD4HEP_INSTANTIATE_HANDLE(TGeoSkinSurface);
 DD4HEP_INSTANTIATE_HANDLE(TGeoBorderSurface);
@@ -35,13 +32,13 @@ DD4HEP_INSTANTIATE_HANDLE(TGeoOpticalSurface);
 
 /// Initializing constructor.
 OpticalSurface::OpticalSurface(Detector& detector,
-                               const string& full_name,
+                               const std::string& full_name,
                                EModel  model,
                                EFinish finish,
                                EType   type,
                                double  value)
 {
-  unique_ptr<Object> obj(new Object(full_name.c_str(), model, finish, type, value));
+  std::unique_ptr<Object> obj(new Object(full_name.c_str(), model, finish, type, value));
   detector.manager().AddOpticalSurface(m_element=obj.release());
 }
 
@@ -56,12 +53,12 @@ OpticalSurface::Property OpticalSurface::property(const std::string& nam)  const
 }
 
 /// Initializing constructor: Creates the object and registers it to the manager
-SkinSurface::SkinSurface(Detector& detector, DetElement de, const string& nam, OpticalSurface surf, Volume vol)
+SkinSurface::SkinSurface(Detector& detector, DetElement de, const std::string& nam, OpticalSurface surf, Volume vol)
 {
   if ( de.isValid() )  {
     if ( vol.isValid() )  {
       if ( surf.isValid() )  {
-        unique_ptr<Object> obj(new Object(nam.c_str(), surf->GetName(), surf.ptr(), vol.ptr()));
+        std::unique_ptr<Object> obj(new Object(nam.c_str(), surf->GetName(), surf.ptr(), vol.ptr()));
         detector.surfaceManager().addSkinSurface(de, m_element=obj.release());
         return;
       }
@@ -98,7 +95,7 @@ Volume   SkinSurface::volume()   const    {
 /// Initializing constructor: Creates the object and registers it to the manager
 BorderSurface::BorderSurface(Detector&      detector,
                              DetElement     de,
-                             const string&  nam,
+                             const std::string&  nam,
                              OpticalSurface surf,
                              PlacedVolume   lft,
                              PlacedVolume   rht)
@@ -106,7 +103,7 @@ BorderSurface::BorderSurface(Detector&      detector,
   if ( de.isValid() )  {
     if ( lft.isValid() && rht.isValid() )  {
       if ( surf.isValid() )   {
-        unique_ptr<Object> obj(new Object(nam.c_str(), surf->GetName(), surf.ptr(), lft.ptr(), rht.ptr()));
+        std::unique_ptr<Object> obj(new Object(nam.c_str(), surf->GetName(), surf.ptr(), lft.ptr(), rht.ptr()));
         detector.surfaceManager().addBorderSurface(de, m_element=obj.release());
         return;
       }
@@ -144,4 +141,4 @@ PlacedVolume   BorderSurface::left()   const    {
 PlacedVolume   BorderSurface::right()  const    {
   return access()->GetNode2();
 }
-#endif
+

--- a/DDCore/src/Path.cpp
+++ b/DDCore/src/Path.cpp
@@ -13,14 +13,14 @@
 //
 //==========================================================================
 
-#include "DD4hep/Path.h"
+/// Framework include files
+#include <DD4hep/Path.h>
+
+/// C/C++ include files
 #include <climits>
 #include <cstring>
 #include <vector>
 #include <stdexcept>
-
-using namespace std;
-using namespace dd4hep;
 
 namespace {
   const char dot = '.';
@@ -31,11 +31,11 @@ namespace {
   
   inline bool is_separator(char c)  { return c == separator;  }
 
-  bool is_root_separator(const string& str, size_t pos)
+  bool is_root_separator(const std::string& str, size_t pos)
   // pos is position of the separator
   {
     if ( str.empty() || is_separator(str[pos]) ) {
-      throw runtime_error("precondition violation");
+      throw std::runtime_error("precondition violation");
     }
     // subsequent logic expects pos to be for leftmost slash of a set
     while (pos > 0 && is_separator(str[pos-1]))
@@ -51,7 +51,7 @@ namespace {
     return str.find_first_of(separators, 2) == pos;
   }
 
-  size_t filename_pos(const string& str,size_t end_pos)
+  size_t filename_pos(const std::string& str,size_t end_pos)
   // return 0 if str itself is filename (or empty)
   {
     // case: "//"
@@ -66,33 +66,35 @@ namespace {
     // set pos to start of last element
     size_t pos(str.find_last_of(separators, end_pos-1));
 
-    return (pos == string::npos // path itself must be a filename (or empty)
+    return (pos == std::string::npos // path itself must be a filename (or empty)
             || (pos == 1 && is_separator(str[0]))) // or net
       ? 0 // so filename is entire string
       : pos + 1; // or starts after delimiter
   }
 
   // return npos if no root_directory found
-  size_t root_directory_start(const string& path, size_t size)  {
+  size_t root_directory_start(const std::string& path, size_t size)  {
     // case "//"
     if (size == 2
         && is_separator(path[0])
-        && is_separator(path[1])) return string::npos;
+        && is_separator(path[1])) return std::string::npos;
     // case "//net {/}"
     if (size > 3
         && is_separator(path[0])
         && is_separator(path[1])
         && !is_separator(path[2]))
     {
-      string::size_type pos(path.find_first_of(separators, 2));
-      return pos < size ? pos : string::npos;
+      std::string::size_type pos(path.find_first_of(separators, 2));
+      return pos < size ? pos : std::string::npos;
     }
     
     // case "/"
     if (size > 0 && is_separator(path[0])) return 0;
-    return string::npos;
+    return std::string::npos;
   }
 }
+
+using Path = dd4hep::Path;
 
 const Path& Path::detail::dot_path()   {
   static Path p(".");
@@ -113,7 +115,7 @@ Path Path::normalize()  const {
   if (empty())
     return *this;
 
-  vector<string> pathes;
+  std::vector<std::string> pathes;
   char tmp[PATH_MAX];
   ::strncpy(tmp, string_data(), sizeof(tmp));
   tmp[sizeof(tmp)-1] = 0;
@@ -124,10 +126,10 @@ Path Path::normalize()  const {
     token = ::strtok_r(0,separators,&save);
   }
   Path temp;
-  vector<string>::const_iterator start(pathes.begin());
-  vector<string>::const_iterator last(pathes.end());
-  vector<string>::const_iterator stop(last--);
-  for (vector<string>::const_iterator itr(start); itr != stop; ++itr)  {
+  std::vector<std::string>::const_iterator start(pathes.begin());
+  std::vector<std::string>::const_iterator last(pathes.end());
+  std::vector<std::string>::const_iterator stop(last--);
+  for (std::vector<std::string>::const_iterator itr(start); itr != stop; ++itr)  {
     // ignore "." except at start and last
     Path itr_path(*itr);
     if (itr_path.native().size() == 1
@@ -136,7 +138,7 @@ Path Path::normalize()  const {
         && itr != last) continue;
 
     // ignore a name and following ".."
-    if ( temp.empty() && itr_path.find(colon) != string::npos )  {
+    if ( temp.empty() && itr_path.find(colon) != std::string::npos )  {
       temp = itr_path;
       continue;
     }
@@ -145,7 +147,7 @@ Path Path::normalize()  const {
         && (itr_path.native())[0] == dot
         && (itr_path.native())[1] == dot) // dot dot
     {
-      string lf(temp.filename().native());  
+      std::string lf(temp.filename().native());  
       if (lf.size() > 0
           && (lf.size() != 1 || (lf[0] != dot && lf[0] != separator))
           && (lf.size() != 2 || (lf[0] != dot && lf[1] != dot))   )
@@ -165,7 +167,7 @@ Path Path::normalize()  const {
         //  }
         //}
 
-        vector<string>::const_iterator next(itr);
+        std::vector<std::string>::const_iterator next(itr);
         if (temp.empty() && ++next != stop && next == last && *last == detail::dot_path())  {
           temp /= detail::dot_path();
         }
@@ -192,7 +194,7 @@ size_t Path::parent_path_end() const  {
          ;
        --end_pos) {}
 
-  return (end_pos == 1 && root_dir_pos == 0 && filename_was_separator) ? string::npos : end_pos;
+  return (end_pos == 1 && root_dir_pos == 0 && filename_was_separator) ? std::string::npos : end_pos;
 }
 
 
@@ -203,7 +205,7 @@ Path& Path::remove_filename()   {
 
 Path  Path::parent_path() const  {
   size_t end_pos(parent_path_end());
-  return end_pos == string::npos ? Path() : Path(string_data(), string_data() + end_pos);
+  return end_pos == std::string::npos ? Path() : Path(string_data(), string_data() + end_pos);
 }
 
 Path Path::filename() const

--- a/DDCore/src/PluginTester.cpp
+++ b/DDCore/src/PluginTester.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/PluginTester.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Primitives.h"
+#include <DD4hep/PluginTester.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Primitives.h>
 
 // C/C++ include files
 #include <stdexcept>
@@ -22,7 +22,9 @@
 using namespace dd4hep;
 
 namespace {
+
   static int s_extensionID = 0;
+  
   PluginTester::ExtensionMap* extensionContainer(const std::type_info& typ) {
     static std::map<const std::type_info*, PluginTester::ExtensionMap> s_map;
     PluginTester::ExtensionMap& m = s_map[&typ];

--- a/DDCore/src/Plugins.cpp
+++ b/DDCore/src/Plugins.cpp
@@ -12,10 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Plugins.h"
+#include <DD4hep/Plugins.h>
 #include <cstdlib>
 
-using namespace std;
 using namespace dd4hep;
 
 namespace {
@@ -85,10 +84,10 @@ namespace   {
     if ( !fp.fptr.ptr ) fp.fptr.ptr = ::dlsym(0, entry);
 #endif
     if ( 0 == fp.fptr.ptr )      {
-      string err = "dd4hep:PluginService: Failed to access symbol "
-        "\""+string(entry)+"\" in plugin library "+string(plugin)+
-        " ["+string(::strerror(errno))+"]";
-      throw runtime_error(err);
+      std::string err = "dd4hep:PluginService: Failed to access symbol "
+        "\""+std::string(entry)+"\" in plugin library "+std::string(plugin)+
+        " ["+std::string(::strerror(errno))+"]";
+      throw std::runtime_error(err);
     }
     return fp.fptr.fcn;
   }
@@ -118,7 +117,7 @@ namespace   {
       _guard._handle = handle = ::dlopen(plugin_name, RTLD_LAZY | RTLD_GLOBAL);
     }
     if ( !handle )   {
-      throw runtime_error("Failed to load plugin manager library: "+string(plugin_name));
+      throw std::runtime_error("Failed to load plugin manager library: "+std::string(plugin_name));
     }
 #else
     if ( 0 != gSystem->Load(plugin_name) ) {}
@@ -145,9 +144,9 @@ PluginDebug::~PluginDebug()   noexcept(false)   {
 }
 
 /// Helper to check factory existence
-string PluginDebug::missingFactory(const string& name) const {
-  string factoryname = "Create("+name+")";
-  string msg = "\t\tNo factory with name " + factoryname + " for type " + name + " found.\n"
+std::string PluginDebug::missingFactory(const std::string& name) const {
+  std::string factoryname = "Create("+name+")";
+  std::string msg = "\t\tNo factory with name " + factoryname + " for type " + name + " found.\n"
     "\t\tPlease check library load path and/or plugin factory name.";
   return msg;
 }
@@ -174,7 +173,7 @@ void PluginService::print_bad_cast(const std::string& id,
                                    const char* msg)   {
   bool dbg = PluginInterface::instance().getDebug();
   if ( dbg )   {
-    stringstream str;
+    std::stringstream str;
     str << "Factory requested: " << id << " (" << typeid(signature).name() << ") :" << msg;
     printout(ERROR,"PluginService","%s", str.str().c_str());
     str.str("");

--- a/DDCore/src/PolarGridRPhi.cpp
+++ b/DDCore/src/PolarGridRPhi.cpp
@@ -12,12 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/PolarGridRPhi.h"
-#include "DDSegmentation/PolarGridRPhi.h"
+#include <DD4hep/PolarGridRPhi.h>
+#include <DDSegmentation/PolarGridRPhi.h>
 
 // C/C++ include files
 
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -74,12 +73,12 @@ void PolarGridRPhi::setGridSizePhi(double cellSize) const  {
 }
 
 /// access the field name used for R
-const string& PolarGridRPhi::fieldNameR() const  {
+const std::string& PolarGridRPhi::fieldNameR() const  {
   return access()->implementation->fieldNameR();
 }
 
 /// access the field name used for Phi
-const string& PolarGridRPhi::fieldNamePhi() const  {
+const std::string& PolarGridRPhi::fieldNamePhi() const  {
   return access()->implementation->fieldNamePhi();
 }
 
@@ -92,6 +91,6 @@ const string& PolarGridRPhi::fieldNamePhi() const  {
     -# size in x
     -# size in z
 */
-vector<double> PolarGridRPhi::cellDimensions(const CellID& id) const  {
+std::vector<double> PolarGridRPhi::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/PolarGridRPhi2.cpp
+++ b/DDCore/src/PolarGridRPhi2.cpp
@@ -12,12 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/PolarGridRPhi2.h"
-#include "DDSegmentation/PolarGridRPhi2.h"
+#include <DD4hep/PolarGridRPhi2.h>
+#include <DDSegmentation/PolarGridRPhi2.h>
 
 // C/C++ include files
 
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -34,12 +33,12 @@ dd4hep::CellID PolarGridRPhi2::cellID(const Position& local,
 }
 
 /// access the grid size in R
-vector<double> PolarGridRPhi2::gridRValues() const  {
+std::vector<double> PolarGridRPhi2::gridRValues() const  {
   return access()->implementation->gridRValues();
 }
 
 /// access the grid size in Phi
-vector<double> PolarGridRPhi2::gridPhiValues() const  {
+std::vector<double> PolarGridRPhi2::gridPhiValues() const  {
   return access()->implementation->gridPhiValues();
 }
 /// set the grid Boundaries in R
@@ -83,12 +82,12 @@ void PolarGridRPhi2::setOffsetPhi(double offset) const  {
 }
 
 /// access the field name used for R
-const string& PolarGridRPhi2::fieldNameR() const  {
+const std::string& PolarGridRPhi2::fieldNameR() const  {
   return access()->implementation->fieldNameR();
 }
 
 /// access the field name used for Phi
-const string& PolarGridRPhi2::fieldNamePhi() const  {
+const std::string& PolarGridRPhi2::fieldNamePhi() const  {
   return access()->implementation->fieldNamePhi();
 }
 
@@ -101,6 +100,6 @@ const string& PolarGridRPhi2::fieldNamePhi() const  {
     -# size in x
     -# size in z
 */
-vector<double> PolarGridRPhi2::cellDimensions(const CellID& id) const  {
+std::vector<double> PolarGridRPhi2::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/Primitives.cpp
+++ b/DDCore/src/Primitives.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Primitives.h"
-#include "DD4hep/Exceptions.h"
-#include "DD4hep/Printout.h"
+#include <DD4hep/Primitives.h>
+#include <DD4hep/Exceptions.h>
+#include <DD4hep/Printout.h>
 
 // C/C++ include files
 #include <cstring>

--- a/DDCore/src/Printout.cpp
+++ b/DDCore/src/Printout.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
+#include <DD4hep/Printout.h>
 
 // C/C++ include files
 #include <mutex>
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <iostream>
 #include <stdexcept>
+
 // Disable some diagnostics for ROOT dictionaries
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wvarargs"

--- a/DDCore/src/PropertyDictionary.h
+++ b/DDCore/src/PropertyDictionary.h
@@ -17,7 +17,7 @@
 #define DDCORE_SRC_PROPERTYDICTIONARY_H
 
 // Framework include files
-#include "DD4hep/ComponentProperties.h"
+#include <DD4hep/ComponentProperties.h>
 
 // C/C++ include files
 #include <vector>

--- a/DDCore/src/PropertyTable.cpp
+++ b/DDCore/src/PropertyTable.cpp
@@ -12,33 +12,29 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/PropertyTable.h"
-#include "DD4hep/NamedObject.h"
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
+#include <DD4hep/PropertyTable.h>
+#include <DD4hep/NamedObject.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
 
-#include "DD4hep/detail/Handle.inl"
+#include <DD4hep/detail/Handle.inl>
 
 // C/C++ includes
 #include <sstream>
 #include <iomanip>
 
-using namespace std;
 using namespace dd4hep;
-
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
 
 DD4HEP_INSTANTIATE_HANDLE(TGDMLMatrix);
 
 /// Initializing constructor.
 PropertyTable::PropertyTable(Detector&     description,
-                             const string& table_name,
-                             const string& property_name,
+                             const std::string& table_name,
+                             const std::string& property_name,
                              size_t        num_rows,
                              size_t        num_cols)
 {
-  unique_ptr<Object> table(new Object(table_name.c_str(), num_rows, num_cols));
+  std::unique_ptr<Object> table(new Object(table_name.c_str(), num_rows, num_cols));
   table->SetTitle(property_name.c_str());
   description.manager().AddGDMLMatrix(m_element=table.release());
 }
-#endif

--- a/DDCore/src/Readout.cpp
+++ b/DDCore/src/Readout.cpp
@@ -12,17 +12,16 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Readout.h"
-#include "DD4hep/detail/SegmentationsInterna.h"
-#include "DD4hep/detail/ObjectsInterna.h"
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/Detector.h"
+#include <DD4hep/Readout.h>
+#include <DD4hep/detail/SegmentationsInterna.h>
+#include <DD4hep/detail/ObjectsInterna.h>
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 /// Copy constructor
 HitCollection::HitCollection(const HitCollection& c)
@@ -31,7 +30,7 @@ HitCollection::HitCollection(const HitCollection& c)
 }
 
 /// Initializing constructor
-HitCollection::HitCollection(const string& n, const string& k, long k_min, long k_max)  
+HitCollection::HitCollection(const std::string& n, const std::string& k, long k_min, long k_max)  
   : name(n), key(k), key_min(k_min), key_max(k_max)
 {
 }
@@ -48,7 +47,7 @@ HitCollection& HitCollection::operator=(const HitCollection& c)   {
 }
 
 /// Initializing constructor to create a new object
-Readout::Readout(const string& nam) {
+Readout::Readout(const std::string& nam) {
   assign(new ReadoutObject(), nam, "readout");
 }
 
@@ -58,12 +57,13 @@ size_t Readout::numCollections() const   {
     Object& ro = object<Object>();
     return ro.hits.size();
   }
-  throw runtime_error("dd4hep: Readout::numCollections: Cannot access object data [Invalid Handle]");
+  except("dd4hep::Readout","numCollections: Cannot access object data [Invalid Handle]");
+  throw std::runtime_error("dd4hep: Readout");
 }
 
 /// Access names of hit collections
-vector<string> Readout::collectionNames()  const   {
-  vector<string> colls;
+std::vector<std::string> Readout::collectionNames()  const   {
+  std::vector<std::string> colls;
   if ( isValid() ) {
     Object& ro = object<Object>();
     if ( !ro.hits.empty() )  {
@@ -72,12 +72,13 @@ vector<string> Readout::collectionNames()  const   {
     }
     return colls;
   }
-  throw runtime_error("dd4hep: Readout::collectionsNames: Cannot access object data [Invalid Handle]");
+  except("dd4hep::Readout", "collectionsNames: Cannot access object data [Invalid Handle]");
+  throw std::runtime_error("dd4hep: Readout");
 }
 
 /// Access hit collectionsy
-vector<const HitCollection*> Readout::collections()  const   {
-  vector<const HitCollection*> colls;
+std::vector<const HitCollection*> Readout::collections()  const   {
+  std::vector<const HitCollection*> colls;
   if ( isValid() ) {
     Object& ro = object<Object>();
     if ( !ro.hits.empty() )  {
@@ -86,7 +87,8 @@ vector<const HitCollection*> Readout::collections()  const   {
     }
     return colls;
   }
-  throw runtime_error("dd4hep: Readout::collections: Cannot access object data [Invalid Handle]");
+  except("dd4hep::Readout", "collections: Cannot access object data [Invalid Handle]");
+  throw std::runtime_error("dd4hep: Readout");
 }
 
 /// Assign IDDescription to readout structure
@@ -102,7 +104,8 @@ void Readout::setIDDescriptor(const Ref_t& new_descriptor) const {
       return;
     }
   }
-  throw runtime_error("dd4hep: Readout::setIDDescriptor: Cannot assign ID descriptor [Invalid Handle]");
+  except("dd4hep::Readout", "setIDDescriptor: Cannot assign ID descriptor [Invalid Handle]");
+  throw std::runtime_error("dd4hep: Readout");
 }
 
 /// Access IDDescription structure
@@ -123,7 +126,8 @@ void Readout::setSegmentation(const Segmentation& seg) const {
       return;
     }
   }
-  throw runtime_error("dd4hep: Readout::setSegmentation: Cannot assign segmentation [Invalid Handle]");
+  except("dd4hep::Readout", "setSegmentation: Cannot assign segmentation [Invalid Handle]");
+  throw std::runtime_error("dd4hep: Readout");
 }
 
 /// Access segmentation structure

--- a/DDCore/src/RootDictionary.h
+++ b/DDCore/src/RootDictionary.h
@@ -17,34 +17,34 @@
 #define DDCORE_SRC_ROOTDICTIONARY_H
 
 // Framework include files
-#include "Evaluator/Evaluator.h"
-#include "DD4hep/DD4hepRootPersistency.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Grammar.h"
-#include "DD4hep/detail/ObjectsInterna.h"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DD4hep/detail/ConditionsInterna.h"
-#include "DD4hep/detail/AlignmentsInterna.h"
-#include "DD4hep/detail/VolumeManagerInterna.h"
+#include <Evaluator/Evaluator.h>
+#include <DD4hep/DD4hepRootPersistency.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Grammar.h>
+#include <DD4hep/detail/ObjectsInterna.h>
+#include <DD4hep/detail/DetectorInterna.h>
+#include <DD4hep/detail/ConditionsInterna.h>
+#include <DD4hep/detail/AlignmentsInterna.h>
+#include <DD4hep/detail/VolumeManagerInterna.h>
 
-#include "DD4hep/World.h"
-#include "DD4hep/DD4hepUI.h"
-#include "DD4hep/Callback.h"
-#include "DD4hep/Conditions.h"
-#include "DD4hep/Alignments.h"
-#include "DD4hep/FieldTypes.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/DetectorData.h"
-#include "DD4hep/DetectorProcessor.h"
-#include "DD4hep/ComponentProperties.h"
-#include "DD4hep/DetectorImp.h"
+#include <DD4hep/World.h>
+#include <DD4hep/DD4hepUI.h>
+#include <DD4hep/Callback.h>
+#include <DD4hep/Conditions.h>
+#include <DD4hep/Alignments.h>
+#include <DD4hep/FieldTypes.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/DetectorData.h>
+#include <DD4hep/DetectorProcessor.h>
+#include <DD4hep/ComponentProperties.h>
+#include <DD4hep/DetectorImp.h>
 
 // C/C++ include files
 #include <vector>
 #include <map>
  #include <string>
 
-#include "TRint.h"
+#include <TRint.h>
 
 namespace dd4hep {
   namespace cond {}
@@ -825,7 +825,7 @@ template class dd4hep::Handle<TNamed>;
 #pragma link C++ function dd4hep::toStringMesh(const TGeoShape*, int);
 #pragma link C++ function dd4hep::toStringMesh(dd4hep::PlacedVolume, int);
 
-#include "DD4hep/ConditionsData.h"
+#include <DD4hep/ConditionsData.h>
 #pragma link C++ class dd4hep::cond::ClientData+;
 #pragma link C++ class dd4hep::cond::AbstractMap+;
 #pragma link C++ class dd4hep::cond::AbstractMap::Params+;

--- a/DDCore/src/SegmentationDictionary.h
+++ b/DDCore/src/SegmentationDictionary.h
@@ -20,31 +20,31 @@
 #define __HAVE_DDSEGMENTATION__
 // -------------------------------------------------------------------------
 #ifdef __HAVE_DDSEGMENTATION__
-#include "DDSegmentation/Segmentation.h"
-#include "DDSegmentation/NoSegmentation.h"
-#include "DDSegmentation/CartesianGrid.h"
-#include "DDSegmentation/CartesianGridXY.h"
-#include "DDSegmentation/CartesianGridXYZ.h"
-#include "DDSegmentation/CartesianGridXZ.h"
-#include "DDSegmentation/CartesianGridYZ.h"
-#include "DDSegmentation/CartesianStripX.h"
-#include "DDSegmentation/CartesianStripY.h"
-#include "DDSegmentation/CartesianStripZ.h"
-#include "DDSegmentation/CylindricalSegmentation.h"
-#include "DDSegmentation/GridPhiEta.h"
-#include "DDSegmentation/GridRPhiEta.h"
-#include "DDSegmentation/MegatileLayerGridXY.h"
-#include "DDSegmentation/MultiSegmentation.h"
-#include "DDSegmentation/NoSegmentation.h"
-#include "DDSegmentation/PolarGrid.h"
-#include "DDSegmentation/PolarGridRPhi2.h"
-#include "DDSegmentation/PolarGridRPhi.h"
-#include "DDSegmentation/ProjectiveCylinder.h"
+#include <DDSegmentation/Segmentation.h>
+#include <DDSegmentation/NoSegmentation.h>
+#include <DDSegmentation/CartesianGrid.h>
+#include <DDSegmentation/CartesianGridXY.h>
+#include <DDSegmentation/CartesianGridXYZ.h>
+#include <DDSegmentation/CartesianGridXZ.h>
+#include <DDSegmentation/CartesianGridYZ.h>
+#include <DDSegmentation/CartesianStripX.h>
+#include <DDSegmentation/CartesianStripY.h>
+#include <DDSegmentation/CartesianStripZ.h>
+#include <DDSegmentation/CylindricalSegmentation.h>
+#include <DDSegmentation/GridPhiEta.h>
+#include <DDSegmentation/GridRPhiEta.h>
+#include <DDSegmentation/MegatileLayerGridXY.h>
+#include <DDSegmentation/MultiSegmentation.h>
+#include <DDSegmentation/NoSegmentation.h>
+#include <DDSegmentation/PolarGrid.h>
+#include <DDSegmentation/PolarGridRPhi2.h>
+#include <DDSegmentation/PolarGridRPhi.h>
+#include <DDSegmentation/ProjectiveCylinder.h>
 
-#include "DDSegmentation/SegmentationParameter.h"
-#include "DDSegmentation/TiledLayerGridXY.h"
-#include "DDSegmentation/TiledLayerSegmentation.h"
-#include "DDSegmentation/WaferGridXY.h"
+#include <DDSegmentation/SegmentationParameter.h>
+#include <DDSegmentation/TiledLayerGridXY.h>
+#include <DDSegmentation/TiledLayerSegmentation.h>
+#include <DDSegmentation/WaferGridXY.h>
 typedef dd4hep::DDSegmentation::VolumeID VolumeID;
 typedef dd4hep::DDSegmentation::CellID CellID;
 

--- a/DDCore/src/Segmentations.cpp
+++ b/DDCore/src/Segmentations.cpp
@@ -12,27 +12,25 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Segmentations.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Plugins.h"
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/detail/SegmentationsInterna.h"
+#include <DD4hep/Segmentations.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Plugins.h>
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/detail/SegmentationsInterna.h>
 
 // C/C++ include files
 #include <iostream>
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 DD4HEP_INSTANTIATE_HANDLE_UNNAMED(SegmentationObject);
 
 /// Constructor to used when creating a new object
-Segmentation::Segmentation(const string& typ, const string& nam, const BitFieldCoder* dec) : Handle<Object>()
+Segmentation::Segmentation(const std::string& typ, const std::string& nam, const BitFieldCoder* dec) : Handle<Object>()
 {
-  string seg_type = "segmentation_constructor__"+typ;
+  std::string seg_type = "segmentation_constructor__"+typ;
   SegmentationObject* obj = PluginService::Create<SegmentationObject*>(seg_type, dec);
   if ( obj != 0 )  {
     assign(obj, nam, typ);
@@ -122,56 +120,56 @@ Handle<SensitiveDetectorObject> Segmentation::sensitive() const  {
   return access()->sensitive;
 }
 
-#include "DDSegmentation/NoSegmentation.h"
+#include <DDSegmentation/NoSegmentation.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::NoSegmentation);
 
-#include "DDSegmentation/CartesianGrid.h"
+#include <DDSegmentation/CartesianGrid.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianGrid);
 
-#include "DDSegmentation/CartesianGridXY.h"
+#include <DDSegmentation/CartesianGridXY.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianGridXY);
 
-#include "DDSegmentation/CartesianGridXZ.h"
+#include <DDSegmentation/CartesianGridXZ.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianGridXZ);
 
-#include "DDSegmentation/CartesianGridYZ.h"
+#include <DDSegmentation/CartesianGridYZ.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianGridYZ);
 
-#include "DDSegmentation/CartesianGridXYZ.h"
+#include <DDSegmentation/CartesianGridXYZ.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianGridXYZ);
 
-#include "DDSegmentation/CartesianStripX.h"
+#include <DDSegmentation/CartesianStripX.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianStripX);
 
-#include "DDSegmentation/CartesianStripY.h"
+#include <DDSegmentation/CartesianStripY.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianStripY);
 
-#include "DDSegmentation/CartesianStripZ.h"
+#include <DDSegmentation/CartesianStripZ.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CartesianStripZ);
 
-#include "DDSegmentation/TiledLayerGridXY.h"
+#include <DDSegmentation/TiledLayerGridXY.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::TiledLayerGridXY);
 
-#include "DDSegmentation/MegatileLayerGridXY.h"
+#include <DDSegmentation/MegatileLayerGridXY.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::MegatileLayerGridXY);
 
-#include "DDSegmentation/WaferGridXY.h"
+#include <DDSegmentation/WaferGridXY.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::WaferGridXY);
 
-#include "DDSegmentation/PolarGridRPhi.h"
+#include <DDSegmentation/PolarGridRPhi.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::PolarGridRPhi);
 
-#include "DDSegmentation/PolarGridRPhi2.h"
+#include <DDSegmentation/PolarGridRPhi2.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::PolarGridRPhi2);
 
-#include "DDSegmentation/GridPhiEta.h"
+#include <DDSegmentation/GridPhiEta.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::GridPhiEta);
 
-#include "DDSegmentation/GridRPhiEta.h"
+#include <DDSegmentation/GridRPhiEta.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::GridRPhiEta);
 
-#include "DDSegmentation/ProjectiveCylinder.h"
+#include <DDSegmentation/ProjectiveCylinder.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::ProjectiveCylinder);
 
-#include "DDSegmentation/MultiSegmentation.h"
+#include <DDSegmentation/MultiSegmentation.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::MultiSegmentation);

--- a/DDCore/src/SegmentationsInterna.cpp
+++ b/DDCore/src/SegmentationsInterna.cpp
@@ -12,12 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/detail/SegmentationsInterna.h"
-#include "DD4hep/InstanceCount.h"
+#include <DD4hep/detail/SegmentationsInterna.h>
+#include <DD4hep/InstanceCount.h>
 
 #include "DDSegmentation/Segmentation.h"
 
-using namespace std;
 using namespace dd4hep;
 
 /// Standard constructor
@@ -37,26 +36,26 @@ SegmentationObject::~SegmentationObject() {
 }
 
 /// Access the encoding string
-string SegmentationObject::fieldDescription() const {
+std::string SegmentationObject::fieldDescription() const {
   return segmentation->fieldDescription();
 }
 
 /// Access the segmentation name
-const string& SegmentationObject::name() const {
+const std::string& SegmentationObject::name() const {
   return segmentation->name();
 }
 /// Set the segmentation name
-void SegmentationObject::setName(const string& value) {
+void SegmentationObject::setName(const std::string& value) {
   segmentation->setName(value);
 }
 
 /// Access the segmentation type
-const string& SegmentationObject::type() const {
+const std::string& SegmentationObject::type() const {
   return segmentation->type();
 }
 
 /// Access the description of the segmentation
-const string& SegmentationObject::description() const {
+const std::string& SegmentationObject::description() const {
   return segmentation->description();
 }
 
@@ -71,7 +70,7 @@ void SegmentationObject::setDecoder(const BitFieldCoder* ptr_decoder) const {
 }
 
 /// Access to parameter by name
-DDSegmentation::Parameter SegmentationObject::parameter(const string& parameterName) const {
+DDSegmentation::Parameter SegmentationObject::parameter(const std::string& parameterName) const {
   return segmentation->parameter(parameterName);
 }
 

--- a/DDCore/src/ShapeUtilities.cpp
+++ b/DDCore/src/ShapeUtilities.cpp
@@ -33,8 +33,6 @@
 #include <TGeoScaledShape.h>
 #include <TGeoCompositeShape.h>
 
-using namespace std;
-
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
 
@@ -48,7 +46,7 @@ namespace dd4hep {
       except("Dimension","Invalid shape pointer!");
       return 0;
     }
-    inline void invalidSetDimensionCall(const TGeoShape* sh, const vector<double>& params)   {
+    inline void invalidSetDimensionCall(const TGeoShape* sh, const std::vector<double>& params)   {
       except("Solid","+++ Shape:%s setDimension: Invalid number of parameters: %ld",
              (sh ? typeName(typeid(*sh)) : typeName(typeid(sh))).c_str(), params.size());
     }
@@ -78,9 +76,7 @@ namespace dd4hep {
   template bool isInstance<PolyhedraRegular>  (const Handle<TGeoShape>& solid);
   template bool isInstance<Polyhedra>         (const Handle<TGeoShape>& solid);
   template bool isInstance<ExtrudedPolygon>   (const Handle<TGeoShape>& solid);
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
   template bool isInstance<TessellatedSolid>   (const Handle<TGeoShape>& solid);
-#endif
   template bool isInstance<BooleanSolid>      (const Handle<TGeoShape>& solid);
 
   template <> bool isInstance<Cone>(const Handle<TGeoShape>& solid)  {
@@ -153,9 +149,7 @@ namespace dd4hep {
   template bool isA<ExtrudedPolygon>(const Handle<TGeoShape>& solid);
   template bool isA<Polycone>(const Handle<TGeoShape>& solid);
   template bool isA<EightPointSolid>(const Handle<TGeoShape>& solid);
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
   template bool isA<TessellatedSolid>(const Handle<TGeoShape>& solid);
-#endif
   template <> bool isA<TwistedTube>(const Handle<TGeoShape>& solid)   {
     return check_shape_type<TwistedTubeObject>(solid)
       &&   ::strcmp(solid->GetTitle(), TWISTEDTUBE_TAG) == 0;
@@ -188,7 +182,7 @@ namespace dd4hep {
   }
 
   /// Retrieve tag name from shape type
-  string get_shape_tag(const TGeoShape* sh)    {
+  std::string get_shape_tag(const TGeoShape* sh)    {
     if ( sh )    {
       TClass* cl = sh->IsA();
       if ( cl == TGeoShapeAssembly::Class() )
@@ -237,10 +231,8 @@ namespace dd4hep {
         return EXTRUDEDPOLYGON_TAG;
       else if ( cl == TGeoScaledShape::Class() )
         return SCALE_TAG;
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
       else if ( cl == TGeoTessellated::Class() )
         return TESSELLATEDSOLID_TAG;
-#endif
       else if (isA<TruncatedTube>(sh) )
         return TRUNCATEDTUBE_TAG;
       else if (isA<PseudoTrap>(sh) )
@@ -260,30 +252,30 @@ namespace dd4hep {
     return "";
   }
 
-  template <typename T> vector<double> dimensions(const TGeoShape* shape)    {
-    stringstream str;
+  template <typename T> std::vector<double> dimensions(const TGeoShape* shape)    {
+    std::stringstream str;
     if ( shape )
       str << "Shape: dimension(" << typeName(typeid(*shape)) << "): Invalid call!";
     else
       str << "Shape: dimension<TGeoShape): Invalid call && pointer!";
-    throw runtime_error(str.str());
+    throw std::runtime_error(str.str());
   }
-  template <> vector<double> dimensions<TGeoShapeAssembly>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoShapeAssembly>(const TGeoShape* shape)    {
     const auto* sh = get_ptr<TGeoShapeAssembly>(shape);
     return { sh->GetDX(), sh->GetDY(), sh->GetDZ() };
   }
-  template <> vector<double> dimensions<TGeoBBox>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoBBox>(const TGeoShape* shape)    {
     const auto* sh = get_ptr<TGeoBBox>(shape);
     return { sh->GetDX(), sh->GetDY(), sh->GetDZ() };
   }
-  template <> vector<double> dimensions<TGeoHalfSpace>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoHalfSpace>(const TGeoShape* shape)    {
     auto* sh = get_ptr<TGeoHalfSpace>(shape);
     return { sh->GetPoint()[0], sh->GetPoint()[1], sh->GetPoint()[2],
         sh->GetNorm()[0], sh->GetNorm()[1], sh->GetNorm()[2] };
   }
-  template <> vector<double> dimensions<TGeoPcon>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoPcon>(const TGeoShape* shape)    {
     const TGeoPcon* sh = get_ptr<TGeoPcon>(shape);
-    vector<double> pars { sh->GetPhi1()*units::deg, sh->GetDphi()*units::deg, double(sh->GetNz()) };
+    std::vector<double> pars { sh->GetPhi1()*units::deg, sh->GetDphi()*units::deg, double(sh->GetNz()) };
     pars.reserve(3+3*sh->GetNz());
     for (Int_t i = 0; i < sh->GetNz(); ++i) {
       pars.emplace_back(sh->GetZ(i));
@@ -292,30 +284,30 @@ namespace dd4hep {
     }
     return pars;
   }
-  template <> vector<double> dimensions<TGeoConeSeg>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoConeSeg>(const TGeoShape* shape)    {
     const TGeoConeSeg* sh = get_ptr<TGeoConeSeg>(shape);
     return { sh->GetDz(), sh->GetRmin1(), sh->GetRmax1(), sh->GetRmin2(), sh->GetRmax2(),
         sh->GetPhi1()*units::deg, sh->GetPhi2()*units::deg };
   }
-  template <> vector<double> dimensions<TGeoCone>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoCone>(const TGeoShape* shape)    {
     const TGeoCone* sh = get_ptr<TGeoCone>(shape);
     return { sh->GetDz(), sh->GetRmin1(), sh->GetRmax1(), sh->GetRmin2(), sh->GetRmax2() };
   }  
-  template <> vector<double> dimensions<TGeoTube>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoTube>(const TGeoShape* shape)    {
     const TGeoTube* sh = get_ptr<TGeoTube>(shape);
     return { sh->GetRmin(), sh->GetRmax(), sh->GetDz() };
   }
-  template <> vector<double> dimensions<TGeoTubeSeg>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoTubeSeg>(const TGeoShape* shape)    {
     const TGeoTubeSeg* sh = get_ptr<TGeoTubeSeg>(shape);
     return { sh->GetRmin(), sh->GetRmax(), sh->GetDz(), sh->GetPhi1()*units::deg, sh->GetPhi2()*units::deg };
   }
-  template <> vector<double> dimensions<TwistedTubeObject>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TwistedTubeObject>(const TGeoShape* shape)    {
     const TwistedTubeObject* sh = get_ptr<TwistedTubeObject>(shape);
     return { sh->GetPhiTwist(), sh->GetRmin(), sh->GetRmax(),
         sh->GetNegativeEndZ(), sh->GetPositiveEndZ(),
         double(sh->GetNsegments()), sh->GetPhi2()*units::deg };
   }
-  template <> vector<double> dimensions<TGeoCtub>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoCtub>(const TGeoShape* shape)    {
     const TGeoCtub* sh = get_ptr<TGeoCtub>(shape);
     const Double_t*	lo = sh->GetNlow();
     const Double_t*	hi = sh->GetNhigh();
@@ -323,42 +315,42 @@ namespace dd4hep {
         sh->GetPhi1()*units::deg, sh->GetPhi2()*units::deg,
         lo[0], lo[1], lo[2], hi[0], hi[1], hi[2] };
   }
-  template <> vector<double> dimensions<TGeoEltu>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoEltu>(const TGeoShape* shape)    {
     const TGeoEltu* sh = get_ptr<TGeoEltu>(shape);
     return { sh->GetA(), sh->GetB(), sh->GetDz() };
   }
-  template <> vector<double> dimensions<TGeoTrd1>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoTrd1>(const TGeoShape* shape)    {
     const TGeoTrd1* sh = get_ptr<TGeoTrd1>(shape);
     return { sh->GetDx1(), sh->GetDx2(), sh->GetDy(), sh->GetDz() };
   }
-  template <> vector<double> dimensions<TGeoTrd2>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoTrd2>(const TGeoShape* shape)    {
     const TGeoTrd2* sh = get_ptr<TGeoTrd2>(shape);
     return { sh->GetDx1(), sh->GetDx2(), sh->GetDy1(), sh->GetDy2(), sh->GetDz() };
   }
-  template <> vector<double> dimensions<TGeoParaboloid>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoParaboloid>(const TGeoShape* shape)    {
     const TGeoParaboloid* sh = get_ptr<TGeoParaboloid>(shape);
     return { sh->GetRlo(), sh->GetRhi(), sh->GetDz() };
   }
-  template <> vector<double> dimensions<TGeoHype>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoHype>(const TGeoShape* shape)    {
     const TGeoHype* sh = get_ptr<TGeoHype>(shape);
     return { sh->GetDz(),
         sh->GetRmin(), sh->GetStIn()*units::deg,
         sh->GetRmax(), sh->GetStOut()*units::deg };
   }
-  template <> vector<double> dimensions<TGeoSphere>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoSphere>(const TGeoShape* shape)    {
     const TGeoSphere* sh = get_ptr<TGeoSphere>(shape);
     return { sh->GetRmin(), sh->GetRmax(),
         sh->GetTheta1()*units::deg, sh->GetTheta2()*units::deg,
         sh->GetPhi1()*units::deg,   sh->GetPhi2()*units::deg };
   }
-  template <> vector<double> dimensions<TGeoTorus>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoTorus>(const TGeoShape* shape)    {
     const TGeoTorus* sh = get_ptr<TGeoTorus>(shape);
     return { sh->GetR(), sh->GetRmin(), sh->GetRmax(),
         sh->GetPhi1()*units::deg, sh->GetDphi()*units::deg };
   }
-  template <> vector<double> dimensions<TGeoPgon>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoPgon>(const TGeoShape* shape)    {
     const TGeoPgon* sh = get_ptr<TGeoPgon>(shape);
-    vector<double> pars { sh->GetPhi1()*units::deg, sh->GetDphi()*units::deg, double(sh->GetNedges()), double(sh->GetNz()) };
+    std::vector<double> pars { sh->GetPhi1()*units::deg, sh->GetDphi()*units::deg, double(sh->GetNedges()), double(sh->GetNz()) };
     pars.reserve(4+3*sh->GetNz());
     for (Int_t i = 0; i < sh->GetNz(); ++i) {
       pars.emplace_back(sh->GetZ(i));
@@ -367,10 +359,10 @@ namespace dd4hep {
     }
     return pars;
   }
-  template <> vector<double> dimensions<TGeoXtru>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoXtru>(const TGeoShape* shape)    {
     const TGeoXtru* sh = get_ptr<TGeoXtru>(shape);
     Int_t nz = sh->GetNz();
-    vector<double> pars { double(nz) };
+    std::vector<double> pars { double(nz) };
     pars.reserve(1+4*nz);
     for(Int_t i=0; i<nz; ++i)   {
       pars.emplace_back(sh->GetZ(i));
@@ -380,45 +372,44 @@ namespace dd4hep {
     }
     return pars;
   }
-  template <> vector<double> dimensions<TGeoArb8>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoArb8>(const TGeoShape* shape)    {
     TGeoArb8* sh = get_ptr<TGeoArb8>(shape);
     struct _V { double xy[8][2]; } *vtx = (_V*)sh->GetVertices();
-    vector<double> pars { sh->GetDz() };
+    std::vector<double> pars { sh->GetDz() };
     for ( size_t i=0; i<8; ++i )   {
       pars.emplace_back(vtx->xy[i][0]);
       pars.emplace_back(vtx->xy[i][1]);
     }
     return pars;
   }
-  template <> vector<double> dimensions<TGeoTrap>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoTrap>(const TGeoShape* shape)    {
     const TGeoTrap* sh = get_ptr<TGeoTrap>(shape);
     return { sh->GetDz(), sh->GetTheta()*units::deg, sh->GetPhi()*units::deg,
         sh->GetH1(), sh->GetBl1(), sh->GetTl1(), sh->GetAlpha1()*units::deg,
         sh->GetH2(), sh->GetBl2(), sh->GetTl2(), sh->GetAlpha2()*units::deg };
   }
-  template <> vector<double> dimensions<TGeoGtra>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoGtra>(const TGeoShape* shape)    {
     const TGeoGtra* sh = get_ptr<TGeoGtra>(shape);
     return { sh->GetDz(), sh->GetTheta()*units::deg, sh->GetPhi()*units::deg,
         sh->GetH1(), sh->GetBl1(), sh->GetTl1(), sh->GetAlpha1()*units::deg,
         sh->GetH2(), sh->GetBl2(), sh->GetTl2(), sh->GetAlpha2()*units::deg,
         sh->GetTwistAngle()*units::deg };
   }
-  template <> vector<double> dimensions<TGeoScaledShape>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoScaledShape>(const TGeoShape* shape)    {
     TGeoScaledShape* sh = get_ptr<TGeoScaledShape>(shape);
     TGeoShape*       s_sh = sh->GetShape();
     const Double_t*  scale = sh->GetScale()->GetScale();
-    vector<double>   pars {scale[0],scale[1],scale[2]};
-    vector<double>   s_pars = get_shape_dimensions(s_sh);
+    std::vector<double>   pars {scale[0],scale[1],scale[2]};
+    std::vector<double>   s_pars = get_shape_dimensions(s_sh);
     for(auto p : s_pars) pars.push_back(p);
     return pars;
   }
   
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
-  template <> vector<double> dimensions<TGeoTessellated>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoTessellated>(const TGeoShape* shape)    {
     TGeoTessellated* sh = get_ptr<TGeoTessellated>(shape);
     int num_facet = sh->GetNfacets();
     int num_vtx   = sh->GetNvertices();
-    vector<double> pars;
+    std::vector<double> pars;
 
     printout(DEBUG,"TessellatedSolid","+++ Saving %d vertices, %d facets",num_vtx, num_facet);
     pars.reserve(num_facet*5+num_vtx*3+2);
@@ -444,9 +435,8 @@ namespace dd4hep {
     }
     return pars;
   }
-#endif
   
-  template <> vector<double> dimensions<TGeoCompositeShape>(const TGeoShape* shape)    {
+  template <> std::vector<double> dimensions<TGeoCompositeShape>(const TGeoShape* shape)    {
     const TGeoCompositeShape* sh = get_ptr<TGeoCompositeShape>(shape);
     const TGeoBoolNode*  boolean = sh->GetBoolNode();
     TGeoMatrix*    right_matrix  = boolean->GetRightMatrix();
@@ -460,9 +450,9 @@ namespace dd4hep {
     const Double_t*   right_tr  = right_matrix->GetTranslation();
     const Double_t*   right_rot = right_matrix->GetRotationMatrix();
 
-    vector<double>    pars { double(oper) };
-    vector<double>    left_par  = Solid(left_solid).dimensions();
-    vector<double>    right_par = Solid(right_solid).dimensions();
+    std::vector<double>    pars { double(oper) };
+    std::vector<double>    left_par  = Solid(left_solid).dimensions();
+    std::vector<double>    right_par = Solid(right_solid).dimensions();
 
     pars.insert(pars.end(), left_par.begin(), left_par.end());
     pars.insert(pars.end(), left_rot, left_rot+9);
@@ -474,43 +464,41 @@ namespace dd4hep {
     return pars;
   }
 
-  template <typename T> vector<double> dimensions(const Handle<TGeoShape>& shape)
+  template <typename T> std::vector<double> dimensions(const Handle<TGeoShape>& shape)
   {  return dimensions<typename T::Object>(get_ptr<typename T::Object>(shape.ptr()));  }
-  template vector<double> dimensions<ShapelessSolid>   (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Box>              (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Scale>            (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<HalfSpace>        (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Polycone>         (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<ConeSegment>      (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Tube>             (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<CutTube>          (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<TwistedTube>      (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<EllipticalTube>   (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Cone>             (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Trap>             (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Trd1>             (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Trd2>             (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Torus>            (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Sphere>           (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Paraboloid>       (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Hyperboloid>      (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<PolyhedraRegular> (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<Polyhedra>        (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<ExtrudedPolygon>  (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<EightPointSolid>  (const Handle<TGeoShape>& shape); 
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
-  template vector<double> dimensions<TessellatedSolid>  (const Handle<TGeoShape>& shape); 
-#endif
-  template vector<double> dimensions<BooleanSolid>     (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<SubtractionSolid> (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<UnionSolid>       (const Handle<TGeoShape>& shape);
-  template vector<double> dimensions<IntersectionSolid>(const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<ShapelessSolid>   (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Box>              (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Scale>            (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<HalfSpace>        (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Polycone>         (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<ConeSegment>      (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Tube>             (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<CutTube>          (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<TwistedTube>      (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<EllipticalTube>   (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Cone>             (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Trap>             (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Trd1>             (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Trd2>             (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Torus>            (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Sphere>           (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Paraboloid>       (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Hyperboloid>      (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<PolyhedraRegular> (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<Polyhedra>        (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<ExtrudedPolygon>  (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<EightPointSolid>  (const Handle<TGeoShape>& shape); 
+  template std::vector<double> dimensions<TessellatedSolid>  (const Handle<TGeoShape>& shape); 
+  template std::vector<double> dimensions<BooleanSolid>     (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<SubtractionSolid> (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<UnionSolid>       (const Handle<TGeoShape>& shape);
+  template std::vector<double> dimensions<IntersectionSolid>(const Handle<TGeoShape>& shape);
 
-  template <> vector<double> dimensions<PseudoTrap>(const Handle<TGeoShape>& shape)   {
+  template <> std::vector<double> dimensions<PseudoTrap>(const Handle<TGeoShape>& shape)   {
     const TGeoCompositeShape* sh = get_ptr<TGeoCompositeShape>(shape.ptr());
     TGeoMatrix*    right_matrix  = sh->GetBoolNode()->GetRightMatrix();
-    stringstream params(right_matrix->GetTitle());
-    vector<double> pars;
+    std::stringstream params(right_matrix->GetTitle());
+    std::vector<double> pars;
     pars.reserve(7);
 #ifdef DIMENSION_DEBUG
     cout << "dimensions: [" << PSEUDOTRAP_TAG << "]" << endl
@@ -527,11 +515,11 @@ namespace dd4hep {
     return pars;
   }
 
-  template <> vector<double> dimensions<TruncatedTube>(const Handle<TGeoShape>& shape)   {
+  template <> std::vector<double> dimensions<TruncatedTube>(const Handle<TGeoShape>& shape)   {
     const TGeoCompositeShape* sh = get_ptr<TGeoCompositeShape>(shape.ptr());
     TGeoMatrix* right_matrix  = sh->GetBoolNode()->GetRightMatrix();
-    stringstream params(right_matrix->GetTitle());
-    vector<double> pars;
+    std::stringstream params(right_matrix->GetTitle());
+    std::vector<double> pars;
     pars.reserve(8);
     for(size_t i=0; i<8; ++i)   {
       double val;
@@ -544,7 +532,7 @@ namespace dd4hep {
     return pars;
   }
   
-  template <> vector<double> dimensions<Solid>(const Handle<TGeoShape>& shape)   {
+  template <> std::vector<double> dimensions<Solid>(const Handle<TGeoShape>& shape)   {
     if ( shape.ptr() )   {
       TClass* cl = shape->IsA();
       if ( cl == TGeoShapeAssembly::Class() )
@@ -593,10 +581,8 @@ namespace dd4hep {
         return dimensions<TGeoXtru>(shape.ptr() );
       else if ( cl == TGeoScaledShape::Class() )
         return dimensions<TGeoScaledShape>(shape.ptr() );
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
       else if ( cl == TGeoTessellated::Class() )
         return dimensions<TGeoTessellated>(shape.ptr() );
-#endif
       else if (isA<TruncatedTube>(shape.ptr() ))
         return dimensions<TruncatedTube>(shape);
       else if (isA<PseudoTrap>(shape.ptr() ))
@@ -614,21 +600,21 @@ namespace dd4hep {
   }
 
   /// Access Shape dimension parameters (As in TGeo, but angles in radians rather than degrees)
-  vector<double> get_shape_dimensions(const Handle<TGeoShape>& shape)    {
+  std::vector<double> get_shape_dimensions(const Handle<TGeoShape>& shape)    {
     return dimensions<Solid>(shape);
   }
   /// Access Shape dimension parameters (As in TGeo, but angles in radians rather than degrees)
-  vector<double> get_shape_dimensions(TGeoShape* shape)   {
+  std::vector<double> get_shape_dimensions(TGeoShape* shape)   {
     return dimensions<Solid>(Solid(shape));
   }
 
   template <typename T> void set_dimensions(T shape, const std::vector<double>& )    {
-    stringstream str;
+    std::stringstream str;
     if ( shape )
       str << "Shape: set_dimension(" << typeName(typeid(*shape)) << "): Invalid call!";
     else
       str << "Shape: set_dimension<TGeoShape): Invalid call && pointer!";
-    throw runtime_error(str.str());
+    throw std::runtime_error(str.str());
   }
 
   template <> void set_dimensions(TGeoShapeAssembly* , const std::vector<double>& )    {
@@ -656,7 +642,7 @@ namespace dd4hep {
     if ( params.size() != 3 + 3*nz )   {
       invalidSetDimensionCall(sh,params);
     }
-    vector<double> pars = params;
+    std::vector<double> pars = params;
     pars[0] /= units::deg;
     pars[1] /= units::deg;
     Solid(sh)._setDimensions(&pars[0]);
@@ -827,7 +813,6 @@ namespace dd4hep {
     s_sh.access()->SetDimensions(&pars[3]);
   }
   
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
   template <> void set_dimensions(TGeoTessellated* sh, const std::vector<double>& params)    {
     int num_vtx   = params[0];
     int num_facet = params[1];
@@ -840,8 +825,8 @@ namespace dd4hep {
       double z = params[++i_par];
       vertices.emplace_back(x, y, z);
     }
-    string nam = sh->GetName();
-    string tit = sh->GetTitle();
+    std::string nam = sh->GetName();
+    std::string tit = sh->GetTitle();
     sh->~TGeoTessellated();
     new(sh) TGeoTessellated(nam.c_str(), vertices);
     sh->SetTitle(tit.c_str());
@@ -859,7 +844,6 @@ namespace dd4hep {
     }
     sh->CloseShape(true, true, false);
   }
-#endif
   
   template <> void set_dimensions(TGeoCompositeShape*, const std::vector<double>&)   {
     // In general TGeoCompositeShape instances have an empty SetDimension call
@@ -873,7 +857,7 @@ namespace dd4hep {
     Solid(sh)._setDimensions(&pars[0]);
 #endif
 #ifdef DIMENSION_DEBUG
-    throw runtime_error("Composite shape. setDimensions is not implemented!");
+    throw std::runtime_error("Composite shape. setDimensions is not implemented!");
 #endif
   }
 
@@ -921,10 +905,8 @@ namespace dd4hep {
   {  set_dimensions(shape.ptr(), params);   }
   template <> void set_dimensions(EightPointSolid shape, const std::vector<double>& params)
   {  set_dimensions(shape.ptr(), params);   }
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
   template <> void set_dimensions(TessellatedSolid shape, const std::vector<double>& params)
   {  set_dimensions(shape.ptr(), params);   }
-#endif
   template <> void set_dimensions(BooleanSolid shape, const std::vector<double>& params)
   {  set_dimensions(shape.ptr(), params);   }
   template <> void set_dimensions(SubtractionSolid shape, const std::vector<double>& params)
@@ -1072,7 +1054,7 @@ namespace dd4hep {
       except("PseudoTrap","+++ Incompatible change of parameters.");
     }
     ((TGeoTranslation*)right_matrix)->SetTranslation(0,0,displacement);
-    stringstream str;
+    std::stringstream str;
     str << x1 << " " << x2 << " " << y1 << " " << y2 << " " << z << " "
         << r << " " << char(atMinusZ ? '1' : '0') << " ";
     right_matrix->SetTitle(str.str().c_str());
@@ -1125,10 +1107,8 @@ namespace dd4hep {
         set_dimensions(ExtrudedPolygon(shape), params);
       else if ( cl == TGeoArb8::Class() )
         set_dimensions(EightPointSolid(shape), params);
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
       else if ( cl == TGeoTessellated::Class() )
         set_dimensions(TessellatedSolid(shape), params);
-#endif
       else if ( cl == TGeoScaledShape::Class() )  {
         TGeoScaledShape* sh = (TGeoScaledShape*) shape.ptr();
         set_dimensions(sh, params);
@@ -1156,25 +1136,25 @@ namespace dd4hep {
     set_dimensions<Solid>(Solid(shape), params);
   }
   /// Set the shape dimensions. As for the TGeo shape, but angles in rad rather than degrees.
-  void set_shape_dimensions(TGeoShape* shape, const vector<double>& params)   {
+  void set_shape_dimensions(TGeoShape* shape, const std::vector<double>& params)   {
     set_dimensions<Solid>(Solid(shape), params);
   }
   /// Set the shape dimensions. As for the TGeo shape, but angles in rad rather than degrees.
-  void set_shape_dimensions(Solid solid, const vector<double>& params)   {
+  void set_shape_dimensions(Solid solid, const std::vector<double>& params)   {
     set_dimensions<Solid>(solid, params);
   }
 
   /// Pretty print of solid attributes
-  string toStringSolid(const TGeoShape* shape, int precision)   {
+  std::string toStringSolid(const TGeoShape* shape, int precision)   {
     if ( !shape )  {
       return "[Invalid shape]";
     }
 
-    stringstream log;
+    std::stringstream log;
     TClass* cl = shape->IsA();
     int prec = log.precision();
-    log.setf(ios::fixed,ios::floatfield);
-    log << setprecision(precision);
+    log.setf(std::ios::fixed,std::ios::floatfield);
+    log << std::setprecision(precision);
     log << cl->GetName();
     if ( cl == TGeoBBox::Class() )   {
       TGeoBBox* sh = (TGeoBBox*) shape;
@@ -1307,14 +1287,14 @@ namespace dd4hep {
         log << "Intersection: ";
       log << " Left:" << toStringSolid(left) << " Right:" << toStringSolid(right);
     }
-    log << setprecision(prec);
+    log << std::setprecision(prec);
     return log.str();
   }
 
   /// Output mesh vertices to string
-  string toStringMesh(const TGeoShape* shape, int prec)  {
+  std::string toStringMesh(const TGeoShape* shape, int prec)  {
     Solid sol(shape);
-    stringstream os;
+    std::stringstream os;
 
     // Prints shape parameters
     Int_t nvert = 0, nsegs = 0, npols = 0;
@@ -1323,31 +1303,31 @@ namespace dd4hep {
     Double_t* points = new Double_t[3*nvert];
     sol->SetPoints(points);
 
-    os << setw(16) << left << sol->IsA()->GetName()
-       << " " << nvert << " Mesh-points:" << endl;
-    os << setw(16) << left << sol->IsA()->GetName() << " " << sol->GetName()
+    os << std::setw(16) << std::left << sol->IsA()->GetName()
+       << " " << nvert << " Mesh-points:" << std::endl;
+    os << std::setw(16) << std::left << sol->IsA()->GetName() << " " << sol->GetName()
        << " N(mesh)=" << sol->GetNmeshVertices()
-       << "  N(vert)=" << nvert << "  N(seg)=" << nsegs << "  N(pols)=" << npols << endl;
+       << "  N(vert)=" << nvert << "  N(seg)=" << nsegs << "  N(pols)=" << npols << std::endl;
     
     for(Int_t i=0; i<nvert; ++i)   {
       Double_t* p = points + 3*i;
-      os << setw(16) << left << sol->IsA()->GetName() << " " << setw(3) << left << i
-         << " Local  ("  << setw(7) << setprecision(prec) << fixed << right << p[0]/dd4hep::cm
-         << ", "         << setw(7) << setprecision(prec) << fixed << right << p[1]/dd4hep::cm
-         << ", "         << setw(7) << setprecision(prec) << fixed << right << p[2]/dd4hep::cm
-         << ")" << endl;
+      os << std::setw(16) << std::left << sol->IsA()->GetName() << " " << std::setw(3) << std::left << i
+         << " Local  ("  << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << p[0]/dd4hep::cm
+         << ", "         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << p[1]/dd4hep::cm
+         << ", "         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << p[2]/dd4hep::cm
+         << ")" << std::endl;
     }
     Box box = sol;
     const Double_t* org = box->GetOrigin();
-    os << setw(16) << left << sol->IsA()->GetName()
+    os << std::setw(16) << std::left << sol->IsA()->GetName()
        << " Bounding box: "
-       << " dx="        << setw(7) << setprecision(prec) << fixed << right << box->GetDX()/dd4hep::cm
-       << " dy="        << setw(7) << setprecision(prec) << fixed << right << box->GetDY()/dd4hep::cm
-       << " dz="        << setw(7) << setprecision(prec) << fixed << right << box->GetDZ()/dd4hep::cm
-       << " Origin: x=" << setw(7) << setprecision(prec) << fixed << right << org[0]/dd4hep::cm
-       << " y="         << setw(7) << setprecision(prec) << fixed << right << org[1]/dd4hep::cm
-       << " z="         << setw(7) << setprecision(prec) << fixed << right << org[2]/dd4hep::cm
-       << endl;
+       << " dx="        << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << box->GetDX()/dd4hep::cm
+       << " dy="        << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << box->GetDY()/dd4hep::cm
+       << " dz="        << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << box->GetDZ()/dd4hep::cm
+       << " Origin: x=" << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << org[0]/dd4hep::cm
+       << " y="         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << org[1]/dd4hep::cm
+       << " z="         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << org[2]/dd4hep::cm
+       << std::endl;
   
     /// -------------------- DONE --------------------
     delete [] points;

--- a/DDCore/src/ShapeUtilities.cpp
+++ b/DDCore/src/ShapeUtilities.cpp
@@ -376,7 +376,7 @@ namespace dd4hep {
     TGeoArb8* sh = get_ptr<TGeoArb8>(shape);
     struct _V { double xy[8][2]; } *vtx = (_V*)sh->GetVertices();
     std::vector<double> pars { sh->GetDz() };
-    for ( size_t i=0; i<8; ++i )   {
+    for ( std::size_t i=0; i<8; ++i )   {
       pars.emplace_back(vtx->xy[i][0]);
       pars.emplace_back(vtx->xy[i][1]);
     }
@@ -504,7 +504,7 @@ namespace dd4hep {
     cout << "dimensions: [" << PSEUDOTRAP_TAG << "]" << endl
          << right_matrix->GetTitle() << endl;
 #endif
-    for(size_t i=0; i<7; ++i)   {
+    for(std::size_t i=0; i<7; ++i)   {
       double val;
       params >> val;
       pars.emplace_back(val);
@@ -521,7 +521,7 @@ namespace dd4hep {
     std::stringstream params(right_matrix->GetTitle());
     std::vector<double> pars;
     pars.reserve(8);
-    for(size_t i=0; i<8; ++i)   {
+    for(std::size_t i=0; i<8; ++i)   {
       double val;
       params >> val;
       pars.emplace_back(val);
@@ -638,7 +638,7 @@ namespace dd4hep {
     if ( params.size() < 3 )   {
       invalidSetDimensionCall(sh,params);
     }
-    size_t nz = size_t(params[2]);
+    std::size_t nz = std::size_t(params[2]);
     if ( params.size() != 3 + 3*nz )   {
       invalidSetDimensionCall(sh,params);
     }
@@ -762,7 +762,7 @@ namespace dd4hep {
   }
   template <> void set_dimensions(TGeoPgon* sh, const std::vector<double>& params)   {
     auto pars = params;
-    if ( params.size() < 4 || params.size() != 4 + 3*size_t(params[3]) )   {
+    if ( params.size() < 4 || params.size() != 4 + 3*std::size_t(params[3]) )   {
       invalidSetDimensionCall(sh,params);
     }
     pars[0]  /= units::deg;
@@ -771,7 +771,7 @@ namespace dd4hep {
   }
   template <> void set_dimensions(TGeoXtru* sh, const std::vector<double>& params)   {
     auto pars = params;
-    if ( params.size() < 1 || params.size() != 1 + 4*size_t(params[0]) )   {
+    if ( params.size() < 1 || params.size() != 1 + 4*std::size_t(params[0]) )   {
       invalidSetDimensionCall(sh,params);
     }
     Solid(sh)._setDimensions(&pars[0]);
@@ -817,7 +817,7 @@ namespace dd4hep {
     int num_vtx   = params[0];
     int num_facet = params[1];
     std::vector<TessellatedSolid::Vertex> vertices;
-    size_t i_par = 1;
+    std::size_t i_par = 1;
     printout(DEBUG,"TessellatedSolid","+++ Loading %d vertices, %d facets",num_vtx, num_facet);
     for (int i=0; i<num_vtx; ++i)   {
       double x = params[++i_par];

--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -33,7 +33,6 @@
 #include <TGeoScaledShape.h>
 #include <TGeoCompositeShape.h>
 
-using namespace std;
 using namespace dd4hep;
 namespace units = dd4hep;
 
@@ -45,7 +44,7 @@ template <typename T> void Solid_type<T>::_setDimensions(double* param)   const 
 
 /// Assign pointrs and register solid to geometry
 template <typename T>
-void Solid_type<T>::_assign(T* n, const string& nam, const string& tit, bool cbbox) {
+void Solid_type<T>::_assign(T* n, const std::string& nam, const std::string& tit, bool cbbox) {
   this->assign(n, nam, tit);
   if (cbbox)
     n->ComputeBBox();
@@ -74,7 +73,7 @@ template <typename T> Solid_type<T>& Solid_type<T>::setName(const char* value)  
 }
 
 /// Set new shape name
-template <typename T> Solid_type<T>& Solid_type<T>::setName(const string& value)    {
+template <typename T> Solid_type<T>& Solid_type<T>::setName(const std::string& value)    {
   this->access()->SetName(value.c_str());
   return *this;
 }
@@ -88,19 +87,19 @@ template <typename T> const char* Solid_type<T>::type() const  {
 }
 
 /// Access the dimensions of the shape: inverse of the setDimensions member function
-template <typename T> vector<double> Solid_type<T>::dimensions()  {
+template <typename T> std::vector<double> Solid_type<T>::dimensions()  {
   return get_shape_dimensions(this->access());
 }
 
 /// Set the shape dimensions. As for the TGeo shape, but angles in rad rather than degrees.
-template <typename T> Solid_type<T>& Solid_type<T>::setDimensions(const vector<double>& params)  {
+template <typename T> Solid_type<T>& Solid_type<T>::setDimensions(const std::vector<double>& params)  {
   set_shape_dimensions(this->access(), params);
   return *this;
 }
 
 /// Divide volume into subsections (See the ROOT manuloa for details)
 template <typename T> TGeoVolume*
-Solid_type<T>::divide(const Volume& voldiv, const string& divname,
+Solid_type<T>::divide(const Volume& voldiv, const std::string& divname,
                       int iaxis, int ndiv, double start, double step)   const {
   T* p = this->ptr();
   if ( p )  {
@@ -117,12 +116,12 @@ Solid_type<T>::divide(const Volume& voldiv, const string& divname,
 }
 
 /// Constructor to create an anonymous new box object (retrieves name from volume)
-ShapelessSolid::ShapelessSolid(const string& nam)  {
+ShapelessSolid::ShapelessSolid(const std::string& nam)  {
   _assign(new TGeoShapeAssembly(), nam, SHAPELESS_TAG, true);
 }
 
-void Scale::make(const string& nam, Solid base, double x_scale, double y_scale, double z_scale)   {
-  auto scale = make_unique<TGeoScale>(x_scale, y_scale, z_scale);
+void Scale::make(const std::string& nam, Solid base, double x_scale, double y_scale, double z_scale)   {
+  auto scale = std::make_unique<TGeoScale>(x_scale, y_scale, z_scale);
   _assign(new TGeoScaledShape(nam.c_str(), base.access(), scale.release()), "", SCALE_TAG, true);
 }
 
@@ -141,7 +140,7 @@ double Scale::scale_z() const {
   return this->access()->GetScale()->GetScale()[2];
 }
 
-void Box::make(const string& nam, double x_val, double y_val, double z_val)   {
+void Box::make(const std::string& nam, double x_val, double y_val, double z_val)   {
   _assign(new TGeoBBox(nam.c_str(), x_val, y_val, z_val), "", BOX_TAG, true);
 }
 
@@ -168,7 +167,7 @@ double Box::z() const {
 }
 
 /// Internal helper method to support object construction
-void HalfSpace::make(const string& nam, const double* const point, const double* const normal)   {
+void HalfSpace::make(const std::string& nam, const double* const point, const double* const normal)   {
   _assign(new TGeoHalfSpace(nam.c_str(),(Double_t*)point, (Double_t*)normal), "", HALFSPACE_TAG,true);
 }
 
@@ -179,18 +178,18 @@ Polycone::Polycone(double startPhi, double deltaPhi) {
 
 /// Constructor to be used when creating a new polycone object. Add at the same time all Z planes
 Polycone::Polycone(double startPhi, double deltaPhi,
-                   const vector<double>& rmin, const vector<double>& rmax, const vector<double>& z) {
-  vector<double> params;
+                   const std::vector<double>& rmin, const std::vector<double>& rmax, const std::vector<double>& z) {
+  std::vector<double> params;
   if (rmin.size() < 2) {
-    throw runtime_error("dd4hep: PolyCone Not enough Z planes. minimum is 2!");
+    throw std::runtime_error("dd4hep: PolyCone Not enough Z planes. minimum is 2!");
   }
   if((z.size()!=rmin.size()) || (z.size()!=rmax.size()) )    {
-    throw runtime_error("dd4hep: Polycone: vectors z,rmin,rmax not of same length");
+    throw std::runtime_error("dd4hep: Polycone: vectors z,rmin,rmax not of same length");
   }
   params.emplace_back(startPhi/units::deg);
   params.emplace_back(deltaPhi/units::deg);
   params.emplace_back(rmin.size());
-  for (size_t i = 0; i < rmin.size(); ++i) {
+  for (std::size_t i = 0; i < rmin.size(); ++i) {
     params.emplace_back(z[i] );
     params.emplace_back(rmin[i] );
     params.emplace_back(rmax[i] );
@@ -199,18 +198,18 @@ Polycone::Polycone(double startPhi, double deltaPhi,
 }
 
 /// Constructor to be used when creating a new polycone object. Add at the same time all Z planes
-Polycone::Polycone(double startPhi, double deltaPhi, const vector<double>& r, const vector<double>& z) {
-  vector<double> params;
+Polycone::Polycone(double startPhi, double deltaPhi, const std::vector<double>& r, const std::vector<double>& z) {
+  std::vector<double> params;
   if (r.size() < 2) {
-    throw runtime_error("dd4hep: PolyCone Not enough Z planes. minimum is 2!");
+    throw std::runtime_error("dd4hep: PolyCone Not enough Z planes. minimum is 2!");
   }
   if((z.size()!=r.size()) )    {
-    throw runtime_error("dd4hep: Polycone: vectors z,r not of same length");
+    throw std::runtime_error("dd4hep: Polycone: vectors z,r not of same length");
   } 
   params.emplace_back(startPhi/units::deg);
   params.emplace_back(deltaPhi/units::deg);
   params.emplace_back(r.size());
-  for (size_t i = 0; i < r.size(); ++i) {
+  for (std::size_t i = 0; i < r.size(); ++i) {
     params.emplace_back(z[i] );
     params.emplace_back(0.0  );
     params.emplace_back(r[i] );
@@ -219,24 +218,24 @@ Polycone::Polycone(double startPhi, double deltaPhi, const vector<double>& r, co
 }
 
 /// Constructor to be used when creating a new object
-Polycone::Polycone(const string& nam, double startPhi, double deltaPhi) {
+Polycone::Polycone(const std::string& nam, double startPhi, double deltaPhi) {
   _assign(new TGeoPcon(nam.c_str(), startPhi/units::deg, deltaPhi/units::deg, 0), "", POLYCONE_TAG, false);
 }
 
 /// Constructor to be used when creating a new polycone object. Add at the same time all Z planes
-Polycone::Polycone(const string& nam, double startPhi, double deltaPhi,
-                   const vector<double>& rmin, const vector<double>& rmax, const vector<double>& z) {
-  vector<double> params;
+Polycone::Polycone(const std::string& nam, double startPhi, double deltaPhi,
+                   const std::vector<double>& rmin, const std::vector<double>& rmax, const std::vector<double>& z) {
+  std::vector<double> params;
   if (rmin.size() < 2) {
-    throw runtime_error("dd4hep: PolyCone Not enough Z planes. minimum is 2!");
+    throw std::runtime_error("dd4hep: PolyCone Not enough Z planes. minimum is 2!");
   }
   if((z.size()!=rmin.size()) || (z.size()!=rmax.size()) )    {
-    throw runtime_error("dd4hep: Polycone: vectors z,rmin,rmax not of same length");
+    throw std::runtime_error("dd4hep: Polycone: vectors z,rmin,rmax not of same length");
   }
   params.emplace_back(startPhi/units::deg);
   params.emplace_back(deltaPhi/units::deg);
   params.emplace_back(rmin.size());
-  for (size_t i = 0; i < rmin.size(); ++i) {
+  for (std::size_t i = 0; i < rmin.size(); ++i) {
     params.emplace_back(z[i] );
     params.emplace_back(rmin[i] );
     params.emplace_back(rmax[i] );
@@ -245,18 +244,18 @@ Polycone::Polycone(const string& nam, double startPhi, double deltaPhi,
 }
 
 /// Constructor to be used when creating a new polycone object. Add at the same time all Z planes
-Polycone::Polycone(const string& nam, double startPhi, double deltaPhi, const vector<double>& r, const vector<double>& z) {
-  vector<double> params;
+Polycone::Polycone(const std::string& nam, double startPhi, double deltaPhi, const std::vector<double>& r, const std::vector<double>& z) {
+  std::vector<double> params;
   if (r.size() < 2) {
-    throw runtime_error("dd4hep: PolyCone Not enough Z planes. minimum is 2!");
+    throw std::runtime_error("dd4hep: PolyCone Not enough Z planes. minimum is 2!");
   }
   if((z.size()!=r.size()) )    {
-    throw runtime_error("dd4hep: Polycone: vectors z,r not of same length");
+    throw std::runtime_error("dd4hep: Polycone: vectors z,r not of same length");
   } 
   params.emplace_back(startPhi/units::deg);
   params.emplace_back(deltaPhi/units::deg);
   params.emplace_back(r.size());
-  for (size_t i = 0; i < r.size(); ++i) {
+  for (std::size_t i = 0; i < r.size(); ++i) {
     params.emplace_back(z[i] );
     params.emplace_back(0.0  );
     params.emplace_back(r[i] );
@@ -265,22 +264,22 @@ Polycone::Polycone(const string& nam, double startPhi, double deltaPhi, const ve
 }
 
 /// Add Z-planes to the Polycone
-void Polycone::addZPlanes(const vector<double>& rmin, const vector<double>& rmax, const vector<double>& z) {
+void Polycone::addZPlanes(const std::vector<double>& rmin, const std::vector<double>& rmax, const std::vector<double>& z) {
   TGeoPcon* sh = *this;
-  vector<double> params;
-  size_t num = sh->GetNz();
+  std::vector<double> params;
+  std::size_t num = sh->GetNz();
   if (rmin.size() < 2)   {
     except("PolyCone","++ addZPlanes: Not enough Z planes. minimum is 2!");
   }
   params.emplace_back(sh->GetPhi1());
   params.emplace_back(sh->GetDphi());
   params.emplace_back(num + rmin.size());
-  for (size_t i = 0; i < num; ++i) {
+  for (std::size_t i = 0; i < num; ++i) {
     params.emplace_back(sh->GetZ(i));
     params.emplace_back(sh->GetRmin(i));
     params.emplace_back(sh->GetRmax(i));
   }
-  for (size_t i = 0; i < rmin.size(); ++i) {
+  for (std::size_t i = 0; i < rmin.size(); ++i) {
     params.emplace_back(z[i] );
     params.emplace_back(rmin[i] );
     params.emplace_back(rmax[i] );
@@ -289,7 +288,7 @@ void Polycone::addZPlanes(const vector<double>& rmin, const vector<double>& rmax
 }
 
 /// Constructor to be used when creating a new cone segment object
-void ConeSegment::make(const string& nam,
+void ConeSegment::make(const std::string& nam,
                        double dz, 
                        double rmin1,     double rmax1,
                        double rmin2,     double rmax2,
@@ -310,7 +309,7 @@ ConeSegment& ConeSegment::setDimensions(double dz,
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void Cone::make(const string& nam, double z, double rmin1, double rmax1, double rmin2, double rmax2) {
+void Cone::make(const std::string& nam, double z, double rmin1, double rmax1, double rmin2, double rmax2) {
   _assign(new TGeoCone(nam.c_str(), z, rmin1, rmax1, rmin2, rmax2 ), "", CONE_TAG, true);
 }
 
@@ -322,7 +321,7 @@ Cone& Cone::setDimensions(double z, double rmin1, double rmax1, double rmin2, do
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void Tube::make(const string& nam, double rmin, double rmax, double z, double start_phi, double end_phi) {
+void Tube::make(const std::string& nam, double rmin, double rmax, double z, double start_phi, double end_phi) {
   // Check if it is a full tube
   if(fabs(end_phi-start_phi-2*M_PI)<10e-6){
     _assign(new TGeoTubeSeg(nam.c_str(), rmin, rmax, z, start_phi/units::deg, start_phi/units::deg+360.),nam,TUBE_TAG,true);
@@ -345,14 +344,14 @@ CutTube::CutTube(double rmin, double rmax, double dz, double start_phi, double e
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-CutTube::CutTube(const string& nam,
+CutTube::CutTube(const std::string& nam,
                  double rmin, double rmax, double dz, double start_phi, double end_phi,
                  double lx, double ly, double lz, double tx, double ty, double tz)  {
   make(nam, rmin,rmax,dz,start_phi/units::deg,end_phi/units::deg,lx,ly,lz,tx,ty,tz);
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void CutTube::make(const string& nam, double rmin, double rmax, double dz, double start_phi, double end_phi,
+void CutTube::make(const std::string& nam, double rmin, double rmax, double dz, double start_phi, double end_phi,
                    double lx, double ly, double lz, double tx, double ty, double tz)  {
   _assign(new TGeoCtub(nam.c_str(), rmin,rmax,dz,start_phi,end_phi,lx,ly,lz,tx,ty,tz),"",CUTTUBE_TAG,true);
 }
@@ -363,13 +362,13 @@ TruncatedTube::TruncatedTube(double dz, double rmin, double rmax, double start_p
 {  make("", dz, rmin, rmax, start_phi/units::deg, delta_phi/units::deg, cut_atStart, cut_atDelta, cut_inside);    }
 
 /// Constructor to create a truncated tube object with attribute initialization
-TruncatedTube::TruncatedTube(const string& nam,
+TruncatedTube::TruncatedTube(const std::string& nam,
                              double dz, double rmin, double rmax, double start_phi, double delta_phi,
                              double cut_atStart, double cut_atDelta, bool cut_inside)
 {  make(nam, dz, rmin, rmax, start_phi/units::deg, delta_phi/units::deg, cut_atStart, cut_atDelta, cut_inside);    }
 
 /// Internal helper method to support object construction
-void TruncatedTube::make(const string& nam,
+void TruncatedTube::make(const std::string& nam,
                          double dz, double rmin, double rmax, double start_phi, double delta_phi,
                          double cut_atStart, double cut_atDelta, bool cut_inside)   {
   // check the parameters
@@ -411,55 +410,55 @@ void TruncatedTube::make(const string& nam,
   TGeoCombiTrans*  combi = new TGeoCombiTrans(trans, rot);
   TGeoSubtraction* sub   = new TGeoSubtraction(tubs, box, nullptr, combi);
   _assign(new TGeoCompositeShape(nam.c_str(), sub),"",TRUNCATEDTUBE_TAG,true);
-  stringstream params;
-  params << dz                  << " " << endl
-         << rmin                << " " << endl
-         << rmax                << " " << endl
-         << start_phi*units::deg << " " << endl
-         << delta_phi*units::deg << " " << endl
-         << cut_atStart          << " " << endl
-         << cut_atDelta          << " " << endl
-         << char(cut_inside ? '1' : '0') << endl;
+  std::stringstream params;
+  params << dz                  << " " << std::endl
+         << rmin                << " " << std::endl
+         << rmax                << " " << std::endl
+         << start_phi*units::deg << " " << std::endl
+         << delta_phi*units::deg << " " << std::endl
+         << cut_atStart          << " " << std::endl
+         << cut_atDelta          << " " << std::endl
+         << char(cut_inside ? '1' : '0') << std::endl;
   combi->SetTitle(params.str().c_str());
-  //cout << "Params: " << params.str() << endl;
+  //cout << "Params: " << params.str() << std::endl;
 #if 0
-  params << TRUNCATEDTUBE_TAG << ":" << endl
-         << "\t dz:          " << dz << " " << endl
-         << "\t rmin:        " << rmin << " " << endl
-         << "\t rmax:        " << rmax << " " << endl
-         << "\t startPhi:    " << start_phi << " " << endl
-         << "\t deltaPhi:    " << delta_phi << " " << endl
-         << "\t r/cutAtStart:" << cut_atStart << " " << endl
-         << "\t R/cutAtDelta:" << cut_atDelta << " " << endl
-         << "\t cutInside:   " << char(cut_inside ? '1' : '0') << endl
-         << "\t\t alpha:     " << alpha << endl
-         << "\t\t sin_alpha: " << sin_alpha << endl
-         << "\t\t boxY:      " << boxY << endl
-         << "\t\t xBox:      " << xBox << endl;
+  params << TRUNCATEDTUBE_TAG << ":" << std::endl
+         << "\t dz:          " << dz << " " << std::endl
+         << "\t rmin:        " << rmin << " " << std::endl
+         << "\t rmax:        " << rmax << " " << std::endl
+         << "\t startPhi:    " << start_phi << " " << std::endl
+         << "\t deltaPhi:    " << delta_phi << " " << std::endl
+         << "\t r/cutAtStart:" << cut_atStart << " " << std::endl
+         << "\t R/cutAtDelta:" << cut_atDelta << " " << std::endl
+         << "\t cutInside:   " << char(cut_inside ? '1' : '0') << std::endl
+         << "\t\t alpha:     " << alpha << std::endl
+         << "\t\t sin_alpha: " << sin_alpha << std::endl
+         << "\t\t boxY:      " << boxY << std::endl
+         << "\t\t xBox:      " << xBox << std::endl;
 #endif
 #if 0
-  cout << "Trans:";  trans.Print(); cout << endl;
-  cout << "Rot:  ";  rot.Print();   cout << endl;
+  cout << "Trans:";  trans.Print(); cout << std::endl;
+  cout << "Rot:  ";  rot.Print();   cout << std::endl;
   cout << " Dz:           " << dz
        << " rmin:         " << rmin
        << " rmax:         " << rmax
        << " r/cutAtStart: " << r
        << " R/cutAtDelta: " << R
        << " cutInside:    " << (cut_inside ? "YES" : "NO ")
-       << endl;
+       << std::endl;
   cout << " cath:      " << cath
        << " hypo:      " << hypo
        << " cos_alpha: " << cos_alpha
        << " alpha:     " << alpha
        << " alpha(deg):" << alpha/dd4hep::deg
-       << endl;
+       << std::endl;
   cout << " Deg:       " << dd4hep::deg
        << " cm:        " << dd4hep::cm
        << " xBox:      " << xBox
-       << endl;
-  cout << "Box:" << "x:" << box->GetDX() << " y:" << box->GetDY() << " z:" << box->GetDZ() << endl;
+       << std::endl;
+  cout << "Box:" << "x:" << box->GetDX() << " y:" << box->GetDY() << " z:" << box->GetDZ() << std::endl;
   cout << "Tubs:" << " rmin:" << rmin << " rmax" << rmax << "dZ" << dZ
-       << " startPhi:" <<  start_phi << " deltaPhi:" << delta_phi << endl;
+       << " startPhi:" <<  start_phi << " deltaPhi:" << delta_phi << std::endl;
 #endif
 }
 
@@ -504,7 +503,7 @@ bool TruncatedTube::cutInside() const   {
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void EllipticalTube::make(const string& nam, double a, double b, double dz) {
+void EllipticalTube::make(const std::string& nam, double a, double b, double dz) {
   _assign(new TGeoEltu(nam.c_str(), a, b, dz), "", ELLIPTICALTUBE_TAG, true);
 }
 
@@ -516,7 +515,7 @@ void TwistedTube::make(const std::string& nam, double twist_angle, double rmin, 
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void Trd1::make(const string& nam, double x1, double x2, double y, double z) {
+void Trd1::make(const std::string& nam, double x1, double x2, double y, double z) {
   _assign(new TGeoTrd1(nam.c_str(), x1, x2, y, z ), "", TRD1_TAG, true);
 }
 
@@ -528,7 +527,7 @@ Trd1& Trd1::setDimensions(double x1, double x2, double y, double z) {
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void Trd2::make(const string& nam, double x1, double x2, double y1, double y2, double z) {
+void Trd2::make(const std::string& nam, double x1, double x2, double y1, double y2, double z) {
   _assign(new TGeoTrd2(nam.c_str(), x1, x2, y1, y2, z ), "", TRD2_TAG, true);
 }
 
@@ -540,7 +539,7 @@ Trd2& Trd2::setDimensions(double x1, double x2, double y1, double y2, double z) 
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void Paraboloid::make(const string& nam, double r_low, double r_high, double delta_z) {
+void Paraboloid::make(const std::string& nam, double r_low, double r_high, double delta_z) {
   _assign(new TGeoParaboloid(nam.c_str(), r_low, r_high, delta_z ), "", PARABOLOID_TAG, true);
 }
 
@@ -552,7 +551,7 @@ Paraboloid& Paraboloid::setDimensions(double r_low, double r_high, double delta_
 }
 
 /// Constructor to create a new anonymous object with attribute initialization
-void Hyperboloid::make(const string& nam, double rin, double stin, double rout, double stout, double dz) {
+void Hyperboloid::make(const std::string& nam, double rin, double stin, double rout, double stout, double dz) {
   _assign(new TGeoHype(nam.c_str(), rin, stin/units::deg, rout, stout/units::deg, dz), "", HYPERBOLOID_TAG, true);
 }
 
@@ -564,7 +563,7 @@ Hyperboloid& Hyperboloid::setDimensions(double rin, double stin, double rout, do
 }
 
 /// Constructor function to be used when creating a new object with attribute initialization
-void Sphere::make(const string& nam, double rmin, double rmax, double startTheta, double endTheta, double startPhi, double endPhi) {
+void Sphere::make(const std::string& nam, double rmin, double rmax, double startTheta, double endTheta, double startPhi, double endPhi) {
   _assign(new TGeoSphere(nam.c_str(), rmin, rmax,
                          startTheta/units::deg, endTheta/units::deg,
                          startPhi/units::deg,   endPhi/units::deg), "", SPHERE_TAG, true);
@@ -578,7 +577,7 @@ Sphere& Sphere::setDimensions(double rmin, double rmax, double startTheta, doubl
 }
 
 /// Constructor to be used when creating a new object with attribute initialization
-void Torus::make(const string& nam, double r, double rmin, double rmax, double startPhi, double deltaPhi) {
+void Torus::make(const std::string& nam, double r, double rmin, double rmax, double startPhi, double deltaPhi) {
   _assign(new TGeoTorus(nam.c_str(), r, rmin, rmax, startPhi/units::deg, deltaPhi/units::deg), "", TORUS_TAG, true);
 }
 
@@ -599,7 +598,7 @@ Trap::Trap(double z, double theta, double phi,
 }
 
 /// Constructor to be used when creating a new anonymous object with attribute initialization
-Trap::Trap(const string& nam,
+Trap::Trap(const std::string& nam,
            double z, double theta, double phi,
            double h1, double bl1, double tl1, double alpha1,
            double h2, double bl2, double tl2, double alpha2) {
@@ -609,7 +608,7 @@ Trap::Trap(const string& nam,
 }
 
 /// Constructor to be used when creating a new anonymous object with attribute initialization
-void Trap::make(const string& nam, double pZ, double pY, double pX, double pLTX) {
+void Trap::make(const std::string& nam, double pZ, double pY, double pX, double pLTX) {
   double fDz  = 0.5*pZ;
   double fTheta = 0;
   double fPhi = 0;
@@ -640,7 +639,7 @@ Trap& Trap::setDimensions(double z, double theta, double phi,
 }
 
 /// Internal helper method to support object construction
-void PseudoTrap::make(const string& nam, double x1, double x2, double y1, double y2, double z, double r, bool atMinusZ)    {
+void PseudoTrap::make(const std::string& nam, double x1, double x2, double y1, double y2, double z, double r, bool atMinusZ)    {
   double x            = atMinusZ ? x1 : x2;
   double h            = 0;
   bool   intersec     = false; // union or intersection solid
@@ -724,7 +723,7 @@ void PseudoTrap::make(const string& nam, double x1, double x2, double y1, double
 
   Solid trap(new TGeoTrd2((nam+"Trd2").c_str(), x1, x2, y1, y2, halfZ));
   Solid tubs(new TGeoTubeSeg((nam+"Tubs").c_str(), 0.,std::abs(r),h,startPhi,startPhi + halfOpeningAngle*2.));
-  stringstream params;
+  std::stringstream params;
   params << x1 << " " << x2 << " " << y1 << " " << y2 << " " << z << " "
          << r << " " << char(atMinusZ ? '1' : '0') << " ";
   TGeoCompositeShape* solid = 0;
@@ -742,21 +741,21 @@ void PseudoTrap::make(const string& nam, double x1, double x2, double y1, double
 }
 
 /// Helper function to create poly hedron
-void PolyhedraRegular::make(const string& nam, int nsides, double rmin, double rmax,
+void PolyhedraRegular::make(const std::string& nam, int nsides, double rmin, double rmax,
                             double zpos, double zneg, double start, double delta) {
   if (rmin < 0e0 || rmin > rmax)
-    throw runtime_error("dd4hep: PolyhedraRegular: Illegal argument rmin:<" + _toString(rmin) + "> is invalid!");
+    throw std::runtime_error("dd4hep: PolyhedraRegular: Illegal argument rmin:<" + _toString(rmin) + "> is invalid!");
   else if (rmax < 0e0)
-    throw runtime_error("dd4hep: PolyhedraRegular: Illegal argument rmax:<" + _toString(rmax) + "> is invalid!");
+    throw std::runtime_error("dd4hep: PolyhedraRegular: Illegal argument rmax:<" + _toString(rmax) + "> is invalid!");
   double params[] = { start/units::deg, delta/units::deg, double(nsides), 2e0, zpos, rmin, rmax, zneg, rmin, rmax };
   _assign(new TGeoPgon(params), nam, POLYHEDRA_TAG, false);
   //_setDimensions(&params[0]);
 }
 
 /// Helper function to create poly hedron
-void Polyhedra::make(const string& nam, int nsides, double start, double delta,
-                     const vector<double>& z, const vector<double>& rmin, const vector<double>& rmax)  {
-  vector<double> temp;
+void Polyhedra::make(const std::string& nam, int nsides, double start, double delta,
+                     const std::vector<double>& z, const std::vector<double>& rmin, const std::vector<double>& rmax)  {
+  std::vector<double> temp;
   if ( rmin.size() != z.size() || rmax.size() != z.size() )  {
     except("Polyhedra",
            "Number of values to define zplanes are incorrect: z:%ld rmin:%ld rmax:%ld",
@@ -768,7 +767,7 @@ void Polyhedra::make(const string& nam, int nsides, double start, double delta,
   temp.emplace_back(delta/units::deg);
   temp.emplace_back(double(nsides));
   temp.emplace_back(double(z.size()));
-  for(size_t i=0; i<z.size(); ++i)   {
+  for(std::size_t i=0; i<z.size(); ++i)   {
     temp.emplace_back(z[i]);
     temp.emplace_back(rmin[i]);
     temp.emplace_back(rmax[i]);
@@ -777,28 +776,27 @@ void Polyhedra::make(const string& nam, int nsides, double start, double delta,
 }
 
 /// Helper function to create the polyhedron
-void ExtrudedPolygon::make(const string&         nam,
-                           const vector<double>& pt_x,
-                           const vector<double>& pt_y,
-                           const vector<double>& sec_z,
-                           const vector<double>& sec_x,
-                           const vector<double>& sec_y,
-                           const vector<double>& sec_scale)
+void ExtrudedPolygon::make(const std::string&         nam,
+                           const std::vector<double>& pt_x,
+                           const std::vector<double>& pt_y,
+                           const std::vector<double>& sec_z,
+                           const std::vector<double>& sec_x,
+                           const std::vector<double>& sec_y,
+                           const std::vector<double>& sec_scale)
 {
   TGeoXtru* solid = new TGeoXtru(sec_z.size());
   _assign(solid, nam, EXTRUDEDPOLYGON_TAG, false);
   // No need to transform coordinates to cm. We are in the dd4hep world: all is already in cm.
   solid->DefinePolygon(pt_x.size(), &(*pt_x.begin()), &(*pt_y.begin()));
-  for( size_t i = 0; i < sec_z.size(); ++i )
+  for( std::size_t i = 0; i < sec_z.size(); ++i )
     solid->DefineSection(i, sec_z[i], sec_x[i], sec_y[i], sec_scale[i]);
 }
 
 /// Creator method for arbitrary eight point solids
-void EightPointSolid::make(const string& nam, double dz, const double* vtx)   {
+void EightPointSolid::make(const std::string& nam, double dz, const double* vtx)   {
   _assign(new TGeoArb8(nam.c_str(), dz, (double*)vtx), "", EIGHTPOINTSOLID_TAG, true);
 }
 
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
 /// Internal helper method to support object construction
 void TessellatedSolid::make(const std::string& nam, int num_facets)   {
   _assign(new TGeoTessellated(nam.c_str(), num_facets), nam, TESSELLATEDSOLID_TAG, false);
@@ -848,7 +846,6 @@ int TessellatedSolid::num_vertex()   const   {
 const TessellatedSolid::Vertex& TessellatedSolid::vertex(int index)    const    {
   return ptr()->GetVertex(index);
 }
-#endif
 
 /// Access right solid of the boolean
 Solid BooleanSolid::rightShape()  const    {
@@ -901,31 +898,31 @@ SubtractionSolid::SubtractionSolid(const Solid& shape1, const Solid& shape2, con
 }
 
 /// Constructor to be used when creating a new object. Position is identity, Rotation is the identity rotation
-SubtractionSolid::SubtractionSolid(const string& nam, const Solid& shape1, const Solid& shape2) {
+SubtractionSolid::SubtractionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2) {
   TGeoSubtraction* sub = new TGeoSubtraction(shape1, shape2, detail::matrix::_identity(), detail::matrix::_identity());
   _assign(new TGeoCompositeShape(nam.c_str(), sub), "", SUBTRACTION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object. Placement by a generic transformation within the mother
-SubtractionSolid::SubtractionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const Transform3D& trans) {
+SubtractionSolid::SubtractionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const Transform3D& trans) {
   TGeoSubtraction* sub = new TGeoSubtraction(shape1, shape2, detail::matrix::_identity(), detail::matrix::_transform(trans));
   _assign(new TGeoCompositeShape(nam.c_str(), sub), "", SUBTRACTION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object. Rotation is the identity rotation
-SubtractionSolid::SubtractionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const Position& pos) {
+SubtractionSolid::SubtractionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const Position& pos) {
   TGeoSubtraction* sub = new TGeoSubtraction(shape1, shape2, detail::matrix::_identity(), detail::matrix::_translation(pos));
   _assign(new TGeoCompositeShape(nam.c_str(), sub), "", SUBTRACTION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object
-SubtractionSolid::SubtractionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const RotationZYX& rot) {
+SubtractionSolid::SubtractionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const RotationZYX& rot) {
   TGeoSubtraction* sub = new TGeoSubtraction(shape1, shape2, detail::matrix::_identity(), detail::matrix::_rotationZYX(rot));
   _assign(new TGeoCompositeShape(nam.c_str(), sub), "", SUBTRACTION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object
-SubtractionSolid::SubtractionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const Rotation3D& rot) {
+SubtractionSolid::SubtractionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const Rotation3D& rot) {
   TGeoSubtraction* sub = new TGeoSubtraction(shape1, shape2, detail::matrix::_identity(), detail::matrix::_rotation3D(rot));
   _assign(new TGeoCompositeShape(nam.c_str(), sub), "", SUBTRACTION_TAG, true);
 }
@@ -961,31 +958,31 @@ UnionSolid::UnionSolid(const Solid& shape1, const Solid& shape2, const Rotation3
 }
 
 /// Constructor to be used when creating a new object. Position is identity, Rotation is identity rotation
-UnionSolid::UnionSolid(const string& nam, const Solid& shape1, const Solid& shape2) {
+UnionSolid::UnionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2) {
   TGeoUnion* uni = new TGeoUnion(shape1, shape2, detail::matrix::_identity(), detail::matrix::_identity());
   _assign(new TGeoCompositeShape(nam.c_str(), uni), "", UNION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object. Placement by a generic transformation within the mother
-UnionSolid::UnionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const Transform3D& trans) {
+UnionSolid::UnionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const Transform3D& trans) {
   TGeoUnion* uni = new TGeoUnion(shape1, shape2, detail::matrix::_identity(), detail::matrix::_transform(trans));
   _assign(new TGeoCompositeShape(nam.c_str(), uni), "", UNION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object. Rotation is identity rotation
-UnionSolid::UnionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const Position& pos) {
+UnionSolid::UnionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const Position& pos) {
   TGeoUnion* uni = new TGeoUnion(shape1, shape2, detail::matrix::_identity(), detail::matrix::_translation(pos));
   _assign(new TGeoCompositeShape(nam.c_str(), uni), "", UNION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object
-UnionSolid::UnionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const RotationZYX& rot) {
+UnionSolid::UnionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const RotationZYX& rot) {
   TGeoUnion *uni = new TGeoUnion(shape1, shape2, detail::matrix::_identity(), detail::matrix::_rotationZYX(rot));
   _assign(new TGeoCompositeShape(nam.c_str(), uni), "", UNION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object
-UnionSolid::UnionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const Rotation3D& rot) {
+UnionSolid::UnionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const Rotation3D& rot) {
   TGeoUnion *uni = new TGeoUnion(shape1, shape2, detail::matrix::_identity(), detail::matrix::_rotation3D(rot));
   _assign(new TGeoCompositeShape(nam.c_str(), uni), "", UNION_TAG, true);
 }
@@ -1021,31 +1018,31 @@ IntersectionSolid::IntersectionSolid(const Solid& shape1, const Solid& shape2, c
 }
 
 /// Constructor to be used when creating a new object. Position is identity, Rotation is identity rotation
-IntersectionSolid::IntersectionSolid(const string& nam, const Solid& shape1, const Solid& shape2) {
+IntersectionSolid::IntersectionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2) {
   TGeoIntersection* inter = new TGeoIntersection(shape1, shape2, detail::matrix::_identity(), detail::matrix::_identity());
   _assign(new TGeoCompositeShape(nam.c_str(), inter), "", INTERSECTION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object. Placement by a generic transformation within the mother
-IntersectionSolid::IntersectionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const Transform3D& trans) {
+IntersectionSolid::IntersectionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const Transform3D& trans) {
   TGeoIntersection* inter = new TGeoIntersection(shape1, shape2, detail::matrix::_identity(), detail::matrix::_transform(trans));
   _assign(new TGeoCompositeShape(nam.c_str(), inter), "", INTERSECTION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object. Position is identity.
-IntersectionSolid::IntersectionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const Position& pos) {
+IntersectionSolid::IntersectionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const Position& pos) {
   TGeoIntersection* inter = new TGeoIntersection(shape1, shape2, detail::matrix::_identity(), detail::matrix::_translation(pos));
   _assign(new TGeoCompositeShape(nam.c_str(), inter), "", INTERSECTION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object
-IntersectionSolid::IntersectionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const RotationZYX& rot) {
+IntersectionSolid::IntersectionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const RotationZYX& rot) {
   TGeoIntersection* inter = new TGeoIntersection(shape1, shape2, detail::matrix::_identity(), detail::matrix::_rotationZYX(rot));
   _assign(new TGeoCompositeShape(nam.c_str(), inter), "", INTERSECTION_TAG, true);
 }
 
 /// Constructor to be used when creating a new object
-IntersectionSolid::IntersectionSolid(const string& nam, const Solid& shape1, const Solid& shape2, const Rotation3D& rot) {
+IntersectionSolid::IntersectionSolid(const std::string& nam, const Solid& shape1, const Solid& shape2, const Rotation3D& rot) {
   TGeoIntersection* inter = new TGeoIntersection(shape1, shape2, detail::matrix::_identity(), detail::matrix::_rotation3D(rot));
   _assign(new TGeoCompositeShape(nam.c_str(), inter), "", INTERSECTION_TAG, true);
 }
@@ -1075,7 +1072,4 @@ INSTANTIATE(TGeoTrd2);
 INSTANTIATE(TGeoCtub);
 INSTANTIATE(TGeoScaledShape);
 INSTANTIATE(TGeoCompositeShape);
-
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
 INSTANTIATE(TGeoTessellated);
-#endif

--- a/DDCore/src/ShapesInterna.cpp
+++ b/DDCore/src/ShapesInterna.cpp
@@ -12,15 +12,14 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/detail/ShapesInterna.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/detail/ShapesInterna.h>
 
 // C/C++ include files
 #include <climits>
 #include <iomanip>
 #include <cstdio>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(dd4hep::TwistedTubeObject)

--- a/DDCore/src/SpecParRegistry.cpp
+++ b/DDCore/src/SpecParRegistry.cpp
@@ -1,25 +1,40 @@
-#include "DD4hep/SpecParRegistry.h"
-#include "DD4hep/Detector.h"
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework includes
+#include <DD4hep/SpecParRegistry.h>
+#include <DD4hep/Detector.h>
+
+// C/C++ include files
 #include <algorithm>
 
-using namespace std;
 using namespace dd4hep;
 
-string_view SpecPar::strValue(const string& key) const {
+std::string_view SpecPar::strValue(const std::string& key) const {
   auto const& item = spars.find(key);
   if (item == end(spars))
-    return string_view();
+    return std::string_view();
   return *begin(item->second);
 }
 
-bool SpecPar::hasValue(const string& key) const {
+bool SpecPar::hasValue(const std::string& key) const {
   if (numpars.find(key) != end(numpars))
     return true;
   else
     return false;
 }
 
-bool SpecPar::hasPath(const string& path) const {
+bool SpecPar::hasPath(const std::string& path) const {
   auto result = std::find(std::begin(paths), std::end(paths), path);
   if (result != end(paths))
     return true;
@@ -28,7 +43,7 @@ bool SpecPar::hasPath(const string& path) const {
 }
 
 template <>
-std::vector<double> SpecPar::value<std::vector<double>>(const string& key) const {
+std::vector<double> SpecPar::value<std::vector<double>>(const std::string& key) const {
   std::vector<double> result;
 
   auto const& nitem = numpars.find(key);
@@ -47,7 +62,7 @@ std::vector<double> SpecPar::value<std::vector<double>>(const string& key) const
 }
 
 template <>
-std::vector<int> SpecPar::value<std::vector<int>>(const string& key) const {
+std::vector<int> SpecPar::value<std::vector<int>>(const std::string& key) const {
   std::vector<int> result;
 
   auto const& nitem = numpars.find(key);
@@ -66,7 +81,7 @@ std::vector<int> SpecPar::value<std::vector<int>>(const string& key) const {
 }
 
 template <>
-std::vector<std::string> SpecPar::value<std::vector<std::string>>(const string& key) const {
+std::vector<std::string> SpecPar::value<std::vector<std::string>>(const std::string& key) const {
   std::vector<std::string> result;
 
   auto const& nitem = numpars.find(key);
@@ -86,7 +101,7 @@ std::vector<std::string> SpecPar::value<std::vector<std::string>>(const string& 
   return result;
 }
 
-double SpecPar::dblValue(const string& key) const {
+double SpecPar::dblValue(const std::string& key) const {
   auto const& item = numpars.find(key);
   if (item == end(numpars))
     return 0;

--- a/DDCore/src/SurfaceInstaller.cpp
+++ b/DDCore/src/SurfaceInstaller.cpp
@@ -12,18 +12,13 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Shapes.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/SurfaceInstaller.h"
-
-// C/C++ include files
-#include <stdexcept>
+#include <DD4hep/Shapes.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/SurfaceInstaller.h>
 
 // ROOT includes
-#include "TClass.h"
+#include <TClass.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep;
 
 typedef DetElement::Children _C;
@@ -33,30 +28,30 @@ SurfaceInstaller::SurfaceInstaller(Detector& description, int argc, char** argv)
   : m_detDesc(description), m_det(), m_stopScanning(false)
 {
   if ( argc > 0 )  {
-    string det_name = argv[0];
-    string n = det_name[0] == '-' ? det_name.substr(1) : det_name;
+    std::string det_name = argv[0];
+    std::string n = det_name[0] == '-' ? det_name.substr(1) : det_name;
     m_det = description.detector(n);
     if ( !m_det.isValid() )   {
-      stringstream err;
+      std::stringstream err;
       err << "The subdetector " << det_name << " is not known to the geometry.";
       printout(INFO,"SurfaceInstaller",err.str().c_str());
-      throw runtime_error(err.str());
+      except(det_name, err.str());
     }
-    printout(INFO,m_det.name(),"+++ Processing SurfaceInstaller for subdetector: '%s'",m_det.name());
+    printout(INFO,m_det.name(), "+++ Processing SurfaceInstaller for subdetector: '%s'",m_det.name());
     return;
   }
-  throw runtime_error("The plugin takes at least one argument. No argument supplied");
+  except("SurfaceInstaller", "The plugin takes at least one argument. No argument supplied");
 }
 
 /// Indicate error message and throw exception
 void SurfaceInstaller::invalidInstaller(const std::string& msg)   const  {
   const char* det = m_det.isValid() ? m_det.name() : "<UNKNOWN>";
-  string typ = m_det.isValid() ? m_det.type() : string("<UNKNOWN>");
+  std::string typ = m_det.isValid() ? m_det.type() : std::string("<UNKNOWN>");
   printout(FATAL,"SurfaceInstaller","+++ Surfaces for: %s",det);
   printout(FATAL,"SurfaceInstaller","+++ %s.",msg.c_str());
   printout(FATAL,"SurfaceInstaller","+++ You sure you apply the correct plugin to generate");
   printout(FATAL,"SurfaceInstaller","+++ surfaces for a detector of type %s",typ.c_str());
-  throw std::runtime_error("+++ Failed to install Surfaces to detector "+string(det));
+  except("SurfaceInstaller", "+++ Failed to install Surfaces to detector "+std::string(det));
 }
 
 /// Shortcut to access the parent detectorelement's volume
@@ -78,19 +73,19 @@ const double* SurfaceInstaller::placementTranslation(DetElement component)  cons
 /// Printout volume information
 void SurfaceInstaller::install(DetElement component, PlacedVolume pv)   {
   if ( pv.volume().isSensitive() )  {
-    stringstream log;
-    PlacementPath all_nodes;
-    ElementPath   det_elts;
+    std::stringstream log;
+    PlacementPath     all_nodes;
+    ElementPath       det_elts;
     detail::tools::elementPath(component,det_elts);
     detail::tools::placementPath(component,all_nodes);
-    string elt_path  = detail::tools::elementPath(det_elts);
-    string node_path = detail::tools::placementPath(all_nodes);
+    std::string elt_path  = detail::tools::elementPath(det_elts);
+    std::string node_path = detail::tools::placementPath(all_nodes);
 
     log << "Lookup " << " Detector[" << det_elts.size() << "]: " << elt_path;
-    printout(INFO,m_det.name(),log.str());
+    printout(INFO,m_det.name(), log.str());
     log.str("");
     log << "       " << " Places[" <<  all_nodes.size()  << "]:   " << node_path;
-    printout(INFO,m_det.name(),log.str());
+    printout(INFO,m_det.name(), log.str());
     log.str("");
     log << "       " << " detail::matrix[" <<  all_nodes.size()  << "]: ";
     for(PlacementPath::const_reverse_iterator i=all_nodes.rbegin(); i!=all_nodes.rend(); ++i)  {
@@ -116,7 +111,7 @@ void SurfaceInstaller::install(DetElement component, PlacedVolume pv)   {
     printout(INFO,m_det.name(),log.str());
     return;
   }
-  cout << component.name() << ": " << pv.name() << endl;
+  std::cout << component.name() << ": " << pv.name() << std::endl;
 }
 
 /// Scan through tree of volume placements

--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -12,13 +12,13 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/detail/Handle.inl"
-#include "DD4hep/detail/ObjectsInterna.h"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "DD4hep/detail/VolumeManagerInterna.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/detail/Handle.inl>
+#include <DD4hep/detail/ObjectsInterna.h>
+#include <DD4hep/detail/DetectorInterna.h>
+#include <DD4hep/detail/VolumeManagerInterna.h>
 
 // C/C++ includes
 #include <set>
@@ -26,7 +26,6 @@
 #include <sstream>
 #include <iomanip>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::detail;
 
@@ -44,19 +43,19 @@ namespace dd4hep {
      *  \version 1.0
      */
     class VolumeManager_Populator {
-      typedef vector<TGeoNode*>        Chain;
-      typedef PlacedVolume::VolIDs     VolIDs;
-      typedef pair<VolumeID, VolumeID> Encoding;
+      typedef std::vector<TGeoNode*>        Chain;
+      typedef PlacedVolume::VolIDs          VolIDs;
+      typedef std::pair<VolumeID, VolumeID> Encoding;
       /// Reference to the Detector instance
-      const Detector& m_detDesc;
+      const Detector&    m_detDesc;
       /// Reference to the volume manager to be populated
-      VolumeManager   m_volManager;
+      VolumeManager      m_volManager;
       /// Set of already added entries
-      set<VolumeID>   m_entries;
+      std::set<VolumeID> m_entries;
       /// Debug flag
-      bool            m_debug    = false;
+      bool               m_debug    = false;
       /// Node counter
-      size_t          m_numNodes = 0;
+      std::size_t        m_numNodes = 0;
 
     public:
       /// Default constructor
@@ -157,7 +156,7 @@ namespace dd4hep {
             }
             else  {
               except("VolumeManager",
-                     "Invalid not instrumented placement:"+string(daughter->GetName())+
+                     "Invalid not instrumented placement:"+std::string(daughter->GetName())+
                      " [Internal error -- bad detector constructor]");
             }
             if ( compound )  {
@@ -219,7 +218,7 @@ namespace dd4hep {
           volume_id   |= ((f->value(val << off) << off)&msk);
           mask        |= msk;
         }
-        return make_pair(volume_id, mask);
+        return std::make_pair(volume_id, mask);
       }
       /// Compute the encoding for a set of VolIDs within a readout descriptor
       static Encoding encoding(const IDDescriptor iddesc, const VolIDs& ids)  {
@@ -233,7 +232,7 @@ namespace dd4hep {
           volume_id |= ((f->value(val << off) << off)&msk);
           mask      |= msk;
         }
-        return make_pair(volume_id, mask);
+        return std::make_pair(volume_id, mask);
       }
 
       void add_entry(SensitiveDetector sd, DetElement parent, DetElement e, 
@@ -242,7 +241,7 @@ namespace dd4hep {
         if ( sd.isValid() )   {
           if (m_entries.find(code.first) == m_entries.end()) {
             Readout       ro           = sd.readout();
-            string        sd_name      = sd.name();
+            std::string   sd_name      = sd.name();
             DetElement    sub_detector = m_detDesc.detector(sd_name);
             VolumeManager section      = m_volManager.addSubdetector(sub_detector, ro);
 
@@ -258,7 +257,7 @@ namespace dd4hep {
             if ( context->flag )  {
               detail::VolumeManagerContextExtension* ext = (detail::VolumeManagerContextExtension*)context;
               ext->placement  = PlacedVolume(n);
-              for (size_t i = nodes.size(); i > 1; --i) {   // Omit the placement of the parent DetElement
+              for (std::size_t i = nodes.size(); i > 1; --i) {   // Omit the placement of the parent DetElement
                 TGeoMatrix* m = nodes[i-1]->GetMatrix();
                 ext->toElement.MultiplyLeft(m);
               }
@@ -283,7 +282,7 @@ namespace dd4hep {
         bool sensitive = pv.volume().isSensitive();
 
         //if ( !sensitive ) return;
-        stringstream log;
+        std::stringstream log;
         log << m_entries.size() << ": Detector: " << e.path()
             << " id:" << volumeID(code.first)
             << " Nodes(" << int(nodes.size()) << "):" << ro.idSpec().str(code.first,code.second);
@@ -393,9 +392,9 @@ void VolumeManagerContext::worldToLocal(const double world[3], double local[3]) 
 }
 
 /// Initializing constructor to create a new object
-VolumeManager::VolumeManager(const Detector& description, const string& nam, DetElement elt, Readout ro, int flags) {
+VolumeManager::VolumeManager(const Detector& description, const std::string& nam, DetElement elt, Readout ro, int flags) {
   printout(INFO, "VolumeManager", " - populating volume ids - be patient ..."  );
-  size_t node_count = 0;
+  std::size_t node_count = 0;
   Object* obj_ptr = new Object();
   assign(obj_ptr, nam, "VolumeManager");
   if (elt.isValid()) {
@@ -430,26 +429,26 @@ VolumeManager VolumeManager::addSubdetector(DetElement det, Readout ro) {
   if (isValid()) {
     Object& o = _data();
     if (!det.isValid()) {
-      throw runtime_error("dd4hep: VolumeManager::addSubdetector: Only valid subdetectors "
-                          "are allowed. [Invalid DetElement]");
+      throw std::runtime_error("dd4hep: VolumeManager::addSubdetector: Only valid subdetectors "
+                               "are allowed. [Invalid DetElement]");
     }
     auto i = o.subdetectors.find(det);
     if (i == o.subdetectors.end()) {
-      string det_name = det.name();
+      std::string det_name = det.name();
       // First check all pre-conditions
       if (!ro.isValid()) {
-        throw runtime_error("dd4hep: VolumeManager::addSubdetector: Only subdetectors with a "
-                            "valid readout descriptor are allowed. [Invalid DetElement:" + det_name + "]");
+        throw std::runtime_error("dd4hep: VolumeManager::addSubdetector: Only subdetectors with a "
+                                 "valid readout descriptor are allowed. [Invalid DetElement:" + det_name + "]");
       }
       PlacedVolume pv = det.placement();
       if (!pv.isValid()) {
-        throw runtime_error("dd4hep: VolumeManager::addSubdetector: Only subdetectors with a "
-                            "valid placement are allowed. [Invalid DetElement:" + det_name + "]");
+        throw std::runtime_error("dd4hep: VolumeManager::addSubdetector: Only subdetectors with a "
+                                 "valid placement are allowed. [Invalid DetElement:" + det_name + "]");
       }
       auto vit = pv.volIDs().find("system");
       if (vit == pv.volIDs().end()) {
-        throw runtime_error("dd4hep: VolumeManager::addSubdetector: Only subdetectors with "
-                            "valid placement VolIDs are allowed. [Invalid DetElement:" + det_name + "]");
+        throw std::runtime_error("dd4hep: VolumeManager::addSubdetector: Only subdetectors with "
+                                 "valid placement VolIDs are allowed. [Invalid DetElement:" + det_name + "]");
       }
 
       i = o.subdetectors.emplace(det, VolumeManager(det,ro)).first;
@@ -457,8 +456,8 @@ VolumeManager VolumeManager::addSubdetector(DetElement det, Readout ro) {
       VolumeManager mgr = (*i).second;
       const BitFieldElement* field = ro.idSpec().field(id.first);
       if (!field) {
-        throw runtime_error("dd4hep: VolumeManager::addSubdetector: IdDescriptor of " + 
-                            string(det.name()) + " has no field " + id.first);
+        throw std::runtime_error("dd4hep: VolumeManager::addSubdetector: IdDescriptor of " + 
+                                 std::string(det.name()) + " has no field " + id.first);
       }
       Object& mo = mgr._data();
       mo.top     = o.top;
@@ -472,8 +471,8 @@ VolumeManager VolumeManager::addSubdetector(DetElement det, Readout ro) {
     }
     return (*i).second;
   }
-  throw runtime_error("dd4hep: VolumeManager::addSubdetector: "
-                      "Failed to add subdetector section. [Invalid Manager Handle]");
+  throw std::runtime_error("dd4hep: VolumeManager::addSubdetector: "
+                           "Failed to add subdetector section. [Invalid Manager Handle]");
 }
 
 /// Access the volume manager by cell id
@@ -487,11 +486,11 @@ VolumeManager VolumeManager::subdetector(VolumeID id) const {
       if ( sys_id == mo.sysID )
         return j.second;
     }
-    throw runtime_error("dd4hep: VolumeManager::subdetector(VolID): "
-                        "Attempt to access unknown subdetector section.");
+    throw std::runtime_error("dd4hep: VolumeManager::subdetector(VolID): "
+                             "Attempt to access unknown subdetector section.");
   }
-  throw runtime_error("dd4hep: VolumeManager::subdetector(VolID): "
-                      "Cannot assign ID descriptor [Invalid Manager Handle]");
+  throw std::runtime_error("dd4hep: VolumeManager::subdetector(VolID): "
+                           "Cannot assign ID descriptor [Invalid Manager Handle]");
 }
 
 /// Access the top level detector element
@@ -499,7 +498,7 @@ DetElement VolumeManager::detector() const {
   if (isValid()) {
     return _data().detector;
   }
-  throw runtime_error("dd4hep: VolumeManager::detector: Cannot access DetElement [Invalid Handle]");
+  throw std::runtime_error("dd4hep: VolumeManager::detector: Cannot access DetElement [Invalid Handle]");
 }
 
 /// Access IDDescription structure
@@ -509,7 +508,7 @@ IDDescriptor VolumeManager::idSpec() const {
 
 /// Register physical volume with the manager (normally: section manager)
 bool VolumeManager::adoptPlacement(VolumeID sys_id, VolumeManagerContext* context) {
-  stringstream err;
+  std::stringstream err;
   Object&  o      = _data();
   VolumeID vid    = context->identifier;
   VolumeID mask   = context->mask;
@@ -521,53 +520,53 @@ bool VolumeManager::adoptPlacement(VolumeID sys_id, VolumeManagerContext* contex
         << " id:" << (void*)vid
         << " pv:" << pv.name()
         << " Sensitive:" << yes_no(pv.volume().isSensitive())
-        << endl;
+        << std::endl;
     goto Fail;
   }
 
   if ( i == o.volumes.end()) {
     o.volumes[vid] = context;
     o.detMask |= mask;
-    err << "Inserted new volume:" << setw(6) << left << o.volumes.size()
+    err << "Inserted new volume:" << std::setw(6) << std::left << o.volumes.size()
         << " Ptr:"  << (void*) pv.ptr()
         << " ["     << pv.name() << "]"
-        << " id:"   << setw(16) << hex << right << setfill('0') << vid  << dec << setfill(' ')
-        << " mask:" << setw(16) << hex << right << setfill('0') << mask << dec << setfill(' ')
-        << " Det:"  << setw(4)  << hex << right << setfill('0') << context->element.volumeID()
-        << " / "    << setw(4)  << sys_id << dec << setfill(' ') << ": " << context->element.path();
+        << " id:"   << std::setw(16) << std::hex << std::right << std::setfill('0') << vid  << std::dec << std::setfill(' ')
+        << " mask:" << std::setw(16) << std::hex << std::right << std::setfill('0') << mask << std::dec << std::setfill(' ')
+        << " Det:"  << std::setw(4)  << std::hex << std::right << std::setfill('0') << context->element.volumeID()
+        << " / "    << std::setw(4)  << sys_id   << std::dec   << std::setfill(' ') << ": " << context->element.path();
     printout(VERBOSE, "VolumeManager", err.str().c_str());
     //printout(ALWAYS, "VolumeManager", err.str().c_str());
     return true;
   }
   err << "+++ Attempt to register duplicate"
-      << " id:"   << setw(16) << hex << right << setfill('0') << vid  << dec << setfill(' ')
-      << " mask:" << setw(16) << hex << right << setfill('0') << mask << dec << setfill(' ')
+      << " id:"   << std::setw(16) << std::hex << std::right << std::setfill('0') << vid  << std::dec << std::setfill(' ')
+      << " mask:" << std::setw(16) << std::hex << std::right << std::setfill('0') << mask << std::dec << std::setfill(' ')
       << " to detector " << o.detector.name()
       << " ptr:" << (void*) pv.ptr()
       << " Name:" << pv.name()
       << " Sensitive:" << yes_no(pv.volume().isSensitive())
-      << endl;
+      << std::endl;
   printout(ERROR, "VolumeManager", "%s", err.str().c_str());
   err.str("");
   context = (*i).second;
   //pv = context->placement;
   err << " !!!!!               +++ Clashing"
-      << " id:"   << setw(16) << hex << right << setfill('0') << vid  << dec << setfill(' ')
-      << " mask:" << setw(16) << hex << right << setfill('0') << mask << dec << setfill(' ')
+      << " id:"   << std::setw(16) << std::hex << std::right << std::setfill('0') << vid  << std::dec << std::setfill(' ')
+      << " mask:" << std::setw(16) << std::hex << std::right << std::setfill('0') << mask << std::dec << std::setfill(' ')
       << " to detector " << o.detector.name()
       << " ptr:" << (void*) pv.ptr()
       << " Name:" << pv.name()
       << " Sensitive:" << yes_no(pv.volume().isSensitive())
-      << endl;
+      << std::endl;
  Fail:
   printout(ERROR, "VolumeManager", "%s", err.str().c_str());
-  // throw runtime_error(err.str());
+  // throw std::runtime_error(err.str());
   return false;
 }
 
 /// Register physical volume with the manager (normally: section manager)
 bool VolumeManager::adoptPlacement(VolumeManagerContext* context) {
-  stringstream err;
+  std::stringstream err;
   if ( isValid() ) {
     Object& o = _data();
     if ( context )   {
@@ -692,25 +691,25 @@ std::ostream& dd4hep::operator<<(std::ostream& os, const VolumeManager& mgr) {
   bool isTop = top == &o;
   //bool hasTop = (o.flags & VolumeManager::ONE) == VolumeManager::ONE;
   //bool isSdet = (o.flags & VolumeManager::TREE) == VolumeManager::TREE && top != &o;
-  string prefix(isTop ? "" : "++  ");
+  std::string prefix(isTop ? "" : "++  ");
   os << prefix << (isTop ? "TOP Level " : "Secondary ") << "Volume manager:" 
      << &o << " " << o.detector.name() << " IDD:"
      << o.id.toString() << " SysID:" << (void*) o.sysID << " " 
      << o.managers.size() << " subsections " << o.volumes.size()
      << " placements ";
   if (!(o.managers.empty() && o.volumes.empty()))
-    os << endl;
+    os << std::endl;
   for ( const auto& i : o.volumes ) {
     const VolumeManagerContext* c = i.second;
     os << prefix
-       << "Element:" << setw(32) << left << c->element.path()
-      //<< " pv:"     << setw(32) << left << c->placement().name()
-       << " id:"     << setw(18) << left << (void*) c->identifier
-       << " mask:"   << setw(18) << left << (void*) c->mask
-       << endl;
+       << "Element:" << std::setw(32) << std::left << c->element.path()
+      //<< " pv:"     << std::setw(32) << std::left << c->placement().name()
+       << " id:"     << std::setw(18) << std::left << (void*) c->identifier
+       << " mask:"   << std::setw(18) << std::left << (void*) c->mask
+       << std::endl;
   }
   for( const auto& i : o.managers )
-    os << prefix << i.second << endl;
+    os << prefix << i.second << std::endl;
   return os;
 }
 

--- a/DDCore/src/VolumeProcessor.cpp
+++ b/DDCore/src/VolumeProcessor.cpp
@@ -12,8 +12,8 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/VolumeProcessor.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/VolumeProcessor.h>
 
 using namespace dd4hep;
 

--- a/DDCore/src/Volumes.cpp
+++ b/DDCore/src/Volumes.cpp
@@ -1157,7 +1157,7 @@ const Volume& Volume::setVisAttributes(const VisAttr& attr) const {
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,29,0)
         // Set directly transparency to the volume, NOT to the material as for ROOT < 6.29
         m_element->ResetTransparency(Char_t((1.0-vis->alpha)*100));
-#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+#else
         // As suggested by Valentin Volkl https://sft.its.cern.ch/jira/browse/DDFORHEP-20
         //
         // According to https://root.cern.ch/phpBB3/viewtopic.php?t=2309#p66013

--- a/DDCore/src/Volumes.cpp
+++ b/DDCore/src/Volumes.cpp
@@ -40,9 +40,7 @@
 #include <sstream>
 #include <iomanip>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 /*
  *  The section below uses the new ROOT features using user extensions to volumes
@@ -71,17 +69,17 @@ namespace {
     return o;
   }
 
-  TGeoVolume* _createTGeoVolume(const string& name, TGeoShape* s, TGeoMedium* m)  {
+  TGeoVolume* _createTGeoVolume(const std::string& name, TGeoShape* s, TGeoMedium* m)  {
     geo_volume_t* e = new geo_volume_t(name.c_str(),s,m);
     e->SetUserExtension(new Volume::Object());
     return e;
   }
-  TGeoVolume* _createTGeoVolumeAssembly(const string& name)  {
+  TGeoVolume* _createTGeoVolumeAssembly(const std::string& name)  {
     geo_assembly_t* e = new geo_assembly_t(name.c_str()); // It is important to use the correct constructor!!
     e->SetUserExtension(new Assembly::Object());
     return e;
   }
-  TGeoVolumeMulti* _createTGeoVolumeMulti(const string& name, TGeoMedium* medium)  {
+  TGeoVolumeMulti* _createTGeoVolumeMulti(const std::string& name, TGeoMedium* medium)  {
     TGeoVolumeMulti* e = new TGeoVolumeMulti(name.c_str(), medium);
     e->SetUserExtension(new VolumeMulti::Object());
     return e;
@@ -89,7 +87,7 @@ namespace {
   PlacedVolume::Object* _data(const PlacedVolume& v) {
     PlacedVolume::Object* o = _userExtension(v);
     if (o) return o;
-    throw runtime_error("dd4hep: Attempt to access invalid handle of type: PlacedVolume");
+    throw std::runtime_error("dd4hep: Attempt to access invalid handle of type: PlacedVolume");
   }
   /// Accessor to the data part of the Volume
   Volume::Object* _data(const Volume& v, bool throw_exception = true) {
@@ -99,7 +97,7 @@ namespace {
       return o;
     else if (!throw_exception)
       return nullptr;
-    throw runtime_error("dd4hep: Attempt to access invalid handle of type: PlacedVolume");
+    throw std::runtime_error("dd4hep: Attempt to access invalid handle of type: PlacedVolume");
   }
 
   class VolumeImport   {
@@ -107,7 +105,7 @@ namespace {
     void setShapeTitle(TGeoVolume* vol)   {
       if ( vol )   {
         TGeoShape* sh = vol->GetShape();
-        string tag = get_shape_tag(sh);
+        std::string tag = get_shape_tag(sh);
         sh->SetTitle(tag.c_str());
       }
     }
@@ -216,7 +214,7 @@ namespace {
       return nullptr;
     }
     map.Add(v, vol);
-    string nam;
+    std::string nam;
     if (newname && newname[0])  {
       nam = newname;
       vol->SetName(newname);
@@ -395,8 +393,8 @@ void PlacedVolumeExtension::Release() const  {
 }
 
 /// Lookup volume ID
-vector<PlacedVolumeExtension::VolID>::const_iterator
-PlacedVolumeExtension::VolIDs::find(const string& name) const {
+std::vector<PlacedVolumeExtension::VolID>::const_iterator
+PlacedVolumeExtension::VolIDs::find(const std::string& name) const {
   for (Base::const_iterator i = this->Base::begin(); i != this->Base::end(); ++i)
     if (name == (*i).first)
       return i;
@@ -404,8 +402,8 @@ PlacedVolumeExtension::VolIDs::find(const string& name) const {
 }
 
 /// Insert a new value into the volume ID container
-std::pair<vector<PlacedVolumeExtension::VolID>::iterator, bool>
-PlacedVolumeExtension::VolIDs::insert(const string& name, int value) {
+std::pair<std::vector<PlacedVolumeExtension::VolID>::iterator, bool>
+PlacedVolumeExtension::VolIDs::insert(const std::string& name, int value) {
   Base::iterator i = this->Base::begin();
   for (; i != this->Base::end(); ++i)
     if (name == (*i).first)
@@ -419,12 +417,12 @@ PlacedVolumeExtension::VolIDs::insert(const string& name, int value) {
 }
 
 /// String representation for debugging
-string PlacedVolumeExtension::VolIDs::str()  const   {
-  stringstream str;
-  str << hex;
+std::string PlacedVolumeExtension::VolIDs::str()  const   {
+  std::stringstream str;
+  str << std::hex;
   for(const auto& i : *this )   {
-    str << i.first << "=" << setw(4) << right
-        << setfill('0') << i.second << setfill(' ') << " ";
+    str << i.first << "=" << std::setw(4) << std::right
+        << std::setfill('0') << i.second << std::setfill(' ') << " ";
   }
   return str.str();
 }
@@ -484,7 +482,7 @@ const PlacedVolume::VolIDs& PlacedVolume::volIDs() const {
 }
 
 /// Add identifier
-PlacedVolume& PlacedVolume::addPhysVolID(const string& nam, int value) {
+PlacedVolume& PlacedVolume::addPhysVolID(const std::string& nam, int value) {
   auto* o = _data(*this);
   if ( !o->params )   {
     o->volIDs.emplace_back(nam, value);
@@ -523,15 +521,15 @@ Position PlacedVolume::position()  const    {
 }
 
 /// String dump
-string PlacedVolume::toString() const {
-  stringstream str;
+std::string PlacedVolume::toString() const {
+  std::stringstream str;
   Object* obj = _data(*this);
   str << m_element->GetName() << ":  vol='" << m_element->GetVolume()->GetName()
       << "' mat:'" << m_element->GetMatrix()->GetName()
       << "' volID[" << obj->volIDs.size() << "] ";
   for (VolIDs::const_iterator i = obj->volIDs.begin(); i != obj->volIDs.end(); ++i)
     str << (*i).first << "=" << (*i).second << "  ";
-  str << ends;
+  str << std::ends;
   return str.str();
 }
 
@@ -613,23 +611,23 @@ void VolumeExtension::Release() const  {
 }
 
 /// Constructor to be used when creating a new geometry tree.
-Volume::Volume(const string& nam) {
+Volume::Volume(const std::string& nam) {
   m_element = _createTGeoVolume(nam,0,0);
 }
 
 /// Constructor to be used when creating a new geometry tree.
-Volume::Volume(const string& nam, const string& title) {
+Volume::Volume(const std::string& nam, const std::string& title) {
   m_element = _createTGeoVolume(nam,0,0);
   m_element->SetTitle(title.c_str());
 }
 
 /// Constructor to be used when creating a new geometry tree. Also sets materuial and solid attributes
-Volume::Volume(const string& nam, const Solid& sol, const Material& mat) {
+Volume::Volume(const std::string& nam, const Solid& sol, const Material& mat) {
   m_element = _createTGeoVolume(nam, sol.ptr(), mat.ptr());
 }
 
 /// Constructor to be used when creating a new geometry tree. Also sets materuial and solid attributes
-Volume::Volume(const string& nam, const string& title, const Solid& sol, const Material& mat) {
+Volume::Volume(const std::string& nam, const std::string& title, const Solid& sol, const Material& mat) {
   m_element = _createTGeoVolume(nam, sol.ptr(), mat.ptr());
   m_element->SetTitle(title.c_str());
 }
@@ -711,7 +709,7 @@ bool Volume::isAssembly()   const   {
 }    
 
 /// Divide volume into subsections (See the ROOT manuloa for details)
-Volume Volume::divide(const string& divname, int iaxis, int ndiv,
+Volume Volume::divide(const std::string& divname, int iaxis, int ndiv,
                       double start, double step, int numed, const char* option)   {
   TGeoVolume* p = m_element;
   if ( p )  {
@@ -740,7 +738,7 @@ PlacedVolume _addNode(TGeoVolume* par, TGeoVolume* daughter, int id, TGeoMatrix*
     except("dd4hep","Volume: Attempt to place volume without placement matrix.");
   }
   if ( transform != detail::matrix::_identity() ) {
-    string nam = string(daughter->GetName()) + "_placement";
+    std::string nam = std::string(daughter->GetName()) + "_placement";
     transform->SetName(nam.c_str());
   }
   TGeoShape* shape = daughter->GetShape();
@@ -796,7 +794,7 @@ PlacedVolume _addNode(TGeoVolume* par, Volume daughter, int copy_nr, const Rotat
   double elements[9];
   rot3D.GetComponents(elements);
   r.SetMatrix(elements);
-  auto matrix = make_unique<TGeoCombiTrans>(TGeoTranslation(0,0,0),r);
+  auto matrix = std::make_unique<TGeoCombiTrans>(TGeoTranslation(0,0,0),r);
   return _addNode(par, daughter, copy_nr, matrix.release());
 }
 
@@ -809,7 +807,7 @@ PlacedVolume _addNode(TGeoVolume* par, Volume daughter, int copy_nr, const Trans
   tr.GetTranslation(pos3D);
   rot3D.GetComponents(elements);
   r.SetMatrix(elements);
-  auto matrix = make_unique<TGeoCombiTrans>(TGeoTranslation(pos3D.x(), pos3D.y(), pos3D.z()),r);
+  auto matrix = std::make_unique<TGeoCombiTrans>(TGeoTranslation(pos3D.x(), pos3D.y(), pos3D.z()),r);
   return _addNode(par, daughter, copy_nr, matrix.release());
 }
 
@@ -1094,16 +1092,16 @@ PlacedVolume Volume::paramVolume3D(const Transform3D& start,
 }
 
 /// Set the volume's option value
-const Volume& Volume::setOption(const string& opt) const {
+const Volume& Volume::setOption(const std::string& opt) const {
   if ( isValid() )   {
     m_element->SetOption(opt.c_str());
     return *this;
   }
-  throw runtime_error("dd4hep: Attempt to access invalid handle of type: PlacedVolume");
+  throw std::runtime_error("dd4hep: Attempt to access invalid handle of type: PlacedVolume");
 }
 
 /// Access the volume's option value
-string Volume::option() const {
+std::string Volume::option() const {
   return m_element->GetOption();
 }
 
@@ -1115,9 +1113,9 @@ const Volume& Volume::setMaterial(const Material& mat) const {
       m_element->SetMedium(medium);
       return *this;
     }
-    throw runtime_error("dd4hep: Volume: Medium " + string(mat.name()) + " is not registered with geometry manager.");
+    throw std::runtime_error("dd4hep: Volume: Medium " + std::string(mat.name()) + " is not registered with geometry manager.");
   }
-  throw runtime_error("dd4hep: Volume: Attempt to assign invalid material.");
+  throw std::runtime_error("dd4hep: Volume: Attempt to assign invalid material.");
 }
 
 /// Access to the Volume material
@@ -1190,7 +1188,7 @@ const Volume& Volume::setVisAttributes(const VisAttr& attr) const {
 }
 
 /// Set Visualization attributes to the volume
-const Volume& Volume::setVisAttributes(const Detector& description, const string& nam) const {
+const Volume& Volume::setVisAttributes(const Detector& description, const std::string& nam) const {
   if (!nam.empty()) {
     VisAttr attr = description.visAttributes(nam);
     setVisAttributes(attr);
@@ -1199,7 +1197,7 @@ const Volume& Volume::setVisAttributes(const Detector& description, const string
 }
 
 /// Attach attributes to the volume
-const Volume& Volume::setAttributes(const Detector& description, const string& rg, const string& ls, const string& vis) const {
+const Volume& Volume::setAttributes(const Detector& description, const std::string& rg, const std::string& ls, const std::string& vis) const {
   if (!rg.empty())
     setRegion(description.region(rg));
   if (!ls.empty())
@@ -1241,7 +1239,7 @@ Box Volume::boundingBox() const {
 }
 
 /// Set the regional attributes to the volume
-const Volume& Volume::setRegion(const Detector& description, const string& nam) const {
+const Volume& Volume::setRegion(const Detector& description, const std::string& nam) const {
   if (!nam.empty()) {
     return setRegion(description.region(nam));
   }
@@ -1260,7 +1258,7 @@ Region Volume::region() const {
 }
 
 /// Set the limits to the volume
-const Volume& Volume::setLimitSet(const Detector& description, const string& nam) const {
+const Volume& Volume::setLimitSet(const Detector& description, const std::string& nam) const {
   if (!nam.empty()) {
     return setLimitSet(description.limitSet(nam));
   }
@@ -1302,7 +1300,7 @@ bool Volume::hasProperties()  const   {
 }
 
 /// Add Volume property (name-value pair)
-void Volume::addProperty(const string& nam, const string& val) const  {
+void Volume::addProperty(const std::string& nam, const std::string& val) const  {
   auto* o = _data(*this);
   if ( !o->properties )   {
     o->properties = new TList();
@@ -1318,7 +1316,7 @@ void Volume::addProperty(const string& nam, const string& val) const  {
 }
 
 /// Access property value. Returns default_value if the property is not present
-string Volume::getProperty(const string& nam, const string& default_val)   const {
+std::string Volume::getProperty(const std::string& nam, const std::string& default_val)   const {
   const auto* o = _data(*this);
   if ( !o->properties )   {
     return default_val;
@@ -1329,12 +1327,12 @@ string Volume::getProperty(const string& nam, const string& default_val)   const
 }
 
 /// Constructor to be used when creating a new assembly object
-Assembly::Assembly(const string& nam) {
+Assembly::Assembly(const std::string& nam) {
   m_element = _createTGeoVolumeAssembly(nam);
 }
 
 /// Constructor to be used when creating a new multi-volume object
-VolumeMulti::VolumeMulti(const string& nam, Material mat) {
+VolumeMulti::VolumeMulti(const std::string& nam, Material mat) {
   m_element = _createTGeoVolumeMulti(nam, mat.ptr());
 }
 
@@ -1354,11 +1352,11 @@ void VolumeMulti::verifyVolumeMulti()   {
 }
 
 /// Output mesh vertices to string
-string dd4hep::toStringMesh(PlacedVolume place, int prec)   {
+std::string dd4hep::toStringMesh(PlacedVolume place, int prec)   {
   Volume       vol   = place->GetVolume();
   TGeoMatrix*  mat   = place->GetMatrix();
   Solid        sol   = vol.solid();
-  stringstream os;
+  std::stringstream os;
   struct _numbering {
     double adjust(double value)  const   {
       if ( std::abs(value) < TGeoShape::Tolerance() )
@@ -1369,7 +1367,7 @@ string dd4hep::toStringMesh(PlacedVolume place, int prec)   {
 
   if ( vol->IsA() == TGeoVolumeAssembly::Class() )    {
     for(int i=0; i<vol->GetNdaughters(); ++i)  {
-      os << toStringMesh(vol->GetNode(i), prec) << endl;
+      os << toStringMesh(vol->GetNode(i), prec) << std::endl;
     }
     return os.str();
   }
@@ -1380,36 +1378,36 @@ string dd4hep::toStringMesh(PlacedVolume place, int prec)   {
   Double_t* points = new Double_t[3*nvert];
   sol->SetPoints(points);
 
-  os << setw(16) << left << sol->IsA()->GetName()
-     << " " << nvert << " Mesh-points:" << endl;
-  os << setw(16) << left << sol->IsA()->GetName() << " " << sol->GetName()
+  os << std::setw(16) << std::left << sol->IsA()->GetName()
+     << " " << nvert << " Mesh-points:" << std::endl;
+  os << std::setw(16) << std::left << sol->IsA()->GetName() << " " << sol->GetName()
      << " N(mesh)=" << sol->GetNmeshVertices()
-     << "  N(vert)=" << nvert << "  N(seg)=" << nsegs << "  N(pols)=" << npols << endl;
+     << "  N(vert)=" << nvert << "  N(seg)=" << nsegs << "  N(pols)=" << npols << std::endl;
     
   for(int i=0; i<nvert; ++i)   {
     Double_t* p = points + 3*i;
     Double_t global[3], local[3] = {p[0], p[1], p[2]};
     mat->LocalToMaster(local, global);
-    os << setw(16) << left << sol->IsA()->GetName() << " " << setw(3) << left << i
-       << " Local  ("  << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(local[0])
-       << ", "         << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(local[1])
-       << ", "         << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(local[2])
-       << ") Global (" << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(global[0])
-       << ", "         << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(global[1])
-       << ", "         << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(global[2])
-       << ")" << endl;
+    os << std::setw(16) << std::left << sol->IsA()->GetName() << " " << std::setw(3) << std::left << i
+       << " Local  ("  << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(local[0])
+       << ", "         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(local[1])
+       << ", "         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(local[2])
+       << ") Global (" << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(global[0])
+       << ", "         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(global[1])
+       << ", "         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(global[2])
+       << ")" << std::endl;
   }
   Box box = sol;
   const Double_t* org = box->GetOrigin();
-  os << setw(16) << left << sol->IsA()->GetName()
+  os << std::setw(16) << std::left << sol->IsA()->GetName()
      << " Bounding box: "
-     << " dx="        << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(box->GetDX())
-     << " dy="        << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(box->GetDY())
-     << " dz="        << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(box->GetDZ())
-     << " Origin: x=" << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(org[0])
-     << " y="         << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(org[1])
-     << " z="         << setw(7) << setprecision(prec) << fixed << right << _vertex.adjust(org[2])
-     << endl;
+     << " dx="        << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(box->GetDX())
+     << " dy="        << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(box->GetDY())
+     << " dz="        << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(box->GetDZ())
+     << " Origin: x=" << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(org[0])
+     << " y="         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(org[1])
+     << " z="         << std::setw(7) << std::setprecision(prec) << std::fixed << std::right << _vertex.adjust(org[2])
+     << std::endl;
   
   /// -------------------- DONE --------------------
   delete [] points;

--- a/DDCore/src/WaferGridXY.cpp
+++ b/DDCore/src/WaferGridXY.cpp
@@ -12,12 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/WaferGridXY.h"
-#include "DDSegmentation/WaferGridXY.h"
+#include <DD4hep/WaferGridXY.h>
+#include <DDSegmentation/WaferGridXY.h>
 
-// C/C++ include files
-
-using namespace std;
 using namespace dd4hep;
 
 /// determine the position based on the cell ID
@@ -63,12 +60,12 @@ double WaferGridXY::waferOffsetY(int inGroup, int inWafer) const  {
 }
 
 /// access the field name used for X
-const string& WaferGridXY::fieldNameX() const {
+const std::string& WaferGridXY::fieldNameX() const {
   return access()->implementation->fieldNameX();
 }
 
 /// access the field name used for Y
-const string& WaferGridXY::fieldNameY() const {
+const std::string& WaferGridXY::fieldNameY() const {
   return access()->implementation->fieldNameY();
 }
 
@@ -81,6 +78,6 @@ const string& WaferGridXY::fieldNameY() const {
     -# size in x
     -# size in y
 */
-vector<double> WaferGridXY::cellDimensions(const CellID& id) const  {
+std::vector<double> WaferGridXY::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/World.cpp
+++ b/DDCore/src/World.cpp
@@ -12,8 +12,8 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/World.h"
-#include "DD4hep/detail/DetectorInterna.h"
+#include <DD4hep/World.h>
+#include <DD4hep/detail/DetectorInterna.h>
 
 /// Access the detector descrion tree
 dd4hep::Detector& dd4hep::World::detectorDescription() const   {

--- a/DDCore/src/XML/Detector.cpp
+++ b/DDCore/src/XML/Detector.cpp
@@ -13,7 +13,7 @@
 #ifndef DD4HEP_NONE
 
 // Framework include files
-#include "XML/XMLDetector.h"
+#include <XML/XMLDetector.h>
 
 // Instantiate here the concrete implementations
 #define DD4HEP_DIMENSION_NS xml

--- a/DDCore/src/XML/DocumentHandler.cpp
+++ b/DDCore/src/XML/DocumentHandler.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "XML/Printout.h"
-#include "XML/UriReader.h"
-#include "XML/DocumentHandler.h"
+#include <XML/Printout.h>
+#include <XML/UriReader.h>
+#include <XML/DocumentHandler.h>
 
 // C/C++ include files
 #include <memory>
@@ -25,41 +25,39 @@
 #ifndef _WIN32
 #include <libgen.h>
 #endif
-#include "TSystem.h"
+#include <TSystem.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::xml;
 
 namespace {
-  string undressed_file_name(const string& fn)   {
+  std::string undressed_file_name(const std::string& fn)   {
     if ( !fn.empty() )   {
       TString tfn(fn);
       gSystem->ExpandPathName(tfn);
-      return string(tfn.Data());
+      return std::string(tfn.Data());
     }
     return fn;
   }
-  int s_minPrintLevel = INFO;
+  int s_minPrintLevel = dd4hep::INFO;
 }
 
 #ifndef __TIXML__
-#include "xercesc/framework/LocalFileFormatTarget.hpp"
-#include "xercesc/framework/StdOutFormatTarget.hpp"
-#include "xercesc/framework/MemBufFormatTarget.hpp"
-#include "xercesc/framework/MemBufInputSource.hpp"
-#include "xercesc/sax/SAXParseException.hpp"
-#include "xercesc/sax/EntityResolver.hpp"
-#include "xercesc/sax/InputSource.hpp"
-#include "xercesc/parsers/XercesDOMParser.hpp"
-#include "xercesc/util/XMLEntityResolver.hpp"
-#include "xercesc/util/PlatformUtils.hpp"
-#include "xercesc/util/XercesDefs.hpp"
-#include "xercesc/util/XMLUni.hpp"
-#include "xercesc/util/XMLURL.hpp"
-#include "xercesc/util/XMLString.hpp"
-#include "xercesc/dom/DOM.hpp"
-#include "xercesc/sax/ErrorHandler.hpp"
+#include <xercesc/framework/LocalFileFormatTarget.hpp>
+#include <xercesc/framework/StdOutFormatTarget.hpp>
+#include <xercesc/framework/MemBufFormatTarget.hpp>
+#include <xercesc/framework/MemBufInputSource.hpp>
+#include <xercesc/sax/SAXParseException.hpp>
+#include <xercesc/sax/EntityResolver.hpp>
+#include <xercesc/sax/InputSource.hpp>
+#include <xercesc/parsers/XercesDOMParser.hpp>
+#include <xercesc/util/XMLEntityResolver.hpp>
+#include <xercesc/util/PlatformUtils.hpp>
+#include <xercesc/util/XercesDefs.hpp>
+#include <xercesc/util/XMLUni.hpp>
+#include <xercesc/util/XMLURL.hpp>
+#include <xercesc/util/XMLString.hpp>
+#include <xercesc/dom/DOM.hpp>
+#include <xercesc/sax/ErrorHandler.hpp>
 
 using namespace xercesc;
 
@@ -95,7 +93,7 @@ namespace dd4hep {
 
     /// Dom Error handler callback
     bool DocumentErrorHandler::handleError(const DOMError& domError) {
-      string err = "DOM UNKNOWN: ";
+      std::string err = "DOM UNKNOWN: ";
       switch (domError.getSeverity()) {
       case DOMError::DOM_SEVERITY_WARNING:
         err = "DOM WARNING: ";
@@ -120,22 +118,22 @@ namespace dd4hep {
     }
     /// Error handler
     void DocumentErrorHandler::error(const SAXParseException& e) {
-      string m(_toString(e.getMessage()));
-      if (m.find("The values for attribute 'name' must be names or name tokens") != string::npos
-          || m.find("The values for attribute 'ID' must be names or name tokens") != string::npos
-          || m.find("for attribute 'name' must be Name or Nmtoken") != string::npos
-          || m.find("for attribute 'ID' must be Name or Nmtoken") != string::npos
-          || m.find("for attribute 'name' is invalid Name or NMTOKEN value") != string::npos
-          || m.find("for attribute 'ID' is invalid Name or NMTOKEN value") != string::npos)
+      std::string m(_toString(e.getMessage()));
+      if (m.find("The values for attribute 'name' must be names or name tokens") != std::string::npos
+          || m.find("The values for attribute 'ID' must be names or name tokens") != std::string::npos
+          || m.find("for attribute 'name' must be Name or Nmtoken") != std::string::npos
+          || m.find("for attribute 'ID' must be Name or Nmtoken") != std::string::npos
+          || m.find("for attribute 'name' is invalid Name or NMTOKEN value") != std::string::npos
+          || m.find("for attribute 'ID' is invalid Name or NMTOKEN value") != std::string::npos)
         return;
-      string sys(_toString(e.getSystemId()));
+      std::string sys(_toString(e.getSystemId()));
       printout(ERROR,"XercesC","+++ Error at file \"%s\", Line %d Column: %d Message:%s",
                sys.c_str(), int(e.getLineNumber()), int(e.getColumnNumber()), m.c_str());
     }
     /// Fatal error handler
     void DocumentErrorHandler::fatalError(const SAXParseException& e) {
-      string m(_toString(e.getMessage()));
-      string sys(_toString(e.getSystemId()));
+      std::string m(_toString(e.getMessage()));
+      std::string sys(_toString(e.getSystemId()));
       printout(FATAL,"XercesC","+++ FATAL Error at file \"%s\", Line %d Column: %d Message:%s",
                sys.c_str(), int(e.getLineNumber()), int(e.getColumnNumber()), m.c_str());
     }
@@ -171,13 +169,13 @@ namespace dd4hep {
         /// Entity resolver overload to use uri reader
         InputSource *read_uri(XMLResourceIdentifier *id)   {
           if ( m_reader )   {
-            string buf, systemID(_toString(id->getSystemId()));
+            std::string buf, systemID(_toString(id->getSystemId()));
             if ( m_reader->load(systemID, buf) )  {
               const XMLByte* input = (const XMLByte*)XMLString::replicate(buf.c_str());
 #if 0
-              string baseURI(_toString(id->getBaseURI()));
-              string schema(_toString(id->getSchemaLocation()));
-              string ns(_toString(id->getNameSpace()));
+              std::string baseURI(_toString(id->getBaseURI()));
+              std::string schema(_toString(id->getSchemaLocation()));
+              std::string ns(_toString(id->getNameSpace()));
               if ( s_minPrintLevel <= INFO ) {
                 printout(INFO,"XercesC","+++ Resolved URI: sysID:%s uri:%s ns:%s schema:%s",
                          systemID.c_str(), baseURI.c_str(), ns.c_str(), schema.c_str());
@@ -208,7 +206,7 @@ namespace dd4hep {
     }
 
     /// Dump DOM tree using XercesC handles
-    void dumpTree(DOMNode* doc, ostream& os) {
+    void dumpTree(DOMNode* doc, std::ostream& os) {
       if ( doc )  {
         DOMImplementation  *imp = DOMImplementationRegistry::getDOMImplementation(Strng_t("LS"));
         MemBufFormatTarget *tar = new MemBufFormatTarget();
@@ -217,7 +215,7 @@ namespace dd4hep {
         out->setByteStream(tar);
         wrt->getDomConfig()->setParameter(Strng_t("format-pretty-print"), true);
         wrt->write(doc, out);
-        os << tar->getRawBuffer() << endl << flush;
+        os << tar->getRawBuffer() << std::endl << std::flush;
         out->release();
         wrt->release();
         return;
@@ -226,15 +224,15 @@ namespace dd4hep {
     }
 
     /// Dump DOM tree using XercesC handles
-    void dump_doc(DOMDocument* doc, ostream& os) {
+    void dump_doc(DOMDocument* doc, std::ostream& os) {
       dumpTree(doc,os);
     }
     /// Dump DOM tree using XercesC handles
-    void dump_tree(Handle_t elt, ostream& os) {
+    void dump_tree(Handle_t elt, std::ostream& os) {
       dumpTree((DOMNode*)elt.ptr(),os);
     }
     /// Dump DOM tree using XercesC handles
-    void dump_tree(Document doc, ostream& os) {
+    void dump_tree(Document doc, std::ostream& os) {
       dump_doc((DOMDocument*)doc.ptr(),os);
     }
   }
@@ -242,36 +240,36 @@ namespace dd4hep {
 
 #ifdef DD4HEP_NONE
 /// System ID of a given XML entity
-string DocumentHandler::system_path(Handle_t base, const string& fn)   {
-  string path = system_path(base);
-  string dir  = ::dirname((char*)path.c_str());
+std::string DocumentHandler::system_path(Handle_t base, const std::string& fn)   {
+  std::string path = system_path(base);
+  std::string dir  = ::dirname((char*)path.c_str());
   return dir+fn;
 }
 #else
 
-#include "TUri.h"
-#include "TUrl.h"
+#include <TUri.h>
+#include <TUrl.h>
 #endif
 
 /// System ID of a given XML entity
-string DocumentHandler::system_path(Handle_t base, const string& fn)   {
-  string path, dir = system_path(base);
+std::string DocumentHandler::system_path(Handle_t base, const std::string& fn)   {
+  std::string path, dir = system_path(base);
   TUri uri_base(dir.c_str()), uri_rel(fn.c_str());
   TUrl url_base(dir.c_str());
   path = TUri::MergePaths(uri_rel,uri_base);
   TUri final(path.c_str());
   final.Normalise();
-  path = url_base.GetProtocol()+string("://")+final.GetUri().Data();
+  path = url_base.GetProtocol()+std::string("://")+final.GetUri().Data();
   if ( path[path.length()-1]=='/' ) path = path.substr(0,path.length()-1);
   return path;
 }
 
 /// System ID of a given XML entity
-string DocumentHandler::system_path(Handle_t base)   {
+std::string DocumentHandler::system_path(Handle_t base)   {
   DOMElement* elt = (DOMElement*)base.ptr();
-  string path = _toString(elt->getBaseURI());
+  std::string path = _toString(elt->getBaseURI());
   if ( path[0] == '/' )  {
-    string tmp = "file:"+path;
+    std::string tmp = "file:"+path;
     return tmp;
   }
   return path;
@@ -279,7 +277,7 @@ string DocumentHandler::system_path(Handle_t base)   {
 
 /// Load secondary XML file with relative addressing with respect to handle
 Document DocumentHandler::load(Handle_t base, const XMLCh* fname, UriReader* reader) const {
-  string path;
+  std::string path;
   DOMElement* elt = (DOMElement*)base.ptr();
   try  {
     Document doc;
@@ -294,21 +292,21 @@ Document DocumentHandler::load(Handle_t base, const XMLCh* fname, UriReader* rea
     }
     return load(path, reader);
   }
-  catch(const exception& exc)   {
-    string b = _toString(elt->getBaseURI());
-    string e = _toString(fname);
+  catch(const std::exception& exc)   {
+    std::string b = _toString(elt->getBaseURI());
+    std::string e = _toString(fname);
     printout(DEBUG,"DocumentHandler","+++ URI exception: %s -> %s [%s]",b.c_str(),e.c_str(),exc.what());
   }
   catch(...)   {
-    string b = _toString(elt->getBaseURI());
-    string e = _toString(fname);
+    std::string b = _toString(elt->getBaseURI());
+    std::string e = _toString(fname);
     printout(DEBUG,"DocumentHandler","+++ URI exception: %s -> %s",b.c_str(),e.c_str());
   }
   if ( reader )   {
-    string buf, sys = system_path(base,fname);
+    std::string buf, sys = system_path(base,fname);
 #if 0
-    string buf, sys, dir = _toString(elt->getBaseURI());
-    string fn = _toString(fname);
+    std::string buf, sys, dir = _toString(elt->getBaseURI());
+    std::string fn = _toString(fname);
     dir = ::dirname((char*)dir.c_str());
     while( fn.substr(0,3) == "../" )  {
       dir = ::dirname((char*)dir.c_str());
@@ -329,21 +327,21 @@ Document DocumentHandler::load(Handle_t base, const XMLCh* fname, UriReader* rea
 }
 
 /// Load XML file and parse it using URI resolver to read data.
-Document DocumentHandler::load(const string& fname, UriReader* reader) const   {
-  string path;
+Document DocumentHandler::load(const std::string& fname, UriReader* reader) const   {
+  std::string path;
   printout(DEBUG,"DocumentHandler","+++ Loading document URI: %s",fname.c_str());
   try  {
     size_t idx = fname.find(':');
     size_t idq = fname.find('/');
-    if ( idq == string::npos ) idq = 0;
-    XMLURL xerurl = (const XMLCh*) Strng_t(idx==string::npos || idx>idq ? "file:"+fname : fname);
-    string proto  = _toString(xerurl.getProtocolName());
+    if ( idq == std::string::npos ) idq = 0;
+    XMLURL xerurl = (const XMLCh*) Strng_t(idx==std::string::npos || idx>idq ? "file:"+fname : fname);
+    std::string proto  = _toString(xerurl.getProtocolName());
     path = _toString(xerurl.getPath());
     printout(DEBUG,"DocumentHandler","+++             protocol:%s path:%s",proto.c_str(), path.c_str());
   }
   catch(...)   {
   }
-  unique_ptr < XercesDOMParser > parser(make_parser(reader));
+  std::unique_ptr < XercesDOMParser > parser(make_parser(reader));
   try {
     if ( !path.empty() )  {
       parser->parse(path.c_str());
@@ -358,13 +356,13 @@ Document DocumentHandler::load(const string& fname, UriReader* reader) const   {
       return (XmlDocument*)0;
     }
   }
-  catch (const exception& e) {
+  catch (const std::exception& e) {
     printout(ERROR,"DocumentHandler","+++ Exception(XercesC): parse(path):%s",e.what());
     try {
       parser->parse(fname.c_str());
       if ( reader ) reader->parserLoaded(path);
     }
-    catch (const exception& ex) {
+    catch (const std::exception& ex) {
       printout(FATAL,"DocumentHandler","+++ Exception(XercesC): parse(URI):%s",ex.what());
       throw;
     }
@@ -375,7 +373,7 @@ Document DocumentHandler::load(const string& fname, UriReader* reader) const   {
 
 /// Parse a standalong XML string into a document.
 Document DocumentHandler::parse(const char* bytes, size_t length, const char* sys_id, UriReader* rdr) const {
-  unique_ptr < XercesDOMParser > parser(make_parser(rdr));
+  std::unique_ptr < XercesDOMParser > parser(make_parser(rdr));
   MemBufInputSource src((const XMLByte*)bytes, length, sys_id, false);
   parser->parse(src);
   DOMDocument* doc = parser->adoptDocument();
@@ -385,7 +383,7 @@ Document DocumentHandler::parse(const char* bytes, size_t length, const char* sy
 }
 
 /// Write xml document to output file (stdout if file name empty)
-int DocumentHandler::output(Document doc, const string& fname) const {
+int DocumentHandler::output(Document doc, const std::string& fname) const {
   XMLFormatTarget *tar = 0;
   DOMImplementation *imp = DOMImplementationRegistry::getDOMImplementation(Strng_t("LS"));
   DOMLSOutput *out = imp->createLSOutput();
@@ -394,7 +392,7 @@ int DocumentHandler::output(Document doc, const string& fname) const {
   if (fname.empty())
     tar = new StdOutFormatTarget();
   else   {
-    string fn = undressed_file_name(fname);
+    std::string fn = undressed_file_name(fname);
     tar = new LocalFileFormatTarget(Strng_t(fn));
   }
   out->setByteStream(tar);
@@ -408,7 +406,7 @@ int DocumentHandler::output(Document doc, const string& fname) const {
 
 #else
 
-#include "XML/tinyxml.h"
+#include <XML/tinyxml.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -434,7 +432,7 @@ namespace dd4hep {
   }}
 
 namespace {
-  static string _clean_fname(const string& s) {
+  static std::string _clean_fname(const std::string& s) {
     std::string const& temp = getEnviron(s);
     std::string temp2 = undressed_file_name(temp.empty() ? s : temp);
     if ( strncmp(temp2.c_str(),"file:",5)==0 ) return temp2.substr(5);
@@ -443,13 +441,13 @@ namespace {
 }
 
 /// System ID of a given XML entity
-string DocumentHandler::system_path(Handle_t base, const string& fname)   {
-  string fn, clean = _clean_fname(fname);
+std::string DocumentHandler::system_path(Handle_t base, const std::string& fname)   {
+  std::string fn, clean = _clean_fname(fname);
   struct stat st;
   Element elt(base);
   // Poor man's URI handling. Xerces is much much better here
   if ( elt ) {
-    string bn = Xml(elt.document()).d->Value();
+    std::string bn = Xml(elt.document()).d->Value();
 #ifdef _WIN32
     char drive[_MAX_DRIVE], dir[_MAX_DIR], file[_MAX_FNAME], ext[_MAX_EXT];
     ::_splitpath(bn.c_str(),drive,dir,file,ext);
@@ -472,8 +470,8 @@ string DocumentHandler::system_path(Handle_t base, const string& fname)   {
 }
 
 /// System ID of a given XML entity
-string DocumentHandler::system_path(Handle_t base)   {
-  string fn;
+std::string DocumentHandler::system_path(Handle_t base)   {
+  std::string fn;
   Element elt(base);
   // Poor man's URI handling. Xerces is much much better here
   if ( elt ) {
@@ -484,7 +482,7 @@ string DocumentHandler::system_path(Handle_t base)   {
 
 /// Load XML file and parse it using URI resolver to read data.
 Document DocumentHandler::load(const std::string& fname, UriReader* reader) const  {
-  string clean = _clean_fname(fname);
+  std::string clean = _clean_fname(fname);
   if ( reader )   {
     printout(WARNING,"DocumentHandler","+++ Loading document URI: %s %s",
              fname.c_str(),"[URI Resolution is not supported by TiXML]");
@@ -526,7 +524,7 @@ Document DocumentHandler::load(const std::string& fname, UriReader* reader) cons
 
 /// Load XML file and parse it using URI resolver to read data.
 Document DocumentHandler::load(Handle_t base, const XmlChar* fname, UriReader* reader) const  {
-  string path = system_path(base, fname);
+  std::string path = system_path(base, fname);
   return load(path,reader);
 }
 
@@ -543,7 +541,7 @@ Document DocumentHandler::parse(const char* bytes, size_t length, const char* /*
       size_t len = length;
       // TiXml does not support white spaces at the end. Check and remove.
       if ( str_len+1 != len || bytes[str_len] != 0 || ::isspace(bytes[str_len-1]) )   {
-        unique_ptr<char[]> data(new char[len+1]);
+        std::unique_ptr<char[]> data(new char[len+1]);
         char* buff = data.get();
         try  {
           ::memcpy(buff, bytes, len+1);
@@ -567,13 +565,13 @@ Document DocumentHandler::parse(const char* bytes, size_t length, const char* /*
         printout(FATAL,"DocumentHandler",
                  "+++ XML Document error: %s Location Line:%d Column:%d",
                  doc->Value(), doc->ErrorRow(), doc->ErrorCol());
-        throw runtime_error(string("dd4hep: ")+doc->ErrorDesc());
+        throw std::runtime_error(std::string("dd4hep: ")+doc->ErrorDesc());
       }
-      throw runtime_error("dd4hep: Unknown error while parsing XML document string with TiXml.");
+      throw std::runtime_error("dd4hep: Unknown error while parsing XML document string with TiXml.");
     }
-    throw runtime_error("dd4hep: FAILED to parse invalid document string [NULL] with TiXml.");
+    throw std::runtime_error("dd4hep: FAILED to parse invalid document string [NULL] with TiXml.");
   }
-  catch(exception& e) {
+  catch(std::exception& e) {
     printout(ERROR,"DocumentHandler","+++ Exception (TinyXML): parse(string):%s",e.what());
   }
   delete doc;
@@ -581,8 +579,8 @@ Document DocumentHandler::parse(const char* bytes, size_t length, const char* /*
 }
 
 /// Write xml document to output file (stdout if file name empty)
-int DocumentHandler::output(Document doc, const string& fname) const {
-  string fn = undressed_file_name(fname);
+int DocumentHandler::output(Document doc, const std::string& fname) const {
+  std::string fn = undressed_file_name(fname);
   FILE* file = fn.empty() ? stdout : ::fopen(fn.c_str(),"w");
   if ( !file ) {
     printout(ERROR,"DocumentHandler","+++ Failed to open output file: %s",fname.c_str());
@@ -595,7 +593,7 @@ int DocumentHandler::output(Document doc, const string& fname) const {
 }
 
 /// Dump partial or full XML trees
-void dd4hep::xml::dump_tree(Handle_t elt, ostream& os) {
+void dd4hep::xml::dump_tree(Handle_t elt, std::ostream& os) {
   TiXmlNode* node = (TiXmlNode*)elt.ptr();
   TiXmlPrinter printer;
   printer.SetStreamPrinting();
@@ -604,7 +602,7 @@ void dd4hep::xml::dump_tree(Handle_t elt, ostream& os) {
 }
 
 /// Dump partial or full XML documents
-void dd4hep::xml::dump_tree(Document doc, ostream& os) {
+void dd4hep::xml::dump_tree(Document doc, std::ostream& os) {
   TiXmlDocument* node = (TiXmlDocument*)doc.ptr();
   TiXmlPrinter printer;
   printer.SetStreamPrinting();
@@ -659,29 +657,29 @@ Document DocumentHandler::parse(const char* bytes, size_t length) const {
 }
 
 /// System ID of a given XML entity
-string DocumentHandler::system_path(Handle_t base, const XmlChar* fname)   {
-  string fn = _toString(fname);
+std::string DocumentHandler::system_path(Handle_t base, const XmlChar* fname)   {
+  std::string fn = _toString(fname);
   return system_path(base, fn);
 }
 
 /// System directory of a given XML entity
-string DocumentHandler::system_directory(Handle_t base, const XmlChar* fname)   {
-  string path = system_path(base,fname);
-  string dir = ::dirname((char*)path.c_str());
+std::string DocumentHandler::system_directory(Handle_t base, const XmlChar* fname)   {
+  std::string path = system_path(base,fname);
+  std::string dir = ::dirname((char*)path.c_str());
   return dir;
 }
 
 /// System directory of a given XML entity
-string DocumentHandler::system_directory(Handle_t base)   {
-  string path = system_path(base);
-  string dir = ::dirname((char*)path.c_str());
+std::string DocumentHandler::system_directory(Handle_t base)   {
+  std::string path = system_path(base);
+  std::string dir = ::dirname((char*)path.c_str());
   return dir;
 }
 
 /// Create new XML document by parsing empty xml buffer
 Document DocumentHandler::create(const char* tag, const char* comment) const {
-  string top(tag);
-  string empty = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n";
+  std::string top(tag);
+  std::string empty = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n";
   empty += "<" + top + "/>\0\0";
   Document doc = parse(empty.c_str(), empty.length() + 1);
   if (comment) {
@@ -698,10 +696,10 @@ Document DocumentHandler::create(const std::string& tag, const std::string& comm
 
 /// Dump partial or full XML trees to stdout
 void dd4hep::xml::dump_tree(Handle_t elt) {
-  dump_tree(elt,cout);
+  dump_tree(elt,std::cout);
 }
 
 /// Dump partial or full XML documents to stdout
 void dd4hep::xml::dump_tree(Document doc) {
-  dump_tree(doc,cout);
+  dump_tree(doc,std::cout);
 }

--- a/DDCore/src/XML/UriReader.cpp
+++ b/DDCore/src/XML/UriReader.cpp
@@ -12,21 +12,19 @@
 //==========================================================================
 
 // Framework include files
-#include "XML/UriReader.h"
-
-using namespace std;
+#include <XML/UriReader.h>
 
 /// Default destructor
 dd4hep::xml::UriReader::~UriReader()   {
 }
 
 /// Resolve a given URI to a string containing the data
-bool dd4hep::xml::UriReader::load(const string& system_id, string& data)   {
+bool dd4hep::xml::UriReader::load(const std::string& system_id, std::string& data)   {
   return this->load(system_id, context(), data);
 }
 
 /// Inform reader about a locally (e.g. by XercesC) handled source load
-void dd4hep::xml::UriReader::parserLoaded(const string& system_id)  {
+void dd4hep::xml::UriReader::parserLoaded(const std::string& system_id)  {
   this->parserLoaded(system_id, context());
 }
 
@@ -57,21 +55,21 @@ bool dd4hep::xml::UriContextReader::isBlocked(const std::string& path)  const  {
 }
 
 /// Resolve a given URI to a string containing the data
-bool dd4hep::xml::UriContextReader::load(const string& system_id, string& data)   {
+bool dd4hep::xml::UriContextReader::load(const std::string& system_id, std::string& data)   {
   return m_reader->load(system_id, context(), data);
 }
 
 /// Resolve a given URI to a string containing the data
-bool dd4hep::xml::UriContextReader::load(const string& system_id, UserContext* ctxt, string& data)   {
+bool dd4hep::xml::UriContextReader::load(const std::string& system_id, UserContext* ctxt, std::string& data)   {
   return m_reader->load(system_id, ctxt, data);
 }
 
 /// Inform reader about a locally (e.g. by XercesC) handled source load
-void dd4hep::xml::UriContextReader::parserLoaded(const string& system_id)  {
+void dd4hep::xml::UriContextReader::parserLoaded(const std::string& system_id)  {
   m_reader->parserLoaded(system_id, context());
 }
 
 /// Inform reader about a locally (e.g. by XercesC) handled source load
-void dd4hep::xml::UriContextReader::parserLoaded(const string& system_id, UserContext* ctxt)  {
+void dd4hep::xml::UriContextReader::parserLoaded(const std::string& system_id, UserContext* ctxt)  {
   m_reader->parserLoaded(system_id, ctxt);
 }

--- a/DDCore/src/XML/Utilities.cpp
+++ b/DDCore/src/XML/Utilities.cpp
@@ -13,19 +13,17 @@
 #ifndef DD4HEP_NONE
 
 // Framework include files
-#include "XML/Utilities.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Plugins.h"
-#include "DD4hep/Detector.h"
-#include "DD4hep/DetFactoryHelper.h"
-#include "Math/Polar2D.h"
+#include <XML/Utilities.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/DetFactoryHelper.h>
+#include <Math/Polar2D.h>
 
 class TObject;
 
-using namespace std;
-using namespace dd4hep;
-using namespace dd4hep::detail;
 using namespace dd4hep::xml::tools;
+using dd4hep::printout;
 
 namespace {
   static constexpr const char* TAG_LIMITSETREF     = "limitsetref";
@@ -40,11 +38,11 @@ namespace {
 }
 
 /// Create layered transformation from xml information
-Transform3D dd4hep::xml::createTransformation(xml::Element e)   {
+dd4hep::Transform3D dd4hep::xml::createTransformation(xml::Element e)   {
   int flag = 0;
   Transform3D position, rotation, result;
   for( xml_coll_t c(e,_U(star)); c; ++c )    {
-    string tag = c.tag();
+    std::string tag = c.tag();
     xml_dim_t x_elt = c;
     if ( tag == "positionRPhiZ" )   {
       if      ( flag == 1 ) result = position  * result;
@@ -82,56 +80,56 @@ Transform3D dd4hep::xml::createTransformation(xml::Element e)   {
 }
 
 /// Create a solid shape using the plugin mechanism from the attributes of the XML element
-Solid dd4hep::xml::createShape(Detector& description,
-                               const std::string& shape_type,
-                               xml::Element element)   {
-  string fac  = shape_type + "__shape_constructor";
+dd4hep::Solid dd4hep::xml::createShape(Detector& description,
+                                       const std::string& shape_type,
+                                       xml::Element element)   {
+  std::string fac  = shape_type + "__shape_constructor";
   xml::Handle_t solid_elt = element;
   Solid solid = Solid(PluginService::Create<TObject*>(fac, &description, &solid_elt));
   if ( !solid.isValid() )  {
     PluginDebug dbg;
     PluginService::Create<TObject*>(fac, &description, &solid_elt);
-    except("xml::createShape","Failed to create solid of type %s [%s]", 
-           shape_type.c_str(),dbg.missingFactory(shape_type).c_str());
+    dd4hep::except("xml::createShape","Failed to create solid of type %s [%s]", 
+                   shape_type.c_str(),dbg.missingFactory(shape_type).c_str());
   }
   return solid;
 }
 
 /// Create a volume using the plugin mechanism from the attributes of the XML element
-Volume dd4hep::xml::createStdVolume(Detector& description, xml::Element element)    {
+dd4hep::Volume dd4hep::xml::createStdVolume(Detector& description, xml::Element element)    {
   xml_dim_t e(element);
   if ( e.hasAttr(_U(material)) )   {
     xml_dim_t x_s = e.child(_U(shape));
-    string    typ = x_s.typeStr();
-    Material  mat = description.material(e.attr<string>(_U(material)));
+    std::string    typ = x_s.typeStr();
+    Material  mat = description.material(e.attr<std::string>(_U(material)));
     Solid     sol = createShape(description, typ, x_s);
     Volume    vol("volume", sol, mat);
-    if ( e.hasAttr(_U(name)) ) vol->SetName(e.attr<string>(_U(name)).c_str());
+    if ( e.hasAttr(_U(name)) ) vol->SetName(e.attr<std::string>(_U(name)).c_str());
     vol.setAttributes(description,e.regionStr(),e.limitsStr(),e.visStr());
     return vol;
   }
   xml_h h = e;
   xml_attr_t a = h.attr_nothrow(_U(type));
   if ( a )   {
-    string typ = h.attr<string>(a);
+    std::string typ = h.attr<std::string>(a);
     if ( typ.substr(1) == "ssembly" )  {
       Assembly vol("assembly");
-      if ( e.hasAttr(_U(name)) ) vol->SetName(e.attr<string>(_U(name)).c_str());
+      if ( e.hasAttr(_U(name)) ) vol->SetName(e.attr<std::string>(_U(name)).c_str());
       vol.setAttributes(description,e.regionStr(),e.limitsStr(),e.visStr());
       return vol;
     }
   }
-  except("xml::createVolume","Failed to create volume. No material specified!");
+  dd4hep::except("xml::createVolume","Failed to create volume. No material specified!");
   return Volume();
 }
 
 /// Create a volume using the plugin mechanism from the attributes of the XML element
-Volume dd4hep::xml::createVolume(Detector& description,
-                                 const std::string& typ,
-                                 xml::Element element)   {
+dd4hep::Volume dd4hep::xml::createVolume(Detector& description,
+                                         const std::string& typ,
+                                         xml::Element element)   {
   if ( !typ.empty() )   {
     xml_dim_t e(element);
-    string fac = typ + "__volume_constructor";
+    std::string fac = typ + "__volume_constructor";
     xml::Handle_t elt = element;
     TObject* obj = PluginService::Create<TObject*>(fac, &description, &elt);
     Volume vol = Volume(dynamic_cast<TGeoVolume*>(obj));
@@ -141,20 +139,20 @@ Volume dd4hep::xml::createVolume(Detector& description,
       except("xml::createShape","Failed to create volume of type %s [%s]", 
              typ.c_str(),dbg.missingFactory(typ).c_str());
     }
-    if ( e.hasAttr(_U(name)) ) vol->SetName(e.attr<string>(_U(name)).c_str());
+    if ( e.hasAttr(_U(name)) ) vol->SetName(e.attr<std::string>(_U(name)).c_str());
     vol.setAttributes(description,e.regionStr(),e.limitsStr(),e.visStr());
     return vol;
   }
-  except("xml::createVolume","Failed to create volume. No materiaWNo type specified!");
+  dd4hep::except("xml::createVolume","Failed to create volume. No materiaWNo type specified!");
   return Volume();
 }
 
-Volume dd4hep::xml::createPlacedEnvelope( dd4hep::Detector& description,
-                                          dd4hep::xml::Handle_t e, 
-                                          dd4hep::DetElement sdet)
+dd4hep::Volume dd4hep::xml::createPlacedEnvelope( dd4hep::Detector& description,
+                                                  dd4hep::xml::Handle_t e, 
+                                                  dd4hep::DetElement sdet)
 {  
   xml_det_t     x_det     = e;
-  string        det_name  = x_det.nameStr();
+  std::string   det_name  = x_det.nameStr();
   
   xml_comp_t    x_env     =  x_det.child( dd4hep::xml::Strng_t("envelope") ) ;
   xml_comp_t    x_shape   =  x_env.child( _U(shape) ); 
@@ -185,23 +183,14 @@ Volume dd4hep::xml::createPlacedEnvelope( dd4hep::Detector& description,
     Box  env_solid = xml_comp_t( x_shape ).createShape();
     
     if( !env_solid.isValid() ){
-      
-      throw std::runtime_error( std::string(" Cannot create envelope volume : ") + x_shape.typeStr() + 
-                                std::string(" for detector " ) + det_name ) ;
+      dd4hep::except("createPlacedEnvelope","Cannot create envelope volume : %s for detector %s.",
+                     x_shape.typeStr(), det_name.c_str());
     }
-
     Material      env_mat   = description.material( x_shape.materialStr() );
-  
     envelope = Volume( det_name+"_envelope", env_solid, env_mat );
   }
-
-
   PlacedVolume  env_pv  ; 
-
-
   Volume        mother = description.pickMotherVolume(sdet);
-
-
   // ---- place the envelope into the mother volume 
   //      only specify transformations given in xml
   //      to allow for optimization 
@@ -223,10 +212,9 @@ Volume dd4hep::xml::createPlacedEnvelope( dd4hep::Detector& description,
   return envelope;
 }
 
-
 void  dd4hep::xml::setDetectorTypeFlag( dd4hep::xml::Handle_t e, dd4hep::DetElement sdet )  {
   xml_det_t     x_det     = e;
-  string        det_name  = x_det.nameStr();
+  std::string   det_name  = x_det.nameStr();
   
   try{
     xml_comp_t  x_dettype = x_det.child( dd4hep::xml::Strng_t("type_flags") ) ;
@@ -245,21 +233,21 @@ void  dd4hep::xml::setDetectorTypeFlag( dd4hep::xml::Handle_t e, dd4hep::DetElem
 
 namespace   {
   template <typename TYPE>
-  std::size_t _propagate(bool      debug,
-                         bool      apply_to_children, 
-                         Volume    vol,
-                         TYPE      item, 
-                         const Volume& (Volume::*apply)(const TYPE&)  const)   {
+  std::size_t _propagate(bool           debug,
+                         bool           apply_to_children, 
+                         dd4hep::Volume vol,
+                         TYPE           item, 
+                         const dd4hep::Volume& (dd4hep::Volume::*apply)(const TYPE&)  const)   {
     std::size_t count = 0;
     if ( !vol->IsAssembly() )  {
-      printout(debug ? ALWAYS : DEBUG,"VolumeConfig", "++ Volume: %s apply setting %s", vol.name(), item.name());
+      printout(debug ? dd4hep::ALWAYS : dd4hep::DEBUG,"VolumeConfig", "++ Volume: %s apply setting %s", vol.name(), item.name());
       (vol.*apply)(item);
       ++count;
     }
     if ( apply_to_children )   {
-      std::set<Volume> handled; 
+      std::set<dd4hep::Volume> handled; 
       for (Int_t idau = 0, ndau = vol->GetNdaughters(); idau < ndau; ++idau)   {
-        Volume v = vol->GetNode(idau)->GetVolume();
+        dd4hep::Volume v = vol->GetNode(idau)->GetVolume();
         if ( handled.find(v) == handled.end() )   {
           handled.insert(v);
           count += _propagate(debug, apply_to_children, v, item, apply);
@@ -268,7 +256,6 @@ namespace   {
     }
     return count;
   }
-
 }
 
 /// Configure volume properties from XML element

--- a/DDCore/src/XML/Utilities.cpp
+++ b/DDCore/src/XML/Utilities.cpp
@@ -20,6 +20,7 @@
 #include <DD4hep/DetFactoryHelper.h>
 #include <Math/Polar2D.h>
 
+// Forward declarations
 class TObject;
 
 using namespace dd4hep::xml::tools;
@@ -174,8 +175,7 @@ dd4hep::Volume dd4hep::xml::createPlacedEnvelope( dd4hep::Detector& description,
     rot = RotationZYX( env_rot.z(),env_rot.y(),env_rot.x() ) ;
   }
 
-  Volume  envelope  ;
-
+  Volume  envelope;
   if(  x_shape.typeStr() == "Assembly" ){
     envelope = Assembly( det_name+"_assembly" ) ;
   } else { 
@@ -183,8 +183,9 @@ dd4hep::Volume dd4hep::xml::createPlacedEnvelope( dd4hep::Detector& description,
     Box  env_solid = xml_comp_t( x_shape ).createShape();
     
     if( !env_solid.isValid() ){
-      dd4hep::except("createPlacedEnvelope","Cannot create envelope volume : %s for detector %s.",
-                     x_shape.typeStr(), det_name.c_str());
+      dd4hep::except("createPlacedEnvelope",
+                     "Cannot create envelope volume : %s for detector %s.",
+                     x_shape.typeStr().c_str(), det_name.c_str());
     }
     Material      env_mat   = description.material( x_shape.materialStr() );
     envelope = Volume( det_name+"_envelope", env_solid, env_mat );

--- a/DDCore/src/XML/XMLElements.cpp
+++ b/DDCore/src/XML/XMLElements.cpp
@@ -34,25 +34,24 @@
 #include <cstdio>
 #include <map>
 
-using namespace std;
 using namespace dd4hep::xml;
 static const size_t INVALID_NODE = ~0U;
 static int          s_float_precision = -1;
 
 // Forward declarations
 namespace dd4hep {
-  std::pair<int, double> _toInteger(const string& value);
-  std::pair<int, double> _toFloatingPoint(const string& value);
-  void   _toDictionary(const string& name, const string& value, const string& typ);
-  string _getEnviron(const string& env);
+  std::pair<int, double> _toInteger(const std::string& value);
+  std::pair<int, double> _toFloatingPoint(const std::string& value);
+  void   _toDictionary(const std::string& name, const std::string& value, const std::string& typ);
+  std::string _getEnviron(const std::string& env);
 }
 
 // Static storage
 namespace {
   bool s_resolve_environment = true;
-  string _checkEnviron(const string& env)  {
+  std::string _checkEnviron(const std::string& env)  {
     if ( s_resolve_environment )  {
-      string r = dd4hep::_getEnviron(env);
+      std::string r = dd4hep::_getEnviron(env);
       return r.empty() ? env : r;
     }
     return env;
@@ -163,12 +162,12 @@ namespace {
   size_t node_count(XmlElement* e, const Tag_t& t) {
     size_t cnt = 0;
     if ( e )  {
-      const string& tag = t;
+      const std::string& tag = t;
       xercesc::DOMElement *ee = Xml(e).e;
       if ( ee )  {
         for(xercesc::DOMElement* elt=ee->getFirstElementChild(); elt; elt=elt->getNextElementSibling()) {
           if ( elt->getParentNode() == ee )   {
-            string child_tag = _toString(elt->getTagName());
+            std::string child_tag = _toString(elt->getTagName());
             if ( tag == "*" || child_tag == tag ) ++cnt;
           }
         }
@@ -178,13 +177,13 @@ namespace {
   }
   XmlElement* node_first(XmlElement* e, const Tag_t& t) {
     if ( e )  {
-      const string& tag = t;
+      const std::string& tag = t;
       xercesc::DOMElement* ee = Xml(e).e;
       if ( ee )  {
         for(xercesc::DOMElement* elt=ee->getFirstElementChild(); elt; elt=elt->getNextElementSibling()) {
           if ( elt->getParentNode() == ee )   {
             if ( tag == "*" ) return _XE(elt);
-            string child_tag = _toString(elt->getTagName());
+            std::string child_tag = _toString(elt->getTagName());
             if ( child_tag == tag ) return _XE(elt);
           }
         }
@@ -195,9 +194,9 @@ namespace {
 }
 
 /// Convert XML char to std::string
-string dd4hep::xml::_toString(const XmlChar *toTranscode) {
+std::string dd4hep::xml::_toString(const XmlChar *toTranscode) {
   char *buff = XmlString::transcode(toTranscode);
-  string tmp(buff == 0 ? "" : buff);
+  std::string tmp(buff == 0 ? "" : buff);
   XmlString::release(&buff);
   if ( tmp.length()<3 ) return tmp;
   if ( !(tmp[0] == '$' && tmp[1] == '{') ) return tmp;
@@ -232,54 +231,54 @@ int dd4hep::xml::get_float_precision()    {
 }
 
 /// Convert attribute value to string
-string dd4hep::xml::_toString(Attribute attr) {
+std::string dd4hep::xml::_toString(Attribute attr) {
   if (attr)
     return _toString(attribute_value(attr));
   return "";
 }
 
-template <typename T> static inline string __to_string(T value, const char* fmt) {
+template <typename T> static inline std::string __to_string(T value, const char* fmt) {
   char text[128];
   ::snprintf(text, sizeof(text), fmt, value);
   return text;
 }
 
 /// Do-nothing version. Present for completeness and argument interchangeability
-string dd4hep::xml::_toString(const char* s) {
+std::string dd4hep::xml::_toString(const char* s) {
   if ( !s || *s == 0 ) return "";
   else if ( !(*s == '$' && *(s+1) == '{') ) return s;
   return _checkEnviron(s);
 }
 
 /// Do-nothing version. Present for completeness and argument interchangeability
-string dd4hep::xml::_toString(const string& s) {
+std::string dd4hep::xml::_toString(const std::string& s) {
   if ( s.length() < 3 || s[0] != '$' ) return s;
   else if ( !(s[0] == '$' && s[1] == '{') ) return s;
   return _checkEnviron(s);
 }
 
 /// Format unsigned long integer to string with arbitrary format
-string dd4hep::xml::_toString(unsigned long v, const char* fmt) {
+std::string dd4hep::xml::_toString(unsigned long v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
 /// Format unsigned integer (32 bits) to string with arbitrary format
-string dd4hep::xml::_toString(unsigned int v, const char* fmt) {
+std::string dd4hep::xml::_toString(unsigned int v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
 /// Format signed integer (32 bits) to string with arbitrary format
-string dd4hep::xml::_toString(int v, const char* fmt) {
+std::string dd4hep::xml::_toString(int v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
 /// Format signed long integer to string with arbitrary format
-string dd4hep::xml::_toString(long v, const char* fmt)   {
+std::string dd4hep::xml::_toString(long v, const char* fmt)   {
   return __to_string(v, fmt);
 }
 
 /// Format single procision float number (32 bits) to string with arbitrary format
-string dd4hep::xml::_toString(float v, const char* fmt) {
+std::string dd4hep::xml::_toString(float v, const char* fmt) {
   if ( s_float_precision >= 0 )   {
     char format[32];
     ::snprintf(format, sizeof(format), "%%.%de", s_float_precision);
@@ -289,7 +288,7 @@ string dd4hep::xml::_toString(float v, const char* fmt) {
 }
 
 /// Format double procision float number (64 bits) to string with arbitrary format
-string dd4hep::xml::_toString(double v, const char* fmt) {
+std::string dd4hep::xml::_toString(double v, const char* fmt) {
   if ( s_float_precision >= 0 )   {
     char format[32];
     ::snprintf(format, sizeof(format), "%%.%de", s_float_precision);
@@ -299,23 +298,23 @@ string dd4hep::xml::_toString(double v, const char* fmt) {
 }
 
 /// Convert Strng_t to std::string
-string dd4hep::xml::_toString(const Strng_t& s)   {
+std::string dd4hep::xml::_toString(const Strng_t& s)   {
   return _toString(Tag_t(s));
 }
 
 /// Convert Tag_t to std::string
-string dd4hep::xml::_toString(const Tag_t& s)     {
+std::string dd4hep::xml::_toString(const Tag_t& s)     {
   return s.str();
 }
 
 /// Format pointer to string with arbitrary format
-string dd4hep::xml::_ptrToString(const void* v, const char* fmt) {
+std::string dd4hep::xml::_ptrToString(const void* v, const char* fmt) {
   return __to_string(v, fmt);
 }
 
 long dd4hep::xml::_toLong(const XmlChar* value) {
   if (value) {
-    string s = _toString(value);
+    std::string s = _toString(value);
     return dd4hep::_toInteger(s).second;
   }
   return -1;
@@ -324,8 +323,8 @@ long dd4hep::xml::_toLong(const XmlChar* value) {
 unsigned long dd4hep::xml::_toULong(const XmlChar* value) {
   long val = _toLong(value);
   if ( val >= 0 ) return (unsigned long) val;
-  string s = _toString(value);
-  throw runtime_error("dd4hep: Severe error during expression evaluation of " + s);
+  std::string s = _toString(value);
+  throw std::runtime_error("dd4hep: Severe error during expression evaluation of " + s);
 }
 
 int dd4hep::xml::_toInt(const XmlChar* value)   {
@@ -338,7 +337,7 @@ unsigned int dd4hep::xml::_toUInt(const XmlChar* value) {
 
 bool dd4hep::xml::_toBool(const XmlChar* value) {
   if (value)   {
-    string s = _toString(value);
+    std::string s = _toString(value);
     char   c = ::toupper(s[0]);
     if ( c == 'T' || c == '1' ) return true;
     if ( c == 'F' || c == '0' ) return false;
@@ -349,7 +348,7 @@ bool dd4hep::xml::_toBool(const XmlChar* value) {
 
 float dd4hep::xml::_toFloat(const XmlChar* value) {
   if (value)   {
-    string s = _toString(value);
+    std::string s = _toString(value);
     return (float) dd4hep::_toFloatingPoint(s).second;
   }
   return 0.0;
@@ -357,14 +356,14 @@ float dd4hep::xml::_toFloat(const XmlChar* value) {
 
 double dd4hep::xml::_toDouble(const XmlChar* value) {
   if (value)   {
-    string s = _toString(value);
+    std::string s = _toString(value);
     return dd4hep::_toFloatingPoint(s).second;
   }
   return 0.0;
 }
 
 void dd4hep::xml::_toDictionary(const XmlChar* name, const XmlChar* value) {
-  string n = _toString(name).c_str(), v = _toString(value);
+  std::string n = _toString(name).c_str(), v = _toString(value);
   dd4hep::_toDictionary(n, v, "number");
 }
 
@@ -390,7 +389,7 @@ template void dd4hep::xml::_toDictionary(const XmlChar* name, const char* value)
 #endif
 template void dd4hep::xml::_toDictionary(const XmlChar* name, const Tag_t& value);
 template void dd4hep::xml::_toDictionary(const XmlChar* name, const Strng_t& value);
-template void dd4hep::xml::_toDictionary(const XmlChar* name, const string& value);
+template void dd4hep::xml::_toDictionary(const XmlChar* name, const std::string& value);
 template void dd4hep::xml::_toDictionary(const XmlChar* name, unsigned long value);
 template void dd4hep::xml::_toDictionary(const XmlChar* name, unsigned int value);
 template void dd4hep::xml::_toDictionary(const XmlChar* name, unsigned short value);
@@ -401,7 +400,7 @@ template void dd4hep::xml::_toDictionary(const XmlChar* name, float value);
 template void dd4hep::xml::_toDictionary(const XmlChar* name, double value);
 
 /// Evaluate string constant using environment stored in the evaluator
-string dd4hep::xml::getEnviron(const string& env)   {
+std::string dd4hep::xml::getEnviron(const std::string& env)   {
   return dd4hep::_getEnviron(env);
 }
 
@@ -413,17 +412,17 @@ bool dd4hep::xml::enableEnvironResolution(bool new_value)   {
 }
 
 template <typename B>
-static inline string i_add(const string& a, B b) {
-  string r = a;
+static inline std::string i_add(const std::string& a, B b) {
+  std::string r = a;
   r += b;
   return r;
 }
 
-Strng_t dd4hep::xml::operator+(const Strng_t& a, const string& b) {
+Strng_t dd4hep::xml::operator+(const Strng_t& a, const std::string& b) {
   return _toString(a.ptr()) + b;
 }
 
-Strng_t dd4hep::xml::operator+(const string& a, const Strng_t& b) {
+Strng_t dd4hep::xml::operator+(const std::string& a, const Strng_t& b) {
   return a + _toString(b.ptr());
 }
 
@@ -432,7 +431,7 @@ Strng_t dd4hep::xml::operator+(const Strng_t& a, const char* b) {
 }
 
 Strng_t dd4hep::xml::operator+(const char* a, const Strng_t& b) {
-  return string(a) + _toString(b.ptr());
+  return std::string(a) + _toString(b.ptr());
 }
 
 Strng_t dd4hep::xml::operator+(const Strng_t& a, const Strng_t& b) {
@@ -440,48 +439,48 @@ Strng_t dd4hep::xml::operator+(const Strng_t& a, const Strng_t& b) {
 }
 
 Tag_t dd4hep::xml::operator+(const Tag_t& a, const char* b) {
-  string res = a.str() + b;
+  std::string res = a.str() + b;
   return Tag_t(res);
 }
 
 Tag_t dd4hep::xml::operator+(const char* a, const Tag_t& b) {
-  string res = a + b.str();
+  std::string res = a + b.str();
   return Tag_t(res);
 }
 
 Tag_t dd4hep::xml::operator+(const Tag_t& a, const Strng_t& b) {
-  string res = a.str() + _toString(b);
+  std::string res = a.str() + _toString(b);
   return Tag_t(res);
 }
 
-Tag_t dd4hep::xml::operator+(const Tag_t& a, const string& b) {
-  string res = a.str() + b;
+Tag_t dd4hep::xml::operator+(const Tag_t& a, const std::string& b) {
+  std::string res = a.str() + b;
   return Tag_t(res);
 }
 
 #ifndef DD4HEP_USE_TINYXML
 Strng_t dd4hep::xml::operator+(const Strng_t& a, const XmlChar* b) {
-  string res = _toString(a.ptr()) + _toString(b);
+  std::string res = _toString(a.ptr()) + _toString(b);
   return Tag_t(res);
 }
 
 Strng_t dd4hep::xml::operator+(const XmlChar* a, const Strng_t& b) {
-  string res = _toString(a) + _toString(b.ptr());
+  std::string res = _toString(a) + _toString(b.ptr());
   return Tag_t(res);
 }
 
-Strng_t dd4hep::xml::operator+(const XmlChar* a, const string& b) {
-  string res = _toString(a) + b;
+Strng_t dd4hep::xml::operator+(const XmlChar* a, const std::string& b) {
+  std::string res = _toString(a) + b;
   return Tag_t(res);
 }
 
-Strng_t dd4hep::xml::operator+(const string& a, const XmlChar* b) {
-  string res = a + _toString(b);
+Strng_t dd4hep::xml::operator+(const std::string& a, const XmlChar* b) {
+  std::string res = a + _toString(b);
   return Tag_t(res);
 }
 
 Tag_t dd4hep::xml::operator+(const Tag_t& a, const XmlChar* b) {
-  string res = a.str() + _toString(b);
+  std::string res = a.str() + _toString(b);
   return Tag_t(res);
 }
 
@@ -509,7 +508,7 @@ Strng_t& Strng_t::operator=(const Strng_t& s) {
   return *this;
 }
 
-Strng_t& Strng_t::operator=(const string& s) {
+Strng_t& Strng_t::operator=(const std::string& s) {
   if (m_xml)
     XmlString::release (&m_xml);
   m_xml = XmlString::transcode(s.c_str());
@@ -553,7 +552,7 @@ Tag_t& Tag_t::operator=(const Strng_t& s) {
   return *this;
 }
 
-Tag_t& Tag_t::operator=(const string& s) {
+Tag_t& Tag_t::operator=(const std::string& s) {
   if (m_xml)
     XmlString::release (&m_xml);
   m_xml = XmlString::transcode(s.c_str());
@@ -594,7 +593,7 @@ XmlElement* NodeList::next() const {
   xercesc::DOMElement *elt = Xml(m_ptr).e;
   for(elt=elt->getNextElementSibling(); elt; elt=elt->getNextElementSibling()) {
     if ( m_tag.str() == "*" ) return m_ptr=Xml(elt).xe;
-    string child_tag = _toString(elt->getTagName());
+    std::string child_tag = _toString(elt->getTagName());
     if ( child_tag == m_tag ) return m_ptr=Xml(elt).xe;
   }
   return m_ptr=0;
@@ -611,7 +610,7 @@ XmlElement* NodeList::previous() const {
   xercesc::DOMElement *elt = Xml(m_ptr).e;
   for(elt=elt->getPreviousElementSibling(); elt; elt=elt->getPreviousElementSibling()) {
     if ( m_tag.str()=="*" ) return m_ptr=Xml(elt).xe;
-    string child_tag = _toString(elt->getTagName());
+    std::string child_tag = _toString(elt->getTagName());
     if ( child_tag == m_tag ) return m_ptr=Xml(elt).xe;
   }
   return m_ptr=0;
@@ -652,12 +651,12 @@ Handle_t Handle_t::clone(XmlDocument* new_doc) const {
       XmlElement* e = _XE(_N(m_node)->Clone()->ToElement());
       if ( e ) return e;
     }
-    throw runtime_error("TiXml: Handle_t::clone: Invalid source handle type [No element type].");
+    throw std::runtime_error("TiXml: Handle_t::clone: Invalid source handle type [No element type].");
 #else
     return Elt_t(_D(new_doc)->importNode(_E(m_node), true));
 #endif
   }
-  throw runtime_error("Xml: Handle_t::clone: Invalid source handle.");
+  throw std::runtime_error("Xml: Handle_t::clone: Invalid source handle.");
 }
 
 /// Access the element's parent element
@@ -676,8 +675,8 @@ bool Handle_t::hasAttr(const XmlChar* tag_value) const {
 }
 
 /// Retrieve a collection of all attributes of this DOM element
-vector<Attribute> Handle_t::attributes() const {
-  vector < Attribute > attrs;
+std::vector<Attribute> Handle_t::attributes() const {
+  std::vector < Attribute > attrs;
   if (m_node) {
 #ifdef DD4HEP_USE_TINYXML
     for(TiXmlAttribute* a=_E(m_node)->FirstAttribute(); a; a=a->Next())
@@ -699,12 +698,12 @@ size_t Handle_t::numChildren(const XmlChar* t, bool throw_exception) const {
     return 0;
   else if (n != INVALID_NODE)
     return n;
-  string msg = "Handle_t::numChildren: ";
+  std::string msg = "Handle_t::numChildren: ";
   if (m_node)
     msg += "Element [" + tag() + "] has no children of type '" + _toString(t) + "'";
   else
     msg += "Element [INVALID] has no children of type '" + _toString(t) + "'";
-  throw runtime_error(msg);
+  throw std::runtime_error(msg);
 }
 
 /// Remove a single child node identified by its handle from the tree of the element
@@ -712,12 +711,12 @@ Handle_t Handle_t::child(const XmlChar* t, bool throw_exception) const {
   Elt_t e = node_first(m_node, t);
   if (e || !throw_exception)
     return e;
-  string msg = "Handle_t::child: ";
+  std::string msg = "Handle_t::child: ";
   if (m_node)
     msg += "Element [" + tag() + "] has no child of type '" + _toString(t) + "'";
   else
     msg += "Element [INVALID]. Cannot remove child of type: '" + _toString(t) + "'";
-  throw runtime_error(msg);
+  throw std::runtime_error(msg);
 }
 
 NodeList Handle_t::children(const XmlChar* tag_value) const {
@@ -738,7 +737,7 @@ Handle_t Handle_t::remove(Handle_t node) const {
 #endif
   if (e)
     return node.ptr();
-  string msg = "Handle_t::remove: ";
+  std::string msg = "Handle_t::remove: ";
   if (m_node && node.ptr())
     msg += "Element [" + tag() + "] has no child of type '" + node.tag() + "'";
   else if (node)
@@ -746,7 +745,7 @@ Handle_t Handle_t::remove(Handle_t node) const {
   else if (!node)
     msg += "Element [INVALID]. Cannot remove [INVALID] child. Big Shit!!!!";
 
-  throw runtime_error(msg);
+  throw std::runtime_error(msg);
 }
 
 /// Remove children with a given tag name from the DOM node
@@ -772,7 +771,7 @@ void Handle_t::setValue(const XmlChar* text_value) const {
 }
 
 /// Set the element's value
-void Handle_t::setValue(const string& text_value) const {
+void Handle_t::setValue(const std::string& text_value) const {
 #ifdef DD4HEP_USE_TINYXML
   _N(m_node)->setNodeValue(text_value.c_str());
 #else
@@ -790,7 +789,7 @@ void Handle_t::setText(const XmlChar* text_value) const {
 }
 
 /// Set the element's text
-void Handle_t::setText(const string& text_value) const {
+void Handle_t::setText(const std::string& text_value) const {
 #ifdef DD4HEP_USE_TINYXML
   _N(m_node)->LinkEndChild(new TiXmlText(text_value.c_str()));
 #else
@@ -840,12 +839,12 @@ Attribute Handle_t::attr_ptr(const XmlChar* t) const {
   Attribute a = attribute_node(m_node, t);
   if (0 != a)
     return a;
-  string msg = "Handle_t::attr_ptr: ";
+  std::string msg = "Handle_t::attr_ptr: ";
   if (m_node)
     msg += "Element [" + tag() + "] has no attribute of type '" + _toString(t) + "'";
   else
     msg += "Element [INVALID] has no attribute of type '" + _toString(t) + "'";
-  throw runtime_error(msg);
+  throw std::runtime_error(msg);
 }
 
 /// Access attribute name (throws exception if not present)
@@ -853,7 +852,7 @@ const XmlChar* Handle_t::attr_name(const Attribute a) const {
   if (a) {
     return Xml(a).a->getName();
   }
-  throw runtime_error("Attempt to access invalid XML attribute object!");
+  throw std::runtime_error("Attempt to access invalid XML attribute object!");
 }
 
 /// Access attribute value by the attribute's unicode name (throws exception if not present)
@@ -901,7 +900,7 @@ Attribute Handle_t::setAttr(const XmlChar* name, double val) const {
 }
 
 /// Generic attribute setter with string value
-Attribute Handle_t::setAttr(const XmlChar* name, const string& val) const {
+Attribute Handle_t::setAttr(const XmlChar* name, const std::string& val) const {
   return setAttr(name, Strng_t(val.c_str()));
 }
 
@@ -944,7 +943,7 @@ Handle_t Handle_t::setRef(const XmlChar* tag_value, const XmlChar* ref_name) {
 }
 
 /// Add reference child as a new child node. The obj must have the "name" attribute!
-Handle_t Handle_t::setRef(const XmlChar* tag_value, const string& ref_name) {
+Handle_t Handle_t::setRef(const XmlChar* tag_value, const std::string& ref_name) {
   return setRef(tag_value, Strng_t(ref_name).ptr());
 }
 
@@ -990,13 +989,13 @@ static unsigned int adler32(unsigned int adler, const XmlChar* xml_buff, size_t 
 typedef unsigned int (fcn_t)(unsigned int, const XmlChar*, size_t);
 unsigned int Handle_t::checksum(unsigned int param, fcn_t fcn) const {
 #ifdef DD4HEP_USE_TINYXML
-  typedef map<string, string> StringMap;
+  typedef map<std::string, std::string> StringMap;
   TiXmlNode* n = Xml(m_node).n;
   if ( n ) {
     if ( 0 == fcn ) fcn = adler32;
     switch (n->Type()) {
     case TiXmlNode::ELEMENT: {
-      map<string,string> m;
+      map<std::string,std::string> m;
       TiXmlElement* e = n->ToElement();
       TiXmlAttribute* p=e->FirstAttribute();
       for(; p; p=p->Next()) m.emplace(p->Name(),p->Value());
@@ -1041,7 +1040,7 @@ Handle_t Document::createElt(const XmlChar* tag_value) const {
 Handle_t Document::root() const {
   if (m_doc)
     return _XE(_D(m_doc)->getDocumentElement());
-  throw runtime_error("Document::root: Invalid handle!");
+  throw std::runtime_error("Document::root: Invalid handle!");
 }
 
 /// Acces the document URI
@@ -1050,7 +1049,7 @@ std::string Document::uri() const   {
     Tag_t val(_D(m_doc)->getDocumentURI());
     return val;
   }
-  throw runtime_error("Document::uri: Invalid handle!");
+  throw std::runtime_error("Document::uri: Invalid handle!");
 }
 
 /// Assign new document. Old document is dropped.
@@ -1096,7 +1095,7 @@ Handle_t Element::clone(Handle_t h) const {
   if (m_element && h) {
     return h.clone(Document::DOC(document()));
   }
-  throw runtime_error("Element::clone: Invalid element pointer -- unable to clone node!");
+  throw std::runtime_error("Element::clone: Invalid element pointer -- unable to clone node!");
 }
 
 Attribute Element::getAttr(const XmlChar* name) const {
@@ -1109,7 +1108,7 @@ Attribute Element::setRef(const XmlChar* tag_value, const XmlChar* ref_name) con
 }
 
 /// Set the reference attribute to the node (adds attribute ref="ref-name")
-Attribute Element::setRef(const XmlChar* tag_value, const string& ref_name) const {
+Attribute Element::setRef(const XmlChar* tag_value, const std::string& ref_name) const {
   return setRef(tag_value, Strng_t(ref_name).ptr());
 }
 
@@ -1148,7 +1147,7 @@ void Element::addComment(const char* text_value) const {
 }
 
 /// Add comment node to the element
-void Element::addComment(const string& text_value) const {
+void Element::addComment(const std::string& text_value) const {
   addComment(text_value.c_str());
 }
 
@@ -1177,13 +1176,13 @@ RefElement& RefElement::operator=(const RefElement& e) {
 
 const XmlChar* RefElement::name() const {
   if (0 == m_name)
-    cout << "Error:tag=" << m_element.tag() << endl;
+    std::cout << "Error:tag=" << m_element.tag() << std::endl;
   return attribute_value(m_name);
 }
 
 const XmlChar* RefElement::refName() const {
   if (0 == m_name)
-    cout << "Error:tag=" << m_element.tag() << endl;
+    std::cout << "Error:tag=" << m_element.tag() << std::endl;
   return attribute_value(m_name);
 }
 
@@ -1221,11 +1220,11 @@ size_t Collection_t::size() const {
 }
 
 /// Helper function to throw an exception
-void Collection_t::throw_loop_exception(const exception& e) const {
+void Collection_t::throw_loop_exception(const std::exception& e) const {
   if (m_node) {
-    throw runtime_error(string(e.what()) + "\n" + "dd4hep: Error interpreting XML nodes of type <" + tag() + "/>");
+    throw std::runtime_error(std::string(e.what()) + "\n" + "dd4hep: Error interpreting XML nodes of type <" + tag() + "/>");
   }
-  throw runtime_error(string(e.what()) + "\n" + "dd4hep: Error interpreting collections XML nodes.");
+  throw std::runtime_error(std::string(e.what()) + "\n" + "dd4hep: Error interpreting collections XML nodes.");
 }
 
 void Collection_t::operator++() const {

--- a/DDCore/src/gdml/GdmlPlugins.cpp
+++ b/DDCore/src/gdml/GdmlPlugins.cpp
@@ -33,8 +33,6 @@
 using namespace std;
 using namespace dd4hep;
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,13,0)
-
 /// ROOT GDML reader plugin
 /**
  *  Factory: DD4hep_ROOTGDMLParse
@@ -186,10 +184,8 @@ static long gdml_extract(Detector& description, int argc, char** argv) {
         extract.SetIgnoreDummyMaterial(true);
         extract.SetNamingSpeed(TGDMLWrite::kfastButUglySufix);
         extract.WriteGDMLfile(&description.manager(), de.placement().ptr(), uri.GetRelativePart());
-#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
-        extract.WriteGDMLfile(&description.manager(), de.placement().ptr(), uri.GetRelativePart());
 #else
-        extract.WriteGDMLfile(&description.manager(), de.volume().ptr(), uri.GetRelativePart());
+        extract.WriteGDMLfile(&description.manager(), de.placement().ptr(), uri.GetRelativePart());
 #endif
         return 1;
       }
@@ -235,14 +231,12 @@ static long gdml_extract(Detector& description, int argc, char** argv) {
         TGDMLWrite extract;
         TUri uri(output.c_str());
         description.manager().SetExportPrecision(precision);
-#if   ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
+#if ROOT_VERSION_CODE > ROOT_VERSION(6,27,1)
         extract.SetIgnoreDummyMaterial(true);
         extract.SetNamingSpeed(TGDMLWrite::kfastButUglySufix);
         extract.WriteGDMLfile(&description.manager(), a._node, uri.GetRelativePart());
-#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
-        extract.WriteGDMLfile(&description.manager(), a._node, uri.GetRelativePart());
 #else
-        extract.WriteGDMLfile(&description.manager(), a._node->GetVolume(), uri.GetRelativePart());
+        extract.WriteGDMLfile(&description.manager(), a._node, uri.GetRelativePart());
 #endif
         return 1;
       }
@@ -348,5 +342,3 @@ static Ref_t create_detector(Detector& description, xml_h e, Ref_t /* sens_det *
 
 // first argument is the type from the xml file
 DECLARE_DETELEMENT(DD4hep_GdmlDetector,create_detector)
-
-#endif

--- a/DDCore/src/plugins/CodeGenerator.cpp
+++ b/DDCore/src/plugins/CodeGenerator.cpp
@@ -10,17 +10,17 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#include "DD4hep/Factories.h"
-#include "DD4hep/Shapes.h"
-#include "DD4hep/Volumes.h"
-#include "DD4hep/Detector.h"
-#include "DD4hep/DetElement.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Path.h"
-#include "DD4hep/detail/ObjectsInterna.h"
-#include "DD4hep/detail/DetectorInterna.h"
+#include <DD4hep/Factories.h>
+#include <DD4hep/Shapes.h>
+#include <DD4hep/Volumes.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/DetElement.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Path.h>
+#include <DD4hep/detail/ObjectsInterna.h>
+#include <DD4hep/detail/DetectorInterna.h>
 
 // C/C++ include files
 #include <stdexcept>
@@ -29,15 +29,15 @@
 #include <fstream>
 
 // ROOT includes
-#include "TClass.h"
-#include "TGeoMatrix.h"
-#include "TGeoBoolNode.h"
-#include "TGeoCompositeShape.h"
+#include <TClass.h>
+#include <TGeoMatrix.h>
+#include <TGeoBoolNode.h>
+#include <TGeoCompositeShape.h>
 
-using namespace std;
 using namespace dd4hep;
 
 namespace {
+  
   std::string prefix = "\t";
   std::string sep(",");
 
@@ -55,18 +55,18 @@ namespace {
     Detector& detector;
     Actor(Detector& d) : detector(d) {}
     ~Actor() = default;
-    ostream& handleHeader   (ostream& log);
-    ostream& handleTrailer  (ostream& log);
-    ostream& handleSolid    (ostream& log, const TGeoShape*  sh);
-    ostream& handleMatrix   (ostream& log, TGeoMatrix* mat);
-    ostream& handleMaterial (ostream& log, TGeoMedium* mat);
-    ostream& handlePlacement(ostream& log, TGeoNode*   parent, TGeoNode* node);
-    ostream& handleStructure(ostream& log, DetElement parent, DetElement de);
+    std::ostream& handleHeader   (std::ostream& log);
+    std::ostream& handleTrailer  (std::ostream& log);
+    std::ostream& handleSolid    (std::ostream& log, const TGeoShape*  sh);
+    std::ostream& handleMatrix   (std::ostream& log, TGeoMatrix* mat);
+    std::ostream& handleMaterial (std::ostream& log, TGeoMedium* mat);
+    std::ostream& handlePlacement(std::ostream& log, TGeoNode*   parent, TGeoNode* node);
+    std::ostream& handleStructure(std::ostream& log, DetElement parent, DetElement de);
   };
   typedef void* pvoid_t;
 
-  ostream& newline(ostream& log)    {
-    return log << endl << prefix;
+  std::ostream& newline(std::ostream& log)    {
+    return log << std::endl << prefix;
   }
   template <typename T> const void* pointer(const Handle<T>& h)   {
     return h.ptr();
@@ -74,59 +74,59 @@ namespace {
   template <typename T> const void* pointer(const T* h)   {
     return h;
   }
-  template <typename T> inline string obj_name(const string& pref, const T* ptr)  {
-    stringstream name;
+  template <typename T> inline std::string obj_name(const std::string& pref, const T* ptr)  {
+    std::stringstream name;
     name << pref << "_" << pointer(ptr);
     return name.str();
   }
 
 
-  ostream& Actor::handleHeader   (ostream& log)    {
-    log << "#include \"TClass.h\"" << endl
-        << "#include \"TGeoNode.h\"" << endl
-        << "#include \"TGeoExtension.h\"" << endl
-        << "#include \"TGeoShapeAssembly.h\"" << endl
-        << "#include \"TGeoMedium.h\"" << endl
-        << "#include \"TGeoVolume.h\"" << endl
-        << "#include \"TGeoShape.h\"" << endl
-        << "#include \"TGeoPhysicalNode.h\"" << endl
-        << "#include \"TGeoCone.h\"" << endl
-        << "#include \"TGeoParaboloid.h\"" << endl
-        << "#include \"TGeoPgon.h\"" << endl
-        << "#include \"TGeoPcon.h\"" << endl
-        << "#include \"TGeoSphere.h\"" << endl
-        << "#include \"TGeoArb8.h\"" << endl
-        << "#include \"TGeoTrd1.h\"" << endl
-        << "#include \"TGeoTrd2.h\"" << endl
-        << "#include \"TGeoTube.h\"" << endl
-        << "#include \"TGeoEltu.h\"" << endl
-        << "#include \"TGeoXtru.h\"" << endl
-        << "#include \"TGeoHype.h\"" << endl
-        << "#include \"TGeoTorus.h\"" << endl
-        << "#include \"TGeoHalfSpace.h\"" << endl
-        << "#include \"TGeoCompositeShape.h\"" << endl
-        << "#include \"TGeoShapeAssembly.h\"" << endl
-        << "#include \"TGeoMatrix.h\"" << endl
-        << "#include \"TGeoBoolNode.h\"" << endl
-        << "#include \"TGeoCompositeShape.h\"" << endl
-        << "#include \"TGeoManager.h\"" << endl << endl
-        << "#include \"DD4hep/Factories.h\"" << endl
-        << "#include \"DD4hep/Shapes.h\"" << endl
-        << "#include \"DD4hep/Volumes.h\"" << endl
-        << "#include \"DD4hep/Detector.h\"" << endl
-        << "#include \"DD4hep/DetElement.h\"" << endl
-        << "#include \"DD4hep/MatrixHelpers.h\"" << endl
-        << "#include \"DD4hep/DD4hepUnits.h\"" << endl
-        << "#include \"DD4hep/Printout.h\"" << endl
-        << "#include \"DD4hep/Path.h\"" << endl
-        << "#include \"DD4hep/detail/ObjectsInterna.h\"" << endl
-        << "#include \"DD4hep/detail/DetectorInterna.h\"" << endl
-        << "#include <vector>" << endl
-        << "#include <map>" << endl
-        << "#include <set>" << endl << endl << endl;
-    log << "using namespace std;" << endl;
-    log << "using namespace dd4hep;" << endl;
-    log << "extern PlacedVolume _addNode(TGeoVolume* par, TGeoVolume* daughter, int id, TGeoMatrix* transform);" << endl;
+  std::ostream& Actor::handleHeader   (std::ostream& log)    {
+    log << "#include \"TClass.h\"" << std::endl
+        << "#include \"TGeoNode.h\"" << std::endl
+        << "#include \"TGeoExtension.h\"" << std::endl
+        << "#include \"TGeoShapeAssembly.h\"" << std::endl
+        << "#include \"TGeoMedium.h\"" << std::endl
+        << "#include \"TGeoVolume.h\"" << std::endl
+        << "#include \"TGeoShape.h\"" << std::endl
+        << "#include \"TGeoPhysicalNode.h\"" << std::endl
+        << "#include \"TGeoCone.h\"" << std::endl
+        << "#include \"TGeoParaboloid.h\"" << std::endl
+        << "#include \"TGeoPgon.h\"" << std::endl
+        << "#include \"TGeoPcon.h\"" << std::endl
+        << "#include \"TGeoSphere.h\"" << std::endl
+        << "#include \"TGeoArb8.h\"" << std::endl
+        << "#include \"TGeoTrd1.h\"" << std::endl
+        << "#include \"TGeoTrd2.h\"" << std::endl
+        << "#include \"TGeoTube.h\"" << std::endl
+        << "#include \"TGeoEltu.h\"" << std::endl
+        << "#include \"TGeoXtru.h\"" << std::endl
+        << "#include \"TGeoHype.h\"" << std::endl
+        << "#include \"TGeoTorus.h\"" << std::endl
+        << "#include \"TGeoHalfSpace.h\"" << std::endl
+        << "#include \"TGeoCompositeShape.h\"" << std::endl
+        << "#include \"TGeoShapeAssembly.h\"" << std::endl
+        << "#include \"TGeoMatrix.h\"" << std::endl
+        << "#include \"TGeoBoolNode.h\"" << std::endl
+        << "#include \"TGeoCompositeShape.h\"" << std::endl
+        << "#include \"TGeoManager.h\"" << std::endl << std::endl
+        << "#include \"DD4hep/Factories.h\"" << std::endl
+        << "#include \"DD4hep/Shapes.h\"" << std::endl
+        << "#include \"DD4hep/Volumes.h\"" << std::endl
+        << "#include \"DD4hep/Detector.h\"" << std::endl
+        << "#include \"DD4hep/DetElement.h\"" << std::endl
+        << "#include \"DD4hep/MatrixHelpers.h\"" << std::endl
+        << "#include \"DD4hep/DD4hepUnits.h\"" << std::endl
+        << "#include \"DD4hep/Printout.h\"" << std::endl
+        << "#include \"DD4hep/Path.h\"" << std::endl
+        << "#include \"DD4hep/detail/ObjectsInterna.h\"" << std::endl
+        << "#include \"DD4hep/detail/DetectorInterna.h\"" << std::endl
+        << "#include <vector>" << std::endl
+        << "#include <map>" << std::endl
+        << "#include <set>" << std::endl << std::endl << std::endl;
+    log << "using namespace std;" << std::endl;
+    log << "using namespace dd4hep;" << std::endl;
+    log << "extern PlacedVolume _addNode(TGeoVolume* par, TGeoVolume* daughter, int id, TGeoMatrix* transform);" << std::endl;
 
     log << "namespace  {" << newline
         << "\t struct CodeGeo  {" << newline
@@ -143,8 +143,8 @@ namespace {
         << "\t\t void add_vis(Detector& d, VisAttr& v)  {" << newline
         << "\t\t  try { d.add(v); } catch(...) {}" << newline
         << "\t\t }" << newline
-        << "\t };" << endl
-        << "}" << endl << endl << endl;
+        << "\t };" << std::endl
+        << "}" << std::endl << std::endl << std::endl;
     log << "TGeoVolume* CodeGeo::load_geometry()   {" << newline;
 
     const auto& constants = detector.constants();
@@ -177,8 +177,8 @@ namespace {
     for(const auto& o : limits)    {
       LimitSet ls = o.second;
       log << "{ LimitSet ls(string(\"" << ls.name() << "\")); " << newline;
-      const set<Limit>& lims = ls.limits();
-      const set<Limit>& cuts = ls.cuts();
+      const std::set<Limit>& lims = ls.limits();
+      const std::set<Limit>& cuts = ls.cuts();
       for(const auto& l : lims)   {
         log << "  { Limit l; l.particles = \"" << l.particles << "\";"
             << " l.name = \""    << l.name << "\";"
@@ -257,7 +257,7 @@ namespace {
     return log;
   }
 
-  ostream& Actor::handleTrailer   (ostream& log)    {
+  std::ostream& Actor::handleTrailer   (std::ostream& log)    {
     log << "static long generate_dd4hep(Detector& detector, int, char**)   {" << newline
         << "CodeGeo gen(detector);"                     << newline
         << "TGeoVolume* vol_top = gen.load_geometry();" << newline
@@ -271,19 +271,19 @@ namespace {
           << "gen.load_structure();" << newline;
     }
     log << "return 1;"
-        << endl << "}"  << endl     << endl
+        << std::endl << "}"  << std::endl     << std::endl
         << "DECLARE_APPLY(DD4hep_Run_" << function << ", generate_dd4hep)"
-        << endl;
+        << std::endl;
     return log;
   }
   
-  ostream& Actor::handleStructure(ostream& log, DetElement parent, DetElement de)   {
+  std::ostream& Actor::handleStructure(std::ostream& log, DetElement parent, DetElement de)   {
     if ( de.isValid() && detelements.find(de) == detelements.end() )  {
-      string name = obj_name("de", de.ptr());
+      std::string name = obj_name("de", de.ptr());
       detelements.emplace(de,name);
       if ( !parent.isValid() )   {
-        cout << "No parent: " << de.path() << " " << pointer(de) << " " << pointer(detector.world()) << endl;
-        log << endl
+        std::cout << "No parent: " << de.path() << " " << pointer(de) << " " << pointer(detector.world()) << std::endl;
+        log << std::endl
             << "DetElement  CodeGeo::load_structure()   {" << newline;
       }
       else  {
@@ -297,7 +297,7 @@ namespace {
           log << "\t de.setPlacement(placements[" << pointer(de.placement()) << "]);" << newline;
         }
         else  {
-          cout << "Placement od DetElement " << de.path() << " Is not valid! [Ignored]" << endl;
+          std::cout << "Placement od DetElement " << de.path() << " Is not valid! [Ignored]" << std::endl;
         }
         log << "\t structure[" << pointer(de) << "] = de; " << newline
             << "}"   << newline;
@@ -306,20 +306,20 @@ namespace {
         handleStructure(log, de, d.second);
       }
       if ( !parent.isValid() )   {
-        log << "return structure[" << pointer(de) << "];" << endl
-            << "}" << endl << endl;
+        log << "return structure[" << pointer(de) << "];" << std::endl
+            << "}" << std::endl << std::endl;
       }
     }
     return log;
   }
 
-  ostream& Actor::handlePlacement(ostream& log, TGeoNode* parent, TGeoNode* node)  {
+  std::ostream& Actor::handlePlacement(std::ostream& log, TGeoNode* parent, TGeoNode* node)  {
     if ( node && placements.find(node) == placements.end() )  {
       PlacedVolume pv(node);
       TGeoVolume* vol = node->GetVolume();
       TGeoMatrix* mat = node->GetMatrix();
 
-      string name = obj_name("vol", vol);
+      std::string name = obj_name("vol", vol);
       placements.emplace(node,name);
 
       handleMatrix(log, mat);
@@ -374,16 +374,16 @@ namespace {
         handlePlacement(log, node, daughter);
       }
       if ( !parent )  {
-        log << "return volumes[" << pointer(vol) << "];" << endl
-            << "}" << endl << endl << endl;
+        log << "return volumes[" << pointer(vol) << "];" << std::endl
+            << "}" << std::endl << std::endl << std::endl;
       }
     }
     return log;
   }
 
-  ostream& Actor::handleMaterial(ostream& log, TGeoMedium* medium)   {
+  std::ostream& Actor::handleMaterial(std::ostream& log, TGeoMedium* medium)   {
     if ( medium && materials.find(medium) == materials.end() )  {
-      string name = obj_name("material",medium);
+      std::string name = obj_name("material",medium);
       materials.emplace(medium,name);
       TGeoMaterial* material = medium->GetMaterial();
       log << "{" << newline
@@ -404,9 +404,9 @@ namespace {
     return log;
   }
   
-  ostream& Actor::handleMatrix(ostream& log, TGeoMatrix* mat)   {
+  std::ostream& Actor::handleMatrix(std::ostream& log, TGeoMatrix* mat)   {
     if ( mat && matrices.find(mat) == matrices.end() )  {
-      string name = obj_name("matrix",mat);
+      std::string name = obj_name("matrix",mat);
       log << "{" << newline
           << "\t TGeoHMatrix* mat = new TGeoHMatrix(\"" << mat->GetName() << "\");" << newline
           << "\t matrices[" << pointer(mat) << "] = mat;" << newline;
@@ -445,8 +445,8 @@ namespace {
   }
   
   /// Pretty print of solid attributes
-  ostream& Actor::handleSolid(ostream& log,  const TGeoShape* shape)    {
-    string name = obj_name("solid", shape);
+  std::ostream& Actor::handleSolid(std::ostream& log,  const TGeoShape* shape)    {
+    std::string name = obj_name("solid", shape);
 
     if ( shapes.find(shape) != shapes.end() )  {
       return log;
@@ -623,7 +623,7 @@ namespace {
     else if (cl == TGeoXtru::Class()) {
       Solid sol(shape);
       const TGeoXtru* sh = (const TGeoXtru*) shape;
-      vector<double> pars = sol.dimensions();
+      std::vector<double> pars = sol.dimensions();
       log << "double param[] = {" << newline;
       for( size_t i=0; i < pars.size(); ++i )
         log << pars[i] << ((i+1<pars.size()) ? ',' : ' ');
@@ -662,7 +662,7 @@ namespace {
 }
 
 static long generate_cxx(Detector& description, int argc, char** argv) {
-  string output;
+  std::string output;
   Actor actor(description);
 
   for(int i=0; i<argc; ++i)  {
@@ -679,19 +679,19 @@ static long generate_cxx(Detector& description, int argc, char** argv) {
     else if ( c == 's' )
       actor.dump_structure = true;
     else   {
-      cout <<
+      std::cout <<
         "Usage: -plugin DD4hep_CxxRootGenerator -arg [-arg]                                  \n"
         "     -output   <string> Set output file for generated code. Default: stdout         \n"
         "     -help              Show thi help message                                       \n"
-        "\tArguments given: " << arguments(argc,argv) << endl << flush;
+        "\tArguments given: " << arguments(argc,argv) << std::endl << std::flush;
       ::exit(EINVAL);
     }
   }
-  unique_ptr<ofstream> out;
-  ostream* os = &cout;
+  std::unique_ptr<std::ofstream> out;
+  std::ostream* os = &std::cout;
   if ( !output.empty() )   {
     Path path(output);
-    out.reset(new ofstream(path.c_str()));
+    out.reset(new std::ofstream(path.c_str()));
     if ( !out->good() )   {
       out.reset();
       except("CxxRootGenerator",
@@ -700,7 +700,7 @@ static long generate_cxx(Detector& description, int argc, char** argv) {
     }
     os = out.get();
     actor.function = path.filename();
-    if ( actor.function.rfind('.') != string::npos )
+    if ( actor.function.rfind('.') != std::string::npos )
       actor.function = actor.function.substr(0, actor.function.rfind('.'));
     printout(INFO, "CxxRootGenerator",
              "++ Dump generated code to output files: %s [function: %s()]",

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -793,7 +793,8 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
     description.manager().AddGDMLMatrix(table);
   }
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,31,1)
-  /// In case there were constant surface properties specified: convert them here
+  //
+  // In case there were constant surface properties specified: convert them here
   for(xml_coll_t properties(e, _U(constant)); properties; ++properties) {
     xml_elt_t p = properties;
     pname = p.attr<string>(_U(name));
@@ -830,6 +831,7 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
                surf->GetName(), pname.c_str(), ptyp.c_str());
     }
   }
+#endif
 }
 
 /** Convert compact constant property (Material properties stored in TGeoManager)

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -41,12 +41,8 @@
 // Root/TGeo include files
 #include <TGeoManager.h>
 #include <TGeoMaterial.h>
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,12,0)
 #include <TGeoPhysicalConstants.h>
-#endif
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
 #include <TGDMLMatrix.h>
-#endif
 #include <TMath.h>
 
 // C/C++ include files
@@ -93,11 +89,9 @@ namespace dd4hep {
   template <> void Converter<Property>::operator()(xml_h element) const;
   template <> void Converter<CartesianField>::operator()(xml_h element) const;
   template <> void Converter<SensitiveDetector>::operator()(xml_h element) const;
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   template <> void Converter<OpticalSurface>::operator()(xml_h element) const;
   template <> void Converter<PropertyTable>::operator()(xml_h element) const;
   template <> void Converter<PropertyConstant>::operator()(xml_h element) const;
-#endif
   template <> void Converter<DetElement>::operator()(xml_h element) const;
   template <> void Converter<STD_Conditions>::operator()(xml_h element) const;
   template <> void Converter<IncludeFile>::operator()(xml_h element) const;
@@ -516,10 +510,8 @@ template <> void Converter<Material>::operator()(xml_h e) const {
              matname, dens_val, temp_val/dd4hep::kelvin, pressure_val/dd4hep::pascal/100.0);
 
     mix->SetRadLen(0e0);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,12,0)
     mix->ComputeDerivedQuantities();
-#endif
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
+    ///
     /// In case there were material properties specified: convert them here
     for(xml_coll_t properties(x_mat, _U(constant)); properties; ++properties) {
       xml_elt_t p = properties;
@@ -576,7 +568,6 @@ template <> void Converter<Material>::operator()(xml_h e) const {
         throw_print("Compact2Objects[ERROR]: Converting material:" + mname + " Property missing: " + ref);
       }
     }
-#endif
   }
   TGeoMedium* medium = mgr.GetMedium(matname);
   if (0 == medium) {
@@ -740,7 +731,6 @@ template <> void Converter<STD_Conditions>::operator()(xml_h e) const {
   }
 }
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
 /** Convert compact optical surface objects (defines)
  *
  *
@@ -840,7 +830,6 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
                surf->GetName(), pname.c_str(), ptyp.c_str());
     }
   }
-#endif
 }
 
 /** Convert compact constant property (Material properties stored in TGeoManager)
@@ -1449,9 +1438,7 @@ template <> void Converter<DetElement>::operator()(xml_h element) const {
       throw runtime_error("Failed to execute subdetector creation plugin. " + dbg.missingFactory(type));
     }
     description.addDetector(det);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
     description.surfaceManager().registerSurfaces(det);
-#endif
     return;
   }
   catch (const exception& e)  {
@@ -1734,13 +1721,12 @@ template <> void Converter<Compact>::operator()(xml_h element) const {
     (Converter<Header>(description))(xml_h(compact.child(_U(info))));
 
   xml_coll_t(compact, _U(properties)).for_each(_U(attributes), Converter<Property>(description));
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   /// These two must be parsed early, because they are needed by the detector constructors
   xml_coll_t(compact, _U(properties)).for_each(_U(constant), Converter<PropertyConstant>(description));
   xml_coll_t(compact, _U(properties)).for_each(_U(matrix),   Converter<PropertyTable>(description));
   xml_coll_t(compact, _U(properties)).for_each(_U(plugin),   Converter<Plugin> (description));
   xml_coll_t(compact, _U(surfaces)).for_each(_U(opticalsurface), Converter<OpticalSurface>(description));
-#endif
+
   xml_coll_t(compact, _U(materials)).for_each(_U(element),  Converter<Atom>(description));
   xml_coll_t(compact, _U(materials)).for_each(_U(material), Converter<Material>(description));
   xml_coll_t(compact, _U(materials)).for_each(_U(plugin),   Converter<Plugin> (description));

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -831,6 +831,7 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
                surf->GetName(), pname.c_str(), ptyp.c_str());
     }
   }
+#endif
 }
 
 /** Convert compact constant property (Material properties stored in TGeoManager)
@@ -896,7 +897,6 @@ template <> void Converter<PropertyTable>::operator()(xml_h e) const {
     tab->Set(i/cols, i%cols, vals[i]);
   //if ( s_debug.matrix ) tab->Print();
 }
-#endif
 
 /** Convert compact visualization attribute to Detector visualization attribute.
  *

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -52,7 +52,6 @@
 #include <climits>
 #include <set>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Namespace for the AIDA detector description toolkit
@@ -105,9 +104,9 @@ namespace dd4hep {
 
 namespace {
   static UInt_t unique_mat_id = 0xAFFEFEED;
-  void throw_print(const string& msg) {
+  void throw_print(const std::string& msg) {
     printout(ERROR, "Compact", msg.c_str());
-    throw runtime_error(msg);
+    throw std::runtime_error(msg);
   }
   class DebugOptions  {
   public:
@@ -130,7 +129,7 @@ namespace {
 static Ref_t create_ConstantField(Detector& /* description */, xml_h e) {
   CartesianField obj;
   xml_comp_t field(e), strength(e.child(_U(strength)));
-  string t = e.attr<string>(_U(field));
+  std::string t = e.attr<std::string>(_U(field));
   ConstantField* ptr = new ConstantField();
   ptr->field_type = ::toupper(t[0]) == 'E' ? CartesianField::ELECTRIC : CartesianField::MAGNETIC;
   ptr->direction.SetX(strength.x());
@@ -194,17 +193,17 @@ DECLARE_XMLELEMENT(solenoid,create_SolenoidField)
 static Ref_t create_DipoleField(Detector& /* description */, xml_h e) {
   xml_comp_t c(e);
   CartesianField obj;
-  DipoleField* ptr = new DipoleField();
-  double lunit = c.hasAttr(_U(lunit)) ? c.attr<double>(_U(lunit)) : 1.0;
-  double funit = c.hasAttr(_U(funit)) ? c.attr<double>(_U(funit)) : 1.0;
-  double val, mult = funit;
+  DipoleField*   ptr   = new DipoleField();
+  double         lunit = c.hasAttr(_U(lunit)) ? c.attr<double>(_U(lunit)) : 1.0;
+  double         funit = c.hasAttr(_U(funit)) ? c.attr<double>(_U(funit)) : 1.0;
+  double         val, mult = funit;
 
   if (c.hasAttr(_U(zmin)))
-    ptr->zmin = _multiply<double>(c.attr<string>(_U(zmin)), lunit);
+    ptr->zmin = _multiply<double>(c.attr<std::string>(_U(zmin)), lunit);
   if (c.hasAttr(_U(zmax)))
-    ptr->zmax = _multiply<double>(c.attr<string>(_U(zmax)), lunit);
+    ptr->zmax = _multiply<double>(c.attr<std::string>(_U(zmax)), lunit);
   if (c.hasAttr(_U(rmax)))
-    ptr->rmax = _multiply<double>(c.attr<string>(_U(rmax)), lunit);
+    ptr->rmax = _multiply<double>(c.attr<std::string>(_U(rmax)), lunit);
   for (xml_coll_t coll(c, _U(dipole_coeff)); coll; ++coll, mult /= lunit) {
     xml_dim_t coeff = coll;
     if ( coeff.hasAttr(_U(value)) )
@@ -223,13 +222,13 @@ DECLARE_XMLELEMENT(DipoleMagnet,create_DipoleField)
 
 static Ref_t create_MultipoleField(Detector& description, xml_h e) {
   xml_dim_t c(e), child;
-  CartesianField obj;
+  CartesianField  obj;
   MultipoleField* ptr = new MultipoleField();
-  double lunit = c.hasAttr(_U(lunit)) ? c.attr<double>(_U(lunit)) : 1.0;
-  double funit = c.hasAttr(_U(funit)) ? c.attr<double>(_U(funit)) : 1.0;
-  double val, mult = funit, bz = 0.0;
-  RotationZYX rot;
-  Position pos;
+  double          lunit = c.hasAttr(_U(lunit)) ? c.attr<double>(_U(lunit)) : 1.0;
+  double          funit = c.hasAttr(_U(funit)) ? c.attr<double>(_U(funit)) : 1.0;
+  double          val, mult = funit, bz = 0.0;
+  RotationZYX     rot;
+  Position        pos;
 
   if (c.hasAttr(_U(Z))) bz = c.Z() * funit;
   if ((child = c.child(_U(position), false))) {   // Position is not mandatory!
@@ -239,7 +238,7 @@ static Ref_t create_MultipoleField(Detector& description, xml_h e) {
     rot.SetComponents(child.z(), child.y(), child.x());
   }
   if ((child = c.child(_U(shape), false))) {      // Shape is not mandatory
-    string type = child.typeStr();
+    std::string type = child.typeStr();
     ptr->volume = xml::createShape(description, type, child);
   }
   ptr->B_z = bz;
@@ -296,7 +295,7 @@ bool check_process_file(Detector& description, std::string filename) {
 template <> void Converter<Debug>::operator()(xml_h e) const {
   for (xml_coll_t coll(e, _U(type)); coll; ++coll) {
     int    val = coll.attr<int>(_U(value));
-    string nam = coll.attr<string>(_U(name));
+    std::string nam = coll.attr<std::string>(_U(name));
     if      ( nam.substr(0,6) == "isotop" ) s_debug.isotopes     = (0 != val);
     else if ( nam.substr(0,6) == "elemen" ) s_debug.elements     = (0 != val);
     else if ( nam.substr(0,6) == "materi" ) s_debug.materials    = (0 != val);
@@ -320,25 +319,25 @@ template <> void Converter<Debug>::operator()(xml_h e) const {
  *
  */
 template <> void Converter<Plugin>::operator()(xml_h e) const {
-  xml_comp_t plugin(e);
-  string name = plugin.nameStr();
-  string type = "default";
+  xml_comp_t  plugin(e);
+  std::string name = plugin.nameStr();
+  std::string type = "default";
 
   if ( xml_attr_t typ_attr = e.attr_nothrow(_U(type)) )   {
-    type = e.attr<string>(typ_attr);
+    type = e.attr<std::string>(typ_attr);
   }
   if ( type == "default" )  {
-    vector<char*> argv;
-    vector<string> arguments;
+    std::vector<char*> argv;
+    std::vector<std::string> arguments;
     for (xml_coll_t coll(e, _U(arg)); coll; ++coll) {
-      string val = coll.attr<string>(_U(value));
+      std::string val = coll.attr<std::string>(_U(value));
       arguments.emplace_back(val);
     }
     for (xml_coll_t coll(e, _U(argument)); coll; ++coll) {
-      string val = coll.attr<string>(_U(value));
+      std::string val = coll.attr<std::string>(_U(value));
       arguments.emplace_back(val);
     }
-    for(vector<string>::iterator i=arguments.begin(); i!=arguments.end(); ++i)
+    for(std::vector<std::string>::iterator i=arguments.begin(); i!=arguments.end(); ++i)
       argv.emplace_back(&((*i)[0]));
     description.apply(name.c_str(),int(argv.size()), &argv[0]);
     return;
@@ -366,9 +365,9 @@ template <> void Converter<Plugin>::operator()(xml_h e) const {
 template <> void Converter<Constant>::operator()(xml_h e) const {
   if ( e.tag() != "include" )   {
     xml_ref_t constant(e);
-    string nam = constant.attr<string>(_U(name));
-    string val = constant.attr<string>(_U(value));
-    string typ = constant.hasAttr(_U(type)) ? constant.attr<string>(_U(type)) : "number";
+    std::string nam = constant.attr<std::string>(_U(name));
+    std::string val = constant.attr<std::string>(_U(value));
+    std::string typ = constant.hasAttr(_U(type)) ? constant.attr<std::string>(_U(type)) : "number";
     Constant c(nam, val, typ);
     _toDictionary(nam, val, typ);
     description.addConstant(c);
@@ -393,11 +392,11 @@ template <> void Converter<Constant>::operator()(xml_h e) const {
  */
 template <> void Converter<Header>::operator()(xml_h e) const {
   xml_comp_t c(e);
-  Header h(e.attr<string>(_U(name)), e.attr<string>(_U(title), "Undefined"));
-  h.setUrl(e.attr<string>(_U(url), "Undefined"));
-  h.setAuthor(e.attr<string>(_U(author), "Undefined"));
-  h.setStatus(e.attr<string>(_U(status), "development"));
-  h.setVersion(e.attr<string>(_U(version), "Undefined"));
+  Header h(e.attr<std::string>(_U(name)), e.attr<std::string>(_U(title), "Undefined"));
+  h.setUrl(e.attr<std::string>(_U(url), "Undefined"));
+  h.setAuthor(e.attr<std::string>(_U(author), "Undefined"));
+  h.setStatus(e.attr<std::string>(_U(status), "development"));
+  h.setVersion(e.attr<std::string>(_U(version), "Undefined"));
   h.setComment(e.hasChild(_U(comment)) ? e.child(_U(comment)).text() : "No Comment");
   description.setHeader(h);
 }
@@ -438,7 +437,7 @@ template <> void Converter<Material>::operator()(xml_h e) const {
 
     if ( !density.ptr() ) {
       throw_print("Compact2Objects[ERROR]: material without density tag ( <D  unit=\"g/cm3\" value=\"..\"/> ) provided: "
-                  + string( matname ) ) ;
+                  + std::string( matname ) ) ;
     }
     if ( density.hasAttr(_U(unit)) )   {
       dens_unit = density.attr<double>(_U(unit))/xml::_toDouble(_Unicode(gram/cm3));
@@ -446,15 +445,15 @@ template <> void Converter<Material>::operator()(xml_h e) const {
     if ( dens_unit != 1.0 )  {
       dens_val *= dens_unit;
       printout(s_debug.materials ? ALWAYS : DEBUG, "Compact","Density unit: %.3f [%s] raw: %.3f normalized: %.3f ",
-               dens_unit, density.attr<string>(_U(unit)).c_str(), dens_val, (dens_val*dens_unit));
+               dens_unit, density.attr<std::string>(_U(unit)).c_str(), dens_val, (dens_val*dens_unit));
     }
     mat = mix = new TGeoMixture(matname, composites.size(), dens_val);
-    size_t         ifrac = 0;
-    vector<double> composite_fractions;
-    double         composite_fractions_total = 0.0;
+    std::size_t         ifrac = 0;
+    std::vector<double> composite_fractions;
+    double              composite_fractions_total = 0.0;
     for (composites.reset(); composites; ++composites)   {
-      string nam      = composites.attr<string>(_U(ref));
-      double fraction = composites.attr<double>(_U(n));
+      std::string nam      = composites.attr<std::string>(_U(ref));
+      double      fraction = composites.attr<double>(_U(n));
       if (0 != (comp_mat = mgr.GetMaterial(nam.c_str())))
         fraction *= comp_mat->GetA();
       else if (0 != (comp_elt = table->FindElement(nam.c_str())))
@@ -465,16 +464,16 @@ template <> void Converter<Material>::operator()(xml_h e) const {
       composite_fractions.emplace_back(fraction);
     }
     for (composites.reset(), ifrac=0; composites; ++composites, ++ifrac) {
-      string nam      = composites.attr<string>(_U(ref));
-      double fraction = composite_fractions[ifrac]/composite_fractions_total;
+      std::string nam      = composites.attr<std::string>(_U(ref));
+      double      fraction = composite_fractions[ifrac]/composite_fractions_total;
       if (0 != (comp_mat = mgr.GetMaterial(nam.c_str())))
         mix->AddElement(comp_mat, fraction);
       else if (0 != (comp_elt = table->FindElement(nam.c_str())))
         mix->AddElement(comp_elt, fraction);
     }
     for (fractions.reset(); fractions; ++fractions) {
-      string nam      = fractions.attr<string>(_U(ref));
-      double fraction = fractions.attr<double>(_U(n));
+      std::string nam      = fractions.attr<std::string>(_U(ref));
+      double      fraction = fractions.attr<double>(_U(n));
       if (0 != (comp_mat = mgr.GetMaterial(nam.c_str())))
         mix->AddElement(comp_mat, fraction);
       else if (0 != (comp_elt = table->FindElement(nam.c_str())))
@@ -490,7 +489,7 @@ template <> void Converter<Material>::operator()(xml_h e) const {
         temp_unit = temperature.attr<double>(_U(unit));
       temp_val = temperature.attr<double>(_U(value)) * temp_unit;
     }
-    xml_h pressure = x_mat.child(_U(P), false);
+    xml_h  pressure     = x_mat.child(_U(P), false);
     double pressure_val = description.stdConditions().pressure;
     if ( pressure.ptr() )   {
       double pressure_unit = _toDouble("pascal");
@@ -516,11 +515,11 @@ template <> void Converter<Material>::operator()(xml_h e) const {
     for(xml_coll_t properties(x_mat, _U(constant)); properties; ++properties) {
       xml_elt_t p = properties;
       if ( p.hasAttr(_U(ref)) )   {
-        bool   err = kFALSE;
-        string ref = p.attr<string>(_U(ref));
+        bool        err = kFALSE;
+        std::string ref = p.attr<std::string>(_U(ref));
         mgr.GetProperty(ref.c_str(), &err); /// Check existence
         if ( err == kFALSE )  {
-          string prop_nam = p.attr<string>(_U(name));
+          std::string prop_nam = p.attr<std::string>(_U(name));
           mat->AddConstProperty(prop_nam.c_str(), ref.c_str());
           printout(s_debug.materials ? ALWAYS : DEBUG, "Compact",
                    "++            material %-16s  add constant property: %s  ->  %s.",
@@ -531,8 +530,8 @@ template <> void Converter<Material>::operator()(xml_h e) const {
         throw_print("Compact2Objects[ERROR]: Converting material:" + mname + " ConstProperty missing in TGeoManager: " + ref);
       }
       else if ( p.hasAttr(_U(value)) )   {
-        stringstream str;
-        string ref, prop_nam = p.attr<string>(_U(name));
+        std::stringstream str;
+        std::string       ref, prop_nam = p.attr<std::string>(_U(name));
         str << prop_nam << "_" << (void*)mat;
         ref = str.str();
         mgr.AddProperty(ref.c_str(), p.attr<double>(_U(value))); /// Check existence
@@ -542,8 +541,8 @@ template <> void Converter<Material>::operator()(xml_h e) const {
                  mat->GetName(), prop_nam.c_str(), ref.c_str());
       }
       else if ( p.hasAttr(_U(option)) )   {
-        string prop_nam = p.attr<string>(_U(name));
-        string prop_typ = p.attr<string>(_U(option));
+        std::string prop_nam = p.attr<std::string>(_U(name));
+        std::string prop_typ = p.attr<std::string>(_U(option));
         mat->AddConstProperty(prop_nam.c_str(), prop_typ.c_str());
         printout(s_debug.materials ? ALWAYS : DEBUG, "Compact",
                  "++            material %-16s  add constant property: %s  ->  %s.",
@@ -554,10 +553,10 @@ template <> void Converter<Material>::operator()(xml_h e) const {
     for(xml_coll_t properties(x_mat, _U(property)); properties; ++properties) {
       xml_elt_t p = properties;
       if ( p.hasAttr(_U(ref)) )   {
-        string ref = p.attr<string>(_U(ref));
+        std::string  ref     = p.attr<std::string>(_U(ref));
         TGDMLMatrix* gdmlMat = mgr.GetGDMLMatrix(ref.c_str());
         if ( gdmlMat )  {
-          string prop_nam = p.attr<string>(_U(name));
+          std::string prop_nam = p.attr<std::string>(_U(name));
           mat->AddProperty(prop_nam.c_str(), ref.c_str());
           printout(s_debug.materials ? ALWAYS : DEBUG, "Compact",
                    "++            material %-16s  add property: %s  ->  %s.",
@@ -579,7 +578,7 @@ template <> void Converter<Material>::operator()(xml_h e) const {
   // TGeo has no notion of a material "formula"
   // Hence, treat the formula the same way as the material itself
   if (x_mat.hasAttr(_U(formula))) {
-    string form = x_mat.attr<string>(_U(formula));
+    std::string form = x_mat.attr<std::string>(_U(formula));
     if (form != matname) {
       medium = mgr.GetMedium(form.c_str());
       if (0 == medium) {
@@ -601,18 +600,18 @@ template <> void Converter<Material>::operator()(xml_h e) const {
 template <> void Converter<Isotope>::operator()(xml_h e) const {
   xml_dim_t isotope(e);
   TGeoManager&      mgr = description.manager();
-  string            nam = isotope.nameStr();
+  std::string       nam = isotope.nameStr();
   TGeoElementTable* tab = mgr.GetElementTable();
   TGeoIsotope*      iso = tab->FindIsotope(nam.c_str());
 
   // Create the isotope object in the event it is not yet present from the XML data
   if ( !iso )   {
-    xml_ref_t atom(isotope.child(_U(atom)));
-    int    n     = isotope.attr<int>(_U(N));
-    int    z     = isotope.attr<int>(_U(Z));
-    double value = atom.attr<double>(_U(value));
-    string unit  = atom.attr<string>(_U(unit));
-    double a     = value * _multiply<double>(unit,"mol/g");
+    xml_ref_t   atom(isotope.child(_U(atom)));
+    std::string unit  = atom.attr<std::string>(_U(unit));
+    double      value = atom.attr<double>(_U(value));
+    double      a     = value * _multiply<double>(unit,"mol/g");
+    int         n     = isotope.attr<int>(_U(N));
+    int         z     = isotope.attr<int>(_U(Z));
     iso = new TGeoIsotope(nam.c_str(), z, n, a);
     printout(s_debug.isotopes ? ALWAYS : DEBUG, "Compact",
              "++ Converting isotope  %-16s  Z:%3d N:%3d A:%8.4f [g/mol]",
@@ -647,12 +646,12 @@ template <> void Converter<Atom>::operator()(xml_h e) const {
   TGeoElement*      elt  = tab->FindElement(name.c_str());
   if ( !elt ) {
     if ( elem.hasChild(_U(atom)) )  {
-      xml_ref_t atom(elem.child(_U(atom)));
-      string formula = elem.attr<string>(_U(formula));
-      double value   = atom.attr<double>(_U(value));
-      string unit    = atom.attr<string>(_U(unit));
-      int    z       = elem.attr<int>(_U(Z));
-      double a       = value*_multiply<double>(unit,"mol/g");
+      xml_ref_t   atom(elem.child(_U(atom)));
+      std::string formula = elem.attr<std::string>(_U(formula));
+      double      value   = atom.attr<double>(_U(value));
+      std::string unit    = atom.attr<std::string>(_U(unit));
+      int         z       = elem.attr<int>(_U(Z));
+      double      a       = value*_multiply<double>(unit,"mol/g");
       printout(s_debug.elements ? ALWAYS : DEBUG, "Compact",
                "++ Converting element  %-16s  [%-3s] Z:%3d A:%8.4f [g/mol]",
                name.c_str(), formula.c_str(), z, a);
@@ -660,15 +659,15 @@ template <> void Converter<Atom>::operator()(xml_h e) const {
     }
     else  {
       int num_isotopes = 0;
-      string formula   = elem.hasAttr(_U(formula)) ? elem.attr<string>(_U(formula)) : name.str();
+      std::string formula = elem.hasAttr(_U(formula)) ? elem.attr<std::string>(_U(formula)) : name.str();
       for( xml_coll_t i(elem,_U(fraction)); i; ++i)
         ++num_isotopes;
       elt = new TGeoElement(name.c_str(), formula.c_str(), num_isotopes);
       tab->AddElement(elt);
       for( xml_coll_t i(elem,_U(fraction)); i; ++i)  {
-        double frac = i.attr<double>(_U(n));
-        string ref  = i.attr<string>(_U(ref));
-        TGeoIsotope* iso = tab->FindIsotope(ref.c_str());
+        double       frac = i.attr<double>(_U(n));
+        std::string  ref  = i.attr<std::string>(_U(ref));
+        TGeoIsotope* iso  = tab->FindIsotope(ref.c_str());
         if ( !iso )  {
           except("Compact","Element %s cannot be constructed. Isotope '%s' (fraction: %.3f) missing!",
                  name.c_str(), ref.c_str(), frac);
@@ -716,7 +715,7 @@ template <> void Converter<STD_Conditions>::operator()(xml_h e) const {
         temp_unit = temperature.attr<double>(_U(unit));
       temp_val = temperature.attr<double>(_U(value)) * temp_unit;
     }
-    xml_h pressure = cond.child(_U(P), false);
+    xml_h  pressure     = cond.child(_U(P), false);
     double pressure_val = description.stdConditions().pressure;
     if ( pressure.ptr() )   {
       double pressure_unit = _toDouble("pascal");
@@ -738,17 +737,17 @@ template <> void Converter<STD_Conditions>::operator()(xml_h e) const {
 template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
   xml_elt_t    e = element;
   TGeoManager& mgr = description.manager();
-  std::string  sname = e.attr<string>(_U(name));
-  string       ref, pname;
+  std::string  sname = e.attr<std::string>(_U(name));
+  std::string  ref, pname;
   
   // Defaults from Geant4
   OpticalSurface::EModel  model  = OpticalSurface::Model::kMglisur;
   OpticalSurface::EFinish finish = OpticalSurface::Finish::kFpolished;
   OpticalSurface::EType   type   = OpticalSurface::Type::kTdielectric_metal;
   Double_t value = 1.0;
-  if ( e.hasAttr(_U(type))   ) type   = OpticalSurface::stringToType(e.attr<string>(_U(type)));
-  if ( e.hasAttr(_U(model))  ) model  = OpticalSurface::stringToModel(e.attr<string>(_U(model)));
-  if ( e.hasAttr(_U(finish)) ) finish = OpticalSurface::stringToFinish(e.attr<string>(_U(finish)));
+  if ( e.hasAttr(_U(type))   ) type   = OpticalSurface::stringToType(e.attr<std::string>(_U(type)));
+  if ( e.hasAttr(_U(model))  ) model  = OpticalSurface::stringToModel(e.attr<std::string>(_U(model)));
+  if ( e.hasAttr(_U(finish)) ) finish = OpticalSurface::stringToFinish(e.attr<std::string>(_U(finish)));
   if ( e.hasAttr(_U(value))  ) value  = e.attr<double>(_U(value));
   OpticalSurface surf(description, sname, model, finish, type, value);
   if ( s_debug.surface )    {
@@ -756,10 +755,10 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
              sname.c_str(), int(type), int(model), int(finish), value);
   }
   for (xml_coll_t props(e, _U(property)); props; ++props)  {
-    pname = props.attr<string>(_U(name));
+    pname = props.attr<std::string>(_U(name));
     if ( props.hasAttr(_U(ref)) )  {
       bool err = kFALSE;
-      ref = props.attr<string>(_U(ref));
+      ref = props.attr<std::string>(_U(ref));
       mgr.GetProperty(ref.c_str(), &err); /// Check existence
       surf->AddProperty(pname.c_str(), ref.c_str());
       if ( s_debug.surface )  {
@@ -767,11 +766,11 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
       }
       continue;
     }
-    size_t       cols = props.attr<long>(_U(coldim));
-    xml_attr_t   opt  = props.attr_nothrow(_U(option));
-    stringstream str(props.attr<string>(_U(values))), str_nam;
-    string val;
-    vector<double> values;
+    std::size_t         cols = props.attr<long>(_U(coldim));
+    xml_attr_t          opt  = props.attr_nothrow(_U(option));
+    std::stringstream   str(props.attr<std::string>(_U(values))), str_nam;
+    std::string         val;
+    std::vector<double> values;
     while ( !str.eof() )   {
       val = "";
       str >> val;
@@ -781,13 +780,13 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
     /// Create table and register table
     TGDMLMatrix* table = new TGDMLMatrix("",values.size()/cols, cols);
     if ( opt )   {
-      string tit = e.attr<string>(opt);
+      std::string tit = e.attr<std::string>(opt);
       str_nam << tit << "|";
     }
     str_nam << pname << "__" << (void*)table;
     table->SetName(str_nam.str().c_str());
     table->SetTitle(pname.c_str());
-    for (size_t i=0, n=values.size(); i<n; ++i)
+    for (std::size_t i=0, n=values.size(); i<n; ++i)
       table->Set(i/cols, i%cols, values[i]);
     surf->AddProperty(pname.c_str(), table->GetName());
     description.manager().AddGDMLMatrix(table);
@@ -797,10 +796,10 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
   // In case there were constant surface properties specified: convert them here
   for(xml_coll_t properties(e, _U(constant)); properties; ++properties) {
     xml_elt_t p = properties;
-    pname = p.attr<string>(_U(name));
+    pname = p.attr<std::string>(_U(name));
     if ( p.hasAttr(_U(ref)) )   {
       bool err = kFALSE;
-      ref = p.attr<string>(_U(ref));
+      ref = p.attr<std::string>(_U(ref));
       mgr.GetProperty(ref.c_str(), &err); /// Check existence
       if ( err == kFALSE )  {
         surf->AddConstProperty(pname.c_str(), ref.c_str());
@@ -814,7 +813,7 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
                   " ConstProperty missing in TGeoManager: " + ref);
     }
     else if ( p.hasAttr(_U(value)) )   {
-      stringstream str;
+      std::stringstream str;
       str << pname << "_" << (void*)surf.ptr();
       ref = str.str();
       mgr.AddProperty(ref.c_str(), p.attr<double>(_U(value))); /// Check existence
@@ -824,7 +823,7 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
                surf->GetName(), pname.c_str(), ref.c_str());
     }
     else if ( p.hasAttr(_U(option)) )   {
-      string ptyp = p.attr<string>(_U(option));
+      std::string ptyp = p.attr<std::string>(_U(option));
       surf->AddConstProperty(pname.c_str(), ptyp.c_str());
       printout(s_debug.surface ? ALWAYS : DEBUG, "Compact",
                "++            surface  %-16s  add constant property: %s  ->  %s.",
@@ -840,8 +839,8 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
  *
  */
 template <> void Converter<PropertyConstant>::operator()(xml_h e) const    {
-  double value = e.attr<double>(_U(value));
-  string name  = e.attr<string>(_U(name));
+  double      value = e.attr<double>(_U(value));
+  std::string name  = e.attr<std::string>(_U(name));
   description.manager().AddProperty(name.c_str(), value);
   if ( s_debug.matrix )    {
     printout(ALWAYS,"Compact","+++ Reading property %s : %f",name.c_str(), value);
@@ -849,7 +848,7 @@ template <> void Converter<PropertyConstant>::operator()(xml_h e) const    {
 #if 0
   xml_attr_t opt = e.attr_nothrow(_U(title));
   if ( opt )    {
-    string  val = e.attr<string>(opt);
+    std::string  val = e.attr<std::string>(opt);
     TNamed* nam = description.manager().GetProperty(name.c_str());
     if ( !nam )   {
       except("Compact","Failed to access just added manager property: %s",name.c_str());
@@ -865,35 +864,35 @@ template <> void Converter<PropertyConstant>::operator()(xml_h e) const    {
  *
  */
 template <> void Converter<PropertyTable>::operator()(xml_h e) const {
-  vector<double> vals;
-  size_t         cols = e.attr<unsigned long>(_U(coldim));
-  stringstream   str(e.attr<string>(_U(values)));
+  std::vector<double> vals;
+  std::size_t         cols = e.attr<unsigned long>(_U(coldim));
+  std::stringstream   str(e.attr<std::string>(_U(values)));
 
   if ( s_debug.matrix )    {
     printout(ALWAYS,"Compact","+++ Reading property table %s with %d columns.",
-             e.attr<string>(_U(name)).c_str(), cols);
+             e.attr<std::string>(_U(name)).c_str(), cols);
   }
   vals.reserve(1024);
   while ( !str.eof() )   {
-    string item;
+    std::string item;
     str >> item;
     if ( item.empty() && !str.good() ) break;
     vals.emplace_back(_toDouble(item));
     if ( s_debug.matrix )    {
-      cout << " state:" << (str.good() ? "OK " : "BAD") << " '" << item << "'";
-      if ( 0 == (vals.size()%cols) ) cout << endl;
+      std::cout << " state:" << (str.good() ? "OK " : "BAD") << " '" << item << "'";
+      if ( 0 == (vals.size()%cols) ) std::cout << std::endl;
     }
   }
   if ( s_debug.matrix )    {
-    cout << endl;
+    std::cout << std::endl;
   }
   /// Create table and register table
   xml_attr_t    opt = e.attr_nothrow(_U(option));
   PropertyTable tab(description,
-                    e.attr<string>(_U(name)),
-                    opt ? e.attr<string>(opt).c_str() : "",
+                    e.attr<std::string>(_U(name)),
+                    opt ? e.attr<std::string>(opt).c_str() : "",
                     vals.size()/cols, cols);
-  for( size_t i=0, n=vals.size(); i < n; ++i )
+  for( std::size_t i=0, n=vals.size(); i < n; ++i )
     tab->Set(i/cols, i%cols, vals[i]);
   //if ( s_debug.matrix ) tab->Print();
 }
@@ -913,7 +912,7 @@ template <> void Converter<PropertyTable>::operator()(xml_h e) const {
  *       alpha="0.5"/>
  */
 template <> void Converter<VisAttr>::operator()(xml_h e) const {
-  VisAttr attr(e.attr<string>(_U(name)));
+  VisAttr attr(e.attr<std::string>(_U(name)));
   float alpha = 1.0;
   float red   = 1.0;
   float green = 1.0;
@@ -921,10 +920,10 @@ template <> void Converter<VisAttr>::operator()(xml_h e) const {
   bool use_ref = false;
   if(e.hasAttr(_U(ref))) {
     use_ref = true;
-    auto refName = e.attr<string>(_U(ref));
+    auto refName = e.attr<std::string>(_U(ref));
     const auto refAttr = description.visAttributes(refName);
     if(!refAttr.isValid() )  {
-      throw runtime_error("reference VisAttr " + refName + " does not exist");
+      except("Compact","+++ Reference VisAttr %s does not exist", refName.c_str());
     }
     // Just copying things manually.
     // I think a handle's copy constructor/assignment would reuse the underlying pointer... maybe?
@@ -948,7 +947,7 @@ template <> void Converter<VisAttr>::operator()(xml_h e) const {
   if (e.hasAttr(_U(visible)))
     attr.setVisible(e.attr<bool>(_U(visible)));
   if (e.hasAttr(_U(lineStyle))) {
-    string ls = e.attr<string>(_U(lineStyle));
+    std::string ls = e.attr<std::string>(_U(lineStyle));
     if (ls == "unbroken")
       attr.setLineStyle(VisAttr::SOLID);
     else if (ls == "broken")
@@ -959,7 +958,7 @@ template <> void Converter<VisAttr>::operator()(xml_h e) const {
       attr.setLineStyle(VisAttr::SOLID);
   }
   if (e.hasAttr(_U(drawingStyle))) {
-    string ds = e.attr<string>(_U(drawingStyle));
+    std::string ds = e.attr<std::string>(_U(drawingStyle));
     if (ds == "wireframe")
       attr.setDrawingStyle(VisAttr::WIREFRAME);
     else if (ds == "solid")
@@ -984,7 +983,7 @@ template <> void Converter<VisAttr>::operator()(xml_h e) const {
 template <> void Converter<Region>::operator()(xml_h elt) const {
   xml_dim_t       e = elt;
   Region          region(e.nameStr());
-  vector<string>& limits       = region.limits();
+  auto&           limits       = region.limits();
   xml_attr_t      cut          = elt.attr_nothrow(_U(cut));
   xml_attr_t      threshold    = elt.attr_nothrow(_U(threshold));
   xml_attr_t store_secondaries = elt.attr_nothrow(_U(store_secondaries));
@@ -1002,7 +1001,7 @@ template <> void Converter<Region>::operator()(xml_h elt) const {
     region.setStoreSecondaries(elt.attr<bool>(store_secondaries));
   }
   for (xml_coll_t user_limits(e, _U(limitsetref)); user_limits; ++user_limits)
-    limits.emplace_back(user_limits.attr<string>(_U(name)));
+    limits.emplace_back(user_limits.attr<std::string>(_U(name)));
   description.addRegion(region);
 }
 
@@ -1015,9 +1014,9 @@ template <> void Converter<Region>::operator()(xml_h elt) const {
  * </readout>
  */
 template <> void Converter<Segmentation>::operator()(xml_h seg) const {
-  string type = seg.attr<string>(_U(type));
-  string name = seg.hasAttr(_U(name)) ? seg.attr<string>(_U(name)) : string();
-  std::pair<Segmentation,IDDescriptor>* opt = _option<pair<Segmentation,IDDescriptor> >();
+  std::string type = seg.attr<std::string>(_U(type));
+  std::string name = seg.hasAttr(_U(name)) ? seg.attr<std::string>(_U(name)) : std::string();
+  std::pair<Segmentation,IDDescriptor>* opt = _option<std::pair<Segmentation,IDDescriptor> >();
 
   const BitFieldCoder* bitfield = &opt->second->decoder;
   Segmentation segment(type, name, bitfield);
@@ -1028,7 +1027,7 @@ template <> void Converter<Segmentation>::operator()(xml_h seg) const {
     for(const auto p : pars )  {
       xml::Strng_t pNam(p->name());
       if ( seg.hasAttr(pNam) ) {
-        string pType = p->type();
+        std::string pType = p->type();
         if ( pType.compare("int") == 0 ) {
           typedef DDSegmentation::TypedSegmentationParameter<int> ParInt;
           static_cast<ParInt*>(p)->setTypedValue(seg.attr<int>(pNam));
@@ -1036,22 +1035,22 @@ template <> void Converter<Segmentation>::operator()(xml_h seg) const {
           typedef DDSegmentation::TypedSegmentationParameter<float> ParFloat;
           static_cast<ParFloat*>(p)->setTypedValue(seg.attr<float>(pNam));
         } else if ( pType.compare("doublevec") == 0 ) {
-          vector<double> valueVector;
-          string par = seg.attr<string>(pNam);
+          std::vector<double> valueVector;
+          std::string par = seg.attr<std::string>(pNam);
           printout(s_debug.segmentation ? ALWAYS : DEBUG, "Compact",
-                   "++ Converting this string structure: %s.",par.c_str());
-          vector<string> elts = DDSegmentation::splitString(par);
-          for (const string& spar : elts )  {
+                   "++ Converting this std::string structure: %s.",par.c_str());
+          std::vector<std::string> elts = DDSegmentation::splitString(par);
+          for (const std::string& spar : elts )  {
             if ( spar.empty() ) continue;
             valueVector.emplace_back(_toDouble(spar));
           }
-          typedef DDSegmentation::TypedSegmentationParameter< vector<double> > ParDouVec;
+          typedef DDSegmentation::TypedSegmentationParameter< std::vector<double> > ParDouVec;
           static_cast<ParDouVec*>(p)->setTypedValue(valueVector);
         } else if ( pType.compare("double" ) == 0) {
           typedef DDSegmentation::TypedSegmentationParameter<double>ParDouble;
           static_cast<ParDouble*>(p)->setTypedValue(seg.attr<double>(pNam));
         } else {
-          p->setValue(seg.attr<string>(pNam));
+          p->setValue(seg.attr<std::string>(pNam));
         }
       } else if (not p->isOptional()) {
         throw_print("FAILED to create segmentation: " + type +
@@ -1075,7 +1074,7 @@ template <> void Converter<Segmentation>::operator()(xml_h seg) const {
           key_max = x_seg.key_max();
         }
         else  {
-          stringstream tree;
+          std::stringstream tree;
           xml::dump_tree(sub,tree);
           throw_print("Nested segmentations: Invalid key specification:"+tree.str());
         }
@@ -1102,8 +1101,8 @@ template <> void Converter<Segmentation>::operator()(xml_h seg) const {
  */
 template <> void Converter<Readout>::operator()(xml_h e) const {
   xml_h seg = e.child(_U(segmentation), false);
-  xml_h id = e.child(_U(id));
-  string name = e.attr<string>(_U(name));
+  xml_h id  = e.child(_U(id));
+  std::string name = e.attr<std::string>(_U(name));
   std::pair<Segmentation,IDDescriptor> opt;
   Readout ro(name);
   
@@ -1131,16 +1130,16 @@ template <> void Converter<Readout>::operator()(xml_h e) const {
            ro.name(), id ? "ID: " : "", id ? id.text().c_str() : "");
   
   for(xml_coll_t colls(e,_U(hits_collections)); colls; ++colls)   {
-    string hits_key;
-    if ( colls.hasAttr(_U(key)) ) hits_key = colls.attr<string>(_U(key));
+    std::string hits_key;
+    if ( colls.hasAttr(_U(key)) ) hits_key = colls.attr<std::string>(_U(key));
     for(xml_coll_t coll(colls,_U(hits_collection)); coll; ++coll)   {
       xml_dim_t c(coll);
-      string coll_name = c.nameStr();
-      string coll_key  = hits_key;
+      std::string coll_name = c.nameStr();
+      std::string coll_key  = hits_key;
       long   key_min = 0, key_max = 0;
 
       if ( c.hasAttr(_U(key)) )   {
-        coll_key = c.attr<string>(_U(key));
+        coll_key = c.attr<std::string>(_U(key));
       }
       if ( c.hasAttr(_U(key_value)) )   {
         key_max = key_min = c.key_value();
@@ -1150,7 +1149,7 @@ template <> void Converter<Readout>::operator()(xml_h e) const {
         key_max = c.key_max();
       }
       else   {
-        stringstream tree;
+        std::stringstream tree;
         xml::dump_tree(e,tree);
         throw_print("Readout: Invalid specification for multiple hit collections."+tree.str());
       }
@@ -1180,14 +1179,14 @@ DECLARE_XML_DOC_READER(readout,load_readout)
  */
 template <> void Converter<LimitSet>::operator()(xml_h e) const {
   Limit limit;
-  LimitSet ls(e.attr<string>(_U(name)));
+  LimitSet ls(e.attr<std::string>(_U(name)));
   printout(s_debug.limits ? ALWAYS : DEBUG, "Compact",
            "++ Converting LimitSet structure: %s.",ls.name());
   for (xml_coll_t c(e, _U(limit)); c; ++c) {
-    limit.name      = c.attr<string>(_U(name));
-    limit.particles = c.attr<string>(_U(particles));
-    limit.content   = c.attr<string>(_U(value));
-    limit.unit      = c.attr<string>(_U(unit));
+    limit.name      = c.attr<std::string>(_U(name));
+    limit.particles = c.attr<std::string>(_U(particles));
+    limit.content   = c.attr<std::string>(_U(value));
+    limit.unit      = c.attr<std::string>(_U(unit));
     limit.value     = _multiply<double>(limit.content, limit.unit);
     ls.addLimit(limit);
     printout(s_debug.limits ? ALWAYS : DEBUG, "Compact",
@@ -1197,9 +1196,9 @@ template <> void Converter<LimitSet>::operator()(xml_h e) const {
   }
   limit.name      = "cut";
   for (xml_coll_t c(e, _U(cut)); c; ++c) {
-    limit.particles = c.attr<string>(_U(particles));
-    limit.content   = c.attr<string>(_U(value));
-    limit.unit      = c.attr<string>(_U(unit));
+    limit.particles = c.attr<std::string>(_U(particles));
+    limit.content   = c.attr<std::string>(_U(value));
+    limit.unit      = c.attr<std::string>(_U(unit));
     limit.value     = _multiply<double>(limit.content, limit.unit);
     ls.addCut(limit);
     printout(s_debug.limits ? ALWAYS : DEBUG, "Compact",
@@ -1217,17 +1216,17 @@ template <> void Converter<LimitSet>::operator()(xml_h e) const {
  *  ... </properties>
  */
 template <> void Converter<Property>::operator()(xml_h e) const {
-  string name = e.attr<string>(_U(name));
+  std::string name = e.attr<std::string>(_U(name));
   Detector::Properties& prp  = description.properties();
   if ( name.empty() )
     throw_print("Failed to convert properties. No name given!");
 
-  vector<xml_attr_t> a = e.attributes();
+  std::vector<xml_attr_t> a = e.attributes();
   if ( prp.find(name) == prp.end() )
     prp.emplace(name, Detector::PropertyValues());
 
   for (xml_attr_t i : a )
-    prp[name].emplace(xml_tag_t(e.attr_name(i)).str(),e.attr<string>(i));
+    prp[name].emplace(xml_tag_t(e.attr_name(i)).str(),e.attr<std::string>(i));
 }
 
 /** Specialized converter for electric and magnetic fields
@@ -1239,9 +1238,9 @@ template <> void Converter<Property>::operator()(xml_h e) const {
  *     </field>
  */
 template <> void Converter<CartesianField>::operator()(xml_h e) const {
-  string msg  = "updated";
-  string name = e.attr<string>(_U(name));
-  string type = e.attr<string>(_U(type));
+  std::string msg  = "updated";
+  std::string name = e.attr<std::string>(_U(name));
+  std::string type = e.attr<std::string>(_U(type));
   CartesianField field = description.field(name);
   if ( !field.isValid() ) {
     // The field is not present: We create it and add it to Detector
@@ -1258,13 +1257,13 @@ template <> void Converter<CartesianField>::operator()(xml_h e) const {
   // Now update the field structure with the generic part ie. set its properties
   CartesianField::Properties& prp = field.properties();
   for ( xml_coll_t c(e, _U(properties)); c; ++c ) {
-    string props_name = c.attr<string>(_U(name));
-    vector<xml_attr_t>a = c.attributes();
+    std::string props_name = c.attr<std::string>(_U(name));
+    std::vector<xml_attr_t>a = c.attributes();
     if ( prp.find(props_name) == prp.end() ) {
       prp.emplace(props_name, Detector::PropertyValues());
     }
     for ( xml_attr_t i : a )
-      prp[props_name].emplace(xml_tag_t(c.attr_name(i)).str(), c.attr<string>(i));
+      prp[props_name].emplace(xml_tag_t(c.attr_name(i)).str(), c.attr<std::string>(i));
 
     if (c.hasAttr(_U(global)) && c.attr<bool>(_U(global))) {
       description.field().properties() = prp;
@@ -1287,12 +1286,12 @@ template <> void Converter<CartesianField>::operator()(xml_h e) const {
  *
  */
 template <> void Converter<SensitiveDetector>::operator()(xml_h element) const {
-  string name = element.attr<string>(_U(name));
+  std::string name = element.attr<std::string>(_U(name));
   try {
     SensitiveDetector sd = description.sensitiveDetector(name);
     xml_attr_t type = element.attr_nothrow(_U(type));
     if ( type )  {
-      sd.setType(element.attr<string>(type));
+      sd.setType(element.attr<std::string>(type));
     }
     xml_attr_t verbose = element.attr_nothrow(_U(verbose));
     if ( verbose ) {
@@ -1304,7 +1303,7 @@ template <> void Converter<SensitiveDetector>::operator()(xml_h element) const {
     }
     xml_attr_t limits = element.attr_nothrow(_U(limits));
     if ( limits ) {
-      string l = element.attr<string>(limits);
+      std::string l = element.attr<std::string>(limits);
       LimitSet ls = description.limitSet(l);
       if (!ls.isValid()) {
         throw_print("Converter<SensitiveDetector>: Request for non-existing limitset:" + l);
@@ -1313,7 +1312,7 @@ template <> void Converter<SensitiveDetector>::operator()(xml_h element) const {
     }
     xml_attr_t region = element.attr_nothrow(_U(region));
     if ( region ) {
-      string r = element.attr<string>(region);
+      std::string r = element.attr<std::string>(region);
       Region reg = description.region(r);
       if (!reg.isValid()) {
         throw_print("Converter<SensitiveDetector>: Request for non-existing region:" + r);
@@ -1322,7 +1321,7 @@ template <> void Converter<SensitiveDetector>::operator()(xml_h element) const {
     }
     xml_attr_t hits = element.attr_nothrow(_U(hits_collection));
     if (hits) {
-      sd.setHitsCollection(element.attr<string>(hits));
+      sd.setHitsCollection(element.attr<std::string>(hits));
     }
     xml_attr_t ecut = element.attr_nothrow(_U(ecut));
     xml_attr_t eunit = element.attr_nothrow(_U(eunit));
@@ -1339,7 +1338,7 @@ template <> void Converter<SensitiveDetector>::operator()(xml_h element) const {
     if (sequence) {
     }
   }
-  catch (const exception& e) {
+  catch (const std::exception& e) {
     printout(ERROR, "Compact", "++ FAILED    to convert sensitive detector: %s: %s", name.c_str(), e.what());
   }
   catch (...) {
@@ -1347,7 +1346,7 @@ template <> void Converter<SensitiveDetector>::operator()(xml_h element) const {
   }
 }
 
-static void setChildTitles(const pair<string, DetElement>& e) {
+static void setChildTitles(const std::pair<std::string, DetElement>& e) {
   DetElement parent = e.second.parent();
   const DetElement::Children& children = e.second.children();
   if (::strlen(e.second->GetTitle()) == 0) {
@@ -1361,10 +1360,10 @@ template <> void Converter<DetElement>::operator()(xml_h element) const {
   static const char* req_typs = ::getenv("REQUIRED_DETECTOR_TYPES");
   static const char* ign_dets = ::getenv("IGNORED_DETECTORS");
   static const char* ign_typs = ::getenv("IGNORED_DETECTOR_TYPES");
-  string type = element.attr<string>(_U(type));
-  string name = element.attr<string>(_U(name));
-  string name_match = ":" + name + ":";
-  string type_match = ":" + type + ":";
+  std::string type = element.attr<std::string>(_U(type));
+  std::string name = element.attr<std::string>(_U(name));
+  std::string name_match = ":" + name + ":";
+  std::string type_match = ":" + type + ":";
 
   if (req_dets && !strstr(req_dets, name_match.c_str()))
     return;
@@ -1385,13 +1384,13 @@ template <> void Converter<DetElement>::operator()(xml_h element) const {
     }
   }
   try {
-    string par_name;
+    std::string par_name;
     xml_attr_t attr_par = element.attr_nothrow(_U(parent));
     xml_elt_t  elt_par(0);
     if (attr_par)
-      par_name = element.attr<string>(attr_par);
+      par_name = element.attr<std::string>(attr_par);
     else if ( (elt_par=element.child(_U(parent),false)) )
-      par_name = elt_par.attr<string>(_U(name));
+      par_name = elt_par.attr<std::string>(_U(name));
     if ( !par_name.empty() ) {
       // We have here a nested detector. If the mother volume is not yet registered
       // it must be done here, so that the detector constructor gets the correct answer from
@@ -1407,9 +1406,9 @@ template <> void Converter<DetElement>::operator()(xml_h element) const {
     SensitiveDetector sd;
     Segmentation seg;
     if ( attr_ro )   {
-      Readout ro = description.readout(element.attr<string>(attr_ro));
+      Readout ro = description.readout(element.attr<std::string>(attr_ro));
       if (!ro.isValid()) {
-        throw runtime_error("No Readout structure present for detector:" + name);
+        except("Compact","No Readout structure present for detector:" + name);
       }
       seg = ro.segmentation();
       sd = SensitiveDetector(name, "sensitive");
@@ -1420,7 +1419,7 @@ template <> void Converter<DetElement>::operator()(xml_h element) const {
     Ref_t sens = sd;
     DetElement det(Ref_t(PluginService::Create<NamedObject*>(type, &description, &element, &sens)));
     if (det.isValid()) {
-      setChildTitles(make_pair(name, det));
+      setChildTitles(std::make_pair(name, det));
       if ( sd.isValid() )  {
         det->flag |= DetElement::Object::HAVE_SENSITIVE_DETECTOR;
       }
@@ -1436,19 +1435,19 @@ template <> void Converter<DetElement>::operator()(xml_h element) const {
     if (!det.isValid())  {
       PluginDebug dbg;
       PluginService::Create<NamedObject*>(type, &description, &element, &sens);
-      throw runtime_error("Failed to execute subdetector creation plugin. " + dbg.missingFactory(type));
+      except("Compact","Failed to execute subdetector creation plugin. %s", dbg.missingFactory(type).c_str());
     }
     description.addDetector(det);
     description.surfaceManager().registerSurfaces(det);
     return;
   }
-  catch (const exception& e)  {
+  catch (const std::exception& e)  {
     printout(ERROR, "Compact", "++ FAILED    to convert subdetector: %s: %s", name.c_str(), e.what());
-    terminate();
+    std::terminate();
   }
   catch (...)  {
     printout(ERROR, "Compact", "++ FAILED    to convert subdetector: %s: %s", name.c_str(), "UNKNONW Exception");
-    terminate();
+    std::terminate();
   }
 }
 
@@ -1475,27 +1474,27 @@ template <> void Converter<IncludeFile>::operator()(xml_h element) const   {
 
 /// Read material entries from a seperate file in one of the include sections of the geometry
 template <> void Converter<JsonFile>::operator()(xml_h element) const {
-  string base = xml::DocumentHandler::system_directory(element);
-  string file = element.attr<string>(_U(ref));
-  vector<char*>  argv{&file[0], &base[0]};
+  std::string base = xml::DocumentHandler::system_directory(element);
+  std::string file = element.attr<std::string>(_U(ref));
+  std::vector<char*>  argv{&file[0], &base[0]};
   description.apply("DD4hep_JsonProcessor",int(argv.size()), &argv[0]);
 }
 
 /// Read alignment entries from a seperate file in one of the include sections of the geometry
 template <> void Converter<XMLFile>::operator()(xml_h element) const {
-  PrintLevel level = s_debug.includes ? ALWAYS : DEBUG;
-  string fname = element.attr<string>(_U(ref));
-  size_t idx = fname.find("://");
+  PrintLevel  level = s_debug.includes ? ALWAYS : DEBUG;
+  std::string fname = element.attr<std::string>(_U(ref));
+  std::size_t idx   = fname.find("://");
   std::error_code ec;
 
-  if ( idx == string::npos && filesystem::exists(fname, ec) )  {
+  if ( idx == std::string::npos && std::filesystem::exists(fname, ec) )  {
     // Regular file without protocol specification
     printout(level, "Compact","++ Processing xml document %s.", fname.c_str());
     this->description.fromXML(fname);
   }
-  else if ( idx == string::npos )  {
+  else if ( idx == std::string::npos )  {
     // File relative to location of xml tag (protocol specification not possible)
-    string location = xml::DocumentHandler::system_path(element, fname);
+    std::string location = xml::DocumentHandler::system_path(element, fname);
     printout(level, "Compact","++ Processing xml document %s.", location.c_str());
     this->description.fromXML(location);
   }
@@ -1516,8 +1515,8 @@ template <> void Converter<World>::operator()(xml_h element) const {
   xml_elt_t  x_world(element);
   xml_comp_t x_shape = x_world.child(_U(shape), false);
   xml_attr_t att = x_world.getAttr(_U(material));
-  Material   mat = att ? description.material(x_world.attr<string>(att)) : description.air();
-  Volume world_vol;
+  Material   mat = att ? description.material(x_world.attr<std::string>(att)) : description.air();
+  Volume     world_vol;
 
   /// Create the shape and the corresponding volume
   if ( x_shape )   {
@@ -1562,15 +1561,15 @@ template <> void Converter<Parallelworld_Volume>::operator()(xml_h element) cons
   xml_comp_t   shape  = parallel.child(_U(shape));
   xml_dim_t    pos    = element.child(_U(position),false);
   xml_dim_t    rot    = element.child(_U(rotation),false);
-  string       name   = element.attr<string>(_U(name));
-  string       path   = element.attr<string>(_U(anchor));
+  std::string  name   = element.attr<std::string>(_U(name));
+  std::string  path   = element.attr<std::string>(_U(anchor));
   bool         conn   = element.attr<bool>(_U(connected),false);
   DetElement   anchor(detail::tools::findElement(description, path));
   Position     position = pos ? Position(pos.x(), pos.y(), pos.z())    : Position();
   RotationZYX  rotation = rot ? RotationZYX(rot.z(), rot.y(), rot.x()) : RotationZYX();
 
   Material mat = parallel.hasAttr(_U(material))
-    ? description.material(parallel.attr<string>(_U(material)))
+    ? description.material(parallel.attr<std::string>(_U(material)))
     : description.air();
   VisAttr vis = parallel.hasAttr(_U(vis))
     ? description.invisible()
@@ -1610,7 +1609,7 @@ template <> void Converter<Parallelworld_Volume>::operator()(xml_h element) cons
 
 /// Read material entries from a seperate file in one of the include sections of the geometry
 template <> void Converter<DetElementInclude>::operator()(xml_h element) const {
-  string type = element.hasAttr(_U(type)) ? element.attr<string>(_U(type)) : string("xml");
+  std::string type = element.hasAttr(_U(type)) ? element.attr<std::string>(_U(type)) : std::string("xml");
   if ( type == "xml" )  {
     xml::DocumentHolder doc(xml::DocumentHandler().load(element, element.attr_value(_U(ref))));
     if ( s_debug.include_guard ) {
@@ -1622,7 +1621,7 @@ template <> void Converter<DetElementInclude>::operator()(xml_h element) const {
       printout(ALWAYS, "Compact","++ Processing xml document %s.",doc.uri().c_str());
     }
     xml_h node = doc.root();
-    string tag = node.tag();
+    std::string tag = node.tag();
     if ( tag == "lccdd" )
       Converter<Compact>(this->description)(node);
     else if ( tag == "define" )
@@ -1683,7 +1682,7 @@ template <> void Converter<Compact>::operator()(xml_h element) const {
     if ( steer.hasAttr(_U(reflect)) )
       build_reflections = steer.attr<bool>(_U(reflect));
     for (xml_coll_t clr(steer, _U(clear)); clr; ++clr) {
-      string nam = clr.hasAttr(_U(name)) ? clr.attr<string>(_U(name)) : string();
+      std::string nam = clr.hasAttr(_U(name)) ? clr.attr<std::string>(_U(name)) : std::string();
       if ( nam.substr(0,6) == "elemen" )   {
         TGeoElementTable*	table = description.manager().GetElementTable();
         table->TGeoElementTable::~TGeoElementTable();

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -831,7 +831,6 @@ template <> void Converter<OpticalSurface>::operator()(xml_h element) const {
                surf->GetName(), pname.c_str(), ptyp.c_str());
     }
   }
-#endif
 }
 
 /** Convert compact constant property (Material properties stored in TGeoManager)

--- a/DDCore/src/plugins/DetElementConfig.cpp
+++ b/DDCore/src/plugins/DetElementConfig.cpp
@@ -42,7 +42,7 @@ namespace  {
       std::size_t count = 0;
       bool propagate = det == detector.world() ? false: x_det.attr<bool>(_U(propagate), false);
       if ( xml_dim_t x_vol = x_det.child(_U(volume), false) )   {
-	count += xml::configVolume(detector, x_vol, det.volume(), propagate, false);
+        count += xml::configVolume(detector, x_vol, det.volume(), propagate, false);
       }
       PrintLevel lvl = x_det.attr<xml::Attribute>(_U(debug), nullptr) ? ALWAYS : DEBUG;
       printout(lvl, "DetElementConfig", "++ Applied %ld settings to %s", count, path.c_str());
@@ -69,6 +69,7 @@ namespace  {
   }
   
 }  // End namespace dd4hep
+
 /// Instantiate factory
 DECLARE_XML_PLUGIN(DD4hep_DetElementConfig, configure_detelement)
 /// Instantiate factory

--- a/DDCore/src/plugins/DetElementVolumeIDs.cpp
+++ b/DDCore/src/plugins/DetElementVolumeIDs.cpp
@@ -54,11 +54,11 @@ namespace dd4hep {
    
     /// Scan a single physical volume and look for sensitive elements below
     std::size_t scanPhysicalVolume(DetElement&        parent,
-				   DetElement         e,
-				   PlacedVolume       pv, 
-				   Encoding           parent_encoding,
-				   SensitiveDetector& sd,
-				   PlacementPath&     chain);
+                                   DetElement         e,
+                                   PlacedVolume       pv, 
+                                   Encoding           parent_encoding,
+                                   SensitiveDetector& sd,
+                                   PlacementPath&     chain);
   public:
     /// Default constructor
     DetElementVolumeIDs(const Detector& description);
@@ -104,29 +104,29 @@ namespace  {
     std::string detector = "/world";
     for(int i = 0; i < argc && argv[i]; ++i)  {
       if ( 0 == ::strncmp("-detector",argv[i],4) )
-	detector = argv[++i];
+        detector = argv[++i];
       else  {
-	std::cout <<
-	  "Usage: -plugin DD4hep_DetElementVolumeIDs  -arg [-arg]               \n\n"
-	  "     -detector <string> Top level DetElement path. Default: '/world' \n"
-	  "     -help              Print this help output                       \n"
-	  "     Arguments given: " << arguments(argc,argv) << std::endl << std::flush;
-	::exit(EINVAL);
+        std::cout <<
+          "Usage: -plugin DD4hep_DetElementVolumeIDs  -arg [-arg]               \n\n"
+          "     -detector <string> Top level DetElement path. Default: '/world' \n"
+          "     -help              Print this help output                       \n"
+          "     Arguments given: " << arguments(argc,argv) << std::endl << std::flush;
+        ::exit(EINVAL);
       }
     }
     DetElement element = description.world();
     if ( detector != "/world" )   {
       element = detail::tools::findElement(description,detector);
       if ( !element.isValid() )  {
-	except("DD4hep_DetElementVolumeIDs","+++ Invalid DetElement path: %s",detector.c_str());
+        except("DD4hep_DetElementVolumeIDs","+++ Invalid DetElement path: %s",detector.c_str());
       }
     }
     DetElementVolumeIDs mgr(description);
     auto count = mgr.populate(element);
     if ( count == 0 )   {
       except("DD4hep_DetElementVolumeIDs",
-	     "+++ NO volume identifiers assigned to DetElement %s. %s",
-	     "Something went wrong!",detector.c_str());
+             "+++ NO volume identifiers assigned to DetElement %s. %s",
+             "Something went wrong!",detector.c_str());
     }
     return count > 0 ? 1 : 0;
   }
@@ -169,22 +169,22 @@ std::size_t DetElementVolumeIDs::populate(DetElement det) {
   entries.clear();
   if ( !pv.isValid() )   {
     except("DetElementVolumeIDs",
-	   "+++ Top level DetElement %s has no valid placement. %s",
-	   "[Something awfully wrong]", det.path().c_str());
+           "+++ Top level DetElement %s has no valid placement. %s",
+           "[Something awfully wrong]", det.path().c_str());
   }
   if ( det == m_detDesc.world() )   {
     for (const auto& i : det.children() )  {
       DetElement   de = i.second;
       pv = de.placement();
       if (pv.isValid()) {
-	PlacementPath     chain;
-	Encoding          coding { 0, 0 };
-	SensitiveDetector sd (0);
-	count += scanPhysicalVolume(de, de, pv, coding, sd, chain);
-	continue;
+        PlacementPath     chain;
+        Encoding          coding { 0, 0 };
+        SensitiveDetector sd (0);
+        count += scanPhysicalVolume(de, de, pv, coding, sd, chain);
+        continue;
       }
       printout(WARNING, "DetElementVolumeIDs", "++ Detector element %s of type %s has no placement.", 
-	       de.name(), de.type().c_str());
+               de.name(), de.type().c_str());
     }
     printout(INFO, "DetElementVolumeIDs", "++ Assigned %ld volume identifiers to DetElements.", count); 
     return count;
@@ -192,8 +192,8 @@ std::size_t DetElementVolumeIDs::populate(DetElement det) {
   SensitiveDetector sd = m_detDesc.sensitiveDetector(det.name());
   if ( !pv.volIDs().empty() && !sd.isValid() )   {
     except("DetElementVolumeIDs",
-	   "+++ No sensitive detector available for top level DetElement %s.",
-	   det.path().c_str());
+           "+++ No sensitive detector available for top level DetElement %s.",
+           det.path().c_str());
   }
   PlacementPath chain;
   count += scanPhysicalVolume(det, det, pv, encoding, sd, chain);
@@ -204,11 +204,11 @@ std::size_t DetElementVolumeIDs::populate(DetElement det) {
 /// Scan a single physical volume and look for sensitive elements below
 std::size_t
 DetElementVolumeIDs::scanPhysicalVolume(DetElement&        parent,
-					DetElement         e,
-					PlacedVolume       pv, 
-					Encoding           parent_encoding,
-					SensitiveDetector& sd,
-					PlacementPath&     chain)
+                                        DetElement         e,
+                                        PlacedVolume       pv, 
+                                        Encoding           parent_encoding,
+                                        SensitiveDetector& sd,
+                                        PlacementPath&     chain)
 {
   TGeoNode* node = pv.ptr();
   std::size_t count = 0;
@@ -226,81 +226,81 @@ DetElementVolumeIDs::scanPhysicalVolume(DetElement&        parent,
     }
     else if ( !sd.isValid() )  {
       if ( is_sensitive )
-	sd = vol.sensitiveDetector();
+        sd = vol.sensitiveDetector();
       else if ( (parent->flag&DetElement::Object::HAVE_SENSITIVE_DETECTOR) )
-	sd = m_detDesc.sensitiveDetector(parent.name());
+        sd = m_detDesc.sensitiveDetector(parent.name());
       else if ( (e->flag&DetElement::Object::HAVE_SENSITIVE_DETECTOR) )
-	sd = m_detDesc.sensitiveDetector(e.name());
+        sd = m_detDesc.sensitiveDetector(e.name());
     }
     chain.emplace_back(node);
     if ( sd.isValid() && !pv_ids.empty() )   {
       Readout ro = sd.readout();
       if ( ro.isValid() )   {
-	vol_encoding  = update_encoding(ro.idSpec(), pv_ids, parent_encoding);
-	have_encoding = true;
+        vol_encoding  = update_encoding(ro.idSpec(), pv_ids, parent_encoding);
+        have_encoding = true;
       }
       else {
-	printout(WARNING, "DetElementVolumeIDs",
-		 "%s: Strange constellation volume %s is sensitive, but has no readout! sd:%p",
-		 parent.name(), pv.volume().name(), sd.ptr());
+        printout(WARNING, "DetElementVolumeIDs",
+                 "%s: Strange constellation volume %s is sensitive, but has no readout! sd:%p",
+                 parent.name(), pv.volume().name(), sd.ptr());
       }
     }
     for (int idau = 0, ndau = node->GetNdaughters(); idau < ndau; ++idau) {
       TGeoNode*    daughter = node->GetDaughter(idau);
       PlacedVolume place_dau(daughter);
       if ( place_dau.data() ) {
-	DetElement   de_dau;
-	/// Check if this particular volume is the placement of one of the
-	/// children of this detector element. If the daughter placement is also
-	/// a detector child, then we must reset the node chain.
-	for( const auto& de : e.children() )  {
-	  if ( de.second.placement().ptr() == daughter )  {
-	    de_dau = de.second;
-	    break;
-	  }
-	}
-	if ( de_dau.isValid() ) {
-	  PlacementPath dau_chain;
-	  count += scanPhysicalVolume(parent, de_dau, place_dau, vol_encoding, sd, dau_chain);
-	}
-	else { // there may be several layers of volumes between mother-child of DE
-	  count += scanPhysicalVolume(parent, e, place_dau, vol_encoding, sd, chain);
-	}
+        DetElement   de_dau;
+        /// Check if this particular volume is the placement of one of the
+        /// children of this detector element. If the daughter placement is also
+        /// a detector child, then we must reset the node chain.
+        for( const auto& de : e.children() )  {
+          if ( de.second.placement().ptr() == daughter )  {
+            de_dau = de.second;
+            break;
+          }
+        }
+        if ( de_dau.isValid() ) {
+          PlacementPath dau_chain;
+          count += scanPhysicalVolume(parent, de_dau, place_dau, vol_encoding, sd, dau_chain);
+        }
+        else { // there may be several layers of volumes between mother-child of DE
+          count += scanPhysicalVolume(parent, e, place_dau, vol_encoding, sd, chain);
+        }
       }
       else  {
-	except("DetElementVolumeIDs",
-	       "Invalid not instrumented placement: %s %s", daughter->GetName(),
-	       " [Internal error -- bad detector constructor]");
+        except("DetElementVolumeIDs",
+               "Invalid not instrumented placement: %s %s", daughter->GetName(),
+               " [Internal error -- bad detector constructor]");
       }
       /// For compounds the upper level sensitive detector does not exist,
       /// because there are multiple at lower layers
       if ( compound )  {
-	sd = SensitiveDetector(0);
+        sd = SensitiveDetector(0);
       }
     }
     if ( sd.isValid() )   {
       if ( !have_encoding && !compound )   {
-	printout(ERROR, "DetElementVolumeIDs",
-		 "Element %s: Missing SD encoding. Volume manager won't work!",
-		 e.path().c_str());
+        printout(ERROR, "DetElementVolumeIDs",
+                 "Element %s: Missing SD encoding. Volume manager won't work!",
+                 e.path().c_str());
       }
       if ( is_sensitive || count > 0 )  {
-	// Either this layer is sensitive of a layer below.
-	if ( node == e.placement().ptr() )  {
-	  // These here are placement nodes, which at the same time are DetElement placements
-	  // 1) We recuperate volumes from lower levels by reusing the subdetector
-	  //    This only works if there is exactly one sensitive detector per subdetector!
-	  // 2) DetElements in the upper hierarchy of the sensitive also get a volume id,
-	  //    and the volume is registered. (to be discussed)
-	  //
-	  e.object<DetElement::Object>().volumeID = vol_encoding.identifier;
-	}
-	// Collect all sensitive volumes, which belong to the next DetElement
-	if ( entries.find(e) == entries.end()) {
-	  entries[e].emplace_back(vol_encoding);
-	  ++numberOfNodes;
-	}
-	++count;
+        // Either this layer is sensitive of a layer below.
+        if ( node == e.placement().ptr() )  {
+          // These here are placement nodes, which at the same time are DetElement placements
+          // 1) We recuperate volumes from lower levels by reusing the subdetector
+          //    This only works if there is exactly one sensitive detector per subdetector!
+          // 2) DetElements in the upper hierarchy of the sensitive also get a volume id,
+          //    and the volume is registered. (to be discussed)
+          //
+          e.object<DetElement::Object>().volumeID = vol_encoding.identifier;
+        }
+        // Collect all sensitive volumes, which belong to the next DetElement
+        if ( entries.find(e) == entries.end()) {
+          entries[e].emplace_back(vol_encoding);
+          ++numberOfNodes;
+        }
+        ++count;
       }
     }
     chain.pop_back();

--- a/DDCore/src/plugins/DetectorCheck.cpp
+++ b/DDCore/src/plugins/DetectorCheck.cpp
@@ -12,24 +12,22 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Factories.h"
-#include "DD4hep/IDDescriptor.h"
-#include "DD4hep/VolumeManager.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/AlignmentsNominalMap.h"
-#include "DD4hep/detail/VolumeManagerInterna.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Factories.h>
+#include <DD4hep/IDDescriptor.h>
+#include <DD4hep/VolumeManager.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/AlignmentsNominalMap.h>
+#include <DD4hep/detail/VolumeManagerInterna.h>
 
 // C/C++ include files
 #include <stdexcept>
 #include <algorithm>
 #include <cstdlib>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep { namespace detail { namespace tools  {
@@ -65,8 +63,8 @@ namespace  {
 
     /// Helper to scan volume ids
     struct FND {
-      const string& test;
-      FND(const string& c) : test(c) {}
+      const std::string& test;
+      FND(const std::string& c) : test(c) {}
       bool operator()(const VolIDs::value_type& c) const { return c.first == test; }
     };
     struct counters  {
@@ -74,9 +72,9 @@ namespace  {
       size_t errors { 0 };
       void reset() { elements = errors = 0; }
       counters& operator+=(const counters& c)  {
-	elements += c.elements;
-	errors   += c.errors;
-	return *this;
+        elements += c.elements;
+        errors   += c.errors;
+        return *this;
       }
     };
 
@@ -173,10 +171,10 @@ void DetectorCheck::execute(DetElement sdet, size_t depth)   {
     else   {
       m_current_sensitive = description.sensitiveDetector(m_det.name());
       if ( !m_current_sensitive.isValid() )   {
-	printout(ERROR, m_name,
-		 "The sensitive detector of subdetector %s "
-		 "is not known to the geometry.", m_det.name());
-	return;
+        printout(ERROR, m_name,
+                 "The sensitive detector of subdetector %s "
+                 "is not known to the geometry.", m_det.name());
+        return;
       }
       m_current_iddesc = m_current_sensitive.readout().idSpec();
     }
@@ -232,31 +230,31 @@ void DetectorCheck::execute(DetElement sdet, size_t depth)   {
 
   if ( check_structure )   {
     printout(count_struct.errors > 0 ? ERROR : ALWAYS, 
-	     m_name, "+++ %s: Checked %10ld structure elements.   Num.Errors:%6ld (structure test)",
-	     tag_fail(count_struct.errors), count_struct.elements, count_struct.errors);
+             m_name, "+++ %s: Checked %10ld structure elements.   Num.Errors:%6ld (structure test)",
+             tag_fail(count_struct.errors), count_struct.elements, count_struct.errors);
   }
   if ( check_geometry )   {
     if ( check_sensitive )  {
       printout(count_geo_sens.errors > 0 ? ERROR : ALWAYS,
-	       m_name, "+++ %s: Checked %10ld sensitive elements.   Num.Errors:%6ld (geometry test)",
-	       tag_fail(count_geo_sens.errors), count_geo_sens.elements, count_geo_sens.errors);
+               m_name, "+++ %s: Checked %10ld sensitive elements.   Num.Errors:%6ld (geometry test)",
+               tag_fail(count_geo_sens.errors), count_geo_sens.elements, count_geo_sens.errors);
     }
     printout(count_geo.errors > 0 ? ERROR : ALWAYS,
-	     m_name, "+++ %s: Checked %10ld placements.           Num.Errors:%6ld (geometry test)",
-	     tag_fail(count_geo.errors), count_geo.elements, count_geo.errors);
+             m_name, "+++ %s: Checked %10ld placements.           Num.Errors:%6ld (geometry test)",
+             tag_fail(count_geo.errors), count_geo.elements, count_geo.errors);
   }
   if ( check_volmgr )   {
     if ( check_sensitive )  {
       printout(count_volmgr_sens.errors > 0 ? ERROR : ALWAYS,
-	       m_name, "+++ %s: Checked %10ld sensitive elements.   Num.Errors:%6ld (phys.VolID test)",
-	       tag_fail(count_volmgr_sens.errors), count_volmgr_sens.elements, count_volmgr_sens.errors);
+               m_name, "+++ %s: Checked %10ld sensitive elements.   Num.Errors:%6ld (phys.VolID test)",
+               tag_fail(count_volmgr_sens.errors), count_volmgr_sens.elements, count_volmgr_sens.errors);
     }
     printout(count_volmgr_place.errors > 0 ? ERROR : ALWAYS,
-	     m_name, "+++ %s: Checked %10ld sensitive placements. Num.Errors:%6ld (phys.VolID test)",
-	     tag_fail(count_volmgr_place.errors), count_volmgr_sens.elements, count_volmgr_place.errors);
+             m_name, "+++ %s: Checked %10ld sensitive placements. Num.Errors:%6ld (phys.VolID test)",
+             tag_fail(count_volmgr_place.errors), count_volmgr_sens.elements, count_volmgr_place.errors);
   }
   printout(ALWAYS, m_name, "+++ %s: Checked a total of %11ld elements. Num.Errors:%6ld (Some elements checked twice)",
-	   tag_fail(total.errors), total.elements, total.errors);
+           tag_fail(total.errors), total.elements, total.errors);
 }
 
 /// Check DetElement integrity
@@ -276,7 +274,7 @@ bool DetectorCheck::checkDetElement(const std::string& path, DetElement detector
   }
   if ( detector.path() != path )    {
     printout(ERROR, m_name, "Invalid DetElement [path mismatch]: %s <> %s",
-	     de_path, path.c_str());
+             de_path, path.c_str());
     ++m_struct_counters.errors;
   }
   if ( !detector.parent().isValid() && detector.world() != detector )   {
@@ -303,7 +301,7 @@ bool DetectorCheck::checkDetElement(const std::string& path, DetElement detector
   if ( count > 1 )   {
     DetElement par = detector.parent();
     printout(ERROR, m_name, "DetElement %s parent: %s is placed %ld times! Only single placement allowed.", 
-	     de_path, par.isValid() ? par.path().c_str() : "", m_structure_elements[detector]);
+             de_path, par.isValid() ? par.path().c_str() : "", m_structure_elements[detector]);
     ++m_struct_counters.errors;
   }
   Alignment ideal = detector.nominal();
@@ -322,9 +320,9 @@ bool DetectorCheck::checkDetElement(const std::string& path, DetElement detector
     }
   }
   printout(nerrs != m_struct_counters.errors ? ERROR : INFO, m_name, 
-	   "DetElement %s [%s] parent: %s placement: %s [%s] volume: %s",
-	   path.c_str(), yes_no(det_valid), yes_no(parent_valid), yes_no(det_place_valid),
-	   yes_no(place_valid), yes_no(vol_valid));
+           "DetElement %s [%s] parent: %s placement: %s [%s] volume: %s",
+           path.c_str(), yes_no(det_valid), yes_no(parent_valid), yes_no(det_place_valid),
+           yes_no(place_valid), yes_no(vol_valid));
   return nerrs == m_struct_counters.errors;
 }
 
@@ -350,7 +348,7 @@ bool DetectorCheck::checkDetElementTree(const std::string& path, DetElement dete
     if ( de.parent().isValid() && de.parent() != detector )    {
       printout(ERROR, m_name, "Invalid DetElement [Parent mismatch]:    %s", de.path().c_str());
       printout(ERROR, m_name, "        apparent parent: %s  structural parent: %s",
-	       de.parent().path().c_str(), detector.path().c_str());
+               de.parent().path().c_str(), detector.path().c_str());
       ++m_struct_counters.errors;
     }
     /// Invalid daughter elements will be detectoed in there:
@@ -419,8 +417,8 @@ void DetectorCheck::checkVolumeTree(DetElement detector, PlacedVolume pv)   {
     /// Check if there is a new parent at the next level:
     for ( const auto& c : detector.children() )   {
       if ( c.second.placement() == place )   {
-	de = c.second;
-	break;
+        de = c.second;
+        break;
       }
     }
     checkVolumeTree(de, place);
@@ -433,7 +431,7 @@ void DetectorCheck::checkVolumeTree(DetElement detector, PlacedVolume pv)   {
 
 /// Check volume integrity
 void DetectorCheck::checkManagerSingleVolume(DetElement detector, PlacedVolume pv, const VolIDs& child_ids, const Chain& chain)   {
-  stringstream err, log;
+  std::stringstream err, log;
   VolumeID     det_vol_id = detector.volumeID();
   VolumeID     vid        = det_vol_id;
   DetElement   top_sdet, det_elem;
@@ -466,7 +464,7 @@ void DetectorCheck::checkManagerSingleVolume(DetElement detector, PlacedVolume p
         ++m_place_counters.errors;
       }
       else if ( !detail::tools::isParentElement(detector,det_elem) )   {
-      // This is sort of a bit wischi-waschi.... 
+        // This is sort of a bit wischi-waschi.... 
         err << "VolumeMgrTest: Wrong associated detector element vid="  << volumeID(vid)
             << " got "        << det_elem.path() << " (" << (void*)det_elem.ptr() << ") "
             << " instead of " << detector.path() << " (" << (void*)detector.ptr() << ")"
@@ -480,30 +478,30 @@ void DetectorCheck::checkManagerSingleVolume(DetElement detector, PlacedVolume p
       }
     }
   }
-  catch(const exception& ex) {
+  catch(const std::exception& ex) {
     err << "Lookup " << pv.name() << " id:" << volumeID(vid)
         << " path:" << detector.path() << " error:" << ex.what();
     ++m_place_counters.errors;
   }
 
   if ( pv.volume().isSensitive() || (0 != det_vol_id) )  {
-    string id_desc;
-    log << "Volume:"  << setw(50) << left << pv.name();
+    std::string id_desc;
+    log << "Volume:"  << std::setw(50) << std::left << pv.name();
     if ( pv.volume().isSensitive() )  {
       IDDescriptor dsc = SensitiveDetector(pv.volume().sensitiveDetector()).readout().idSpec();
       log << " IDDesc:" << (char*)(dsc.ptr() == m_current_iddesc.ptr() ? "OK " : "BAD");
       if ( dsc.ptr() != m_current_iddesc.ptr() ) ++m_place_counters.errors;
     }
     else  {
-      log << setw(11) << " ";
+      log << std::setw(11) << " ";
     }
     id_desc = m_current_iddesc.str(vid);
-    log << " [" << char(pv.volume().isSensitive() ? 'S' : 'N') << "] " << right
+    log << " [" << char(pv.volume().isSensitive() ? 'S' : 'N') << "] " << std::right
         << " vid:" << volumeID(vid)
         << " " << id_desc;
     if ( !err.str().empty() )   {
       printout(ERROR, m_det.name(),err.str()+" "+log.str());
-      //throw runtime_error(err.str());
+      //throw std::runtime_error(err.str());
       return;
     }
     id_desc = m_current_iddesc.str(det_elem.volumeID());
@@ -549,7 +547,7 @@ void DetectorCheck::checkManagerSingleVolume(DetElement detector, PlacedVolume p
         /// Check nominal and DetElement trafos for pointer equality:
         if ( &det_elem.nominal().worldTransformation() != &m_volMgr.worldTransformation(m_mapping,det_elem.volumeID()) )
         {
-            printout(ERROR, m_det.name(), "DETELEMENT_PERSISTENCY FAILED: World transformation have DIFFERET pointer!");
+          printout(ERROR, m_det.name(), "DETELEMENT_PERSISTENCY FAILED: World transformation have DIFFERET pointer!");
           ++m_place_counters.errors;
         }
 
@@ -585,7 +583,7 @@ void DetectorCheck::checkManagerSingleVolume(DetElement detector, PlacedVolume p
         }
       }
     }
-    catch(const exception& ex) {
+    catch(const std::exception& ex) {
       err << "Matrix " << pv.name() << " id:" << volumeID(vid)
           << " path:" << detector.path() << " error:" << ex.what();
       ++m_place_counters.errors;
@@ -596,7 +594,7 @@ void DetectorCheck::checkManagerSingleVolume(DetElement detector, PlacedVolume p
 
 /// Walk through tree of detector elements
 void DetectorCheck::checkManagerVolumeTree(DetElement detector, PlacedVolume pv, VolIDs ids, const Chain& chain,
-                           size_t depth, size_t mx_depth)  
+                                           size_t depth, size_t mx_depth)  
 {
   if ( depth <= mx_depth )  {
     const TGeoNode* current  = pv.ptr();
@@ -611,15 +609,15 @@ void DetectorCheck::checkManagerVolumeTree(DetElement detector, PlacedVolume pv,
       Chain  child_chain(chain);
       DetElement de = detector;
       if ( is_world )  {
-	/// Check if there is a new parent at the next level:
-	for ( const auto& c : detector.children() )   {
-	  if ( c.second.placement() == place )   {
-	    de = c.second;
-	    break;
-	  }
-	}
-	m_current_detector = de;
-	get_current_sensitive_detector();
+        /// Check if there is a new parent at the next level:
+        for ( const auto& c : detector.children() )   {
+          if ( c.second.placement() == place )   {
+            de = c.second;
+            break;
+          }
+        }
+        m_current_detector = de;
+        get_current_sensitive_detector();
       }
       place.access(); // Test validity
       child_chain.emplace_back(place);
@@ -657,7 +655,7 @@ void DetectorCheck::help(int argc,char** argv)   {
 
 /// Action routine to execute the test
 long DetectorCheck::run(Detector& description,int argc,char** argv)    {
-  string name;
+  std::string name;
   bool volmgr = false;
   bool geometry = false;
   bool structure = false;

--- a/DDCore/src/plugins/DetectorChecksum.cpp
+++ b/DDCore/src/plugins/DetectorChecksum.cpp
@@ -29,6 +29,7 @@
 #include <TColor.h>
 #include <TGeoBoolNode.h>
 #include <TGeoSystemOfUnits.h>
+
 // C/C++ include files
 #include <iostream>
 #include <sstream>
@@ -38,9 +39,10 @@
 #include <cfenv>
 
 using namespace dd4hep;
-using namespace dd4hep::detail;
+using DetectorChecksum = dd4hep::detail::DetectorChecksum;
 
 namespace {
+  
   bool is_volume(const TGeoVolume* volume)  {
     Volume v(volume);
     return v.data() != 0;

--- a/DDCore/src/plugins/DetectorFields.cpp
+++ b/DDCore/src/plugins/DetectorFields.cpp
@@ -12,10 +12,12 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Printout.h"
-#include "DD4hep/FieldTypes.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/DetFactoryHelper.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/FieldTypes.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/DetFactoryHelper.h>
+
+// C/C++ include files
 #include <cmath>
 
 using namespace dd4hep;

--- a/DDCore/src/plugins/DetectorHelperTest.cpp
+++ b/DDCore/src/plugins/DetectorHelperTest.cpp
@@ -12,19 +12,16 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Factories.h"
-#include "DD4hep/DetectorHelper.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Factories.h>
+#include <DD4hep/DetectorHelper.h>
 
 // C/C++ include files
 #include <stdexcept>
 #include <algorithm>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
-
 
 namespace  {
 

--- a/DDCore/src/plugins/Geant4XML.cpp
+++ b/DDCore/src/plugins/Geant4XML.cpp
@@ -11,23 +11,22 @@
 //
 //==========================================================================
 
-#include "XML/Conversions.h"
-#include "DD4hep/DetFactoryHelper.h"
+#include <XML/Conversions.h>
+#include <DD4hep/DetFactoryHelper.h>
 
 namespace dd4hep {
   struct Geant4;
   class GdmlFile;
   class Property;
   class SensitiveDetector;
-}
-using namespace dd4hep;
 
-namespace dd4hep {
   template <> void Converter<Geant4>::operator()(xml_h e) const;
   template <> void Converter<GdmlFile>::operator()(xml_h e) const;
   template <> void Converter<Property>::operator()(xml_h e) const;
   template <> void Converter<SensitiveDetector>::operator()(xml_h e) const;
 }
+
+using namespace dd4hep;
 
 template <> void Converter<Geant4>::operator()(xml_h element) const {
   xml_elt_t compact(element);

--- a/DDCore/src/plugins/GeometryWalk.cpp
+++ b/DDCore/src/plugins/GeometryWalk.cpp
@@ -12,26 +12,24 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Factories.h"
-#include "DD4hep/IDDescriptor.h"
-#include "DD4hep/VolumeManager.h"
-#include "DD4hep/DetectorTools.h"
-//#include "DD4hep/DetectorAlignment.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Factories.h>
+#include <DD4hep/IDDescriptor.h>
+#include <DD4hep/VolumeManager.h>
+#include <DD4hep/DetectorTools.h>
 
 // C/C++ include files
 #include <stdexcept>
 #include <algorithm>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
-typedef detail::tools::ElementPath   ElementPath;
-typedef detail::tools::PlacementPath PlacementPath;
+using ElementPath = detail::tools::ElementPath;
+using PlacementPath = detail::tools::PlacementPath;
 
 namespace  {
+
   /** @class GeometryWalk
    *
    *  Test the volume manager by scanning the sensitive
@@ -43,8 +41,8 @@ namespace  {
   struct GeometryWalk  {
     /// Helper to scan volume ids
     struct FND {
-      const string& test;
-      FND(const string& c) : test(c) {}
+      const std::string& test;
+      FND(const std::string& c) : test(c) {}
       bool operator()(const PlacedVolume::VolIDs::value_type& c) const { return c.first == test; }
     };
     VolumeManager m_mgr;
@@ -69,35 +67,35 @@ typedef DetElement::Children _C;
 GeometryWalk::GeometryWalk(Detector& description, DetElement sdet) : m_det(sdet) {
   m_mgr = description.volumeManager();
   if ( !m_det.isValid() )   {
-    stringstream err;
+    std::stringstream err;
     err << "The subdetector " << m_det.name() << " is not known to the geometry.";
     printout(INFO,"GeometryWalk",err.str().c_str());
-    throw runtime_error(err.str());
+    throw std::runtime_error(err.str());
   }
   walk(m_det,PlacedVolume::VolIDs());
 }
 
 /// Printout volume information
 void GeometryWalk::print(DetElement e, PlacedVolume pv, const PlacedVolume::VolIDs& /* child_ids */)  const {
-  stringstream log;
+  std::stringstream log;
   PlacementPath all_nodes;
   ElementPath   det_elts;
   detail::tools::elementPath(e,det_elts);
   detail::tools::placementPath(e,all_nodes);
-  string elt_path  = detail::tools::elementPath(det_elts);
-  string node_path = detail::tools::placementPath(all_nodes);
-  log << "Lookup " << left << setw(32) << pv.name() << " Detector[" << det_elts.size() << "]: " << elt_path;
+  std::string elt_path  = detail::tools::elementPath(det_elts);
+  std::string node_path = detail::tools::placementPath(all_nodes);
+  log << "Lookup " << std::left << std::setw(32) << pv.name() << " Detector[" << det_elts.size() << "]: " << elt_path;
   printout(INFO,m_det.name(),log.str());
   log.str("");
-  log << "       " << left << setw(32) << "       " << " Places[" <<  all_nodes.size()  << "]:   " << node_path;
+  log << "       " << std::left << std::setw(32) << "       " << " Places[" <<  all_nodes.size()  << "]:   " << node_path;
   printout(INFO,m_det.name(),log.str());
   log.str("");
-  log << "       " << left << setw(32) << "       " << " detail::matrix[" <<  all_nodes.size()  << "]: ";
+  log << "       " << std::left << std::setw(32) << "       " << " detail::matrix[" <<  all_nodes.size()  << "]: ";
   for(PlacementPath::const_iterator i=all_nodes.begin(); i!=all_nodes.end(); ++i)  {
     log << (void*)((*i)->GetMatrix()) << "  ";
     if ( i+1 == all_nodes.end() ) log << "( -> " << (*i)->GetName() << ")";
   }
-  printout(INFO,m_det.name(),log.str());
+  printout(INFO, m_det.name(), log.str());
 }
 
 /// Walk through tree of volume placements
@@ -114,20 +112,20 @@ void GeometryWalk::walk(DetElement e, PlacedVolume::VolIDs ids)  const   {
 
 /// Action routine to execute the test
 long GeometryWalk::run(Detector& description,int argc,char** argv)    {
-  cout << "++ Processing plugin....GeometryWalker.." << endl;
+  std::cout << "++ Processing plugin....GeometryWalker.." << std::endl;
   DetElement world = description.world();
   for(int in=1; in < argc; ++in)  {
-    string name = argv[in]+1;
+    std::string name = argv[in]+1;
     if ( name == "all" || name == "All" || name == "ALL" )  {
       const _C& children = world.children();
       for (_C::const_iterator i=children.begin(); i!=children.end(); ++i)  {
         DetElement sdet = (*i).second;
-        cout << "++ Processing subdetector: " << sdet.name() << endl;
+        std::cout << "++ Processing subdetector: " << sdet.name() << std::endl;
         GeometryWalk test(description, sdet);
       }
       return 1;
     }
-    cout << "++ Processing subdetector: " << name << endl;
+    std::cout << "++ Processing subdetector: " << name << std::endl;
     GeometryWalk test(description, description.detector(name));
   }
   return 1;

--- a/DDCore/src/plugins/JsonProcessor.cpp
+++ b/DDCore/src/plugins/JsonProcessor.cpp
@@ -46,11 +46,9 @@ namespace {
   class detector;
 }
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
-static void setChildTitles(const pair<string, DetElement>& e) {
+static void setChildTitles(const std::pair<std::string, DetElement>& e) {
   DetElement parent = e.second.parent();
   const DetElement::Children& children = e.second.children();
   if (::strlen(e.second->GetTitle()) == 0) {
@@ -65,10 +63,10 @@ namespace dd4hep  {
 
 /// This is the identical converter as it is used for the XML compact!
 template <> void Converter<detector>::operator()(json_h element) const {
-  string type = element.attr<string>(_U(type));
-  string name = element.attr<string>(_U(name));
-  string name_match = ":" + name + ":";
-  string type_match = ":" + type + ":";
+  std::string type = element.attr<std::string>(_U(type));
+  std::string name = element.attr<std::string>(_U(name));
+  std::string name_match = ":" + name + ":";
+  std::string type_match = ":" + type + ":";
 
   try {
     json_attr_t attr_par = element.attr_nothrow(_U(parent));
@@ -76,7 +74,7 @@ template <> void Converter<detector>::operator()(json_h element) const {
       // We have here a nested detector. If the mother volume is not yet registered
       // it must be done here, so that the detector constructor gets the correct answer from
       // the call to Detector::pickMotherVolume(DetElement).
-      string par_name = element.attr<string>(attr_par);
+      std::string par_name = element.attr<std::string>(attr_par);
       DetElement parent_detector = description.detector(par_name);
       if ( !parent_detector.isValid() )  {
         except("Compact","Failed to access valid parent detector of %s",name.c_str());
@@ -87,9 +85,9 @@ template <> void Converter<detector>::operator()(json_h element) const {
     SensitiveDetector sd;
     Segmentation seg;
     if ( attr_ro )   {
-      Readout ro = description.readout(element.attr<string>(attr_ro));
+      Readout ro = description.readout(element.attr<std::string>(attr_ro));
       if (!ro.isValid()) {
-        throw runtime_error("No Readout structure present for detector:" + name);
+        throw std::runtime_error("No Readout structure present for detector:" + name);
       }
       seg = ro.segmentation();
       sd = SensitiveDetector(name, "sensitive");
@@ -100,7 +98,7 @@ template <> void Converter<detector>::operator()(json_h element) const {
     Handle<NamedObject> sens = sd;
     DetElement det(PluginService::Create<NamedObject*>(type, &description, &element, &sens));
     if (det.isValid()) {
-      setChildTitles(make_pair(name, det));
+      setChildTitles(std::make_pair(name, det));
       if ( sd.isValid() )  {
         det->flag |= DetElement::Object::HAVE_SENSITIVE_DETECTOR;
       }
@@ -116,18 +114,18 @@ template <> void Converter<detector>::operator()(json_h element) const {
     if (!det.isValid()) {
       PluginDebug dbg;
       PluginService::Create<NamedObject*>(type, &description, &element, &sens);
-      throw runtime_error("Failed to execute subdetector creation plugin. " + dbg.missingFactory(type));
+      throw std::runtime_error("Failed to execute subdetector creation plugin. " + dbg.missingFactory(type));
     }
     description.addDetector(det);
     return;
   }
-  catch (const exception& e) {
+  catch (const std::exception& e) {
     printout(ERROR, "Compact", "++ FAILED    to convert subdetector: %s: %s", name.c_str(), e.what());
-    terminate();
+    std::terminate();
   }
   catch (...) {
     printout(ERROR, "Compact", "++ FAILED    to convert subdetector: %s: %s", name.c_str(), "UNKNONW Exception");
-    terminate();
+    std::terminate();
   }
 }
 
@@ -140,8 +138,8 @@ static long handle_json(Detector& description, int argc, char** argv) {
              "\n");
     exit(EINVAL);
   }
-  string file = argv[0];
-  if ( file[0] != '/' ) file = string(argv[1]) + "/" + file;
+  std::string file = argv[0];
+  if ( file[0] != '/' ) file = std::string(argv[1]) + "/" + file;
 
   printout(INFO,"JsonProcessor","++ Processing JSON input: %s",file.c_str());
   json::DocumentHolder doc(json::DocumentHandler().load(file.c_str()));

--- a/DDCore/src/plugins/LCDD2Output.cpp
+++ b/DDCore/src/plugins/LCDD2Output.cpp
@@ -11,51 +11,56 @@
 //
 //==========================================================================
 
+// Framework includes
 #include "XML/Conversions.h"
 #include "DD4hep/Detector.h"
 #include "DD4hep/Objects.h"
 #include "DD4hep/Printout.h"
 #include "DD4hep/IDDescriptor.h"
 
+// ROOT includes
 #include "TMap.h"
 #include "TROOT.h"
 #include "TColor.h"
 #include "TGeoMatrix.h"
 #include "TGeoManager.h"
+
+/// C/C++ include files
 #include <iostream>
 #include <iomanip>
 
-using namespace std;
+/// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
-  using namespace detail;
 
   void dumpNode(TGeoNode* n, int level) {
     TGeoMatrix* mat = n->GetMatrix();
     TGeoVolume* vol = n->GetVolume();
     TGeoMedium* med = vol->GetMedium();
-    TGeoShape* shape = vol->GetShape();
-    TObjArray* nodes = vol->GetNodes();
+    TGeoShape*  shape = vol->GetShape();
+    TObjArray*  nodes = vol->GetNodes();
     for (int i = 0; i < level; ++i)
-      cout << " ";
-    cout << " ++Node:|" << n->GetName() << "| ";
-    cout << " Volume: " << vol->GetName() << " material:" << med->GetName() << " shape:" << shape->GetName() << endl;
+      std::cout << " ";
+    std::cout << " ++Node:|" << n->GetName() << "| ";
+    std::cout << " Volume: " << vol->GetName() << " material:" << med->GetName()
+              << " shape:" << shape->GetName() << std::endl;
     for (int i = 0; i < level; ++i)
-      cout << " ";
+      std::cout << " ";
     const Double_t* tr = mat->GetTranslation();
-    cout << "         matrix:|" << mat->GetName() << "|" << mat->IsTranslation() << mat->IsRotation() << mat->IsScale()
-         << " tr:x=" << tr[0] << " y=" << tr[1] << " z=" << tr[2];
+    std::cout << "         matrix:|" << mat->GetName()
+              << "|" << mat->IsTranslation() << mat->IsRotation() << mat->IsScale()
+              << " tr:x=" << tr[0] << " y=" << tr[1] << " z=" << tr[2];
     if (mat->IsRotation()) {
       Double_t theta, phi, psi;
       TGeoRotation rot(*mat);
       rot.GetAngles(phi, theta, psi);
-      cout << " rot: theta:" << theta << " phi:" << phi << " psi:" << psi;
+      std::cout << " rot: theta:" << theta << " phi:" << phi << " psi:" << psi;
     }
-    cout << endl;
+    std::cout << std::endl;
     PlacedVolume plv(n);
     for (int i = 0; i < level; ++i)
-      cout << " ";
-    cout << "         volume:" << plv.toString();
-    cout << endl;
+      std::cout << " ";
+    std::cout << "         volume:" << plv.toString();
+    std::cout << std::endl;
     TIter next(nodes);
     TGeoNode *geoNode;
     while ((geoNode = (TGeoNode *) next())) {
@@ -69,8 +74,8 @@ namespace dd4hep {
     TGeoShape* shape = vol->GetShape();
 
     for (int i = 0; i < level; ++i)
-      cout << " ";
-    cout << "++Volume: " << vol->GetName() << " material:" << med->GetName() << " shape:" << shape->GetName() << endl;
+      std::cout << " ";
+    std::cout << "++Volume: " << vol->GetName() << " material:" << med->GetName() << " shape:" << shape->GetName() << std::endl;
     TIter next(nodes);
     TGeoNode *geoNode;
     while ((geoNode = (TGeoNode *) next())) {

--- a/DDCore/src/plugins/LCDDConverter.cpp
+++ b/DDCore/src/plugins/LCDDConverter.cpp
@@ -12,52 +12,54 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Plugins.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Volumes.h"
-#include "DD4hep/FieldTypes.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/Segmentations.h"
-#include "DD4hep/detail/ObjectsInterna.h"
-#include "DD4hep/detail/DetectorInterna.h"
-#include "XML/DocumentHandler.h"
 #include "LCDDConverter.h"
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Volumes.h>
+#include <DD4hep/FieldTypes.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Segmentations.h>
+#include <DD4hep/detail/ObjectsInterna.h>
+#include <DD4hep/detail/DetectorInterna.h>
+#include <XML/DocumentHandler.h>
 
 // ROOT includes
-#include "TROOT.h"
-#include "TColor.h"
-#include "TGeoShape.h"
+#include <TROOT.h>
+#include <TColor.h>
+#include <TGeoShape.h>
 
-#include "TGeoArb8.h"
-#include "TGeoBoolNode.h"
-#include "TGeoCompositeShape.h"
-#include "TGeoCone.h"
-#include "TGeoEltu.h"
-#include "TGeoHype.h"
-#include "TGeoMatrix.h"
-#include "TGeoParaboloid.h"
-#include "TGeoPara.h"
-#include "TGeoPcon.h"
-#include "TGeoPgon.h"
-#include "TGeoShapeAssembly.h"
-#include "TGeoSphere.h"
-#include "TGeoTorus.h"
-#include "TGeoTrd1.h"
-#include "TGeoTrd2.h"
-#include "TGeoTube.h"
-#include "TGeoScaledShape.h"
+#include <TGeoArb8.h>
+#include <TGeoBoolNode.h>
+#include <TGeoCompositeShape.h>
+#include <TGeoCone.h>
+#include <TGeoEltu.h>
+#include <TGeoHype.h>
+#include <TGeoMatrix.h>
+#include <TGeoParaboloid.h>
+#include <TGeoPara.h>
+#include <TGeoPcon.h>
+#include <TGeoPgon.h>
+#include <TGeoShapeAssembly.h>
+#include <TGeoSphere.h>
+#include <TGeoTorus.h>
+#include <TGeoTrd1.h>
+#include <TGeoTrd2.h>
+#include <TGeoTube.h>
+#include <TGeoScaledShape.h>
 
-#include "TGeoNode.h"
-#include "TClass.h"
-#include "TMath.h"
+#include <TGeoNode.h>
+#include <TClass.h>
+#include <TMath.h>
+
+/// C/C++ include files
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <iomanip>
 
-using namespace dd4hep::detail;
 using namespace dd4hep;
-using namespace std;
+using namespace dd4hep::detail;
+
 namespace {
   typedef Position XYZRotation;
 
@@ -86,8 +88,8 @@ namespace {
       c = 0;
     }
     XYZRotation rr(a, b, c);
-    cout << " X:" << a << " " << rr.X() << " Y:" << b << " " << rr.Y() << " Z:" << c << " " << rr.Z()
-         << " lx:" << r[0] << " ly:" << r[4] << " lz:" << r[8] << endl;
+    std::cout << " X:" << a << " " << rr.X() << " Y:" << b << " " << rr.Y() << " Z:" << c << " " << rr.Z()
+              << " lx:" << r[0] << " ly:" << r[4] << " lz:" << r[8] << std::endl;
     return XYZRotation(a, b, c);
   }
 #endif
@@ -100,9 +102,9 @@ namespace {
     return node.data() != 0;
   }
 
-  string genName(const string& n)  {  return n; }
-  string genName(const string& n, const void* ptr)  {
-    string nn = genName(n);
+  std::string genName(const std::string& n)  {  return n; }
+  std::string genName(const std::string& n, const void* ptr)  {
+    std::string nn = genName(n);
     char text[32];
     ::snprintf(text,sizeof(text),"%p",ptr);
     nn += "_";
@@ -111,11 +113,11 @@ namespace {
   }
 }
 
-void LCDDConverter::GeometryInfo::check(const string& name, const TNamed* _n, map<string, const TNamed*>& _m) const {
-  map<string, const TNamed*>::const_iterator i = _m.find(name);
+void LCDDConverter::GeometryInfo::check(const std::string& name, const TNamed* _n, std::map<std::string, const TNamed*>& _m) const {
+  std::map<std::string, const TNamed*>::const_iterator i = _m.find(name);
   if (i != _m.end()) {
     const char* isa = _n ? _n->IsA()->GetName() : (*i).second ? (*i).second->IsA()->GetName() : "Unknown";
-    cout << isa << "(position):  duplicate entry with name:" << name << " " << (void*) _n << " " << (void*) (*i).second << endl;
+    std::cout << isa << "(position):  duplicate entry with name:" << name << " " << (void*) _n << " " << (void*) (*i).second << std::endl;
   }
   _m.insert(make_pair(name, _n));
 }
@@ -132,7 +134,7 @@ LCDDConverter::~LCDDConverter() {
 }
 
 /// Dump element in GDML format to output stream
-xml_h LCDDConverter::handleElement(const string& /* name */, Atom element) const {
+xml_h LCDDConverter::handleElement(const std::string& /* name */, Atom element) const {
   GeometryInfo& geo = data();
   xml_h e = geo.xmlElements[element];
   if (!e) {
@@ -155,7 +157,7 @@ xml_h LCDDConverter::handleElement(const string& /* name */, Atom element) const
 }
 
 /// Dump material in GDML format to output stream
-xml_h LCDDConverter::handleMaterial(const string& name, Material medium) const {
+xml_h LCDDConverter::handleMaterial(const std::string& name, Material medium) const {
   GeometryInfo& geo = data();
   xml_h mat = geo.xmlMaterials[medium];
   if (!mat) {
@@ -184,7 +186,7 @@ xml_h LCDDConverter::handleMaterial(const string& name, Material medium) const {
       }
       for (int i = 0, n = mix->GetNelements(); i < n; i++) {
         TGeoElement *elt = mix->GetElement(i);
-        //string formula = elt->GetTitle() + string("_elm");
+        //std::string formula = elt->GetTitle() + std::string("_elm");
         if (nmix) {
           mat.append(obj = xml_elt_t(geo.doc, _U(composite)));
           obj.setAttr(_U(n), nmix[i]);
@@ -216,7 +218,7 @@ xml_h LCDDConverter::handleMaterial(const string& name, Material medium) const {
 }
 
 /// Dump solid in GDML format to output stream
-xml_h LCDDConverter::handleSolid(const string& name, const TGeoShape* shape) const {
+xml_h LCDDConverter::handleSolid(const std::string& name, const TGeoShape* shape) const {
   GeometryInfo& geo = data();
   SolidMap::iterator sit = geo.xmlSolids.find(shape);
   if (!shape) {
@@ -236,7 +238,7 @@ xml_h LCDDConverter::handleSolid(const string& name, const TGeoShape* shape) con
     xml_h solid(0);
     xml_h zplane(0);
     TClass* isa = shape->IsA();
-    string shape_name = shape->GetName(); //genName(shape->GetName(),shape);
+    std::string shape_name = shape->GetName(); //genName(shape->GetName(),shape);
     geo.checkShape(name, shape);
     if (isa == TGeoBBox::Class()) {
       const TGeoBBox* sh = (const TGeoBBox*) shape;
@@ -501,10 +503,10 @@ xml_h LCDDConverter::handleSolid(const string& name, const TGeoShape* shape) con
       xml_h right   = handleSolid(rs->GetName(), rs);
       xml_h first_solid(0), second_solid(0);
       if (!left) {
-        throw runtime_error("G4Converter: No left Detector Solid present for composite shape:" + name);
+        throw std::runtime_error("G4Converter: No left Detector Solid present for composite shape:" + name);
       }
       if (!right) {
-        throw runtime_error("G4Converter: No right Detector Solid present for composite shape:" + name);
+        throw std::runtime_error("G4Converter: No right Detector Solid present for composite shape:" + name);
       }
 
       //specific case!
@@ -545,8 +547,8 @@ xml_h LCDDConverter::handleSolid(const string& name, const TGeoShape* shape) con
         solid = xml_elt_t(geo.doc,_U(intersection));
 
       xml_h obj;
-      string lnam = left.attr<string>(_U(name));
-      string rnam = right.attr<string>(_U(name));
+      std::string lnam = left.attr<std::string>(_U(name));
+      std::string rnam = right.attr<std::string>(_U(name));
 
       geo.doc_solids.append(solid);
       solid.append(first_solid = xml_elt_t(geo.doc, _U(first)));
@@ -591,8 +593,8 @@ xml_h LCDDConverter::handleSolid(const string& name, const TGeoShape* shape) con
       }
     }
     if (!solid) {
-      string err = "Failed to handle unknown solid shape:" + name + " of type " + string(shape->IsA()->GetName());
-      throw runtime_error(err);
+      std::string err = "Failed to handle unknown solid shape:" + name + " of type " + std::string(shape->IsA()->GetName());
+      throw std::runtime_error(err);
     }
     return data().xmlSolids[shape] = solid;
   }
@@ -605,7 +607,7 @@ xml_h LCDDConverter::handlePosition(const std::string& name, const TGeoMatrix* t
   if (!pos) {
     const double* tr = trafo->GetTranslation();
     if (tr[0] != 0.0 || tr[1] != 0.0 || tr[2] != 0.0) {
-      string gen_name = genName(name,trafo);
+      std::string gen_name = genName(name,trafo);
       geo.checkPosition(gen_name, trafo);
       geo.doc_define.append(pos = xml_elt_t(geo.doc, _U(position)));
       pos.setAttr(_U(name), gen_name);
@@ -639,7 +641,7 @@ xml_h LCDDConverter::handleRotation(const std::string& name, const TGeoMatrix* t
   if (!rot) {
     XYZRotation r = getXYZangles(trafo->GetRotationMatrix());
     if (!(r.X() == 0.0 && r.Y() == 0.0 && r.Z() == 0.0)) {
-      string gen_name = genName(name,trafo);
+      std::string gen_name = genName(name,trafo);
       geo.checkRotation(gen_name, trafo);
       geo.doc_define.append(rot = xml_elt_t(geo.doc, _U(rotation)));
       rot.setAttr(_U(name), gen_name);
@@ -667,13 +669,13 @@ xml_h LCDDConverter::handleRotation(const std::string& name, const TGeoMatrix* t
 }
 
 /// Dump logical volume in GDML format to output stream
-xml_h LCDDConverter::handleVolume(const string& /* name */, Volume volume) const {
+xml_h LCDDConverter::handleVolume(const std::string& /* name */, Volume volume) const {
   GeometryInfo& geo = data();
   xml_h vol = geo.xmlVolumes[volume];
   if (!vol) {
     const TGeoVolume* v = volume;
     Volume      _v(v);
-    string      n      = genName(v->GetName(),v);
+    std::string n      = genName(v->GetName(),v);
     TGeoMedium* medium = v->GetMedium();
     TGeoShape*  sh     = v->GetShape();
     xml_ref_t   sol    = handleSolid(sh->GetName(), sh);
@@ -685,15 +687,15 @@ xml_h LCDDConverter::handleVolume(const string& /* name */, Volume volume) const
     }
     else {
       if (!sol)
-        throw runtime_error("G4Converter: No Detector Solid present for volume:" + n);
+        throw std::runtime_error("G4Converter: No Detector Solid present for volume:" + n);
       else if (!m)
-        throw runtime_error("G4Converter: No Detector material present for volume:" + n);
+        throw std::runtime_error("G4Converter: No Detector material present for volume:" + n);
 
       vol = xml_elt_t(geo.doc, _U(volume));
       vol.setAttr(_U(name), n);
       if (m) {
-        string    mat_name = medium->GetName();
-        xml_ref_t med      = handleMaterial(mat_name, Material(medium));
+        std::string mat_name = medium->GetName();
+        xml_ref_t   med      = handleMaterial(mat_name, Material(medium));
         vol.setRef(_U(materialref), med.name());
       }
       vol.setRef(_U(solidref), sol.name());
@@ -734,7 +736,7 @@ xml_h LCDDConverter::handleVolume(const string& /* name */, Volume volume) const
 }
 
 /// Dump logical volume in GDML format to output stream
-xml_h LCDDConverter::handleVolumeVis(const string& /* name */, const TGeoVolume* volume) const {
+xml_h LCDDConverter::handleVolumeVis(const std::string& /* name */, const TGeoVolume* volume) const {
   GeometryInfo& geo = data();
   xml_h         vol = geo.xmlVolumes[volume];
   if (!vol) {
@@ -755,7 +757,7 @@ xml_h LCDDConverter::handleVolumeVis(const string& /* name */, const TGeoVolume*
 }
 
 /// Dump logical volume in GDML format to output stream
-void LCDDConverter::collectVolume(const string& /* name */, const TGeoVolume* volume) const {
+void LCDDConverter::collectVolume(const std::string& /* name */, const TGeoVolume* volume) const {
   Volume v(volume);
   if ( is_volume(volume) )     {
     GeometryInfo&     geo = data();
@@ -774,11 +776,11 @@ void LCDDConverter::collectVolume(const string& /* name */, const TGeoVolume* vo
   }
 }
 
-void LCDDConverter::checkVolumes(const string& /* name */, Volume v) const {
-  string n = v.name()+_toString(v.ptr(),"_%p");
+void LCDDConverter::checkVolumes(const std::string& /* name */, Volume v) const {
+  std::string n = v.name()+_toString(v.ptr(),"_%p");
   NameSet::const_iterator i = m_checkNames.find(n);
   if (i != m_checkNames.end()) {
-    stringstream str;
+    std::stringstream str;
     str << "++ CheckVolumes: Volume " << n << " ";
     if (is_volume(v.ptr()))     {
       SensitiveDetector sd = v.sensitiveDetector();
@@ -790,7 +792,7 @@ void LCDDConverter::checkVolumes(const string& /* name */, Volume v) const {
         str << "with VisAttrs " << vis.name() << " ";
       }
     }
-    str << "has duplicate entries." << endl;
+    str << "has duplicate entries." << std::endl;
     printout(ERROR,"LCDDConverter",str.str().c_str());
     return;
   }
@@ -798,7 +800,7 @@ void LCDDConverter::checkVolumes(const string& /* name */, Volume v) const {
 }
 
 /// Dump volume placement in GDML format to output stream
-xml_h LCDDConverter::handlePlacement(const string& name,PlacedVolume node) const {
+xml_h LCDDConverter::handlePlacement(const std::string& name,PlacedVolume node) const {
   GeometryInfo& geo = data();
   xml_h place = geo.xmlPlacements[node];
   if (!place) {
@@ -834,7 +836,7 @@ xml_h LCDDConverter::handlePlacement(const string& name,PlacedVolume node) const
     geo.xmlPlacements[node] = place;
   }
   else {
-    cout << "Attempt to DOUBLE-place physical volume:" << name << " No:" << node->GetNumber() << endl;
+    std::cout << "Attempt to DOUBLE-place physical volume:" << name << " No:" << node->GetNumber() << std::endl;
   }
   return place;
 }
@@ -862,8 +864,8 @@ xml_h LCDDConverter::handleLimitSet(const std::string& /* name */, LimitSet lim)
   if (!xml) {
     geo.doc_limits.append(xml = xml_elt_t(geo.doc, _U(limitset)));
     xml.setAttr(_U(name), lim.name());
-    const set<Limit>& obj = lim.limits();
-    for (set<Limit>::const_iterator i = obj.begin(); i != obj.end(); ++i) {
+    const std::set<Limit>& obj = lim.limits();
+    for (std::set<Limit>::const_iterator i = obj.begin(); i != obj.end(); ++i) {
       xml_h x = xml_elt_t(geo.doc, _U(limit));
       const Limit& l = *i;
       xml.append(x);
@@ -882,13 +884,13 @@ xml_h LCDDConverter::handleSegmentation(Segmentation seg) const {
   xml_h xml;
   if (seg.isValid()) {
     typedef DDSegmentation::Parameters _P;
-    string typ = seg.type();
+    std::string typ = seg.type();
     _P p = seg.parameters();
     xml = xml_elt_t(data().doc, Unicode(typ));
     for (_P::const_iterator i = p.begin(); i != p.end(); ++i) {
       const _P::value_type& v = *i;
       if (v->name() == "lunit") {
-        string val = v->value() == _toDouble("mm") ? "mm" : v->value() == _toDouble("cm") ? "cm" :
+        std::string val = v->value() == _toDouble("mm") ? "mm" : v->value() == _toDouble("cm") ? "cm" :
           v->value() == _toDouble("m") ? "m" : v->value() == _toDouble("micron") ? "micron" :
           v->value() == _toDouble("nanometer") ? "namometer" : "??";
         xml.setAttr(Unicode(v->name()), Unicode(val));
@@ -910,7 +912,7 @@ xml_h LCDDConverter::handleSegmentation(Segmentation seg) const {
 }
 
 /// Convert the geometry type SensitiveDetector into the corresponding Detector object(s).
-xml_h LCDDConverter::handleSensitive(const string& /* name */, SensitiveDetector sd) const {
+xml_h LCDDConverter::handleSensitive(const std::string& /* name */, SensitiveDetector sd) const {
   GeometryInfo& geo = data();
   xml_h sensdet = geo.xmlSensDets[sd];
   if (!sensdet) {
@@ -971,7 +973,7 @@ xml_h LCDDConverter::handleIdSpec(const std::string& name, IDDescriptor id_spec)
 }
 
 /// Convert the geometry visualisation attributes to the corresponding Detector object(s).
-xml_h LCDDConverter::handleVis(const string& /* name */, VisAttr attr) const {
+xml_h LCDDConverter::handleVis(const std::string& /* name */, VisAttr attr) const {
   GeometryInfo& geo = data();
   xml_h vis = geo.xmlVis[attr];
   if (!vis) {
@@ -1010,7 +1012,7 @@ xml_h LCDDConverter::handleField(const std::string& /* name */, OverlayedField f
   xml_h field = geo.xmlFields[f];
   if (!field) {
     Handle<NamedObject> fld(f);
-    string type = f->GetTitle();
+    std::string type = f->GetTitle();
     field = xml_elt_t(geo.doc, Unicode(type));
     field.setAttr(_U(name), f->GetName());
     fld = PluginService::Create<NamedObject*>(type + "_Convert2Detector", &m_detDesc, &field, &fld);
@@ -1019,8 +1021,8 @@ xml_h LCDDConverter::handleField(const std::string& /* name */, OverlayedField f
     if (!fld.isValid()) {
       PluginDebug dbg;
       PluginService::Create<NamedObject*>(type + "_Convert2Detector", &m_detDesc, &field, &fld);
-      throw runtime_error("Failed to locate plugin to convert electromagnetic field:"
-                          + string(f->GetName()) + " of type " + type + ". "
+      throw std::runtime_error("Failed to locate plugin to convert electromagnetic field:"
+                          + std::string(f->GetName()) + " of type " + type + ". "
                           + dbg.missingFactory(type));
     }
     geo.doc_fields.append(field);
@@ -1030,11 +1032,11 @@ xml_h LCDDConverter::handleField(const std::string& /* name */, OverlayedField f
 
 /// Handle the geant 4 specific properties
 void LCDDConverter::handleProperties(Detector::Properties& prp) const {
-  map<string, string> processors;
+  std::map<std::string, std::string> processors;
   static int s_idd = 9999999;
-  string id;
+  std::string id;
   for (Detector::Properties::const_iterator i = prp.begin(); i != prp.end(); ++i) {
-    const string& nam = (*i).first;
+    const std::string& nam = (*i).first;
     const Detector::PropertyValues& vals = (*i).second;
     if (nam.substr(0, 6) == "geant4") {
       Detector::PropertyValues::const_iterator id_it = vals.find("id");
@@ -1049,25 +1051,25 @@ void LCDDConverter::handleProperties(Detector::Properties& prp) const {
       processors.insert(make_pair(id, nam));
     }
   }
-  for (map<string, string>::const_iterator i = processors.begin(); i != processors.end(); ++i) {
+  for (std::map<std::string, std::string>::const_iterator i = processors.begin(); i != processors.end(); ++i) {
     const GeoHandler* ptr = this;
-    string nam = (*i).second;
+    std::string nam = (*i).second;
     const Detector::PropertyValues& vals = prp[nam];
-    string type = vals.find("type")->second;
-    string tag = type + "_Geant4_action";
+    std::string type = vals.find("type")->second;
+    std::string tag = type + "_Geant4_action";
     long result = PluginService::Create<long>(tag, &m_detDesc, ptr, &vals);
     if (0 == result) {
       PluginDebug dbg;
       result = PluginService::Create<long>(tag, &m_detDesc, ptr, &vals);
       if (0 == result) {
-        throw runtime_error("Failed to locate plugin to interprete files of type"
+        throw std::runtime_error("Failed to locate plugin to interprete files of type"
                             " \"" + tag + "\" - no factory:" + type + ". " +
                             dbg.missingFactory(tag));
       }
     }
     result = *(long*) result;
     if (result != 1) {
-      throw runtime_error("Failed to invoke the plugin " + tag + " of type " + type);
+      throw std::runtime_error("Failed to invoke the plugin " + tag + " of type " + type);
     }
     printout(INFO,"","+++ Executed Successfully Detector setup module %s.",type.c_str());
   }
@@ -1097,7 +1099,7 @@ void LCDDConverter::handleHeader() const {
 
 template <typename O, typename C, typename F> void handle(const O* o, const C& c, F pmf) {
   for (typename C::const_iterator i = c.begin(); i != c.end(); ++i) {
-    string n = (*i)->GetName();
+    std::string n = (*i)->GetName();
     (o->*pmf)(n, *i);
   }
 }
@@ -1116,7 +1118,7 @@ template <typename O, typename C, typename F> void handleRMap(const O* o, const 
 xml_doc_t LCDDConverter::createGDML(DetElement top) {
   Detector& description = m_detDesc;
   if (!top.isValid()) {
-    throw runtime_error("Attempt to call createGDML with an invalid geometry!");
+    throw std::runtime_error("Attempt to call createGDML with an invalid geometry!");
   }
   GeometryInfo& geo = *(m_dataPtr = new GeometryInfo);
   m_data->clear();
@@ -1171,7 +1173,7 @@ xml_doc_t LCDDConverter::createGDML(DetElement top) {
 /// Create geometry conversion
 xml_doc_t LCDDConverter::createVis(DetElement top) {
   if (!top.isValid()) {
-    throw runtime_error("Attempt to call createDetector with an invalid geometry!");
+    throw std::runtime_error("Attempt to call createDetector with an invalid geometry!");
   }
 
   GeometryInfo& geo = *(m_dataPtr = new GeometryInfo);
@@ -1196,7 +1198,7 @@ xml_doc_t LCDDConverter::createVis(DetElement top) {
 xml_doc_t LCDDConverter::createDetector(DetElement top) {
   Detector& description = m_detDesc;
   if (!top.isValid()) {
-    throw runtime_error("Attempt to call createDetector with an invalid geometry!");
+    throw std::runtime_error("Attempt to call createDetector with an invalid geometry!");
   }
 
   GeometryInfo& geo = *(m_dataPtr = new GeometryInfo);
@@ -1306,12 +1308,12 @@ static long create_visASCII(Detector& description, int /* argc */, char** argv) 
   LCDDConverter wr(description);
   /* xml_doc_t doc = */ wr.createVis(description.world());
   LCDDConverter::GeometryInfo& geo = wr.data();
-  map<string, xml_comp_t> vis_map;
+  std::map<std::string, xml_comp_t> vis_map;
   for (xml_coll_t c(geo.doc_display, _U(vis)); c; ++c)
     vis_map.insert(make_pair(xml_comp_t(c).nameStr(), xml_comp_t(c)));
 
   const char* sep = ";";
-  ofstream os(argv[0]);
+  std::ofstream os(argv[0]);
   for (xml_coll_t c(geo.doc_structure, _U(volume)); c; ++c) {
     xml_comp_t vol = c;
     xml_comp_t ref = c.child(_U(visref));
@@ -1321,9 +1323,9 @@ static long create_visASCII(Detector& description, int /* argc */, char** argv) 
        << "visible:" << vis.visible() << sep << "r:"
        << col.R() << sep << "g:" << col.G() << sep << "b:" << col.B() << sep 
        << "alpha:" << col.alpha() << sep << "line_style:"
-       << vis.attr < string > (_U(line_style)) << sep 
-       << "drawing_style:" << vis.attr < string> (_U(drawing_style)) << sep 
-       << "show_daughters:" << vis.show_daughters() << sep << endl;
+       << vis.attr < std::string > (_U(line_style)) << sep 
+       << "drawing_style:" << vis.attr < std::string> (_U(drawing_style)) << sep 
+       << "show_daughters:" << vis.show_daughters() << sep << std::endl;
   }
   os.close();
   return 1;

--- a/DDCore/src/plugins/PluginInvoker.cpp
+++ b/DDCore/src/plugins/PluginInvoker.cpp
@@ -12,19 +12,17 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "XML/Conversions.h"
-#include "XML/XMLElements.h"
-#include "XML/DocumentHandler.h"
-#include "DD4hep/DetFactoryHelper.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <XML/Conversions.h>
+#include <XML/XMLElements.h>
+#include <XML/DocumentHandler.h>
+#include <DD4hep/DetFactoryHelper.h>
 
 // C/C++ include files
 #include <stdexcept>
 
-/*
- *   dd4hep namespace declaration
- */
+/// Namespace for the AIDA detector description toolkit
 namespace dd4hep  {
 
   namespace   {
@@ -47,9 +45,8 @@ namespace dd4hep  {
   template <> void Converter<plugin>::operator()(xml_h element)  const;
   template <> void Converter<dd4hep::arg>::operator()(xml_h element)  const;
 }
-using namespace std;
+
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 /** Convert arg objects
  *
@@ -59,8 +56,8 @@ using namespace dd4hep::detail;
  */
 template <> void Converter<dd4hep::arg>::operator()(xml_h e)  const  {
   xml_comp_t c(e);
-  string val = c.valueStr();
-  vector<string>* args = (vector<string>*)param;
+  std::string val = c.valueStr();
+  std::vector<std::string>* args = (std::vector<std::string>*)param;
   args->emplace_back(val);
 }
 
@@ -72,13 +69,13 @@ template <> void Converter<dd4hep::arg>::operator()(xml_h e)  const  {
  */
 template <> void Converter<plugin>::operator()(xml_h e)  const  {
   xml_comp_t c(e);
-  string nam = c.nameStr();
-  vector<string> args;
-  vector<const char*> cargs;
+  std::string nam = c.nameStr();
+  std::vector<std::string> args;
+  std::vector<const char*> cargs;
   //args.emplace_back("plugin:"+nam);
 
   xml_coll_t(e,"arg").for_each(Converter<dd4hep::arg>(description,&args));
-  for(vector<string>::const_iterator i=args.begin(); i!=args.end();++i)
+  for(std::vector<std::string>::const_iterator i=args.begin(); i!=args.end();++i)
     cargs.emplace_back((*i).c_str());
   printout(INFO,"ConverterPlugin","+++ Now executing plugin:%s [%d args]",nam.c_str(),int(cargs.size()));
   description.apply(nam.c_str(),int(cargs.size()),(char**)&cargs[0]);
@@ -93,20 +90,20 @@ template <> void Converter<plugin>::operator()(xml_h e)  const  {
 template <> void Converter<include_file>::operator()(xml_h element) const   {
   xml::DocumentHolder doc(xml::DocumentHandler().load(element, element.attr_value(_U(ref))));
   xml_h node = doc.root();
-  string tag = node.tag();
+  std::string tag = node.tag();
   if ( tag == "plugin" )
     Converter<plugin>(description,param)(node);
   else if ( tag == "plugins" )
     Converter<plugins>(description,param)(node);
   else
-    throw runtime_error("Undefined tag name in XML structure:"+tag+" XML parsing abandoned.");
+    throw std::runtime_error("Undefined tag name in XML structure:"+tag+" XML parsing abandoned.");
 }
 
 /** Convert plugins objects
  *
- *  @author  M.Frank
- *  @version 1.0
- *  @date    01/04/2014
+ *  \author  M.Frank
+ *  \version 1.0
+ *  \date    01/04/2014
  */
 template <> void Converter<plugins>::operator()(xml_h e)  const  {
   xml_coll_t(e, _U(define)).for_each(_U(constant),  Converter<Constant>(description,param));

--- a/DDCore/src/plugins/ReadoutSegmentations.cpp
+++ b/DDCore/src/plugins/ReadoutSegmentations.cpp
@@ -12,8 +12,8 @@
 //==========================================================================
 
 // Framework includes
-#include "DD4hep/detail/SegmentationsInterna.h"
-#include "DD4hep/Factories.h"
+#include <DD4hep/detail/SegmentationsInterna.h>
+#include <DD4hep/Factories.h>
 
 using namespace dd4hep;
 using namespace dd4hep::DDSegmentation;
@@ -25,59 +25,59 @@ namespace {
   }
 }
 
-#include "DDSegmentation/NoSegmentation.h"
+#include <DDSegmentation/NoSegmentation.h>
 DECLARE_SEGMENTATION(NoSegmentation,create_segmentation<dd4hep::DDSegmentation::NoSegmentation>)
 
-#include "DDSegmentation/CartesianGridXY.h"
+#include <DDSegmentation/CartesianGridXY.h>
 DECLARE_SEGMENTATION(CartesianGridXY,create_segmentation<dd4hep::DDSegmentation::CartesianGridXY>)
 
-#include "DDSegmentation/CartesianGridXZ.h"
+#include <DDSegmentation/CartesianGridXZ.h>
 DECLARE_SEGMENTATION(CartesianGridXZ,create_segmentation<dd4hep::DDSegmentation::CartesianGridXZ>)
 
-#include "DDSegmentation/CartesianGridYZ.h"
+#include <DDSegmentation/CartesianGridYZ.h>
 DECLARE_SEGMENTATION(CartesianGridYZ,create_segmentation<dd4hep::DDSegmentation::CartesianGridYZ>)
 
-#include "DDSegmentation/CartesianGridXYZ.h"
+#include <DDSegmentation/CartesianGridXYZ.h>
 DECLARE_SEGMENTATION(CartesianGridXYZ,create_segmentation<dd4hep::DDSegmentation::CartesianGridXYZ>)
 
-#include "DDSegmentation/CartesianGridXYStaggered.h"
+#include <DDSegmentation/CartesianGridXYStaggered.h>
 DECLARE_SEGMENTATION(CartesianGridXYStaggered,dd4hep::create_segmentation<dd4hep::DDSegmentation::CartesianGridXYStaggered>)
 
-#include "DDSegmentation/CartesianStripX.h"
+#include <DDSegmentation/CartesianStripX.h>
 DECLARE_SEGMENTATION(CartesianStripX,create_segmentation<dd4hep::DDSegmentation::CartesianStripX>)
 
-#include "DDSegmentation/CartesianStripY.h"
+#include <DDSegmentation/CartesianStripY.h>
 DECLARE_SEGMENTATION(CartesianStripY,create_segmentation<dd4hep::DDSegmentation::CartesianStripY>)
 
-#include "DDSegmentation/CartesianStripZ.h"
+#include <DDSegmentation/CartesianStripZ.h>
 DECLARE_SEGMENTATION(CartesianStripZ,create_segmentation<dd4hep::DDSegmentation::CartesianStripZ>)
 
-#include "DDSegmentation/TiledLayerGridXY.h"
+#include <DDSegmentation/TiledLayerGridXY.h>
 DECLARE_SEGMENTATION(TiledLayerGridXY,create_segmentation<dd4hep::DDSegmentation::TiledLayerGridXY>)
 
-#include "DDSegmentation/MegatileLayerGridXY.h"
+#include <DDSegmentation/MegatileLayerGridXY.h>
 DECLARE_SEGMENTATION(MegatileLayerGridXY,create_segmentation<dd4hep::DDSegmentation::MegatileLayerGridXY>)
 
-#include "DDSegmentation/WaferGridXY.h"
+#include <DDSegmentation/WaferGridXY.h>
 DECLARE_SEGMENTATION(WaferGridXY,create_segmentation<dd4hep::DDSegmentation::WaferGridXY>)
 
-#include "DDSegmentation/PolarGridRPhi.h"
+#include <DDSegmentation/PolarGridRPhi.h>
 DECLARE_SEGMENTATION(PolarGridRPhi,create_segmentation<dd4hep::DDSegmentation::PolarGridRPhi>)
 
-#include "DDSegmentation/GridPhiEta.h"
+#include <DDSegmentation/GridPhiEta.h>
 DECLARE_SEGMENTATION(GridPhiEta,create_segmentation<dd4hep::DDSegmentation::GridPhiEta>)
 
-#include "DDSegmentation/GridRPhiEta.h"
+#include <DDSegmentation/GridRPhiEta.h>
 DECLARE_SEGMENTATION(GridRPhiEta,create_segmentation<dd4hep::DDSegmentation::GridRPhiEta>)
 
-#include "DDSegmentation/PolarGridRPhi2.h"
+#include <DDSegmentation/PolarGridRPhi2.h>
 DECLARE_SEGMENTATION(PolarGridRPhi2,create_segmentation<dd4hep::DDSegmentation::PolarGridRPhi2>)
 
-#include "DDSegmentation/ProjectiveCylinder.h"
+#include <DDSegmentation/ProjectiveCylinder.h>
 DECLARE_SEGMENTATION(ProjectiveCylinder,create_segmentation<dd4hep::DDSegmentation::ProjectiveCylinder>)
 
-#include "DDSegmentation/MultiSegmentation.h"
+#include <DDSegmentation/MultiSegmentation.h>
 DECLARE_SEGMENTATION(MultiSegmentation,create_segmentation<dd4hep::DDSegmentation::MultiSegmentation>)
 
-#include "DDSegmentation/HexGrid.h"
+#include <DDSegmentation/HexGrid.h>
 DECLARE_SEGMENTATION(HexGrid,create_segmentation<dd4hep::DDSegmentation::HexGrid>)

--- a/DDCore/src/plugins/ShapePlugins.cpp
+++ b/DDCore/src/plugins/ShapePlugins.cpp
@@ -25,7 +25,6 @@
 #include <fstream>
 #include <memory>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::detail;
 
@@ -47,7 +46,7 @@ static Handle<TObject> create_Scaled(Detector&, xml_h e)   {
   xml_dim_t scale(e);
   Solid shape(xml_comp_t(scale.child(_U(shape))).createShape());
   Solid solid = Scale(shape.ptr(), scale.x(1.0), scale.y(1.0), scale.z(1.0));
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Scale__shape_constructor,create_Scaled)
@@ -67,7 +66,7 @@ DECLARE_XML_SHAPE(Scale__shape_constructor,create_Scaled)
 static Handle<TObject> create_Assembly(Detector&, xml_h e)   {
   xml_dim_t dim(e);
   Solid solid = Handle<TNamed>(new TGeoShapeAssembly());
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Assembly__shape_constructor,create_Assembly)
@@ -87,7 +86,7 @@ DECLARE_XML_SHAPE(Assembly__shape_constructor,create_Assembly)
 static Handle<TObject> create_Box(Detector&, xml_h e)   {
   xml_dim_t dim(e);
   Solid solid = Box(dim.dx(),dim.dy(),dim.dz());
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Box__shape_constructor,create_Box)
@@ -113,7 +112,7 @@ static Handle<TObject> create_HalfSpace(Detector&, xml_h e)   {
   double p[3] = { point.x(),  point.y(),  point.z()};
   double n[3] = { normal.x(), normal.y(), normal.z()};
   Solid solid = HalfSpace(p, n);
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(HalfSpace__shape_constructor,create_HalfSpace)
@@ -134,7 +133,7 @@ static Handle<TObject> create_Cone(Detector&, xml_h element)   {
   xml_dim_t e(element);
   double rmi1 = e.rmin1(0.0), rma1 = e.rmax1();
   Solid solid = Cone(e.z(0.0), rmi1, rma1, e.rmin2(rmi1), e.rmax2(rma1));
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Cone__shape_constructor,create_Cone)
@@ -159,7 +158,7 @@ DECLARE_XML_SHAPE(Cone__shape_constructor,create_Cone)
 static Handle<TObject> create_Polycone(Detector&, xml_h element)   {
   xml_dim_t e(element);
   int num = 0;
-  vector<double> rmin,rmax,z;
+  std::vector<double> rmin,rmax,z;
   double start = e.startphi(0e0), deltaphi = e.deltaphi(2*M_PI);
   for(xml_coll_t c(e,_U(zplane)); c; ++c, ++num)  {
     xml_comp_t plane(c);
@@ -168,10 +167,10 @@ static Handle<TObject> create_Polycone(Detector&, xml_h element)   {
     z.emplace_back(plane.z());
   }
   if ( num < 2 )  {
-    throw runtime_error("PolyCone Shape> Not enough Z planes. minimum is 2!");
+    throw std::runtime_error("PolyCone Shape> Not enough Z planes. minimum is 2!");
   }
   Solid solid = Polycone(start,deltaphi,rmin,rmax,z);
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Polycone__shape_constructor,create_Polycone)
@@ -215,7 +214,7 @@ static Handle<TObject> create_ConeSegment(Detector&, xml_h element)   {
     /// New naming: angles from [startphi,startphi+deltaphi]
     solid = ConeSegment(e.dz(),e.rmin1(0.0),e.rmax1(),e.rmin2(0.0),e.rmax2(),start_phi,start_phi+delta_phi);
   }
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(ConeSegment__shape_constructor,create_ConeSegment)
@@ -256,7 +255,7 @@ static Handle<TObject> create_Tube(Detector&, xml_h element)   {
     double phi2 = phi1 + e.deltaphi(2*M_PI);
     solid = Tube(e.rmin(0.0),e.rmax(),e.dz(0.0),phi1,phi2);
   }
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Tube__shape_constructor,create_Tube)
@@ -284,7 +283,7 @@ static Handle<TObject> create_TwistedTube(Detector&, xml_h element)   {
   }
   solid = TwistedTube(e.twist(0.0), e.rmin(0.0),e.rmax(),zneg, zpos, nseg, e.deltaphi(2*M_PI));
 
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(TwistedTube__shape_constructor,create_TwistedTube)
@@ -306,7 +305,7 @@ static Handle<TObject> create_CutTube(Detector&, xml_h element)   {
                         e.attr<double>(_U(tx)),
                         e.attr<double>(_U(ty)),
                         e.attr<double>(_U(tz)));
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(CutTube__shape_constructor,create_CutTube)
@@ -320,7 +319,7 @@ DECLARE_XML_SHAPE(CutTube__shape_constructor,create_CutTube)
 static Handle<TObject> create_EllipticalTube(Detector&, xml_h element)   {
   xml_dim_t e(element);
   Solid solid = EllipticalTube(e.a(),e.b(),e.dz());
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(EllipticalTube__shape_constructor,create_EllipticalTube)
@@ -338,7 +337,7 @@ static Handle<TObject> create_TruncatedTube(Detector&, xml_h element)   {
                               e.attr<double>(xml_tag_t("cutAtStart")),
                               e.attr<double>(xml_tag_t("cutAtDelta")),
                               e.attr<bool>(xml_tag_t("cutInside")));
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(TruncatedTube__shape_constructor,create_TruncatedTube)
@@ -379,7 +378,7 @@ static Handle<TObject> create_Trap(Detector&, xml_h element)   {
     double y2 = (attr=element.attr_nothrow(_U(y2))) ? element.attr<double>(attr) : y1;
     solid = Trap(e.z(0.0),e.theta(0),e.phi(0),y1,x1,x2,e.alpha1(0),y2,x3,x4,e.alpha2(0));
   }
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Trap__shape_constructor,create_Trap)
@@ -393,7 +392,7 @@ DECLARE_XML_SHAPE(Trap__shape_constructor,create_Trap)
 static Handle<TObject> create_PseudoTrap(Detector&, xml_h element)   {
   xml_dim_t e(element);
   Solid solid = PseudoTrap(e.x1(),e.x2(),e.y1(),e.y2(),e.z(),e.radius(),e.attr<bool>(xml_tag_t("minusZ")));
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(PseudoTrap__shape_constructor,create_PseudoTrap)
@@ -412,7 +411,7 @@ DECLARE_XML_SHAPE(PseudoTrap__shape_constructor,create_PseudoTrap)
 static Handle<TObject> create_Trd1(Detector&, xml_h element)   {
   xml_dim_t e(element);
   Solid solid = Trd1(e.x1(),e.x2(),e.y(),e.z(0.0));
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Trd1__shape_constructor,create_Trd1)
@@ -431,7 +430,7 @@ DECLARE_XML_SHAPE(Trd1__shape_constructor,create_Trd1)
 static Handle<TObject> create_Trd2(Detector&, xml_h element)   {
   xml_dim_t e(element);
   Solid solid = Trd2(e.x1(),e.x2(),e.y1(),e.y2(),e.z(0.0));
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Trapezoid__shape_constructor,create_Trd2)
@@ -473,7 +472,7 @@ static Handle<TObject> create_Torus(Detector&, xml_h element)   {
     /// TGeo naming: angles from [startphi,startphi+deltaphi]
     solid = Torus(e.r(), e.rmin(0.0), e.rmax(), start_phi, delta_phi);
   }
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Torus__shape_constructor,create_Torus)
@@ -519,7 +518,7 @@ static Handle<TObject> create_Sphere(Detector&, xml_h element)   {
     endtheta = starttheta + e.deltatheta();
 
   Solid solid = Sphere(e.rmin(0e0), e.rmax(), starttheta, endtheta, startphi, endphi);
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Sphere__shape_constructor,create_Sphere)
@@ -538,7 +537,7 @@ DECLARE_XML_SHAPE(Sphere__shape_constructor,create_Sphere)
 static Handle<TObject> create_Paraboloid(Detector&, xml_h element)   {
   xml_dim_t e(element);
   Solid solid = Paraboloid(e.rmin(0.0),e.rmax(),e.dz());
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Paraboloid__shape_constructor,create_Paraboloid)
@@ -559,7 +558,7 @@ DECLARE_XML_SHAPE(Paraboloid__shape_constructor,create_Paraboloid)
 static Handle<TObject> create_Hyperboloid(Detector&, xml_h element)   {
   xml_dim_t e(element);
   Solid solid = Hyperboloid(e.rmin(), e.inner_stereo(), e.rmax(), e.outer_stereo(), e.dz());
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Hyperboloid__shape_constructor,create_Hyperboloid)
@@ -579,7 +578,7 @@ DECLARE_XML_SHAPE(Hyperboloid__shape_constructor,create_Hyperboloid)
 static Handle<TObject> create_PolyhedraRegular(Detector&, xml_h element)   {
   xml_dim_t e(element);
   Solid solid = PolyhedraRegular(e.numsides(),e.rmin(),e.rmax(),e.dz());
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(PolyhedraRegular__shape_constructor,create_PolyhedraRegular)
@@ -608,7 +607,7 @@ static Handle<TObject> create_Polyhedra(Detector&, xml_h element)   {
     z.emplace_back(plane.z());
   }
   Solid solid = Polyhedra(e.numsides(),e.startphi(),e.deltaphi(),z,rmin,rmax);
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(Polyhedra__shape_constructor,create_Polyhedra)
@@ -635,7 +634,7 @@ static Handle<TObject> create_ExtrudedPolygon(Detector&, xml_h element)   {
     pt_y.emplace_back(point.attr<double>(_U(y)));
   }
   Solid solid = ExtrudedPolygon(pt_x, pt_y, sec_z, sec_x, sec_y, sec_scale);
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(ExtrudedPolygon__shape_constructor,create_ExtrudedPolygon)
@@ -657,12 +656,11 @@ static Handle<TObject> create_EightPointSolid(Detector&, xml_h element)   {
     v[num][1] = vtx.y();
   }
   Solid solid = EightPointSolid(e.dz(),&v[0][0]);
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(EightPointSolid__shape_constructor,create_EightPointSolid)
 
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
 /// Plugin factory to create tessellated shapes
 /**
  *
@@ -679,7 +677,7 @@ static Handle<TObject> create_TessellatedSolid(Detector&, xml_h element)   {
   int num_facets = 0;
   for ( xml_coll_t facet(element, _U(facet)); facet; ++facet ) ++num_facets;
   TessellatedSolid solid = TessellatedSolid(num_facets);
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   for ( xml_coll_t facet(element, _U(facet)); facet; ++facet )   {
     xml_dim_t f(facet);
     size_t i0 = f.attr<size_t>(_U(v0));
@@ -696,10 +694,9 @@ static Handle<TObject> create_TessellatedSolid(Detector&, xml_h element)   {
   return solid;
 }
 DECLARE_XML_SHAPE(TessellatedSolid__shape_constructor,create_TessellatedSolid)
-#endif
 
 /** Plugin function for creating a boolean solid from an xml element <shape type=\"BooleanShape\"/>. 
- *  Expects exactly two child elements <shape/> and a string attribute 'operation', which is one of
+ *  Expects exactly two child elements <shape/> and a std::string attribute 'operation', which is one of
  *  'subtraction', 'union' or 'intersection'. Optionally <position/> and/or <rotation/> can be specified.
  *  More complex boolean solids can be created by nesting the xml elements accordingly.
  *
@@ -793,7 +790,7 @@ static Handle<TObject> create_BooleanShape(Detector&, xml_h element)   {
                              std::string(" - needs to be one of 'subtraction','union' or 'intersection' ") ) ;  
   }
   Solid solid = resultSolid ;
-  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<string>(_U(name)).c_str());
+  if ( e.hasAttr(_U(name)) ) solid->SetName(e.attr<std::string>(_U(name)).c_str());
   return solid;
 }
 DECLARE_XML_SHAPE(BooleanShapeOld__shape_constructor,create_BooleanShape)
@@ -812,15 +809,15 @@ static Handle<TObject> create_BooleanMulti(Detector& description, xml_h element)
   //printout(ALWAYS,"","Boolean shape ---> %s",op.c_str());
   for (xml_coll_t i(e ,_U(star)); i; ++i )   {
     xml_comp_t x_elt = i;
-    string tag = x_elt.tag();
+    std::string tag = x_elt.tag();
     if ( tag == "shape" && !result.isValid() )  {
       result = xml::createShape(description, x_elt.typeStr(), x_elt);
-      if ( (attr=i.attr_nothrow(_U(name))) ) result->SetName(i.attr<string>(attr).c_str());
+      if ( (attr=i.attr_nothrow(_U(name))) ) result->SetName(i.attr<std::string>(attr).c_str());
       flag = 1;
     }
     else if ( tag == "shape" && !solid.isValid() )  {
       solid = xml::createShape(description,  x_elt.typeStr(), x_elt); 
-      if ( (attr=i.attr_nothrow(_U(name))) ) result->SetName(i.attr<string>(attr).c_str());
+      if ( (attr=i.attr_nothrow(_U(name))) ) result->SetName(i.attr<std::string>(attr).c_str());
       flag = 3;
     }
     else if ( result.isValid() && solid.isValid() )  {
@@ -870,7 +867,7 @@ static Handle<TObject> create_BooleanMulti(Detector& description, xml_h element)
         result = tmp;
         trafo  = position = rotation = Transform3D();
         solid = xml::createShape(description,  x_elt.typeStr(), x_elt); 
-        if ( (attr=i.attr_nothrow(_U(name))) ) result->SetName(i.attr<string>(attr).c_str());
+        if ( (attr=i.attr_nothrow(_U(name))) ) result->SetName(i.attr<std::string>(attr).c_str());
         flag = 3;
       }
     }
@@ -893,7 +890,7 @@ static Handle<TObject> create_BooleanMulti(Detector& description, xml_h element)
   }
   attr = element.attr_nothrow(_U(name));
   if ( attr )   {
-    string nam = element.attr<string>(attr);
+    std::string nam = element.attr<std::string>(attr);
     result->SetName(nam.c_str());
   }
   return result;
@@ -920,8 +917,8 @@ DECLARE_XML_VOLUME(DD4hep_StdVolume,create_std_volume)
  *  \version 1.0
  */
 static Handle<TObject> create_gen_volume(Detector& description, xml_h element)   {
-  xml_dim_t elt = element;
-  string    typ = elt.attr<string>(_U(type));
+  xml_dim_t   elt = element;
+  std::string typ = elt.attr<std::string>(_U(type));
   return xml::createVolume(description, typ, element);
 }
 DECLARE_XML_VOLUME(DD4hep_GenericVolume,create_gen_volume)
@@ -943,7 +940,7 @@ TGeoCombiTrans* createPlacement(const Rotation3D& iRot, const Position& iTrans) 
  */
 static Ref_t create_shape(Detector& description, xml_h e, SensitiveDetector sens)  {
   xml_det_t    x_det     = e;
-  string       name      = x_det.nameStr();
+  std::string  name      = x_det.nameStr();
   xml_dim_t    x_reflect = x_det.child(_U(reflect), false);
   DetElement   det         (name,x_det.id());
   Material     mat       = description.air();
@@ -952,21 +949,21 @@ static Ref_t create_shape(Detector& description, xml_h e, SensitiveDetector sens
   int count = 0;
   
   if ( x_det.hasChild(_U(material)) )  {
-    mat = description.material(x_det.child(_U(material)).attr<string>(_U(name)));
+    mat = description.material(x_det.child(_U(material)).attr<std::string>(_U(name)));
     printout(INFO,"TestShape","+++ Volume material is %s", mat.name());      
   }
   for ( xml_coll_t itm(e, _U(check)); itm; ++itm, ++count )   {
-    xml_dim_t  x_check  = itm;
-    xml_comp_t shape      (x_check.child(_U(shape)));
-    xml_dim_t  pos        (x_check.child(_U(position), false));
-    xml_dim_t  rot        (x_check.child(_U(rotation), false));
-    bool       reflect  = x_check.hasChild(_U(reflect));
-    bool       reflectZ = x_check.hasChild(_U(reflect_z));
-    bool       reflectY = x_check.hasChild(_U(reflect_y));
-    bool       reflectX = x_check.hasChild(_U(reflect_x));
-    string     shape_type = shape.typeStr();
-    Solid      solid;
-    Volume     volume;
+    xml_dim_t   x_check  = itm;
+    xml_comp_t  shape      (x_check.child(_U(shape)));
+    xml_dim_t   pos        (x_check.child(_U(position), false));
+    xml_dim_t   rot        (x_check.child(_U(rotation), false));
+    bool        reflect  = x_check.hasChild(_U(reflect));
+    bool        reflectZ = x_check.hasChild(_U(reflect_z));
+    bool        reflectY = x_check.hasChild(_U(reflect_y));
+    bool        reflectX = x_check.hasChild(_U(reflect_x));
+    std::string shape_type = shape.typeStr();
+    Solid       solid;
+    Volume      volume;
 
     if ( shape_type == "CAD_Assembly" || shape_type == "CAD_MultiVolume" )   {
       volume = xml::createVolume(description, shape_type, shape);
@@ -977,7 +974,7 @@ static Ref_t create_shape(Detector& description, xml_h e, SensitiveDetector sens
       volume = Volume(name+_toString(count,"_vol_%d"),solid, mat);
     }
     if ( x_det.hasChild(_U(sensitive)) )  {
-      string sens_type = x_det.child(_U(sensitive)).attr<string>(_U(type));
+      std::string sens_type = x_det.child(_U(sensitive)).attr<std::string>(_U(type));
       volume.setSensitiveDetector(sens);
       sens.setType(sens_type);
       printout(INFO,"TestShape","+++ Sensitive type is %s", sens_type.c_str());
@@ -1060,12 +1057,10 @@ static Ref_t create_shape(Detector& description, xml_h e, SensitiveDetector sens
       instance_test = isInstance<ExtrudedPolygon>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),SCALE_TAG) )
       instance_test = isInstance<Scale>(solid);
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
     else if ( 0 == strcasecmp(solid->GetTitle(),TESSELLATEDSOLID_TAG) )  {
       instance_test = isInstance<TessellatedSolid>(solid);
       shape_type = TESSELLATEDSOLID_TAG;
     }
-#endif
     else if ( 0 == strcasecmp(solid->GetTitle(),POLYCONE_TAG) )
       instance_test = isInstance<Polycone>(solid);
     else if ( 0 == strcasecmp(solid->GetTitle(),TWISTEDTUBE_TAG) )   {
@@ -1176,7 +1171,7 @@ static Ref_t create_shape(Detector& description, xml_h e, SensitiveDetector sens
   /// Execute test plugin(s) on the placed volume if desired
   for ( xml_coll_t itm(e, xml_tag_t("test")); itm; ++itm, ++count )   {
     xml_comp_t   x_test = itm;
-    string typ = x_test.typeStr();
+    std::string typ = x_test.typeStr();
     const void* argv[] = { &e, &pv, 0};
     Ref_t result = (NamedObject*)PluginService::Create<void*>(typ, &description, 2, (char**)argv);
     if ( !result.isValid() )  {
@@ -1214,8 +1209,8 @@ void* shape_mesh_verifier(Detector& description, int argc, char** argv)    {
   int          ref_cr = x_test.hasAttr(_U(create)) ? x_test.attr<int>(_U(create)) : 0;
   int          nseg   = x_test.hasAttr(_U(segmentation)) ? x_test.attr<int>(_U(segmentation)) : -1;
   TString      ref    = x_test.refStr().c_str();
-  string       ref_str;  
-  stringstream os;
+  std::string  ref_str;  
+  std::stringstream os;
 
   if ( nseg > 0 )   {
     description.manager().SetNsegments(nseg);
@@ -1234,7 +1229,7 @@ void* shape_mesh_verifier(Detector& description, int argc, char** argv)    {
   }
   gSystem->ExpandPathName(ref);
   if ( ref_cr )   {
-    ofstream out(ref, ofstream::out);
+    std::ofstream out(ref, std::fstream::out);
     if ( !out.is_open() )   {
       except("Mesh_Verifier","+++ FAILED to open(WRITE) reference file: "+x_test.refStr());
     }
@@ -1244,7 +1239,7 @@ void* shape_mesh_verifier(Detector& description, int argc, char** argv)    {
   }
   else if ( ref.Length() > 0 )  {
     char c;
-    ifstream in(ref.Data(), ofstream::in);
+    std::ifstream in(ref.Data(), std::fstream::in);
     if ( !in.is_open() )   {
       except("Mesh_Verifier","+++ FAILED to access reference file: "+x_test.refStr());
     }

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -133,7 +133,7 @@ static long display(Detector& description, int argc, char** argv) {
     else  {
       std::cout <<
         "Usage: -plugin DD4hep_GeometryDisplay  -arg [-arg]                                \n\n"
-	"     Invoke the ROOT geometry display using the factory mechanism.                \n\n"
+        "     Invoke the ROOT geometry display using the factory mechanism.                \n\n"
         "     -detector <string> Top level DetElement path. Default: '/world'                \n"
         "     -option   <string> ROOT Draw option.    Default: 'ogl'                         \n"
         "     -level    <number> Visualization level  [TGeoManager::SetVisLevel]  Default: 4 \n"
@@ -253,9 +253,9 @@ DECLARE_APPLY(DD4hep_Rint,run_interpreter)
 static long root_ui(Detector& description, int /* argc */, char** /* argv */) {
   char cmd[256];
   std::snprintf(cmd, sizeof(cmd),
-		"dd4hep::detail::DD4hepUI* gDD4hepUI = new "
-		"dd4hep::detail::DD4hepUI(*(dd4hep::Detector*)%p);",
-		(void*)&description);
+                "dd4hep::detail::DD4hepUI* gDD4hepUI = new "
+                "dd4hep::detail::DD4hepUI(*(dd4hep::Detector*)%p);",
+                (void*)&description);
   gInterpreter->ProcessLine(cmd);
   printout(ALWAYS,"DD4hepUI",
            "Use the ROOT interpreter variable gDD4hepUI "
@@ -459,21 +459,21 @@ static long root_elements(Detector& description, int argc, char** argv) {
   xml::DocumentHandler docH;
   xml::Element         element(0);
   if ( type == "xml" )  {
-     const char comment[] = "\n"
-    "      +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n"
-    "      ++++   Generic detector description in C++               ++++\n"
-    "      ++++   dd4hep Detector description generator.            ++++\n"
-    "      ++++                                                     ++++\n"
-    "      ++++   Parser:"
-    XML_IMPLEMENTATION_TYPE
-    "                ++++\n"
-    "      ++++                                                     ++++\n"
-    "      ++++   Table of elements as defined in ROOT: " ROOT_RELEASE  "     ++++\n"
-    "      ++++                                                     ++++\n"
-    "      ++++                              M.Frank CERN/LHCb      ++++\n"
-    "      +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n  ";
-     doc = docH.create("materials", comment);
-     element = doc.root();
+    const char comment[] = "\n"
+      "      +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n"
+      "      ++++   Generic detector description in C++               ++++\n"
+      "      ++++   dd4hep Detector description generator.            ++++\n"
+      "      ++++                                                     ++++\n"
+      "      ++++   Parser:"
+      XML_IMPLEMENTATION_TYPE
+      "                ++++\n"
+      "      ++++                                                     ++++\n"
+      "      ++++   Table of elements as defined in ROOT: " ROOT_RELEASE  "     ++++\n"
+      "      ++++                                                     ++++\n"
+      "      ++++                              M.Frank CERN/LHCb      ++++\n"
+      "      +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n  ";
+    doc = docH.create("materials", comment);
+    element = doc.root();
   }
   dd4hep_ptr<ElementPrint> printer(element
                                    ? new ElementPrintXML(element)
@@ -814,11 +814,11 @@ static long load_volmgr(Detector& description, int, char**) {
   }
   catch (const std::exception& e) {
     except("DD4hep_VolumeManager", "Exception: %s\n     %s", e.what(),
-	   "dd4hep: while programming VolumeManager. Are your volIDs correct?");
+           "dd4hep: while programming VolumeManager. Are your volIDs correct?");
   }
   catch (...) {
     except("DD4hep_VolumeManager",
-	   "UNKNOWN exception while programming VolumeManager. Are your volIDs correct?");
+           "UNKNOWN exception while programming VolumeManager. Are your volIDs correct?");
   }
   return 0;
 }
@@ -843,7 +843,7 @@ static long dump_geometry2root(Detector& description, int argc, char** argv) {
     if ( output.empty() )   {
       std::cout <<
         "Usage: -plugin DD4hep_Geometry2ROOT -arg [-arg]                             \n\n"
-	"     Output DD4hep detector description object to a ROOT file.              \n\n"
+        "     Output DD4hep detector description object to a ROOT file.              \n\n"
         "     -output <string>         Output file name.                               \n"
         "\tArguments given: " << arguments(argc,argv) << std::endl << std::flush;
       ::exit(EINVAL);
@@ -877,7 +877,7 @@ static long load_geometryFromroot(Detector& description, int argc, char** argv) 
     if ( input.empty() )   {
       std::cout <<
         "Usage: DD4hep_RootLoader -arg [-arg]                                        \n\n"
-	"     Load DD4hep detector description from ROOT file to memory.             \n\n"
+        "     Load DD4hep detector description from ROOT file to memory.             \n\n"
         "     -input  <string>         Input file name.                                \n"
         "\tArguments given: " << arguments(argc,argv) << std::endl << std::flush;
       ::exit(EINVAL);
@@ -911,7 +911,7 @@ static long dump_geometry2tgeo(Detector& description, int argc, char** argv) {
     if ( output.empty() )   {
       std::cout <<
         "Usage: -plugin <name> -arg [-arg]                                             \n"
-	"     Output TGeo information to a ROOT file.                                \n\n"
+        "     Output TGeo information to a ROOT file.                                \n\n"
         "     name:   factory name     DD4hepGeometry2TGeo                             \n"
         "     -output <string>         Output file name.                               \n"
         "\tArguments given: " << arguments(argc,argv) << std::endl << std::flush;
@@ -1096,7 +1096,7 @@ static long dump_volume_tree(Detector& description, int argc, char** argv) {
             "     -sensitive         Only print information for sensitive volumes                \n"
             "     -topstats          Print statistics about top level node                       \n"       
             "\tArguments given: " << arguments(ac,av) << std::endl << std::flush;
-	  _exit(0);
+          _exit(0);
         }
       }
       if ( m_printMaxLevel < 999999 )
@@ -1190,42 +1190,42 @@ static long dump_volume_tree(Detector& description, int argc, char** argv) {
           }
         }
         opt_info = log.str();
-	log.str("");
+        log.str("");
       }
       ///  
       if ( m_printVis && pv.volume().visAttributes().isValid() )   {
         log << " Vis:" << pv.volume().visAttributes().name();
-	opt_info += log.str();
-	log.str("");
+        opt_info += log.str();
+        log.str("");
       }
       TGeoVolume* volume = ideal ? ideal->GetVolume() : 0;
       if ( !m_printSensitivesOnly || (m_printSensitivesOnly && sensitive) )  {
-	Volume vol = pv.volume();
+        Volume vol = pv.volume();
         char  sens = vol.isSensitive() ? 'S' : ' ';
         if ( m_printPointers )    {
           if ( ideal == aligned )  {
             std::snprintf(fmt,sizeof(fmt),"%03d %%s [Ideal:%p] %%-%ds %%-16s Vol:%%s shape:%%s \t %c %%s",
-                       level+1,(void*)ideal,2*level+1,sens);
+                          level+1,(void*)ideal,2*level+1,sens);
           }
           else  {
             std::snprintf(fmt,sizeof(fmt),"%03d %%s Ideal:%p Aligned:%p %%-%ds %%-16s Vol:%%s shape:%%s %c %%s",
-                       level+1,(void*)ideal,(void*)aligned,2*level+1,sens);
+                          level+1,(void*)ideal,(void*)aligned,2*level+1,sens);
           }
         }
         else  {
           if ( ideal == aligned )  {
             std::snprintf(fmt,sizeof(fmt),"%03d %%s %%-%ds %%-16s Vol:%%s shape:%%s \t %c %%s",
-                       level+1,2*level+1,sens);
+                          level+1,2*level+1,sens);
           }
           else  {
             std::snprintf(fmt,sizeof(fmt),"%03d %%s Ideal:%p Aligned:%p %%-%ds %%-16s Vol:%%s shape:%%s %c %%s",
-                       level+1,(void*)ideal,(void*)aligned,2*level+1,sens);
+                          level+1,(void*)ideal,(void*)aligned,2*level+1,sens);
           }
         }
-	const auto* sh = volume ? volume->GetShape() : nullptr;
+        const auto* sh = volume ? volume->GetShape() : nullptr;
         printout(INFO,"VolumeDump",fmt,pref.c_str(),"",
                  aligned->GetName(),
-		 vol.name(),
+                 vol.name(),
                  sh ? sh->IsA()->GetName() : "[Invalid Shape]",
                  opt_info.c_str());
         if ( sens == 'S' ) ++m_numSensitive;
@@ -1236,7 +1236,7 @@ static long dump_volume_tree(Detector& description, int argc, char** argv) {
         TGeoMaterial* mptr = mat->GetMaterial();
         bool ok = mat.A() == mptr->GetA() && mat.Z() == mptr->GetZ();
         std::snprintf(fmt,sizeof(fmt),"%03d %%s %%-%ds Material: %%-16s A:%%6.2f %%6.2f  Z:%%6.2f %%6.2f",
-                   level+1,2*level+1);
+                      level+1,2*level+1);
         ++m_numMaterial;
         if ( !ok ) ++m_numMaterialERR;
         printout(ok ? INFO : ERROR, "VolumeDump", fmt,
@@ -1393,12 +1393,12 @@ static int placed_volume_processor(Detector& description, int argc, char** argv)
       return PlacedVolumeScanner().scanPlacements(*proc, pv, 0, recursive) > 0 ? 1 : 0;
     }
     except("PlacedVolumeProcessor",
-	   "++ The detector element with path:%s has no valid placement!",
-	   path.c_str());
+           "++ The detector element with path:%s has no valid placement!",
+           path.c_str());
   }
   except("PlacedVolumeProcessor",
-	 "++ The detector element path:%s is not part of this description!",
-	 path.c_str());
+         "++ The detector element path:%s is not part of this description!",
+         path.c_str());
   return 0;
 }
 DECLARE_APPLY(DD4hep_PlacedVolumeProcessor,placed_volume_processor)
@@ -1437,64 +1437,64 @@ template <int flag> long dump_detelement_tree(Detector& description, int argc, c
     }
     void parse_args(int ac, char** av)   {
       for(int i=0; i<ac; ++i)  {
-	if      ( ::strncmp(av[i],"--sensitive",     5)==0 ) { sensitive_only = true;  }
-	else if ( ::strncmp(av[i], "-sensitive",     5)==0 ) { sensitive_only = true;  }
-	else if ( ::strncmp(av[i], "--no-sensitive", 8)==0 ) { sensitive_only = false; }
-	else if ( ::strncmp(av[i], "-materials",     4)==0 ) { dump_materials = true;  }
-	else if ( ::strncmp(av[i], "--materials",    5)==0 ) { dump_materials = true;  }
-	else if ( ::strncmp(av[i], "-shapes",        4)==0 ) { dump_shapes    = true;  }
-	else if ( ::strncmp(av[i], "--shapes",       5)==0 ) { dump_shapes    = true;  }
-	else if ( ::strncmp(av[i], "-positions",     4)==0 ) { dump_positions = true;  }
-	else if ( ::strncmp(av[i], "--positions",    5)==0 ) { dump_positions = true;  }
-	else if ( ::strncmp(av[i], "-no-sensitive",  7)==0 ) { sensitive_only = false; }
-	else if ( ::strncmp(av[i], "--volids",       5)==0 ) { dump_volids    = true;  }
-	else if ( ::strncmp(av[i], "-volids",        5)==0 ) { dump_volids    = true;  }
-	else if ( ::strncmp(av[i], "--detector",     5)==0 ) { path = av[++i];       }
-	else if ( ::strncmp(av[i], "-detector",      5)==0 ) { path = av[++i];       }
-	else if ( ::strncmp(av[i], "--level",        5)==0 ) { analysis_level = ::atol(av[++i]); }
-	else if ( ::strncmp(av[i], "-level",         5)==0 ) { analysis_level = ::atol(av[++i]); }
-	else   {
-	  std::cout << "  "
-	       << (flag==0 ? "DD4hep_DetectorDump" : "DD4hep_DetectorVolumeDump") << " -arg [-arg]   \n\n"
-	       << "         Dump " << (flag==0 ? "DetElement" : "Detector volume") << " tree.          \n"
-	       << "         Configure produced output information using the following options:       \n\n"
-	    "   --sensitive             Process only sensitive volumes.                                \n"
-	    "    -sensitive             dto.                                                           \n"
-	    "   --no-sensitive          Invert sensitive only flag.                                    \n"
-	    "    -no-sensitive          dto.                                                           \n"
-	    "   --shapes                Print shape information.                                       \n"
-	    "    -shapes                dto.                                                           \n"
-	    "   --positions             Print position information.                                    \n"
-	    "    -positions             dto.                                                           \n"
-	    "   --materials             Print material information.                                    \n"
-	    "    -materials             dto.                                                           \n"
-	    "   --detector    <path>    Process elements only if <path> is part of the DetElement path.\n"
-	    "    -detector    <path>    dto.                                                           \n"
-	    "    -level       <number>  Maximal depth to be explored by the scan                       \n"
-	    "   --level       <number>  dto.                                                           \n"
-	    "    -volids                Print volume identifiers of placements.                        \n"
-	    "   --volids                dto.                                                           \n"
-	    "\tArguments given: " << arguments(ac,av) << std::endl << std::flush;        
-	  ::exit(EINVAL);
-	}
+        if      ( ::strncmp(av[i],"--sensitive",     5)==0 ) { sensitive_only = true;  }
+        else if ( ::strncmp(av[i], "-sensitive",     5)==0 ) { sensitive_only = true;  }
+        else if ( ::strncmp(av[i], "--no-sensitive", 8)==0 ) { sensitive_only = false; }
+        else if ( ::strncmp(av[i], "-materials",     4)==0 ) { dump_materials = true;  }
+        else if ( ::strncmp(av[i], "--materials",    5)==0 ) { dump_materials = true;  }
+        else if ( ::strncmp(av[i], "-shapes",        4)==0 ) { dump_shapes    = true;  }
+        else if ( ::strncmp(av[i], "--shapes",       5)==0 ) { dump_shapes    = true;  }
+        else if ( ::strncmp(av[i], "-positions",     4)==0 ) { dump_positions = true;  }
+        else if ( ::strncmp(av[i], "--positions",    5)==0 ) { dump_positions = true;  }
+        else if ( ::strncmp(av[i], "-no-sensitive",  7)==0 ) { sensitive_only = false; }
+        else if ( ::strncmp(av[i], "--volids",       5)==0 ) { dump_volids    = true;  }
+        else if ( ::strncmp(av[i], "-volids",        5)==0 ) { dump_volids    = true;  }
+        else if ( ::strncmp(av[i], "--detector",     5)==0 ) { path = av[++i];       }
+        else if ( ::strncmp(av[i], "-detector",      5)==0 ) { path = av[++i];       }
+        else if ( ::strncmp(av[i], "--level",        5)==0 ) { analysis_level = ::atol(av[++i]); }
+        else if ( ::strncmp(av[i], "-level",         5)==0 ) { analysis_level = ::atol(av[++i]); }
+        else   {
+          std::cout << "  "
+                    << (flag==0 ? "DD4hep_DetectorDump" : "DD4hep_DetectorVolumeDump") << " -arg [-arg]   \n\n"
+                    << "         Dump " << (flag==0 ? "DetElement" : "Detector volume") << " tree.          \n"
+                    << "         Configure produced output information using the following options:       \n\n"
+            "   --sensitive             Process only sensitive volumes.                                \n"
+            "    -sensitive             dto.                                                           \n"
+            "   --no-sensitive          Invert sensitive only flag.                                    \n"
+            "    -no-sensitive          dto.                                                           \n"
+            "   --shapes                Print shape information.                                       \n"
+            "    -shapes                dto.                                                           \n"
+            "   --positions             Print position information.                                    \n"
+            "    -positions             dto.                                                           \n"
+            "   --materials             Print material information.                                    \n"
+            "    -materials             dto.                                                           \n"
+            "   --detector    <path>    Process elements only if <path> is part of the DetElement path.\n"
+            "    -detector    <path>    dto.                                                           \n"
+            "    -level       <number>  Maximal depth to be explored by the scan                       \n"
+            "   --level       <number>  dto.                                                           \n"
+            "    -volids                Print volume identifiers of placements.                        \n"
+            "   --volids                dto.                                                           \n"
+            "\tArguments given: " << arguments(ac,av) << std::endl << std::flush;        
+          ::exit(EINVAL);
+        }
       }
     }
     IDDescriptor get_id_descriptor(PlacedVolume pv)   {
       Volume v = pv.volume();
       SensitiveDetector sd = v.sensitiveDetector();
       if ( sd.isValid() )   {
-	IDDescriptor dsc = sd.readout().idSpec();
-	if ( dsc.isValid() ) return dsc;
+        IDDescriptor dsc = sd.readout().idSpec();
+        if ( dsc.isValid() ) return dsc;
       }
       for (Int_t idau = 0, ndau = v->GetNdaughters(); idau < ndau; ++idau)  {
-	IDDescriptor dsc = get_id_descriptor(v->GetNode(idau));
-	if ( dsc.isValid() ) return dsc;
+        IDDescriptor dsc = get_id_descriptor(v->GetNode(idau));
+        if ( dsc.isValid() ) return dsc;
       }
       return IDDescriptor();
     }
     void validate_id_descriptor(DetElement de, IDDescriptor& desc)   {
       desc = (!de.parent() || de.parent() == det_world)
-	? IDDescriptor() : get_id_descriptor(de.placement());
+        ? IDDescriptor() : get_id_descriptor(de.placement());
     }
 
     long dump(DetElement de, int level, IDDescriptor& id_desc, VolIDs chain)   {
@@ -1503,11 +1503,11 @@ template <int flag> long dump_detelement_tree(Detector& description, int argc, c
       bool  use_elt = path.empty() || de.path().find(path) != std::string::npos;
 
       if ( have_match < 0 && use_elt )  {
-	have_match = level;
+        have_match = level;
       }
       use_elt = use_elt && ((level-have_match) <= analysis_level);
       if ( de != det_world )    {
-	chain.insert(chain.end(), place.volIDs().begin(), place.volIDs().end());
+        chain.insert(chain.end(), place.volIDs().begin(), place.volIDs().end());
       }
       if ( use_elt )   {
         if ( !sensitive_only || 0 != de.volumeID() )  {
@@ -1523,7 +1523,7 @@ template <int flag> long dump_detelement_tree(Detector& description, int argc, c
               break;
             }
             std::snprintf(fmt,sizeof(fmt),"%03d %%-%ds %%s NumDau:%%d VolID:%%08X Place:%%p [ideal:%%p aligned:%%p]  %%c",
-                       level+1,2*level+1);
+                          level+1,2*level+1);
             printout(INFO,"DetectorDump",fmt,"",de.path().c_str(),int(children.size()),
                      (unsigned long)de.volumeID(), (void*)de.idealPlacement().ptr(),
                      (void*)place.ptr(), sens);
@@ -1531,19 +1531,19 @@ template <int flag> long dump_detelement_tree(Detector& description, int argc, c
           case 1:
             ++count;
             std::snprintf(fmt,sizeof(fmt),
-                       "%03d %%-%ds Detector: %%s NumDau:%%d VolID:%%p",
-                       level+1,2*level+1);
+                          "%03d %%-%ds Detector: %%s NumDau:%%d VolID:%%p",
+                          level+1,2*level+1);
             printout(INFO,"DetectorDump", fmt, "", de.path().c_str(), int(children.size()), (void*)de.volumeID());
             if ( de.placement() == de.idealPlacement() )  {
               std::snprintf(fmt,sizeof(fmt),
-                         "%03d %%-%ds Placement: %%s  %%c",
-                         level+1,2*level+3);
+                            "%03d %%-%ds Placement: %%s  %%c",
+                            level+1,2*level+3);
               printout(INFO,"DetectorDump",fmt,"", de.placementPath().c_str(), sens);
               break;
             }
             std::snprintf(fmt,sizeof(fmt),
-                       "%03d %%-%ds Placement: %%s  [ideal:%%p aligned:%%p] %%c",
-                       level+1,2*level+3);
+                          "%03d %%-%ds Placement: %%s  [ideal:%%p aligned:%%p] %%c",
+                          level+1,2*level+3);
             printout(INFO,"DetectorDump",fmt,"", de.placementPath().c_str(),
                      (void*)de.idealPlacement().ptr(), (void*)place.ptr(), sens);          
             break;
@@ -1569,24 +1569,24 @@ template <int flag> long dump_detelement_tree(Detector& description, int argc, c
             std::snprintf(fmt,sizeof(fmt), "%03d %%-%ds Position: (%%9.4f,%%9.4f,%%9.4f) [cm] w/r to world",  level+1,2*level+3);
             printout(INFO,"DetectorDump",fmt,"", world[0], world[1], world[2]);
           }
-	  if ( dump_volids && !place.volIDs().empty() )    {
-	    std::stringstream log;
-	    log << " VID:";
-	    for( const auto& i : chain )
-	      log << " " << i.first << ':' << std::dec << std::setw(2) << i.second;
-	    if ( id_desc.isValid() )  {
-	      log << " (encoded:0x" << std::setfill('0') << std::setw(8) << std::hex
-		  << id_desc.encode(chain)
-		  << std::setfill(' ') << std::dec << ") ";
-	    }
-	    std::snprintf(fmt,sizeof(fmt),"%03d %%-%ds %%s", level+1, 2*level+1);
+          if ( dump_volids && !place.volIDs().empty() )    {
+            std::stringstream log;
+            log << " VID:";
+            for( const auto& i : chain )
+              log << " " << i.first << ':' << std::dec << std::setw(2) << i.second;
+            if ( id_desc.isValid() )  {
+              log << " (encoded:0x" << std::setfill('0') << std::setw(8) << std::hex
+                  << id_desc.encode(chain)
+                  << std::setfill(' ') << std::dec << ") ";
+            }
+            std::snprintf(fmt,sizeof(fmt),"%03d %%-%ds %%s", level+1, 2*level+1);
             printout(INFO,"DetectorDump", fmt, "", log.str().c_str());
-	  }
+          }
         }
       }
       for ( const auto& c : children )   {
-	validate_id_descriptor(c.second, id_desc);
-	dump(c.second, level+1, id_desc, chain);
+        validate_id_descriptor(c.second, id_desc);
+        dump(c.second, level+1, id_desc, chain);
       }
       return 1;
     }
@@ -1628,12 +1628,12 @@ static long detelement_cache(Detector& description, int argc, char** argv) {
       detector = argv[++i];
     else  {
       std::cout <<
-	"Usage: -plugin DD4hep_DetElementCache  -arg [-arg]                 \n\n"
-	"     Fill cache with transformation information in DetElements.    \n\n"
-	"     -detector <string>  Top level DetElement path. Default: '/world'\n"
-	"     --detector <string> dto.                                        \n"
-	"     -help              Print this help.                             \n"
-	"     Arguments given: " << arguments(argc,argv) << std::endl << std::flush;
+        "Usage: -plugin DD4hep_DetElementCache  -arg [-arg]                 \n\n"
+        "     Fill cache with transformation information in DetElements.    \n\n"
+        "     -detector <string>  Top level DetElement path. Default: '/world'\n"
+        "     --detector <string> dto.                                        \n"
+        "     -help              Print this help.                             \n"
+        "     Arguments given: " << arguments(argc,argv) << std::endl << std::flush;
       ::exit(EINVAL);
     }
   }
@@ -1682,7 +1682,7 @@ static long detectortype_cache(Detector& description, int argc, char** argv)  {
     else   {
       std::cout <<
         "Usage: DD4hep_DetectorTypes -type <type> -arg [-arg]                          \n"
-	"     Dump detector types from detector description.                         \n\n"
+        "     Dump detector types from detector description.                         \n\n"
         "     -type   <string>         Add new type to be listed. Multiple possible.   \n"
         "\tArguments given: " << arguments(argc,argv) << std::endl << std::flush;
       ::exit(EINVAL);

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -48,8 +48,8 @@
 using namespace dd4hep;
 using namespace dd4hep::detail;
 
-
 namespace  {
+
   struct ProcessorArgs   {
     bool use = false;
     int  start = 0, end = 0, argc = 0, count=0;
@@ -1711,7 +1711,7 @@ DECLARE_APPLY(DD4hep_DetectorTypes,detectortype_cache)
  *  \version 1.0
  *  \date    01/04/2014
  */
-#include "DD4hep/SurfaceInstaller.h"
+#include <DD4hep/SurfaceInstaller.h>
 typedef SurfaceInstaller TestSurfacesPlugin;
 DECLARE_SURFACE_INSTALLER(TestSurfaces,TestSurfacesPlugin)
 
@@ -1723,7 +1723,7 @@ DECLARE_SURFACE_INSTALLER(TestSurfaces,TestSurfacesPlugin)
  *  \version 1.0
  *  \date    01/04/2014
  */
-#include "DD4hep/PluginTester.h"
+#include <DD4hep/PluginTester.h>
 static long install_plugin_tester(Detector& description, int , char** ) {
   PluginTester* test = description.extension<PluginTester>(false);
   if ( !test )  {

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -37,10 +37,7 @@
 #include <TSystem.h>
 #include <TClass.h>
 #include <TRint.h>
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
 #include <TGDMLMatrix.h>
-#endif
-
 
 // C/C++ include files
 #include <cerrno>
@@ -279,7 +276,6 @@ DECLARE_APPLY(DD4hep_InteractiveUI,root_ui)
 static long root_dump_gdml_tables(Detector& description, int /* argc */, char** /* argv */) {
   size_t num_tables = 0;
   size_t num_elements = 0;
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   const TObjArray* c = description.manager().GetListOfGDMLMatrices();
   TObjArrayIter arr(c);
   printout(INFO,"Dump_GDMLTables","+++ Dumping known GDML tables from TGeoManager.");
@@ -289,7 +285,6 @@ static long root_dump_gdml_tables(Detector& description, int /* argc */, char** 
     ++num_tables;
     gdmlMat->Print();
   }
-#endif
   printout(INFO,"Dump_GDMLTables",
            "+++ Successfully dumped %ld GDML tables with %ld elements.",
            num_tables, num_elements);
@@ -309,7 +304,6 @@ DECLARE_APPLY(DD4hep_Dump_GDMLTables,root_dump_gdml_tables)
 static long root_dump_optical_surfaces(Detector& description, int /* argc */, char** /* argv */) {
   size_t num_surfaces = 0;
   printout(ALWAYS,"","");
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   const TObjArray* c = description.manager().GetListOfOpticalSurfaces();
   TObjArrayIter arr(c);
   printout(ALWAYS,"Dump_OpticalSurfaces","+++ Dumping known Optical Surfaces from TGeoManager.");
@@ -318,7 +312,6 @@ static long root_dump_optical_surfaces(Detector& description, int /* argc */, ch
     ++num_surfaces;
     optSurt->Print();
   }
-#endif
   printout(ALWAYS,"Dump_OpticalSurfaces",
            "+++ Successfully dumped %ld Optical surfaces.",num_surfaces);
   return 1;
@@ -337,7 +330,6 @@ DECLARE_APPLY(DD4hep_Dump_OpticalSurfaces,root_dump_optical_surfaces)
 static long root_dump_skin_surfaces(Detector& description, int /* argc */, char** /* argv */) {
   size_t num_surfaces = 0;
   printout(ALWAYS,"","");
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   const TObjArray* c = description.manager().GetListOfSkinSurfaces();
   TObjArrayIter arr(c);
   printout(ALWAYS,"Dump_SkinSurfaces","+++ Dumping known Skin Surfaces from TGeoManager.");
@@ -346,7 +338,6 @@ static long root_dump_skin_surfaces(Detector& description, int /* argc */, char*
     ++num_surfaces;
     skinSurf->Print();
   }
-#endif
   printout(ALWAYS,"Dump_SkinSurfaces",
            "+++ Successfully dumped %ld Skin surfaces.",num_surfaces);
   return 1;
@@ -365,7 +356,6 @@ DECLARE_APPLY(DD4hep_Dump_SkinSurfaces,root_dump_skin_surfaces)
 static long root_dump_border_surfaces(Detector& description, int /* argc */, char** /* argv */) {
   size_t num_surfaces = 0;
   printout(ALWAYS,"","");
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   const TObjArray* c = description.manager().GetListOfBorderSurfaces();
   TObjArrayIter arr(c);
   printout(ALWAYS,"Dump_BorderSurfaces","+++ Dumping known Border Surfaces from TGeoManager.");
@@ -374,7 +364,6 @@ static long root_dump_border_surfaces(Detector& description, int /* argc */, cha
     ++num_surfaces;
     bordSurt->Print();
   }
-#endif
   printout(ALWAYS,"Dump_BorderSurfaces",
            "+++ Successfully dumped %ld Border surfaces.",num_surfaces);
   return 1;
@@ -562,7 +551,6 @@ static long root_materials(Detector& description, int argc, char** argv) {
       ::printf("  %-6s Fraction: %7.3f Z=%3d A=%6.2f N=%3d Neff=%6.2f\n",
                elt->GetName(), frac, elt->Z(), elt->A(), elt->N(), elt->Neff());
     }
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
     /// Print material property
     virtual void printProperty(elt_h, TNamed* prop, TGDMLMatrix* matrix)   {
       if ( matrix )
@@ -572,7 +560,6 @@ static long root_materials(Detector& description, int argc, char** argv) {
         ::printf("  Property: %-20s [ERROR: NO TABLE!] --> %s\n",
                  prop->GetName(), prop->GetTitle());
     }
-#endif
     virtual void operator()(TGeoMaterial* mat)  {
       Double_t* mix = mat->IsMixture() ? ((TGeoMixture*)mat)->GetWmixt() : 0;
       elt_h     mh  = print(mat);
@@ -580,12 +567,10 @@ static long root_materials(Detector& description, int argc, char** argv) {
         TGeoElement* elt = mat->GetElement(i);
         print(mh, elt, mix ? mix[i] : 1);
       }
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
       TListIter mat_iter(&mat->GetProperties());
       for( TObject* i = mat_iter.Next(); i; i=mat_iter.Next() )   {
         printProperty(mh, (TNamed*)i, description.manager().GetGDMLMatrix(i->GetTitle()));
       }
-#endif
     }
   };
   /// XML printer to produce XML output
@@ -641,13 +626,11 @@ static long root_materials(Detector& description, int argc, char** argv) {
       elt.setAttr(_U(n),frac);
       elt.setAttr(_U(ref),element->GetName());
     }
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
     virtual void printProperty(elt_h mat, TNamed* prop, TGDMLMatrix* /* matrix */)   {
       elt_h elt = mat.addChild(_U(property));
       elt.setAttr(_U(name),prop->GetName());
       elt.setAttr(_U(ref), prop->GetTitle());
     }
-#endif
   };
 
   std::string type = "text", output = "", name = "";

--- a/DDCore/src/plugins/TGeoCodeGenerator.cpp
+++ b/DDCore/src/plugins/TGeoCodeGenerator.cpp
@@ -10,14 +10,14 @@
 // Author     : M.Frank
 //
 //==========================================================================
-#include "DD4hep/Factories.h"
-#include "DD4hep/Shapes.h"
-#include "DD4hep/Volumes.h"
-#include "DD4hep/Detector.h"
-#include "DD4hep/MatrixHelpers.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Path.h"
+#include <DD4hep/Factories.h>
+#include <DD4hep/Shapes.h>
+#include <DD4hep/Volumes.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/MatrixHelpers.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Path.h>
 
 // C/C++ include files
 #include <stdexcept>
@@ -26,12 +26,11 @@
 #include <fstream>
 
 // ROOT includes
-#include "TClass.h"
-#include "TGeoMatrix.h"
-#include "TGeoBoolNode.h"
-#include "TGeoCompositeShape.h"
+#include <TClass.h>
+#include <TGeoMatrix.h>
+#include <TGeoBoolNode.h>
+#include <TGeoCompositeShape.h>
 
-using namespace std;
 using namespace dd4hep;
 
 namespace {
@@ -57,68 +56,68 @@ namespace {
 
     Actor() = default;
     ~Actor() = default;
-    ostream& handleHeader   (ostream& log);
-    ostream& handleTrailer  (ostream& log);
-    ostream& handleSolid    (ostream& log, const TGeoShape*  sh);
-    ostream& handleMatrix   (ostream& log, TGeoMatrix* mat);
-    ostream& handleElement  (ostream& log, TGeoElement* elt);
-    ostream& handleMaterial (ostream& log, TGeoMedium* mat);
-    ostream& handlePlacement(ostream& log, TGeoNode*   parent, TGeoNode* node);
+    std::ostream& handleHeader   (std::ostream& log);
+    std::ostream& handleTrailer  (std::ostream& log);
+    std::ostream& handleSolid    (std::ostream& log, const TGeoShape*  sh);
+    std::ostream& handleMatrix   (std::ostream& log, TGeoMatrix* mat);
+    std::ostream& handleElement  (std::ostream& log, TGeoElement* elt);
+    std::ostream& handleMaterial (std::ostream& log, TGeoMedium* mat);
+    std::ostream& handlePlacement(std::ostream& log, TGeoNode*   parent, TGeoNode* node);
   };
   typedef void* pvoid_t;
 
-  ostream& newline(ostream& log)    {
-    return log << endl << prefix;
+  std::ostream& newline(std::ostream& log)    {
+    return log << std::endl << prefix;
   }
 
-  ostream& Actor::handleHeader   (ostream& log)    {
-    log << "#include \"TClass.h\"" << endl
-        << "#include \"TGeoNode.h\"" << endl
-        << "#include \"TGeoExtension.h\"" << endl
-        << "#include \"TGeoShapeAssembly.h\"" << endl
-        << "#include \"TGeoMedium.h\"" << endl
-        << "#include \"TGeoVolume.h\"" << endl
-        << "#include \"TGeoShape.h\"" << endl
-        << "#include \"TGeoPhysicalNode.h\"" << endl
-        << "#include \"TGeoCone.h\"" << endl
-        << "#include \"TGeoParaboloid.h\"" << endl
-        << "#include \"TGeoPgon.h\"" << endl
-        << "#include \"TGeoPcon.h\"" << endl
-        << "#include \"TGeoSphere.h\"" << endl
-        << "#include \"TGeoArb8.h\"" << endl
-        << "#include \"TGeoTrd1.h\"" << endl
-        << "#include \"TGeoTrd2.h\"" << endl
-        << "#include \"TGeoTube.h\"" << endl
-        << "#include \"TGeoEltu.h\"" << endl
-        << "#include \"TGeoXtru.h\"" << endl
-        << "#include \"TGeoHype.h\"" << endl
-        << "#include \"TGeoTorus.h\"" << endl
-        << "#include \"TGeoHalfSpace.h\"" << endl
-        << "#include \"TGeoCompositeShape.h\"" << endl
-        << "#include \"TGeoShapeAssembly.h\"" << endl
-        << "#include \"TGeoMatrix.h\"" << endl
-        << "#include \"TGeoBoolNode.h\"" << endl
-        << "#include \"TGeoCompositeShape.h\"" << endl
-        << "#include \"TGeoManager.h\"" << endl
-        << "#include <vector>" << endl
-        << "#include <map>" << endl
-        << "#include <set>" << endl << endl << endl;
+  std::ostream& Actor::handleHeader   (std::ostream& log)    {
+    log << "#include \"TClass.h\"" << std::endl
+        << "#include \"TGeoNode.h\"" << std::endl
+        << "#include \"TGeoExtension.h\"" << std::endl
+        << "#include \"TGeoShapeAssembly.h\"" << std::endl
+        << "#include \"TGeoMedium.h\"" << std::endl
+        << "#include \"TGeoVolume.h\"" << std::endl
+        << "#include \"TGeoShape.h\"" << std::endl
+        << "#include \"TGeoPhysicalNode.h\"" << std::endl
+        << "#include \"TGeoCone.h\"" << std::endl
+        << "#include \"TGeoParaboloid.h\"" << std::endl
+        << "#include \"TGeoPgon.h\"" << std::endl
+        << "#include \"TGeoPcon.h\"" << std::endl
+        << "#include \"TGeoSphere.h\"" << std::endl
+        << "#include \"TGeoArb8.h\"" << std::endl
+        << "#include \"TGeoTrd1.h\"" << std::endl
+        << "#include \"TGeoTrd2.h\"" << std::endl
+        << "#include \"TGeoTube.h\"" << std::endl
+        << "#include \"TGeoEltu.h\"" << std::endl
+        << "#include \"TGeoXtru.h\"" << std::endl
+        << "#include \"TGeoHype.h\"" << std::endl
+        << "#include \"TGeoTorus.h\"" << std::endl
+        << "#include \"TGeoHalfSpace.h\"" << std::endl
+        << "#include \"TGeoCompositeShape.h\"" << std::endl
+        << "#include \"TGeoShapeAssembly.h\"" << std::endl
+        << "#include \"TGeoMatrix.h\"" << std::endl
+        << "#include \"TGeoBoolNode.h\"" << std::endl
+        << "#include \"TGeoCompositeShape.h\"" << std::endl
+        << "#include \"TGeoManager.h\"" << std::endl
+        << "#include <vector>" << std::endl
+        << "#include <map>" << std::endl
+        << "#include <set>" << std::endl << std::endl << std::endl;
     log << "TGeoVolume* generate_geometry()   {" << newline;
     return log;
   }
 
-  ostream& Actor::handleTrailer   (ostream& log)    {
-    log << endl << "}" << endl << endl;
+  std::ostream& Actor::handleTrailer   (std::ostream& log)    {
+    log << std::endl << "}" << std::endl << std::endl;
     log << "void " << function << "() {" << newline
         << "if ( !gGeoManager ) gGeoManager = new TGeoManager();" << newline
         << "TGeoVolume* vol_top = generate_geometry();" << newline
         << "gGeoManager->SetTopVolume(vol_top);" << newline
         << "vol_top->Draw(\"ogl\");" << newline
-        << endl << "}" << endl;
+        << std::endl << "}" << std::endl;
     return log;
   }
 
-  ostream& Actor::handlePlacement(ostream& log, TGeoNode* parent, TGeoNode* node)  {
+  std::ostream& Actor::handlePlacement(std::ostream& log, TGeoNode* parent, TGeoNode* node)  {
     if ( node && nodes.find(node) == nodes.end() )  {
       TGeoVolume* vol = node->GetVolume();
       TGeoMatrix* mat = node->GetMatrix();
@@ -163,13 +162,13 @@ namespace {
             << "->GetNode(" << ndau << ");" << newline;
       }
       else   {
-        log << "return vol_" << pvoid_t(vol) << ";" << endl;
+        log << "return vol_" << pvoid_t(vol) << ";" << std::endl;
       }
     }
     return log;
   }
 
-  ostream& Actor::handleElement  (ostream& log, TGeoElement* elt)   {
+  std::ostream& Actor::handleElement  (std::ostream& log, TGeoElement* elt)   {
     if ( elt && elements.find(elt) == elements.end() )  {
       elements.insert(elt);
       log << "TGeoElement* elt_" << pvoid_t(elt) << " = new TGeoElement(\""
@@ -191,7 +190,7 @@ namespace {
     return log;
   }
 
-  ostream& Actor::handleMaterial(ostream& log, TGeoMedium* medium)   {
+  std::ostream& Actor::handleMaterial(std::ostream& log, TGeoMedium* medium)   {
     if ( medium && materials.find(medium) == materials.end() )  {
       materials.insert(medium);
       if ( !dump_mat )    {
@@ -218,9 +217,7 @@ namespace {
               << newline;
         }
         mix->SetRadLen(0e0);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,12,0)
         mix->ComputeDerivedQuantities();
-#endif
       }
       else {
         double z = mat->GetZ(), a = mat->GetA();
@@ -245,7 +242,7 @@ namespace {
     return log;
   }
   
-  ostream& Actor::handleMatrix(ostream& log, TGeoMatrix* mat)   {
+  std::ostream& Actor::handleMatrix(std::ostream& log, TGeoMatrix* mat)   {
     if ( mat && matrices.find(mat) == matrices.end() )  {
       const Double_t*	rot = mat->GetRotationMatrix();
       const Double_t*	tra = mat->GetTranslation();
@@ -282,7 +279,7 @@ namespace {
   }
   
   /// Pretty print of solid attributes
-  ostream& Actor::handleSolid(ostream& log,  const TGeoShape* shape)    {
+  std::ostream& Actor::handleSolid(std::ostream& log,  const TGeoShape* shape)    {
     if ( !shape || solids.find(shape) != solids.end() )  {
       return log;
     }
@@ -399,7 +396,7 @@ namespace {
     }
     else if (cl == TGeoPgon::Class()) {
       const TGeoPgon* sh = (const TGeoPgon*) shape;
-      vector<double> params;
+      std::vector<double> params;
       params.emplace_back(sh->GetPhi1());
       params.emplace_back(sh->GetDphi());
       params.emplace_back(double(sh->GetNedges()));
@@ -415,7 +412,7 @@ namespace {
     }
     else if (cl == TGeoPcon::Class()) {
       const TGeoPcon* sh = (const TGeoPcon*) shape;
-      vector<double> params;
+      std::vector<double> params;
       params.emplace_back(sh->GetPhi1());
       params.emplace_back(sh->GetDphi());
       params.emplace_back(double(sh->GetNz()));
@@ -534,7 +531,7 @@ namespace {
 }
 
 static long generate_cxx(Detector& description, int argc, char** argv) {
-  string output;
+  std::string output;
   Actor actor;
 
   for(int i=0; i<argc; ++i)  {
@@ -551,21 +548,21 @@ static long generate_cxx(Detector& description, int argc, char** argv) {
     else if ( c == 'm' )
       actor.dump_mat = true;
     else   {
-      cout <<
+      std::cout <<
         "Usage: -plugin DD4hep_CxxRootGenerator -arg [-arg]                                  \n"
         "     -output   <string> Set output file for generated code. Default: stdout         \n"
         "     -visualization     Also dump visualization attributes of volumes               \n"
         "     -materials         Also dump proper materials. Default to IRON                 \n"
         "     -help              Show thi help message                                       \n"
-        "\tArguments given: " << arguments(argc,argv) << endl << flush;
+        "\tArguments given: " << arguments(argc,argv) << std::endl << std::flush;
       ::exit(EINVAL);
     }
   }
-  unique_ptr<ofstream> out;
-  ostream* os = &cout;
+  std::unique_ptr<std::ofstream> out;
+  std::ostream* os = &std::cout;
   if ( !output.empty() )   {
     Path path(output);
-    out.reset(new ofstream(path.c_str()));
+    out.reset(new std::ofstream(path.c_str()));
     if ( !out->good() )   {
       out.reset();
       except("CxxRootGenerator",
@@ -574,7 +571,7 @@ static long generate_cxx(Detector& description, int argc, char** argv) {
     }
     os = out.get();
     actor.function = path.filename();
-    if ( actor.function.rfind('.') != string::npos )
+    if ( actor.function.rfind('.') != std::string::npos )
       actor.function = actor.function.substr(0, actor.function.rfind('.'));
     printout(INFO, "CxxRootGenerator",
              "++ Dump generated code to output files: %s [function: %s()]",

--- a/DDCore/src/plugins/VisDensityProcessor.cpp
+++ b/DDCore/src/plugins/VisDensityProcessor.cpp
@@ -14,8 +14,9 @@
 #define DD4HEP_DDCORE_VISDENSITYPROCESSOR_H
 
 // Framework include files
-#include "DD4hep/VolumeProcessor.h"
+#include <DD4hep/VolumeProcessor.h>
 
+/// Namespace for the AIDA detector description toolkit
 namespace dd4hep  {
   
   /// DD4hep DetElement creator for the CMS geometry.
@@ -59,14 +60,13 @@ namespace dd4hep  {
 //
 //==========================================================================
 
-//#include "DD4hep/VisDensityProcessor.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/DetectorHelper.h"
-#include "DD4hep/DetFactoryHelper.h"
+//#include <DD4hep/VisDensityProcessor.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/DetectorHelper.h>
+#include <DD4hep/DetFactoryHelper.h>
 #include <sstream>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Initializing constructor
@@ -124,7 +124,7 @@ static void* create_object(Detector& description, int argc, char** argv)   {
         continue;
       }
       else if ( ::strncmp(argv[i],"-name",4) == 0 )   {
-        string     name = argv[++i];
+        std::string name = argv[++i];
         proc->name = name;
         continue;
       }
@@ -132,13 +132,13 @@ static void* create_object(Detector& description, int argc, char** argv)   {
         proc->show = true;
         continue;
       }
-      cout <<
+      std::cout <<
         "Usage: DD4hep_VisDensityProcessor -arg [-arg]                                       \n"
         "     -vis          <name>     Set the visualization attribute for inactive materials\n"
         "     -min-vis      <name>     Set the visualization attribute for inactive materials\n"
         "     -min-density  <number>   Minimal density to show the volume.                   \n"
         "     -show                    Print setup to output device (stdout)                 \n"
-        "\tArguments given: " << arguments(argc,argv) << endl << flush;
+        "\tArguments given: " << arguments(argc,argv) << std::endl << std::flush;
       ::exit(EINVAL);
     }
   }

--- a/DDCore/src/plugins/VisProcessor.cpp
+++ b/DDCore/src/plugins/VisProcessor.cpp
@@ -13,9 +13,10 @@
 #ifndef DD4HEP_DDCORE_VISMATERIALPROCESSOR_H
 #define DD4HEP_DDCORE_VISMATERIALPROCESSOR_H
 
-// Framework include files
-#include "DD4hep/VolumeProcessor.h"
+/// Framework include files
+#include <DD4hep/VolumeProcessor.h>
 
+/// Namespace for the AIDA detector description toolkit
 namespace dd4hep  {
 
   
@@ -66,14 +67,16 @@ namespace dd4hep  {
 //
 //==========================================================================
 
-//#include "DD4hep/VisMaterialProcessor.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/DetectorTools.h"
-#include "DD4hep/DetectorHelper.h"
-#include "DD4hep/DetFactoryHelper.h"
+/// Framework include files
+//#include <DD4hep/VisMaterialProcessor.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/DetectorTools.h>
+#include <DD4hep/DetectorHelper.h>
+#include <DD4hep/DetFactoryHelper.h>
+
+/// C/C++ include files
 #include <sstream>
 
-using namespace std;
 using namespace dd4hep;
 
 namespace {
@@ -212,20 +215,20 @@ static void* create_object(Detector& description, int argc, char** argv)   {
         continue;
       }
       else if ( ::strncmp(argv[i],"-fraction",3) == 0 )   {
-        stringstream str(argv[++i]);
+        std::stringstream str(argv[++i]);
         if ( str.good() )  {
           str >> proc->fraction;
           if ( !str.fail() ) continue;
         }
       }
       else if ( ::strncmp(argv[i],"-path",4) == 0 )   {
-        string     path = argv[++i];
-        DetElement de = detail::tools::findElement(description,path);
+        std::string path = argv[++i];
+        DetElement  de = detail::tools::findElement(description,path);
         if ( de.isValid() ) continue;
         printout(ERROR,"VisMaterialProcessor","++ Invalid DetElement path: %s",path.c_str());
       }
       else if ( ::strncmp(argv[i],"-name",4) == 0 )   {
-        string     name = argv[++i];
+        std::string name = argv[++i];
         proc->name = name;
         continue;
       }
@@ -233,7 +236,7 @@ static void* create_object(Detector& description, int argc, char** argv)   {
         proc->show = true;
         continue;
       }
-      cout <<
+      std::cout <<
         "Usage: DD4hep_VisMaterialProcessor -arg [-arg]                                      \n"
         "     -vis-active   <name>     Set the visualization attribute for   active materials\n"
         "     -vis-inactive <name>     Set the visualization attribute for inactive materials\n"
@@ -246,7 +249,7 @@ static void* create_object(Detector& description, int argc, char** argv)   {
         "     -fraction     <double>   Set the fraction above which the active elment content\n"
         "                              defines an active volume.                             \n"
         "     -show                    Print setup to output device (stdout)                 \n"
-        "\tArguments given: " << arguments(argc,argv) << endl << flush;
+        "\tArguments given: " << arguments(argc,argv) << std::endl << std::flush;
       ::exit(EINVAL);
     }
   }

--- a/DDCore/src/segmentations/MultiSegmentation.cpp
+++ b/DDCore/src/segmentations/MultiSegmentation.cpp
@@ -11,20 +11,19 @@
 #include <iomanip>
 #include <stdexcept>
 
-using namespace std;
-
 namespace dd4hep {
+
   namespace DDSegmentation {
 
     /// default constructor using an encoding string
-    MultiSegmentation::MultiSegmentation(const string& cellEncoding)
+    MultiSegmentation::MultiSegmentation(const std::string& cellEncoding)
       :	Segmentation(cellEncoding), m_discriminator(0), m_debug(0)
     {
       // define type and description
       _type        = "MultiSegmentation";
       _description = "Multi-segmenation wrapper segmentation";
       //registerParameter<int>("debug", "Debug flag", m_debug, 0);
-      registerParameter<string>("key",   "Diskriminating field", m_discriminatorId, "");
+      registerParameter<std::string>("key",   "Diskriminating field", m_discriminatorId, "");
     }
 
     /// Default constructor used by derived classes passing an existing decoder
@@ -35,7 +34,7 @@ namespace dd4hep {
       _type        = "MultiSegmentation";
       _description = "Multi-segmenation wrapper segmentation";
       //registerParameter<int>("debug", "Debug flag", m_debug, 0);
-      registerParameter<string>("key",   "Diskriminating field", m_discriminatorId, "");
+      registerParameter<std::string>("key",   "Diskriminating field", m_discriminatorId, "");
     }
 
     /// destructor
@@ -82,7 +81,8 @@ namespace dd4hep {
           }
         }
       }
-      throw runtime_error("MultiSegmentation: Invalid sub-segmentation identifier!");;
+      except("MultiSegmentation", "Invalid sub-segmentation identifier!");
+      throw std::string("Invalid sub-segmentation identifier!");
     }
      
     /// determine the position based on the cell ID
@@ -95,13 +95,9 @@ namespace dd4hep {
       return subsegmentation(vID).cellID(localPosition, globalPosition, vID);
     }
 
-    vector<double> MultiSegmentation::cellDimensions(const CellID& cID) const {
+    std::vector<double> MultiSegmentation::cellDimensions(const CellID& cID) const {
       return subsegmentation(cID).cellDimensions(cID);
     }
 
   } /* namespace DDSegmentation */
 } /* namespace dd4hep */
-
-// This is done DDCore/src/plugins/ReadoutSegmentations.cpp so the plugin is not part of libDDCore
-// needs also #include "DD4hep/Factories.h"
-// DECLARE_SEGMENTATION(MultiSegmentation,create_segmentation<dd4hep::DDSegmentation::MultiSegmentation>)

--- a/DDDigi/plugins/DigiRandomNoise.cpp
+++ b/DDDigi/plugins/DigiRandomNoise.cpp
@@ -82,13 +82,12 @@ namespace dd4hep {
 
 // C/C++ include files
 
-using namespace std;
 using namespace dd4hep::digi;
 
 DECLARE_DIGIACTION_NS(dd4hep::digi,DigiRandomNoise)
 
 /// Standard constructor
-DigiRandomNoise::DigiRandomNoise(const DigiKernel& kernel, const string& nam)
+DigiRandomNoise::DigiRandomNoise(const DigiKernel& kernel, const std::string& nam)
   : DigiEventAction(kernel, nam)
 {
   declareProperty("Probability", m_probability);

--- a/DDDigi/src/DigiActionSequence.cpp
+++ b/DDDigi/src/DigiActionSequence.cpp
@@ -18,11 +18,10 @@
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep::digi;
 
 /// Standard constructor
-DigiActionSequence::DigiActionSequence(const DigiKernel& kernel, const string& nam)
+DigiActionSequence::DigiActionSequence(const DigiKernel& kernel, const std::string& nam)
   : DigiSynchronize(kernel, nam)
 {
   InstanceCount::increment(this);
@@ -50,7 +49,7 @@ void DigiActionSequence::execute(DigiContext& context)  const   {
 }
 
 /// Standard constructor
-DigiSequentialActionSequence::DigiSequentialActionSequence(const DigiKernel& kernel, const string& nam)
+DigiSequentialActionSequence::DigiSequentialActionSequence(const DigiKernel& kernel, const std::string& nam)
   : DigiActionSequence(kernel, nam)
 {
   this->m_parallel = false;
@@ -63,7 +62,7 @@ DigiSequentialActionSequence::~DigiSequentialActionSequence() {
 }
 
 /// Standard constructor
-DigiParallelActionSequence::DigiParallelActionSequence(const DigiKernel& kernel, const string& nam)
+DigiParallelActionSequence::DigiParallelActionSequence(const DigiKernel& kernel, const std::string& nam)
   : DigiActionSequence(kernel, nam)
 {
   this->m_parallel = true;

--- a/DDDigi/src/DigiHandle.cpp
+++ b/DDDigi/src/DigiHandle.cpp
@@ -25,12 +25,11 @@
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::digi;
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
+
   /// Namespace for the Digitization part of the AIDA detector description toolkit
   namespace digi {
  
@@ -75,14 +74,14 @@ namespace dd4hep {
     template <typename TYPE> TYPE* _create_object(const DigiKernel& kernel, const TypeName& typ)    {
       TYPE* object = _raw_create<TYPE>(typ.first, kernel, typ.second);
       if (!object && typ.first == typ.second) {
-        string _t = typeName(typeid(TYPE));
+        std::string _t = typeName(typeid(TYPE));
         printout(DEBUG, "DigiHandle", "Object factory for %s not found. Try out %s",
                  typ.second.c_str(), _t.c_str());
         object = _raw_create<TYPE>(_t, kernel, typ.second);
         if (!object) {
           size_t idx = _t.rfind(':');
-          if (idx != string::npos)
-            _t = string(_t.substr(idx + 1));
+          if (idx != std::string::npos)
+            _t = std::string(_t.substr(idx + 1));
           printout(DEBUG, "DigiHandle", "Try out object factory for %s",_t.c_str());
           object = _raw_create<TYPE>(_t, kernel, typ.second);
         }
@@ -95,7 +94,7 @@ namespace dd4hep {
     }
 
     template <typename TYPE> 
-    DigiHandle<TYPE>::DigiHandle(const DigiKernel& kernel, const string& type_name)  {
+    DigiHandle<TYPE>::DigiHandle(const DigiKernel& kernel, const std::string& type_name)  {
       value = _create_object<TYPE>(kernel,TypeName::split(type_name));
     }
 
@@ -124,7 +123,7 @@ namespace dd4hep {
         value->addRef();
     }
 
-    template <typename TYPE> Property& DigiHandle<TYPE>::operator[](const string& property_name) const {
+    template <typename TYPE> Property& DigiHandle<TYPE>::operator[](const std::string& property_name) const {
       PropertyManager& pm = checked_value(value)->properties();
       return pm[property_name];
     }
@@ -185,7 +184,7 @@ namespace dd4hep {
     KernelHandle::KernelHandle(DigiKernel* k) : value(k)  {
     }
 
-    Property& KernelHandle::operator[](const string& property_name) const {
+    Property& KernelHandle::operator[](const std::string& property_name) const {
       PropertyManager& pm = checked_value(value)->properties();
       return pm[property_name];
     }
@@ -200,6 +199,7 @@ namespace dd4hep {
 namespace dd4hep {
   /// Namespace for the Digitization part of the AIDA detector description toolkit
   namespace digi {
+
     template class DigiHandle<DigiAction>;
     template class DigiHandle<DigiInputAction>;
     template class DigiHandle<DigiEventAction>;

--- a/DDDigi/src/DigiLockedAction.cpp
+++ b/DDDigi/src/DigiLockedAction.cpp
@@ -16,14 +16,11 @@
 #include <DD4hep/InstanceCount.h>
 #include <DDDigi/DigiLockedAction.h>
 
-// C/C++ include files
-
-using namespace std;
 using namespace dd4hep::digi;
 
 
 /// Standard constructor
-DigiLockedAction::DigiLockedAction(const DigiKernel& kernel, const string& nam)
+DigiLockedAction::DigiLockedAction(const DigiKernel& kernel, const std::string& nam)
   : DigiEventAction(kernel, nam)
 {
   InstanceCount::increment(this);

--- a/DDDigi/src/DigiMonitorHandler.cpp
+++ b/DDDigi/src/DigiMonitorHandler.cpp
@@ -20,11 +20,10 @@
 
 /// C/C++ include files
 
-using namespace std;
 using namespace dd4hep::digi;
 
 /// Standard constructor
-DigiMonitorHandler::DigiMonitorHandler(const DigiKernel& kernel, const string& nam)
+DigiMonitorHandler::DigiMonitorHandler(const DigiKernel& kernel, const std::string& nam)
   : DigiAction(kernel, nam)
 {
   declareProperty("MonitorOutput", m_output_file);
@@ -52,24 +51,24 @@ void DigiMonitorHandler::adopt(DigiAction* source, TNamed* object)    {
 void DigiMonitorHandler::save()    {
   if ( !m_output_file.empty() )    {
     TFile* output = TFile::Open(m_output_file.c_str(),
-				"DD4hep Digitization monitoring information",
-				"RECREATE");
+                                "DD4hep Digitization monitoring information",
+                                "RECREATE");
     TDirectory::TContext top_context(output);
     if ( output && !output->IsZombie() )    {
       for( const auto& m : m_monitors )   {
-	const auto* act   = m.first;
-	const auto& items = m.second;
-	const auto& nam   = act->name();
-	std::string title = "Monitor items of digitization action "+nam;
-	TDirectory* direc = output->mkdir(nam.c_str(), title.c_str(), kTRUE);
-	TDirectory::TContext action_context(direc);
-	for( const auto* itm : items )   {
-	  Int_t nbytes = direc->WriteTObject(itm);
-	  if ( nbytes <= 0 )  {
-	    error("+++ Failed to write object: %s -> %s", nam.c_str(), itm->GetName());
-	  }
-	}
-	direc->Write();
+        const auto* act   = m.first;
+        const auto& items = m.second;
+        const auto& nam   = act->name();
+        std::string title = "Monitor items of digitization action "+nam;
+        TDirectory* direc = output->mkdir(nam.c_str(), title.c_str(), kTRUE);
+        TDirectory::TContext action_context(direc);
+        for( const auto* itm : items )   {
+          Int_t nbytes = direc->WriteTObject(itm);
+          if ( nbytes <= 0 )  {
+            error("+++ Failed to write object: %s -> %s", nam.c_str(), itm->GetName());
+          }
+        }
+        direc->Write();
       }
       output->Write();
       output->Close();

--- a/DDDigi/src/DigiSegmentation.cpp
+++ b/DDDigi/src/DigiSegmentation.cpp
@@ -18,7 +18,6 @@
 #include <DD4hep/Plugins.h>
 #include <DD4hep/Shapes.h>
 
-
 std::shared_ptr<dd4hep::digi::DigiCellScanner>
 dd4hep::digi::create_cell_scanner(Solid solid, Segmentation segment)   {
   std::string typ = "DigiCellScanner" +
@@ -29,7 +28,6 @@ dd4hep::digi::create_cell_scanner(Solid solid, Segmentation segment)   {
 
 std::shared_ptr<dd4hep::digi::DigiCellScanner>
 dd4hep::digi::create_cell_scanner(const std::string& typ, Segmentation segment)   {
-  using namespace dd4hep;
   SegmentationObject* seg = segment.ptr();
   DigiCellScanner*   scan = PluginService::Create<DigiCellScanner*>(typ, seg);
   if ( !scan )   {

--- a/DDDigi/src/DigiSynchronize.cpp
+++ b/DDDigi/src/DigiSynchronize.cpp
@@ -20,7 +20,6 @@
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep::digi;
 
 
@@ -31,7 +30,7 @@ DigiParallelWorker<DigiEventAction, DigiSynchronize::work_t, std::size_t, DigiSy
 }
 
 /// Standard constructor
-DigiSynchronize::DigiSynchronize(const DigiKernel& kernel, const string& nam)
+DigiSynchronize::DigiSynchronize(const DigiKernel& kernel, const std::string& nam)
   : DigiEventAction(kernel, nam)
 {
   InstanceCount::increment(this);
@@ -44,11 +43,11 @@ DigiSynchronize::~DigiSynchronize() {
 
 /// Pre-track action callback
 void DigiSynchronize::execute(DigiContext& context)  const   {
-  auto start = chrono::high_resolution_clock::now();
+  auto start = std::chrono::high_resolution_clock::now();
   if ( !m_actors.empty() )   {
     m_kernel.submit(context, m_actors.get_group(), m_actors.size(), &context, m_parallel);
   }
-  chrono::duration<double> secs = chrono::high_resolution_clock::now() - start;
+  std::chrono::duration<double> secs = std::chrono::high_resolution_clock::now() - start;
   const DigiEvent& ev = *context.event;
   debug("%s+++ Event: %8d (DigiSynchronize) Parallel: %-4s  %3ld actions [%8.3g sec]",
         ev.id(), ev.eventNumber, yes_no(m_parallel), m_actors.size(),

--- a/DDDigi/src/noise/DigiSubdetectorSequence.cpp
+++ b/DDDigi/src/noise/DigiSubdetectorSequence.cpp
@@ -27,11 +27,10 @@
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep::digi;
 
 /// Standard constructor
-DigiSubdetectorSequence::DigiSubdetectorSequence(const DigiKernel& kernel, const string& nam)
+DigiSubdetectorSequence::DigiSubdetectorSequence(const DigiKernel& kernel, const std::string& nam)
   : DigiActionSequence(kernel, nam)
 {
   declareProperty("detector",m_detectorName);
@@ -69,13 +68,13 @@ void DigiSubdetectorSequence::scan_sensitive(PlacedVolume pv, VolumeID vid, Volu
   Volume vol = pv.volume();
   if ( vol.isSensitive() )    {
     Solid sol = vol.solid();
-    auto  key = make_pair(sol->IsA(), m_segmentation);
+    auto  key = std::make_pair(sol->IsA(), m_segmentation);
     auto  is  = m_scanners.find(key);
     if ( is == m_scanners.end() )  {
-      is = m_scanners.insert(make_pair(key, create_cell_scanner(sol, m_segmentation))).first;
+      is = m_scanners.insert(std::make_pair(key, create_cell_scanner(sol, m_segmentation))).first;
     }
   }
-  for (int idau = 0, ndau = pv->GetNdaughters(); idau < ndau; ++idau) {
+  for ( int idau = 0, ndau = pv->GetNdaughters(); idau < ndau; ++idau ) {
     PlacedVolume  p(pv->GetDaughter(idau));
     const VolIDs& new_ids = p.volIDs();
     if ( !new_ids.empty() )   {
@@ -99,8 +98,8 @@ void DigiSubdetectorSequence::scan_detector(DetElement de, VolumeID vid, VolumeI
     for (const auto& id : new_ids)   {
       if ( id.first == m_segmentName )   {
         VolumeID rid = detail::reverseBits<VolumeID>(new_vid);
-        m_parallelVid.emplace(make_pair(rid, Context(de, new_vid, rid, new_msk)));
-        m_parallelDet.emplace(make_pair(de, new_vid));
+        m_parallelVid.emplace(std::make_pair(rid, Context(de, new_vid, rid, new_msk)));
+        m_parallelDet.emplace(std::make_pair(de, new_vid));
         scan_sensitive(de.placement(), new_vid, new_msk);
         return;
       }
@@ -114,12 +113,12 @@ void DigiSubdetectorSequence::scan_detector(DetElement de, VolumeID vid, VolumeI
 void DigiSubdetectorSequence::process_cell(DigiContext&, const DigiCellScanner& , const DigiCellData& /* data */)  const   {
 #if 0
   Segmentation seg  = m_sensDet.readout().segmentation();
-    string       desc = m_idDesc.str(data.cell_id);
-    info("Sensitive: [%s/%s]   vid:%s %s",
-         data.solid->IsA()->GetName(),
-         seg.type().c_str(),
-         volumeID(data.cell_id).c_str(),
-         desc.c_str());
+  std::string       desc = m_idDesc.str(data.cell_id);
+  info("Sensitive: [%s/%s]   vid:%s %s",
+       data.solid->IsA()->GetName(),
+       seg.type().c_str(),
+       volumeID(data.cell_id).c_str(),
+       desc.c_str());
   if ( data.cell_id )  {
   }
 #endif
@@ -133,7 +132,7 @@ void DigiSubdetectorSequence::process_context(DigiContext& context,
 {
   Volume vol = pv.volume();
   if ( vol.isSensitive() )    {
-    auto key = make_pair(vol->GetShape()->IsA(), m_segmentation);
+    auto key = std::make_pair(vol->GetShape()->IsA(), m_segmentation);
     auto is  = m_scanners.find(key);
     if ( is == m_scanners.end() )   {
       except("Fatal error in process_context: Invalid cell scanner. vid: %016X",vid);
@@ -157,7 +156,7 @@ void DigiSubdetectorSequence::execute(DigiContext& context)  const   {
     const Context& c = d.second;
     auto vid = c.detector_id;
     auto det = c.detector;
-    string id_desc   = m_idDesc.str(vid);
+    std::string id_desc = m_idDesc.str(vid);
     info("  Order:%-64s    vid:%s %s %s",
          det.path().c_str(), volumeID(d.first).c_str(), volumeID(vid).c_str(), id_desc.c_str());
     process_context(context, c, c.detector.placement(), c.detector_id, c.detector_mask);
@@ -168,11 +167,11 @@ void DigiSubdetectorSequence::execute(DigiContext& context)  const   {
 }
 
 /// Access subdetector from the detector description
-dd4hep::DetElement DigiSubdetectorSequence::subdetector(const string& nam)   const   {
+dd4hep::DetElement DigiSubdetectorSequence::subdetector(const std::string& nam)   const   {
   return m_kernel.detectorDescription().detector(nam);
 }
 
 /// Access sensitive detector from the detector description
-dd4hep::SensitiveDetector DigiSubdetectorSequence::sensitiveDetector(const string& nam)   const   {
+dd4hep::SensitiveDetector DigiSubdetectorSequence::sensitiveDetector(const std::string& nam)   const   {
   return m_kernel.detectorDescription().sensitiveDetector(nam);
 }

--- a/DDDigi/src/noise/FalphaNoise.cpp
+++ b/DDDigi/src/noise/FalphaNoise.cpp
@@ -19,7 +19,6 @@
 #include <iostream>
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep::detail;
 
 #ifdef  __GSL_FALPHA_NOISE

--- a/DDDigi/test_task_queue.cpp
+++ b/DDDigi/test_task_queue.cpp
@@ -12,8 +12,6 @@
 //==========================================================================
 #include <tbb/tbb.h>
 #include <iostream>
-using namespace tbb;
-using namespace std;
 
 class say_hello {
   int cnt = 0;
@@ -26,10 +24,9 @@ public:
   }
 };
 
-int main( )
-{
-  task_scheduler_init init(2);
-  task_group tg1, tg2, tg3;
+int main()   {
+  tbb::task_scheduler_init init(2);
+  tbb::task_group tg1, tg2, tg3;
   for(int i=0; i<200; ++i)  {
     tg1.run(std::move(say_hello("child(1)",i)));
     tg2.run(std::move(say_hello("child(2)",i)));

--- a/DDEve/DDEve/DDEve.C
+++ b/DDEve/DDEve/DDEve.C
@@ -32,12 +32,8 @@ void DDEve(const char* xmlConfig=0, const char* evtData=0)  {
   }
   ::snprintf(text,sizeof(text)," -I%s/include -D__DD4HEP_DDEVE_EXCLUSIVE__ -Wno-shadow -g -O0",dd4hep);
   gSystem->AddIncludePath(text);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   TString fname = "libDDG4IO";
   const char* io_lib = gSystem->FindDynamicLibrary(fname,kTRUE);
-#else
-  const char* io_lib = "libDDG4IO";
-#endif
   if ( io_lib )  {
     result = gSystem->Load("libDDG4IO");
     if ( 0 != result )  {

--- a/DDEve/DDEve/DDEve.cpp
+++ b/DDEve/DDEve/DDEve.cpp
@@ -16,7 +16,7 @@
 #include <iostream>
 
 // ROOT include files
-#include "TRint.h"
+#include <TRint.h>
 #include "DDEve.C"
 
 int main(int argc, char** argv)    {

--- a/DDEve/lcio/LCIOEventHandler.cpp
+++ b/DDEve/lcio/LCIOEventHandler.cpp
@@ -13,24 +13,23 @@
 
 // Framework include files
 #include "LCIOEventHandler.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Objects.h"
-#include "DD4hep/Factories.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Objects.h>
+#include <DD4hep/Factories.h>
 
-#include "IO/LCReader.h"
-#include "EVENT/LCCollection.h"
-#include "EVENT/SimCalorimeterHit.h"
-#include "EVENT/SimTrackerHit.h"
-#include "EVENT/MCParticle.h"
+#include <IO/LCReader.h>
+#include <EVENT/LCCollection.h>
+#include <EVENT/SimCalorimeterHit.h>
+#include <EVENT/SimTrackerHit.h>
+#include <EVENT/MCParticle.h>
 
-#include "TSystem.h"
-#include "TGMsgBox.h"
+#include <TSystem.h>
+#include <TGMsgBox.h>
 
 // C/C++ include files
 #include <stdexcept>
 #include <climits>
 
-using namespace std;
 using namespace lcio;
 using namespace dd4hep;
 using namespace EVENT;
@@ -168,25 +167,25 @@ bool LCIOEventHandler::NextEvent()   {
       const _S* collnames = m_event->getCollectionNames();
       for( _S::const_iterator i = collnames->begin(); i != collnames->end(); ++i) {
         LCCollection* c = m_event->getCollection(*i);
-        m_data[c->getTypeName()].push_back(make_pair((*i).c_str(),c->getNumberOfElements()));
+        m_data[c->getTypeName()].push_back(std::make_pair((*i).c_str(),c->getNumberOfElements()));
         m_branches[*i] = c;
       }
       m_hasEvent = true;
       return 1;
     }
-    throw runtime_error("+++ EventHandler::readEvent: Failed to read event");
+    throw std::runtime_error("+++ EventHandler::readEvent: Failed to read event");
   }
-  throw runtime_error("+++ EventHandler::readEvent: No file open!");
+  throw std::runtime_error("+++ EventHandler::readEvent: No file open!");
 }
 
 /// Load the previous event
 bool LCIOEventHandler::PreviousEvent()   {
-  throw runtime_error("+++ This version of the LCIO reader can only access files sequentially!\n"
-                      "+++ Access to the previous event is not supported.");
+  throw std::runtime_error("+++ This version of the LCIO reader can only access files sequentially!\n"
+                           "+++ Access to the previous event is not supported.");
 }
 
 /// Goto a specified event in the file
 bool LCIOEventHandler::GotoEvent(long /* event_number */)   {
-  throw runtime_error("+++ This version of the LCIO reader can only access files sequentially!\n"
-                      "+++ Random access is not supported.");
+  throw std::runtime_error("+++ This version of the LCIO reader can only access files sequentially!\n"
+                           "+++ Random access is not supported.");
 }

--- a/DDEve/src/Annotation.cpp
+++ b/DDEve/src/Annotation.cpp
@@ -12,10 +12,10 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/Annotation.h"
-#include "DD4hep/InstanceCount.h"
-#include "TEveViewer.h"
-#include "TGLViewer.h"
+#include <DDEve/Annotation.h>
+#include <DD4hep/InstanceCount.h>
+#include <TEveViewer.h>
+#include <TGLViewer.h>
 
 // C/C++ include files
 

--- a/DDEve/src/Calo2DProjection.cpp
+++ b/DDEve/src/Calo2DProjection.cpp
@@ -12,18 +12,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/Calo2DProjection.h"
-#include "DDEve/Annotation.h"
-#include "DDEve/Factories.h"
-#include "DD4hep/InstanceCount.h"
+#include <DDEve/Calo2DProjection.h>
+#include <DDEve/Annotation.h>
+#include <DDEve/Factories.h>
+#include <DD4hep/InstanceCount.h>
 
 // Root include files
-#include "TEveCalo.h"
-#include "TEveScene.h"
-#include "TGLViewer.h"
-#include "TEveArrow.h"
+#include <TEveCalo.h>
+#include <TEveScene.h>
+#include <TGLViewer.h>
+#include <TEveArrow.h>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(Calo2DProjection)
@@ -61,18 +60,18 @@ void Calo2DProjection::ConfigureGeometry(const DisplayConfiguration::ViewConfig&
       TEveElementList& sens = m_eve->GetGeoTopic("Sensitive");
       TEveElementList& struc = m_eve->GetGeoTopic("Structure");
       for(TEveElementList::List_i i=sens.BeginChildren(); i!=sens.EndChildren(); ++i)  {
-	TEveElementList* ll = dynamic_cast<TEveElementList*>(*i);
-	if ( ll && cfg.name == ll->GetName() )  {
-	  m_projMgr->ImportElements(*i,m_geoScene);
-	  goto Done;
-	}
+        TEveElementList* ll = dynamic_cast<TEveElementList*>(*i);
+        if ( ll && cfg.name == ll->GetName() )  {
+          m_projMgr->ImportElements(*i,m_geoScene);
+          goto Done;
+        }
       }
       for(TEveElementList::List_i i=struc.BeginChildren(); i!=struc.EndChildren(); ++i)  {
-	TEveElementList* ll = dynamic_cast<TEveElementList*>(*i);
-	if ( ll && cfg.name == ll->GetName() )  {
-	  m_projMgr->ImportElements(*i,m_geoScene);
-	  goto Done;
-	}
+        TEveElementList* ll = dynamic_cast<TEveElementList*>(*i);
+        if ( ll && cfg.name == ll->GetName() )  {
+          m_projMgr->ImportElements(*i,m_geoScene);
+          goto Done;
+        }
       }
     Done:
       continue;
@@ -110,8 +109,8 @@ void Calo2DProjection::ConfigureGeometry(const DisplayConfiguration::ViewConfig&
 #endif
       legend_y += a->GetTextSize();
       printout(INFO,"Calo2DProjection","+++ %s: add detector %s [%s] rmin=%f towerH:%f emax=%f",
-	       name().c_str(),n,ctx.config.hits.c_str(),calo3d.rmin,calo3d.towerH,
-	       calo3d.emax);
+               name().c_str(),n,ctx.config.hits.c_str(),calo3d.rmin,calo3d.towerH,
+               calo3d.emax);
     }
   }
 }
@@ -122,5 +121,5 @@ void Calo2DProjection::ConfigureEvent(const DisplayConfiguration::ViewConfig& co
 }
 
 /// Call to import geometry topics
-void Calo2DProjection::ImportGeoTopics(const string& /* title */)   {
+void Calo2DProjection::ImportGeoTopics(const std::string& /* title */)   {
 }

--- a/DDEve/src/Calo3DProjection.cpp
+++ b/DDEve/src/Calo3DProjection.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/Calo3DProjection.h"
-#include "DDEve/Factories.h"
-#include "DD4hep/InstanceCount.h"
+#include <DDEve/Calo3DProjection.h>
+#include <DDEve/Factories.h>
+#include <DD4hep/InstanceCount.h>
 
 using namespace dd4hep;
 

--- a/DDEve/src/CaloLego.cpp
+++ b/DDEve/src/CaloLego.cpp
@@ -12,23 +12,24 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/CaloLego.h"
-#include "DDEve/Annotation.h"
-#include "DDEve/Factories.h"
-#include "DD4hep/InstanceCount.h"
+#include <DDEve/CaloLego.h>
+#include <DDEve/Annotation.h>
+#include <DDEve/Factories.h>
+#include <DD4hep/InstanceCount.h>
 
 // Root include files
-#include "TH2.h"
-#include "TEveCalo.h"
-#include "TEveTrans.h"
-#include "TEveScene.h"
-#include "TGLViewer.h"
-#include "TGLWidget.h"
-#include "TEveCaloLegoOverlay.h"
-#include "TEveLegoEventHandler.h"
+#include <TH2.h>
+#include <TEveCalo.h>
+#include <TEveTrans.h>
+#include <TEveScene.h>
+#include <TGLViewer.h>
+#include <TGLWidget.h>
+#include <TEveCaloLegoOverlay.h>
+#include <TEveLegoEventHandler.h>
 
+// C/C++ include files
 #include <limits>
-using namespace std;
+
 using namespace dd4hep;
 
 ClassImp(CaloLego)
@@ -123,5 +124,5 @@ void CaloLego::ConfigureEvent(const DisplayConfiguration::ViewConfig& config)  {
 }
 
 /// Call to import geometry topics
-void CaloLego::ImportGeoTopics(const string&)   {
+void CaloLego::ImportGeoTopics(const std::string&)   {
 }

--- a/DDEve/src/ContextMenu.cpp
+++ b/DDEve/src/ContextMenu.cpp
@@ -12,20 +12,19 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/ContextMenu.h"
+#include <DDEve/ContextMenu.h>
 
 // ROOT include files
-#include "TList.h"
-#include "TClassMenuItem.h"
+#include <TList.h>
+#include <TClassMenuItem.h>
 
 // C/C++ include files
 #include <stdexcept>
 #include <map>
 
-using namespace std;
 using namespace dd4hep;
 
-typedef map<string,ContextMenu*> Contexts;
+typedef std::map<std::string,ContextMenu*> Contexts;
 static Contexts& mapped_entries()  {
   static Contexts e;
   return e;
@@ -55,7 +54,7 @@ ClassImp(ContextMenu)
 /// Initializing constructor
 ContextMenu::ContextMenu(TClass* cl) : m_class(cl)  {
   if ( !cl )   {
-    throw runtime_error("Failure: Cannot create context menu for NULL class!");
+    throw std::runtime_error("Failure: Cannot create context menu for NULL class!");
   }
 }
 
@@ -89,12 +88,12 @@ ContextMenu& ContextMenu::AddSeparator()   {
 }
 
 /// Add user callback 
-ContextMenu& ContextMenu::Add(const string& title, Callback cb, void* ud)   {
+ContextMenu& ContextMenu::Add(const std::string& title, Callback cb, void* ud)   {
   ContextMenuHandler* handler = new ContextMenuHandler(cb, ud);
   TClassMenuItem* item = 
     new TClassMenuItem(TClassMenuItem::kPopupUserFunction,
-		       ContextMenuHandler::Class(),title.c_str(),
-		       "Context",handler,"TObject*",2);
+                       ContextMenuHandler::Class(),title.c_str(),
+                       "Context",handler,"TObject*",2);
   m_calls.push_back(handler);
   m_class->GetMenuList()->AddLast(item);
   return *this;

--- a/DDEve/src/DD4hepMenu.cpp
+++ b/DDEve/src/DD4hepMenu.cpp
@@ -12,30 +12,29 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Plugins.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
-#include "DD4hep/InstanceCount.h"
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
+#include <DD4hep/InstanceCount.h>
 
-#include "DDEve/View.h"
-#include "DDEve/DD4hepMenu.h"
-#include "DDEve/PopupMenu.h"
-#include "DDEve/EventControl.h"
+#include <DDEve/View.h>
+#include <DDEve/DD4hepMenu.h>
+#include <DDEve/PopupMenu.h>
+#include <DDEve/EventControl.h>
 
 // ROOT include files
-#include "TEveBrowser.h"
-#include "TEveManager.h"
-#include "TEveElement.h"
-#include "TEveWindow.h"
-#include "TEveViewer.h"
-#include "TGLViewer.h"
-#include "TGClient.h"
-#include "TSystem.h"
+#include <TEveBrowser.h>
+#include <TEveManager.h>
+#include <TEveElement.h>
+#include <TEveWindow.h>
+#include <TEveViewer.h>
+#include <TGLViewer.h>
+#include <TGClient.h>
+#include <TSystem.h>
 
 // Forward declarations
 class TEveWindowSlot;
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(DD4hepMenu)

--- a/DDEve/src/DDEveEventData.cpp
+++ b/DDEve/src/DDEveEventData.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/DDEveEventData.h"
+#include <DDEve/DDEveEventData.h>
 
 using namespace dd4hep;
 

--- a/DDEve/src/DDEvePlugins.cpp
+++ b/DDEve/src/DDEvePlugins.cpp
@@ -11,9 +11,8 @@
 //
 //==========================================================================
 
-
 // Framework include files
-#include "DD4hep/detail/Plugins.inl"
-#include "DDEve/Factories.h"
+#include <DD4hep/detail/Plugins.inl>
+#include <DDEve/Factories.h>
 
 DD4HEP_IMPLEMENT_PLUGIN_REGISTRY(dd4hep::View*, (dd4hep::Display*, const char*))

--- a/DDEve/src/DDG4EventHandler.cpp
+++ b/DDEve/src/DDG4EventHandler.cpp
@@ -24,7 +24,6 @@
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(DDG4EventHandler)
@@ -48,12 +47,12 @@ DECLARE_CONSTRUCTOR(DD4hep_DDEve_DDG4EventHandler,_create)
 DDG4EventHandler::DDG4EventHandler() : EventHandler(), m_file(0,0), m_entry(-1) {
   void* ptr = PluginService::Create<void*>("DD4hep_DDEve_DDG4HitAccess",(const char*)"");
   if ( 0 == ptr )   {
-    throw runtime_error("FATAL: Failed to access function pointer from factory DD4hep_DDEve_DDG4HitAccess");
+    throw std::runtime_error("FATAL: Failed to access function pointer from factory DD4hep_DDEve_DDG4HitAccess");
   }
   m_simhitConverter = FCN(ptr).hits;
   ptr = PluginService::Create<void*>("DD4hep_DDEve_DDG4ParticleAccess",(const char*)"");
   if ( 0 == ptr )   {
-    throw runtime_error("FATAL: Failed to access function pointer from factory DD4hep_DDEve_DDG4ParticleAccess");
+    throw std::runtime_error("FATAL: Failed to access function pointer from factory DD4hep_DDEve_DDG4ParticleAccess");
   }
   m_particleConverter = FCN(ptr).particles;
 }
@@ -181,9 +180,9 @@ Int_t DDG4EventHandler::ReadEvent(Long64_t event_number)   {
       return nbytes;
     }
     printout(ERROR,"DDG4EventHandler","+++ ReadEvent: Cannot read event data for entry:%d",event_number);
-    throw runtime_error("+++ EventHandler::readEvent: Failed to read event");
+    throw std::runtime_error("+++ EventHandler::readEvent: Failed to read event");
   }
-  throw runtime_error("+++ EventHandler::readEvent: No file open!");
+  throw std::runtime_error("+++ EventHandler::readEvent: No file open!");
 }
 
 /// Open new data file
@@ -203,7 +202,7 @@ bool DDG4EventHandler::Open(const std::string&, const std::string& name)   {
       for(Int_t i=0; i<br->GetSize(); ++i)  {
         TBranch* b = (TBranch*)br->At(i);
         if ( !b ) continue;
-        m_branches[b->GetName()] = make_pair(b,(void*)0);
+        m_branches[b->GetName()] = std::make_pair(b,(void*)0);
         printout(INFO,"DDG4EventHandler::open","+++ Branch %s has %ld entries.",b->GetName(),b->GetEntries());
       }
       for(Int_t i=0; i<br->GetSize(); ++i)  {
@@ -214,7 +213,7 @@ bool DDG4EventHandler::Open(const std::string&, const std::string& name)   {
       m_hasFile = true;
       return true;
     }
-    throw runtime_error("+++ Failed to access tree EVENT in ROOT file:"+name);
+    throw std::runtime_error("+++ Failed to access tree EVENT in ROOT file:"+name);
   }
-  throw runtime_error("+++ Failed to open ROOT file:"+name);
+  throw std::runtime_error("+++ Failed to open ROOT file:"+name);
 }

--- a/DDEve/src/Display.cpp
+++ b/DDEve/src/Display.cpp
@@ -146,7 +146,7 @@ void Display::LoadXML(const char* xmlFile)     {
 
 /// Load geometry from compact xml file
 void Display::LoadGeometryRoot(const char* /* rootFile */)     {
-  throw runtime_error("This call is not implemented !");
+  throw std::runtime_error("This call is not implemented !");
 }
 
 /// Load geometry with panel
@@ -169,7 +169,7 @@ GenericEventHandler& Display::eventHandler() const   {
   if ( m_evtHandler )  {
     return *m_evtHandler;
   }
-  throw runtime_error("Invalid event handler");
+  throw std::runtime_error("Invalid event handler");
 }
 
 /// Add new menu to the main menu bar
@@ -238,7 +238,7 @@ Display::CalodataContext& Display::GetCaloHistogram(const std::string& nam)   {
       i = m_calodata.emplace(nam,ctx).first;
       return (*i).second;      
     }
-    throw runtime_error("Cannot access calodata configuration "+nam);
+    throw std::runtime_error("Cannot access calodata configuration "+nam);
   }
   return (*i).second;
 }
@@ -289,7 +289,7 @@ void Display::MessageBox(PrintLevel level, const std::string& text, const std::s
 }
 
 /// Popup XML file chooser. returns chosen file name; empty on cancel
-string Display::OpenXmlFileDialog(const std::string& default_dir)   const {
+std::string Display::OpenXmlFileDialog(const std::string& default_dir)   const {
   static const char *evtFiletypes[] = { 
     "xml files",    "*.xml",
     "XML files",    "*.XML",
@@ -310,7 +310,7 @@ string Display::OpenXmlFileDialog(const std::string& default_dir)   const {
 }
 
 /// Popup ROOT file chooser. returns chosen file name; empty on cancel
-string Display::OpenEventFileDialog(const std::string& default_dir)   const {
+std::string Display::OpenEventFileDialog(const std::string& default_dir)   const {
   static const char *evtFiletypes[] = { 
     "ROOT files",    "*.root",
     "SLCIO files",   "*.slcio",
@@ -348,7 +348,7 @@ void Display::BuildMenus(TGMenuBar* menubar)   {
 TFile* Display::Open(const char* name) const   {
   TFile* f = TFile::Open(name);
   if ( f && !f->IsZombie() ) return f;
-  throw runtime_error("+++ Failed to open ROOT file:"+string(name));
+  throw std::runtime_error("+++ Failed to open ROOT file:"+std::string(name));
 }
 
 /// Consumer event data
@@ -358,7 +358,7 @@ void Display::OnFileOpen(EventHandler& /* handler */ )   {
 /// Consumer event data
 void Display::OnNewEvent(EventHandler& handler )   {
   typedef EventHandler::TypedEventCollections Types;
-  typedef vector<EventHandler::Collection> Collections;
+  typedef std::vector<EventHandler::Collection> Collections;
   const Types& types = handler.data();
   TEveElement* particles = 0;
 
@@ -477,7 +477,7 @@ TEveElementList& Display::GetGeoTopic(const std::string& name)    {
 TEveElementList& Display::GetGeoTopic(const std::string& name) const   {
   Topics::const_iterator i=m_geoTopics.find(name);
   if ( i == m_geoTopics.end() )  {
-    throw runtime_error("Display: Attempt to access non-existing geometry topic:"+name);
+    throw std::runtime_error("Display: Attempt to access non-existing geometry topic:"+name);
   }
   return *((*i).second);
 }
@@ -498,7 +498,7 @@ TEveElementList& Display::GetEveTopic(const std::string& name)    {
 TEveElementList& Display::GetEveTopic(const std::string& name) const   {
   Topics::const_iterator i=m_eveTopics.find(name);
   if ( i == m_eveTopics.end() )  {
-    throw runtime_error("Display: Attempt to access non-existing event topic:"+name);
+    throw std::runtime_error("Display: Attempt to access non-existing event topic:"+name);
   }
   return *((*i).second);
 }
@@ -542,7 +542,7 @@ void Display::LoadGeoChildren(TEveElement* start, int levels, bool redraw)  {
         DetElement de = (*i).second;
         SensitiveDetector sd = m_detDesc->sensitiveDetector(de.name());
         TEveElementList& parent = sd.isValid() ? sens : struc;
-        pair<bool,TEveElement*> e = Utilities::LoadDetElement(de,levels,&parent);
+        std::pair<bool,TEveElement*> e = Utilities::LoadDetElement(de,levels,&parent);
         if ( e.second && e.first )  {
           parent.AddElement(e.second);
         }
@@ -556,7 +556,7 @@ void Display::LoadGeoChildren(TEveElement* start, int levels, bool redraw)  {
         const char* node_name = n->GetName();
         int level = Utilities::findNodeWithMatrix(detectorDescription().world().placement().ptr(),n,&mat);
         if ( level > 0 )   {
-          pair<bool,TEveElement*> e(false,0);
+          std::pair<bool,TEveElement*> e(false,0);
           const DetElement::Children& c = world.children();
           for (DetElement::Children::const_iterator i = c.begin(); i != c.end(); ++i) {
             DetElement de = (*i).second;

--- a/DDEve/src/Display.cpp
+++ b/DDEve/src/Display.cpp
@@ -12,50 +12,49 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/View.h"
-#include "DDEve/Display.h"
-#include "DDEve/ViewMenu.h"
-#include "DDEve/DD4hepMenu.h"
-#include "DDEve/ElementList.h"
-#include "DDEve/GenericEventHandler.h"
-#include "DDEve/EveShapeContextMenu.h"
-#include "DDEve/EvePgonSetProjectedContextMenu.h"
-#include "DDEve/Utilities.h"
-#include "DDEve/DDEveEventData.h"
-#include "DDEve/HitActors.h"
-#include "DDEve/ParticleActors.h"
+#include <DDEve/View.h>
+#include <DDEve/Display.h>
+#include <DDEve/ViewMenu.h>
+#include <DDEve/DD4hepMenu.h>
+#include <DDEve/ElementList.h>
+#include <DDEve/GenericEventHandler.h>
+#include <DDEve/EveShapeContextMenu.h>
+#include <DDEve/EvePgonSetProjectedContextMenu.h>
+#include <DDEve/Utilities.h>
+#include <DDEve/DDEveEventData.h>
+#include <DDEve/HitActors.h>
+#include <DDEve/ParticleActors.h>
 
-#include "DD4hep/Detector.h"
-#include "DD4hep/DetectorData.h"
-#include "DD4hep/Printout.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/DetectorData.h>
+#include <DD4hep/Printout.h>
 
 // ROOT include files
-#include "TROOT.h"
-#include "TH2.h"
-#include "TFile.h"
-#include "TSystem.h"
-#include "TGTab.h"
-#include "TGMsgBox.h"
-#include "TGClient.h"
-#include "TGFileDialog.h"
-#include "TEveScene.h"
-#include "TEveBrowser.h"
-#include "TEveManager.h"
-#include "TEveCaloData.h"
-#include "TEveCalo.h"
-#include "TEveViewer.h"
-#include "TEveCompound.h"
-#include "TEveBoxSet.h"
-#include "TEvePointSet.h"
-#include "TEveGeoShape.h"
-#include "TEveTrackPropagator.h"
-#include "TGeoManager.h"
+#include <TROOT.h>
+#include <TH2.h>
+#include <TFile.h>
+#include <TSystem.h>
+#include <TGTab.h>
+#include <TGMsgBox.h>
+#include <TGClient.h>
+#include <TGFileDialog.h>
+#include <TEveScene.h>
+#include <TEveBrowser.h>
+#include <TEveManager.h>
+#include <TEveCaloData.h>
+#include <TEveCalo.h>
+#include <TEveViewer.h>
+#include <TEveCompound.h>
+#include <TEveBoxSet.h>
+#include <TEvePointSet.h>
+#include <TEveGeoShape.h>
+#include <TEveTrackPropagator.h>
+#include <TGeoManager.h>
 
 // C/C++ include files
 #include <stdexcept>
 #include <climits>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::detail;
 
@@ -194,15 +193,15 @@ void Display::ImportConfiguration(const DisplayConfiguration& config)   {
 }
 
 /// Access to calo data histograms by name as defined in the configuration
-Display::CalodataContext& Display::GetCaloHistogram(const string& nam)   {
+Display::CalodataContext& Display::GetCaloHistogram(const std::string& nam)   {
   Calodata::iterator i = m_calodata.find(nam);
   if ( i == m_calodata.end() )  {
     DataConfigurations::const_iterator j = m_calodataConfigs.find(nam);
     if ( j != m_calodataConfigs.end() )   {
       CalodataContext ctx;
       ctx.config = (*j).second;
-      string use = ctx.config.use;
-      string hits = ctx.config.hits;
+      std::string use = ctx.config.use;
+      std::string hits = ctx.config.hits;
       if ( use.empty() )  {
         const char* n = nam.c_str();
         const DisplayConfiguration::Calodata& cd = (*j).second.data.calodata;
@@ -245,13 +244,13 @@ Display::CalodataContext& Display::GetCaloHistogram(const string& nam)   {
 }
 
 /// Access a data filter by name. Data filters are used to customize views
-const Display::ViewConfig* Display::GetViewConfiguration(const string& nam)  const   {
+const Display::ViewConfig* Display::GetViewConfiguration(const std::string& nam)  const   {
   ViewConfigurations::const_iterator i = m_viewConfigs.find(nam);
   return (i == m_viewConfigs.end()) ? 0 : &((*i).second);
 }
 
 /// Access a data filter by name. Data filters are used to customize calodatas
-const Display::DataConfig* Display::GetCalodataConfiguration(const string& nam)  const   {
+const Display::DataConfig* Display::GetCalodataConfiguration(const std::string& nam)  const   {
   DataConfigurations::const_iterator i = m_calodataConfigs.find(nam);
   return (i == m_calodataConfigs.end()) ? 0 : &((*i).second);
 }
@@ -270,12 +269,8 @@ void Display::UnregisterEvents(View* view)   {
 }
 
 /// Open standard message box
-void Display::MessageBox(PrintLevel level, const string& text, const string& title) const   {
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
-  string path = TString::Format("%s/", TROOT::GetIconPath().Data()).Data();
-#else
-  string path = TString::Format("%s/icons/", gSystem->Getenv("ROOTSYS")).Data();
-#endif
+void Display::MessageBox(PrintLevel level, const std::string& text, const std::string& title) const   {
+  std::string path = TString::Format("%s/", TROOT::GetIconPath().Data()).Data();
   const TGPicture* pic = 0;
   if ( level == VERBOSE )
     pic = client().GetPicture((path+"mb_asterisk_s.xpm").c_str());
@@ -294,7 +289,7 @@ void Display::MessageBox(PrintLevel level, const string& text, const string& tit
 }
 
 /// Popup XML file chooser. returns chosen file name; empty on cancel
-string Display::OpenXmlFileDialog(const string& default_dir)   const {
+string Display::OpenXmlFileDialog(const std::string& default_dir)   const {
   static const char *evtFiletypes[] = { 
     "xml files",    "*.xml",
     "XML files",    "*.XML",
@@ -307,7 +302,7 @@ string Display::OpenXmlFileDialog(const string& default_dir)   const {
   fi.fFilename  = 0;
   new TGFileDialog(client().GetRoot(), 0, kFDOpen, &fi);
   if ( fi.fFilename ) {
-    string ret = fi.fFilename;
+    std::string ret = fi.fFilename;
     if ( ret.find("file:") != 0 ) return "file:"+ret;
     return ret;
   }
@@ -315,7 +310,7 @@ string Display::OpenXmlFileDialog(const string& default_dir)   const {
 }
 
 /// Popup ROOT file chooser. returns chosen file name; empty on cancel
-string Display::OpenEventFileDialog(const string& default_dir)   const {
+string Display::OpenEventFileDialog(const std::string& default_dir)   const {
   static const char *evtFiletypes[] = { 
     "ROOT files",    "*.root",
     "SLCIO files",   "*.slcio",
@@ -372,38 +367,38 @@ void Display::OnNewEvent(EventHandler& handler )   {
   for(Types::const_iterator ityp=types.begin(); ityp!=types.end(); ++ityp)  {
     const Collections& colls = (*ityp).second;
     for(Collections::const_iterator j=colls.begin(); j!=colls.end(); ++j)   {
-      size_t len = (*j).second;
+      std::size_t len = (*j).second;
       if ( len > 0 )   {
-	const char* nam = (*j).first;
-	DataConfigurations::const_iterator icfg = m_collectionsConfigs.find(nam);
-	DataConfigurations::const_iterator cfgend = m_collectionsConfigs.end();
+        const char* nam = (*j).first;
+        DataConfigurations::const_iterator icfg = m_collectionsConfigs.find(nam);
+        DataConfigurations::const_iterator cfgend = m_collectionsConfigs.end();
         EventHandler::CollectionType typ = handler.collectionType(nam);
         if ( typ == EventHandler::CALO_HIT_COLLECTION ||
              typ == EventHandler::TRACKER_HIT_COLLECTION )  {
           if ( icfg != cfgend )  {
             const DataConfig& cfg = (*icfg).second;
-	    if ( ::toupper(cfg.use[0]) == 'T' || ::toupper(cfg.use[0]) == 'Y' )  {
-	      if ( cfg.hits == "PointSet" )  {
-		PointsetCreator cr(nam,len,cfg);
-		handler.collectionLoop((*j).first, cr);
-		ImportEvent(cr.element());
-	      }
-	      else if ( cfg.hits == "BoxSet" )  {
-		BoxsetCreator cr(nam,len,cfg);
-		handler.collectionLoop((*j).first, cr);
-		ImportEvent(cr.element());
-	      }
-	      else if ( cfg.hits == "TowerSet" )  {
-		TowersetCreator cr(nam,len,cfg);
-		handler.collectionLoop((*j).first, cr);
-		ImportEvent(cr.element());
-	      }
-	      else {  // Default is point set
-		PointsetCreator cr(nam,len);
-		handler.collectionLoop((*j).first, cr);
-		ImportEvent(cr.element());
-	      }
-	    }
+            if ( ::toupper(cfg.use[0]) == 'T' || ::toupper(cfg.use[0]) == 'Y' )  {
+              if ( cfg.hits == "PointSet" )  {
+                PointsetCreator cr(nam,len,cfg);
+                handler.collectionLoop((*j).first, cr);
+                ImportEvent(cr.element());
+              }
+              else if ( cfg.hits == "BoxSet" )  {
+                BoxsetCreator cr(nam,len,cfg);
+                handler.collectionLoop((*j).first, cr);
+                ImportEvent(cr.element());
+              }
+              else if ( cfg.hits == "TowerSet" )  {
+                TowersetCreator cr(nam,len,cfg);
+                handler.collectionLoop((*j).first, cr);
+                ImportEvent(cr.element());
+              }
+              else {  // Default is point set
+                PointsetCreator cr(nam,len);
+                handler.collectionLoop((*j).first, cr);
+                ImportEvent(cr.element());
+              }
+            }
           }
           else  {
             PointsetCreator cr(nam,len);
@@ -417,21 +412,21 @@ void Display::OnNewEvent(EventHandler& handler )   {
           // last track is gone ie. when we re-initialize the event scene
 
           // $$$ Do not know exactly what the field parameters mean
-	  if ( (icfg=m_collectionsConfigs.find("StartVertexPoints")) != cfgend )   {
-	    StartVertexCreator cr("StartVertexPoints", len, (*icfg).second);
-	    handler.collectionLoop((*j).first, cr);
-	    printout(INFO,"Display","+++ StartVertexPoints: Filled %d start vertex points.....",cr.count);
-	    ImportEvent(cr.element());
-	  }
-	  if ( (icfg=m_collectionsConfigs.find("MCParticles")) != cfgend )   {
-	    MCParticleCreator cr(new TEveTrackPropagator("","",new TEveMagFieldDuo(350, -3.5, 2.0)),
-				 new TEveCompound("MC_Particles","MC_Particles"),
-				 icfg == cfgend ? 0 : &((*icfg).second));
-	    handler.collectionLoop((*j).first, cr);
-	    printout(INFO,"Display","+++ StartVertexPoints: Filled %d patricle tracks.....",cr.count);
-	    cr.close();
-	    particles = cr.particles;
-	  }
+          if ( (icfg=m_collectionsConfigs.find("StartVertexPoints")) != cfgend )   {
+            StartVertexCreator cr("StartVertexPoints", len, (*icfg).second);
+            handler.collectionLoop((*j).first, cr);
+            printout(INFO,"Display","+++ StartVertexPoints: Filled %d start vertex points.....",cr.count);
+            ImportEvent(cr.element());
+          }
+          if ( (icfg=m_collectionsConfigs.find("MCParticles")) != cfgend )   {
+            MCParticleCreator cr(new TEveTrackPropagator("","",new TEveMagFieldDuo(350, -3.5, 2.0)),
+                                 new TEveCompound("MC_Particles","MC_Particles"),
+                                 icfg == cfgend ? 0 : &((*icfg).second));
+            handler.collectionLoop((*j).first, cr);
+            printout(INFO,"Display","+++ StartVertexPoints: Filled %d patricle tracks.....",cr.count);
+            cr.close();
+            particles = cr.particles;
+          }
         }
       }
     }
@@ -442,7 +437,7 @@ void Display::OnNewEvent(EventHandler& handler )   {
     CalodataContext& ctx = (*i).second;
     TH2F* h = ctx.eveHist->GetHist(0);
     EtaPhiHistogramActor actor(h);
-    size_t n = eventHandler().collectionLoop(ctx.config.hits, actor);
+    std::size_t n = eventHandler().collectionLoop(ctx.config.hits, actor);
     ctx.eveHist->DataChanged();
     printout(INFO,"FillEtaPhiHistogram","+++ %s: Filled %ld hits from %s....",
              ctx.calo3D->GetName(), n, ctx.config.hits.c_str());
@@ -467,7 +462,7 @@ TEveElementList& Display::GetGeo()   {
 }
 
 /// Access/Create a topic by name
-TEveElementList& Display::GetGeoTopic(const string& name)    {
+TEveElementList& Display::GetGeoTopic(const std::string& name)    {
   Topics::iterator i=m_geoTopics.find(name);
   if ( i == m_geoTopics.end() )  {
     TEveElementList* topic = new ElementList(name.c_str(), name.c_str(), true, true);
@@ -479,7 +474,7 @@ TEveElementList& Display::GetGeoTopic(const string& name)    {
 }
 
 /// Access/Create a topic by name. Throws exception if the topic does not exist
-TEveElementList& Display::GetGeoTopic(const string& name) const   {
+TEveElementList& Display::GetGeoTopic(const std::string& name) const   {
   Topics::const_iterator i=m_geoTopics.find(name);
   if ( i == m_geoTopics.end() )  {
     throw runtime_error("Display: Attempt to access non-existing geometry topic:"+name);
@@ -488,7 +483,7 @@ TEveElementList& Display::GetGeoTopic(const string& name) const   {
 }
 
 /// Access/Create a topic by name
-TEveElementList& Display::GetEveTopic(const string& name)    {
+TEveElementList& Display::GetEveTopic(const std::string& name)    {
   Topics::iterator i=m_eveTopics.find(name);
   if ( i == m_eveTopics.end() )  {
     TEveElementList* topic = new ElementList(name.c_str(), name.c_str(), true, true);
@@ -500,7 +495,7 @@ TEveElementList& Display::GetEveTopic(const string& name)    {
 }
 
 /// Access/Create a topic by name. Throws exception if the topic does not exist
-TEveElementList& Display::GetEveTopic(const string& name) const   {
+TEveElementList& Display::GetEveTopic(const std::string& name) const   {
   Topics::const_iterator i=m_eveTopics.find(name);
   if ( i == m_eveTopics.end() )  {
     throw runtime_error("Display: Attempt to access non-existing event topic:"+name);
@@ -514,12 +509,12 @@ void Display::ImportGeo(TEveElement* el)   {
 }
 
 /// Call to import geometry elements by topic
-void Display::ImportGeo(const string& topic, TEveElement* el)  { 
+void Display::ImportGeo(const std::string& topic, TEveElement* el)  { 
   GetGeoTopic(topic).AddElement(el);
 }
 
 /// Call to import event elements by topic
-void Display::ImportEvent(const string& topic, TEveElement* el)  { 
+void Display::ImportEvent(const std::string& topic, TEveElement* el)  { 
   GetEveTopic(topic).AddElement(el);
 }
 

--- a/DDEve/src/DisplayConfiguration.cpp
+++ b/DDEve/src/DisplayConfiguration.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/DisplayConfiguration.h"
+#include <DDEve/DisplayConfiguration.h>
 
 // C/C++ include files
 #include <stdexcept>

--- a/DDEve/src/DisplayConfigurationParser.cpp
+++ b/DDEve/src/DisplayConfigurationParser.cpp
@@ -12,23 +12,21 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/DetectorLoad.h"
-#include "DD4hep/Printout.h"
-#include "XML/Conversions.h"
-#include "XML/XMLElements.h"
-#include "XML/DocumentHandler.h"
-#include "DD4hep/DetFactoryHelper.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/DetectorLoad.h>
+#include <DD4hep/Printout.h>
+#include <XML/Conversions.h>
+#include <XML/XMLElements.h>
+#include <XML/DocumentHandler.h>
+#include <DD4hep/DetFactoryHelper.h>
 
-#include "DDEve/Display.h"
-#include "DDEve/DisplayConfiguration.h"
+#include <DDEve/Display.h>
+#include <DDEve/DisplayConfiguration.h>
 
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep;
-
 
 namespace dd4hep  {  namespace   {
     /// Some utility class to specialize the convetrers:
@@ -81,7 +79,7 @@ namespace {
 }
 
 static void extract(DisplayConfiguration::Config& c, xml_h e, int typ)   {
-  c.name  = e.attr<string>(_U(name));
+  c.name  = e.attr<std::string>(_U(name));
   c.type = typ;
   c.data.defaults.show_evt  = e.hasAttr(u_show_evt) ? e.attr<int>(u_show_evt)  :  1;
   c.data.defaults.load_geo  = e.hasAttr(u_load_geo) ? e.attr<int>(u_load_geo)  : -1;
@@ -91,8 +89,8 @@ static void extract(DisplayConfiguration::Config& c, xml_h e, int typ)   {
   c.data.calo3d.towerH      = e.hasAttr(u_towerH)   ? e.attr<float>(u_towerH)  : 25.0;
   if ( e.hasAttr(_U(dz))   ) c.data.calo3d.dz   = e.attr<float>(_U(dz));
   if ( e.hasAttr(_U(rmin)) ) c.data.calo3d.rmin = e.attr<float>(_U(rmin));
-  if ( e.hasAttr(u_use)    ) c.use  = e.attr<string>(u_use);
-  if ( e.hasAttr(u_hits)   ) c.hits = e.attr<string>(u_hits);
+  if ( e.hasAttr(u_use)    ) c.use  = e.attr<std::string>(u_use);
+  if ( e.hasAttr(u_hits)   ) c.hits = e.attr<std::string>(u_hits);
   if ( e.hasAttr(_U(threshold)) ) c.data.calo3d.threshold = e.attr<float>(_U(threshold));
 }
 
@@ -126,15 +124,15 @@ template <> void Converter<calodata_configs>::operator()(xml_h e)  const  {
 template <> void Converter<collection_configs>::operator()(xml_h e)  const  {
   Configurations* configs = (Configurations*)param;
   DisplayConfiguration::Config c;
-  c.name = e.attr<string>(_U(name));
+  c.name = e.attr<std::string>(_U(name));
   c.type = DisplayConfiguration::COLLECTION;
   c.data.hits.color     = e.hasAttr(_U(color)) ? e.attr<int>(_U(color))   : 0xBBBBBB;
   c.data.hits.alpha     = e.hasAttr(_U(alpha)) ? e.attr<float>(_U(alpha)) : -1.0;
   c.data.hits.emax      = e.hasAttr(u_emax)    ? e.attr<float>(u_emax)    : 25.0;
   c.data.hits.towerH    = e.hasAttr(u_towerH)  ? e.attr<float>(u_towerH)  : 25.0;
   c.data.hits.threshold = e.hasAttr(_U(threshold)) ? e.attr<float>(_U(threshold)) : 0.0;
-  if ( e.hasAttr(u_hits)   ) c.hits = e.attr<string>(u_hits);
-  if ( e.hasAttr(u_use)    ) c.use = e.attr<string>(u_use);
+  if ( e.hasAttr(u_hits)   ) c.hits = e.attr<std::string>(u_hits);
+  if ( e.hasAttr(u_use)    ) c.use = e.attr<std::string>(u_use);
   configs->push_back(c);
 }
 
@@ -153,8 +151,8 @@ template <> void Converter<view>::operator()(xml_h e)  const  {
   ViewConfigurations* configs = (ViewConfigurations*)param;
   DisplayConfiguration::ViewConfig c;
   extract(c,e,DisplayConfiguration::VIEW);
-  c.name  = e.attr<string>(_U(name));
-  c.type  = e.attr<string>(_U(type));
+  c.name  = e.attr<std::string>(_U(name));
+  c.type  = e.attr<std::string>(_U(type));
   c.show_structure = e.hasAttr(_U(structure)) ? e.attr<bool>(_U(structure)) : true;
   c.show_sensitive = e.hasAttr(_U(sensitive)) ? e.attr<bool>(_U(sensitive)) : true;
   printout(INFO,"DisplayConfiguration","+++ View: %s sensitive:%d structure:%d.",
@@ -180,14 +178,14 @@ template <> void Converter<view>::operator()(xml_h e)  const  {
 template <> void Converter<calodata>::operator()(xml_h e)  const  {
   Configurations* configs = (Configurations*)param;
   DisplayConfiguration::Config c;
-  c.name = e.attr<string>(_U(name));
+  c.name = e.attr<std::string>(_U(name));
   c.type = DisplayConfiguration::CALODATA;
   if ( e.hasAttr(u_use)    )   {
-    c.use  = e.attr<string>(u_use);
-    c.hits = e.attr<string>(u_hits);
+    c.use  = e.attr<std::string>(u_use);
+    c.hits = e.attr<std::string>(u_hits);
   }
   else  {
-    c.hits = e.attr<string>(u_hits);
+    c.hits = e.attr<std::string>(u_hits);
     c.data.calodata.n_eta   = e.attr<int>(u_n_eta);
     c.data.calodata.eta_min = e.attr<float>(u_eta_min);
     c.data.calodata.eta_max = e.attr<float>(u_eta_max);
@@ -219,10 +217,10 @@ template <> void Converter<calodata>::operator()(xml_h e)  const  {
 template <> void Converter<collection>::operator()(xml_h e)  const  {
   Configurations* configs = (Configurations*)param;
   DisplayConfiguration::Config c;
-  c.name = e.attr<string>(_U(name));
-  c.hits = e.attr<string>(u_hits);
+  c.name = e.attr<std::string>(_U(name));
+  c.hits = e.attr<std::string>(u_hits);
   c.type = DisplayConfiguration::COLLECTION;
-  c.use  = e.hasAttr(u_use) ? e.attr<string>(u_use) : string();
+  c.use  = e.hasAttr(u_use) ? e.attr<std::string>(u_use) : std::string();
   c.data.hits.size  = e.attr<float>(_U(size));
   c.data.hits.type  = e.attr<float>(_U(type));
   c.data.hits.color = e.hasAttr(_U(color))  ? e.attr<int>(_U(color)) : kRed;
@@ -249,7 +247,7 @@ template <> void Converter<include>::operator()(xml_h e)  const  {
   if ( e )  {
     DetectorLoad* load = dynamic_cast<DetectorLoad*>(&this->description);
     if ( load )   {
-      load->processXML(e,e.attr<string>(_U(ref)));
+      load->processXML(e,e.attr<std::string>(_U(ref)));
       return;
     }
     except("DisplayConfiguration","++ Invalid DetectorLoad instance in XML converter <include>");
@@ -298,7 +296,7 @@ template <> void Converter<ddeve>::operator()(xml_h e)  const  {
   disp->ImportConfiguration(cfg);
 }
 
-#include "TEveProjections.h"
+#include <TEveProjections.h>
 /** Basic entry point to read display configuration files
  *
  *  @author  M.Frank

--- a/DDEve/src/ElementList.cpp
+++ b/DDEve/src/ElementList.cpp
@@ -12,16 +12,15 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDEve/EveUserContextMenu.h"
-#include "DDEve/ElementList.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDEve/EveUserContextMenu.h>
+#include <DDEve/ElementList.h>
 
 // ROOT include files
 
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(ElementList)

--- a/DDEve/src/EvePgonSetProjectedContextMenu.cpp
+++ b/DDEve/src/EvePgonSetProjectedContextMenu.cpp
@@ -12,16 +12,15 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/ContextMenu.h"
-#include "DDEve/EvePgonSetProjectedContextMenu.h"
+#include <DDEve/ContextMenu.h>
+#include <DDEve/EvePgonSetProjectedContextMenu.h>
 
 // ROOT include files
-#include "TEvePolygonSetProjected.h"
+#include <TEvePolygonSetProjected.h>
 
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(EvePgonSetProjectedContextMenu)

--- a/DDEve/src/EveShapeContextMenu.cpp
+++ b/DDEve/src/EveShapeContextMenu.cpp
@@ -12,17 +12,16 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DDEve/EveShapeContextMenu.h"
+#include <DD4hep/Printout.h>
+#include <DDEve/EveShapeContextMenu.h>
 
 // ROOT include files
-#include "TEveGeoShape.h"
-#include "TEveManager.h"
+#include <TEveGeoShape.h>
+#include <TEveManager.h>
 
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(EveShapeContextMenu)

--- a/DDEve/src/EveUserContextMenu.cpp
+++ b/DDEve/src/EveUserContextMenu.cpp
@@ -12,19 +12,18 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DDEve/Display.h"
-#include "DDEve/ContextMenu.h"
-#include "DDEve/EveUserContextMenu.h"
+#include <DD4hep/Printout.h>
+#include <DDEve/Display.h>
+#include <DDEve/ContextMenu.h>
+#include <DDEve/EveUserContextMenu.h>
 
 // ROOT include files
-#include "TEveGeoShape.h"
-#include "TEveManager.h"
-#include "TEveElement.h"
+#include <TEveGeoShape.h>
+#include <TEveManager.h>
+#include <TEveElement.h>
 
 // C/C++ include files
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(EveUserContextMenu)

--- a/DDEve/src/EventControl.cpp
+++ b/DDEve/src/EventControl.cpp
@@ -12,10 +12,10 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/Display.h"
-#include "DDEve/EventControl.h"
-#include "DDEve/EventHandler.h"
-#include "DD4hep/InstanceCount.h"
+#include <DDEve/Display.h>
+#include <DDEve/EventControl.h>
+#include <DDEve/EventHandler.h>
+#include <DD4hep/InstanceCount.h>
 
 // ROOT include files
 #include <TROOT.h>
@@ -25,12 +25,11 @@
 #include <TGFrame.h>
 #include <TGButton.h>
 #include <TG3DLine.h>
-#include "TGFileDialog.h"
+#include <TGFileDialog.h>
 
-#include "TTree.h"
+#include <TTree.h>
 #include <libgen.h>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(EventControl)
@@ -117,22 +116,22 @@ void EventControl::OnNewEvent(EventHandler& handler)   {
   typedef EventHandler::TypedEventCollections Types;
   typedef std::vector<EventHandler::Collection> Collections;
   const Types& types = handler.data();
-  size_t cnt = 1;
+  std::size_t cnt = 1;
   m_lines[0].second.first->SetText("Hit collection name");
   m_lines[0].second.second->SetText("No.Hits");
   for(const auto& t : types)  {
     const Collections& colls = t.second;
     Line line  = m_lines[cnt++];
-    string cl  = t.first;
-    size_t idx = cl.rfind("Geant4");
-    if ( idx != string::npos ) { 
+    std::string cl  = t.first;
+    std::size_t idx = cl.rfind("Geant4");
+    if ( idx != std::string::npos ) { 
       cl = cl.substr(idx);
       cl = cl.substr(0,cl.find('*'));
     }
-    else if ( (idx=cl.rfind("::")) != string::npos )  {
+    else if ( (idx=cl.rfind("::")) != std::string::npos )  {
       cl = cl.substr(idx+2);
-      if ( (idx=cl.rfind('*')) != string::npos ) cl = cl.substr(0,idx);
-      if ( (idx=cl.rfind('>')) != string::npos ) cl = cl.substr(0,idx);
+      if ( (idx=cl.rfind('*')) != std::string::npos ) cl = cl.substr(0,idx);
+      if ( (idx=cl.rfind('>')) != std::string::npos ) cl = cl.substr(0,idx);
     }
     line.second.first->SetTextColor(kRed);
     line.second.second->SetTextColor(kRed);
@@ -159,15 +158,12 @@ void EventControl::OnNewEvent(EventHandler& handler)   {
 
 /// User callback to add elements to the control
 void EventControl::OnBuild()   {
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
-  string icondir = TString::Format("%s/", TROOT::GetIconPath().Data()).Data();
-#else
-  string icondir = TString::Format("%s/icons/", gSystem->Getenv("ROOTSYS")).Data();
-#endif
+  std::string icondir = TString::Format("%s/", TROOT::GetIconPath().Data()).Data();
   TGGroupFrame* group = new TGGroupFrame(m_frame,"Event I/O Control");
   TGCompositeFrame* top = new TGHorizontalFrame(group);
   TGPictureButton* b = 0;
   char text[1024];
+
   group->SetTitlePos(TGGroupFrame::kLeft);
   m_frame->AddFrame(group, new TGLayoutHints(kLHintsExpandX|kLHintsCenterX, 2, 2, 2, 2));
   m_eventGroup = group;

--- a/DDEve/src/EventControl.cpp
+++ b/DDEve/src/EventControl.cpp
@@ -79,11 +79,6 @@ void EventControl::GotoEvent()   {
 
 /// Open a new event data file
 bool EventControl::Open()   {
-  // e- shots:
-  //m_display->eventHandler().Open("/home/frankm/SW/DD4hep_head_dbg.root_v5.34.10/build/CLICSiD_2014-06-10_15-26.root");
-  // pi- shots:
-  //m_display->eventHandler().Open("/home/frankm/SW/DD4hep_head_dbg.root_v5.34.10/build/CLICSiD_2014-06-18_12-48.root");
-
   std::string fname = m_display->OpenEventFileDialog(".");
   if ( !fname.empty() )  {
     return m_display->eventHandler().Open(m_display->getEventHandlerName(),fname);

--- a/DDEve/src/EventHandler.cpp
+++ b/DDEve/src/EventHandler.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/EventHandler.h"
+#include <DDEve/EventHandler.h>
 
 using namespace dd4hep;
 

--- a/DDEve/src/FrameControl.cpp
+++ b/DDEve/src/FrameControl.cpp
@@ -12,8 +12,8 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/FrameControl.h"
-#include "DD4hep/Printout.h"
+#include <DDEve/FrameControl.h>
+#include <DD4hep/Printout.h>
 
 // ROOT include files
 #include <TSystem.h>
@@ -22,7 +22,6 @@
 
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(FrameControl)

--- a/DDEve/src/GenericEventHandler.cpp
+++ b/DDEve/src/GenericEventHandler.cpp
@@ -12,16 +12,16 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/GenericEventHandler.h"
-#include "DD4hep/Primitives.h"
-#include "DD4hep/Factories.h"
-#include "DD4hep/Plugins.h"
+#include <DDEve/GenericEventHandler.h>
+#include <DD4hep/Primitives.h>
+#include <DD4hep/Factories.h>
+#include <DD4hep/Plugins.h>
 #include <stdexcept>
 
 /// ROOT include files
-#include "TROOT.h"
-#include "TGMsgBox.h"
-#include "TSystem.h"
+#include <TROOT.h>
+#include <TGMsgBox.h>
+#include <TSystem.h>
 #include <climits>
 
 using namespace std;
@@ -74,7 +74,7 @@ string GenericEventHandler::datasourceName() const {
 }
 
 /// Access to the collection type by name
-EventHandler::CollectionType GenericEventHandler::collectionType(const string& collection) const   {
+EventHandler::CollectionType GenericEventHandler::collectionType(const std::string& collection) const   {
   if ( m_current && m_current->hasEvent() )  {
     return m_current->collectionType(collection);
   }
@@ -82,7 +82,7 @@ EventHandler::CollectionType GenericEventHandler::collectionType(const string& c
 }
 
 /// Loop over collection and extract data
-size_t GenericEventHandler::collectionLoop(const string& collection, DDEveHitActor& actor) {
+std::size_t GenericEventHandler::collectionLoop(const std::string& collection, DDEveHitActor& actor) {
   if ( m_current && m_current->hasEvent() )  {
     return m_current->collectionLoop(collection,actor);
   }
@@ -90,7 +90,7 @@ size_t GenericEventHandler::collectionLoop(const string& collection, DDEveHitAct
 }
 
 /// Loop over collection and extract particle data
-size_t GenericEventHandler::collectionLoop(const string& collection, DDEveParticleActor& actor)    {
+std::size_t GenericEventHandler::collectionLoop(const std::string& collection, DDEveParticleActor& actor)    {
   if ( m_current && m_current->hasEvent() )  {
     return m_current->collectionLoop(collection,actor);
   }
@@ -98,23 +98,23 @@ size_t GenericEventHandler::collectionLoop(const string& collection, DDEvePartic
 }
 
 /// Open a new event data file
-bool GenericEventHandler::Open(const string& file_type, const string& file_name)   {
-  size_t idx = file_name.find("lcio");
-  size_t idr = file_name.find("root");
-  string err;
+bool GenericEventHandler::Open(const std::string& file_type, const std::string& file_name)   {
+  std::size_t idx = file_name.find("lcio");
+  std::size_t idr = file_name.find("root");
+  std::string err;
   m_hasFile = false;
   m_hasEvent = false;
   try  {
     detail::deletePtr(m_current);
     //  prefer event handler configured in xml
-    if ( file_type.find("FCC") != string::npos ) {
+    if ( file_type.find("FCC") != std::string::npos ) {
       m_current = (EventHandler*)PluginService::Create<void*>("DD4hep_DDEve_FCCEventHandler",(const char*)0);
     }
     // fall back to defaults according to file ending
-    else if ( idx != string::npos )   {
+    else if ( idx != std::string::npos )   {
       m_current = (EventHandler*)PluginService::Create<void*>("DD4hep_DDEve_LCIOEventHandler",(const char*)0);
     }
-    else if ( idr != string::npos )   {
+    else if ( idr != std::string::npos )   {
       m_current = (EventHandler*)PluginService::Create<void*>("DD4hep_DDEve_DDG4EventHandler",(const char*)0);
     }
     else   {
@@ -135,13 +135,9 @@ bool GenericEventHandler::Open(const string& file_type, const string& file_name)
   }
   catch(const exception& e)  {
     err = "\nAn exception occurred \n"
-      "while opening event data:\n" + string(e.what()) + "\n\n";
+      "while opening event data:\n" + std::string(e.what()) + "\n\n";
   }
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
-  string path = TString::Format("%s/stop_t.xpm", TROOT::GetIconPath().Data()).Data();
-#else
-  string path = TString::Format("%s/icons/stop_t.xpm", gSystem->Getenv("ROOTSYS")).Data();
-#endif
+  std::string path = TString::Format("%s/stop_t.xpm", TROOT::GetIconPath().Data()).Data();
   const TGPicture* pic = gClient->GetPicture(path.c_str());
   new TGMsgBox(gClient->GetRoot(),0,"Failed to open event data",err.c_str(),pic,
                kMBDismiss,0,kVerticalFrame,kTextLeft|kTextCenterY);
@@ -162,13 +158,9 @@ bool GenericEventHandler::NextEvent()   {
     throw runtime_error("+++ EventHandler::readEvent: No file open!");
   }
   catch(const exception& e)  {
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
-    string path = TString::Format("%s/stop_t.xpm", TROOT::GetIconPath().Data()).Data();
-#else
-    string path = TString::Format("%s/icons/stop_t.xpm", gSystem->Getenv("ROOTSYS")).Data();
-#endif
-    string err = "\nAn exception occurred \n"
-      "while reading a new event:\n" + string(e.what()) + "\n\n";
+    std::string path = TString::Format("%s/stop_t.xpm", TROOT::GetIconPath().Data()).Data();
+    std::string err = "\nAn exception occurred \n"
+      "while reading a new event:\n" + std::string(e.what()) + "\n\n";
     const TGPicture* pic = gClient->GetPicture(path.c_str());
     new TGMsgBox(gClient->GetRoot(),0,"Failed to read event", err.c_str(),pic,
                  kMBDismiss,0,kVerticalFrame,kTextLeft|kTextCenterY);

--- a/DDEve/src/GenericEventHandler.cpp
+++ b/DDEve/src/GenericEventHandler.cpp
@@ -24,7 +24,6 @@
 #include <TSystem.h>
 #include <climits>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(GenericEventHandler)
@@ -43,7 +42,7 @@ EventHandler* GenericEventHandler::current() const   {
   if ( m_current )  {
     return m_current;
   }
-  throw runtime_error("Invalid event handler");
+  throw std::runtime_error("Invalid event handler");
 }
 
 /// Notfy all subscribers
@@ -69,7 +68,7 @@ long GenericEventHandler::numEvents() const   {
 }
 
 /// Access the data source name
-string GenericEventHandler::datasourceName() const {
+std::string GenericEventHandler::datasourceName() const {
   return current()->datasourceName();
 }
 
@@ -118,7 +117,7 @@ bool GenericEventHandler::Open(const std::string& file_type, const std::string& 
       m_current = (EventHandler*)PluginService::Create<void*>("DD4hep_DDEve_DDG4EventHandler",(const char*)0);
     }
     else   {
-      throw runtime_error("Attempt to open file:"+file_name+" of unknown type:"+file_type);
+      throw std::runtime_error("Attempt to open file:"+file_name+" of unknown type:"+file_type);
     }
     if ( m_current )   {
       if ( m_current->Open(file_type, file_name) )   {
@@ -133,7 +132,7 @@ bool GenericEventHandler::Open(const std::string& file_type, const std::string& 
       err = "+++ Failed to create fikle reader for file '"+file_name+"' of type '"+file_type+"'";
     }
   }
-  catch(const exception& e)  {
+  catch(const std::exception& e)  {
     err = "\nAn exception occurred \n"
       "while opening event data:\n" + std::string(e.what()) + "\n\n";
   }
@@ -155,9 +154,9 @@ bool GenericEventHandler::NextEvent()   {
         return 1;
       }
     }
-    throw runtime_error("+++ EventHandler::readEvent: No file open!");
+    throw std::runtime_error("+++ EventHandler::readEvent: No file open!");
   }
-  catch(const exception& e)  {
+  catch(const std::exception& e)  {
     std::string path = TString::Format("%s/stop_t.xpm", TROOT::GetIconPath().Data()).Data();
     std::string err = "\nAn exception occurred \n"
       "while reading a new event:\n" + std::string(e.what()) + "\n\n";

--- a/DDEve/src/HitActors.cpp
+++ b/DDEve/src/HitActors.cpp
@@ -12,18 +12,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/HitActors.h"
-#include "DD4hep/Objects.h"
-#include "DD4hep/DD4hepUnits.h"
+#include <DDEve/HitActors.h>
+#include <DD4hep/Objects.h>
+#include <DD4hep/DD4hepUnits.h>
 
 // ROOT include files
-#include "TH2.h"
-#include "TVector3.h"
-#include "TEveBoxSet.h"
-#include "TEvePointSet.h"
-#include "TEveCompound.h"
+#include <TH2.h>
+#include <TVector3.h>
+#include <TEveBoxSet.h>
+#include <TEvePointSet.h>
+#include <TEveCompound.h>
 
-using namespace std;
 using namespace dd4hep;
 
 #ifdef DD4HEP_USE_GEANT4_UNITS
@@ -125,7 +124,8 @@ TEveElement* BoxsetCreator::element() const   {
 void BoxsetCreator::operator()(const DDEveHit& hit)   {
   double ene = hit.deposit*MEV_2_GEV <= emax ? hit.deposit*MEV_2_GEV : emax;
   TVector3 scale(ene/towerH,ene/towerH,ene/towerH);
-  cout << "Hit:" << ene << " deposit:" << hit.deposit << " " << " emax:" << emax << " towerH:" << towerH << endl;
+  std::cout << "Hit:" << ene << " deposit:" << hit.deposit << " "
+            << " emax:" << emax << " towerH:" << towerH << std::endl;
   TVector3 p(hit.x*MM_2_CM, hit.y*MM_2_CM, hit.z*MM_2_CM);
   double phi = p.Phi();
   float s1X = -0.5*(scale(0)*std::sin(phi)+scale(2)*std::cos(phi));

--- a/DDEve/src/MultiView.cpp
+++ b/DDEve/src/MultiView.cpp
@@ -12,14 +12,13 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/MultiView.h"
-#include "DDEve/Factories.h"
-#include "DDEve/DisplayConfiguration.h"
-#include "DD4hep/Plugins.h"
+#include <DDEve/MultiView.h>
+#include <DDEve/Factories.h>
+#include <DDEve/DisplayConfiguration.h>
+#include <DD4hep/Plugins.h>
 
 #include <iostream>
 
-using namespace std;
 using namespace dd4hep;
 
 ClassImp(MultiView)
@@ -35,7 +34,7 @@ static void _build(Display* display, View* v, TEveWindowSlot* slot)  {
 }
 
 /// Initializing constructor
-MultiView::MultiView(Display* eve, const string& nam) : View(eve, nam)
+MultiView::MultiView(Display* eve, const std::string& nam) : View(eve, nam)
 {
 }
 
@@ -72,7 +71,7 @@ View& MultiView::Build(TEveWindow* slot)   {
   /// First panel
   if ( panels.size()>0)   {
     const DisplayConfiguration::Config& cfg = panels[0];
-    string typ = "DD4hep_DDEve_"+cfg.use;
+    std::string typ = "DD4hep_DDEve_"+cfg.use;
     v = PluginService::Create<View*>(typ.c_str(),m_eve,cfg.name.c_str());
   }
   else  {
@@ -84,7 +83,7 @@ View& MultiView::Build(TEveWindow* slot)   {
   /// Second panel
   if ( panels.size()>1)   {
     const DisplayConfiguration::Config& cfg = panels[1];
-    string typ = "DD4hep_DDEve_"+cfg.use;
+    std::string typ = "DD4hep_DDEve_"+cfg.use;
     v = PluginService::Create<View*>(typ.c_str(),m_eve,cfg.name.c_str());
   }
   else  {

--- a/DDEve/src/ParticleActors.cpp
+++ b/DDEve/src/ParticleActors.cpp
@@ -12,22 +12,21 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/ParticleActors.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Objects.h"
+#include <DDEve/ParticleActors.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Objects.h>
 
-#include "TEveTrack.h"
-#include "TEveBoxSet.h"
-#include "TEvePointSet.h"
-#include "TEveCompound.h"
-#include "TEveTrackPropagator.h"
+#include <TEveTrack.h>
+#include <TEveBoxSet.h>
+#include <TEvePointSet.h>
+#include <TEveCompound.h>
+#include <TEveTrackPropagator.h>
 
-#include "TParticle.h"
-#include "TDatabasePDG.h"
-#include "TGeoManager.h"
+#include <TParticle.h>
+#include <TDatabasePDG.h>
+#include <TGeoManager.h>
 
-using namespace std;
 using namespace dd4hep;
 
 #ifdef DD4HEP_USE_GEANT4_UNITS

--- a/DDEve/src/PopupMenu.cpp
+++ b/DDEve/src/PopupMenu.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/PopupMenu.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
+#include <DDEve/PopupMenu.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
 
 // C/C++ include files
 

--- a/DDEve/src/Projection.cpp
+++ b/DDEve/src/Projection.cpp
@@ -12,10 +12,10 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DDEve/Projection.h"
-#include "DDEve/Display.h"
-#include "DDEve/Utilities.h"
+#include <DD4hep/Printout.h>
+#include <DDEve/Projection.h>
+#include <DDEve/Display.h>
+#include <DDEve/Utilities.h>
 
 // Eve include files
 #include <TEveManager.h>
@@ -23,11 +23,10 @@
 #include <TEveWindow.h>
 #include <TGLViewer.h>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Initializing constructor
-Projection::Projection(Display* eve, const string& nam)
+Projection::Projection(Display* eve, const std::string& nam)
   : View(eve, nam), m_projMgr(0), m_axis(0)
 {
 }

--- a/DDEve/src/RhoPhiProjection.cpp
+++ b/DDEve/src/RhoPhiProjection.cpp
@@ -13,8 +13,8 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/RhoPhiProjection.h"
-#include "DDEve/Factories.h"
+#include <DDEve/RhoPhiProjection.h>
+#include <DDEve/Factories.h>
 
 using namespace dd4hep;
 

--- a/DDEve/src/RhoZProjection.cpp
+++ b/DDEve/src/RhoZProjection.cpp
@@ -13,8 +13,8 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/RhoZProjection.h"
-#include "DDEve/Factories.h"
+#include <DDEve/RhoZProjection.h>
+#include <DDEve/Factories.h>
 
 using namespace dd4hep;
 

--- a/DDEve/src/Utilities.cpp
+++ b/DDEve/src/Utilities.cpp
@@ -12,28 +12,26 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Objects.h"
-#include "DD4hep/DetElement.h"
-#include "DD4hep/Volumes.h"
-#include "DD4hep/Printout.h"
-#include "DDEve/Utilities.h"
-#include "DDEve/EventHandler.h"
-#include "DDEve/ElementList.h"
+#include <DD4hep/Objects.h>
+#include <DD4hep/DetElement.h>
+#include <DD4hep/Volumes.h>
+#include <DD4hep/Printout.h>
+#include <DDEve/Utilities.h>
+#include <DDEve/EventHandler.h>
+#include <DDEve/ElementList.h>
 
-#include "TGeoNode.h"
-#include "TGeoShape.h"
-#include "TGeoVolume.h"
-#include "TGeoManager.h"
-#include "TGeoShapeAssembly.h"
+#include <TGeoNode.h>
+#include <TGeoShape.h>
+#include <TGeoVolume.h>
+#include <TGeoManager.h>
+#include <TGeoShapeAssembly.h>
 
-#include "TEveGeoShape.h"
-#include "TEveGeoNode.h"
-#include "TEveElement.h"
-#include "TEveTrans.h"
+#include <TEveGeoShape.h>
+#include <TEveGeoNode.h>
+#include <TEveElement.h>
+#include <TEveTrans.h>
 
 using namespace dd4hep;
-using namespace dd4hep::detail;
-using namespace std;
 
 /// Set the rendering flags for the object and the next level children
 void Utilities::SetRnrChildren(TEveElementList* l, bool b)  {
@@ -84,7 +82,7 @@ Utilities::createEveShape(int level,
   TGeoVolume* vol = n ? n->GetVolume() : 0;
   bool created = false;
 
-  if ( 0 == vol || level > max_level ) return make_pair(created,(TEveElement*)0);
+  if ( 0 == vol || level > max_level ) return std::make_pair(created,(TEveElement*)0);
 
   VisAttr vis(Volume(vol).visAttributes());
   TGeoShape* geoShape = vol->GetShape();
@@ -154,20 +152,20 @@ Utilities::createEveShape(int level,
     TGeoHMatrix dau_mat(mat);
     TGeoMatrix* matrix = daughter->GetMatrix();
     dau_mat.Multiply(matrix);
-    pair<bool,TEveElement*> dau_shape = 
+    std::pair<bool,TEveElement*> dau_shape = 
       createEveShape(level+1, max_level, element, daughter, dau_mat, daughter->GetName());
     if ( dau_shape.first )  {
       element->AddElement(dau_shape.second);
     }
   }
-  return make_pair(created,element);
+  return std::make_pair(created,element);
 }
 
-int Utilities::findNodeWithMatrix(TGeoNode* p, TGeoNode* n, TGeoHMatrix* mat, string* sub_path)  {
+int Utilities::findNodeWithMatrix(TGeoNode* p, TGeoNode* n, TGeoHMatrix* mat, std::string* sub_path)  {
   if ( p == n ) return 1;
   TGeoHMatrix dau_mat;
   for (Int_t idau = 0, ndau = p->GetNdaughters(); idau < ndau; ++idau) {
-    string spath;
+    std::string spath;
     TGeoNode*   daughter = p->GetDaughter(idau);
     TGeoHMatrix* daughter_matrix = 0;
     if ( mat )  {
@@ -203,5 +201,5 @@ std::pair<bool,TEveElement*> Utilities::LoadDetElement(DetElement de,int levels,
       return e;
     }
   }
-  return make_pair(false,(TEveGeoShape*)0);
+  return std::make_pair(false,(TEveGeoShape*)0);
 }

--- a/DDEve/src/View.cpp
+++ b/DDEve/src/View.cpp
@@ -13,12 +13,12 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/View.h"
-#include "DDEve/Display.h"
-#include "DDEve/ElementList.h"
-#include "DDEve/Utilities.h"
-#include "DDEve/Annotation.h"
-#include "DD4hep/InstanceCount.h"
+#include <DDEve/View.h>
+#include <DDEve/Display.h>
+#include <DDEve/ElementList.h>
+#include <DDEve/Utilities.h>
+#include <DDEve/Annotation.h>
+#include <DD4hep/InstanceCount.h>
 
 // Eve include files
 #include <TEveManager.h>
@@ -26,18 +26,17 @@
 #include <TEveCalo.h>
 #include <TGLViewer.h>
 
-using namespace std;
 using namespace dd4hep;
 
 template <typename T>
-static inline typename T::const_iterator find(const T& cont,const string& str)  {
+static inline typename T::const_iterator find(const T& cont,const std::string& str)  {
   for(typename T::const_iterator i=cont.begin(); i!=cont.end(); ++i)  
     if ( (*i).name == str ) return i;
   return cont.end();
 }
 
 /// Initializing constructor
-View::View(Display* eve, const string& nam)
+View::View(Display* eve, const std::string& nam)
   : m_eve(eve), m_view(0), m_geoScene(0), m_eveScene(0), m_global(0), m_name(nam), m_showGlobal(false)
 {
   m_config = m_eve->GetViewConfiguration(m_name);
@@ -79,7 +78,7 @@ void View::Initialize()  {
 }
 
 /// Add the view to the global list of eve objects
-TEveElementList* View::AddToGlobalItems(const string& nam)   {
+TEveElementList* View::AddToGlobalItems(const std::string& nam)   {
   if ( 0 == m_global )   {
     m_global = new ElementList(nam.c_str(), nam.c_str(), true, true);
     if ( m_geoScene ) m_global->AddElement(geoScene());
@@ -119,16 +118,16 @@ TEveElement* View::ImportEventElement(TEveElement* el, TEveElementList* list)  {
 }
 
 /// Access the global instance of the subdetector geometry
-pair<bool,TEveElement*> 
+std::pair<bool,TEveElement*> 
 View::GetGlobalGeometry(DetElement de, const DisplayConfiguration::Config& /* cfg */)   {
   SensitiveDetector sd = m_eve->detectorDescription().sensitiveDetector(de.name());
   TEveElementList& global = m_eve->GetGeoTopic(sd.isValid() ? "Sensitive" : "Structure");
   TEveElement* elt = global.FindChild(de.name());
-  return pair<bool,TEveElement*>(true,elt);
+  return std::pair<bool,TEveElement*>(true,elt);
 }
 
 /// Create a new instance of the geometry of a sub-detector
-pair<bool,TEveElement*> 
+std::pair<bool,TEveElement*> 
 View::CreateGeometry(DetElement de, const DisplayConfiguration::Config& cfg)   {
   SensitiveDetector sd = m_eve->detectorDescription().sensitiveDetector(de.name());
   TEveElementList& topic = GetGeoTopic(sd.isValid() ? "Sensitive" : "Structure");
@@ -157,14 +156,14 @@ void View::ConfigureGeometryFromGlobal()    {
 
 /// Configure a single geometry view
 void View::ConfigureGeometry(const DisplayConfiguration::ViewConfig& config)    {
-  string dets;
+  std::string dets;
   DisplayConfiguration::Configurations::const_iterator ic;
   float legend_y = Annotation::DefaultTextSize()+Annotation::DefaultMargin();
   DetElement world = m_eve->detectorDescription().world();
   const DetElement::Children& c = world.children();
   for( ic=config.subdetectors.begin(); ic != config.subdetectors.end(); ++ic)   {
     const DisplayConfiguration::Config& cfg = *ic;
-    string nam = cfg.name;
+    std::string nam = cfg.name;
     if ( nam == "global" ) {
       m_view->AddScene(m_eve->manager().GetGlobalScene());
       m_view->AddScene(m_eve->manager().GetEventScene());
@@ -186,7 +185,7 @@ void View::ConfigureGeometry(const DisplayConfiguration::ViewConfig& config)    
         DetElement de = (*i).second;
         SensitiveDetector sd = m_eve->detectorDescription().sensitiveDetector(nam);
         TEveElementList& topic = GetGeoTopic(sd.isValid() ? "Sensitive" : "Structure");
-        pair<bool,TEveElement*> e(false,0);
+        std::pair<bool,TEveElement*> e(false,0);
         if ( cfg.data.defaults.load_geo > 0 )       // Create a new instance
           e = CreateGeometry(de,cfg);               // with the given number of levels
         else if ( cfg.data.defaults.load_geo < 0 )  // Use the global geometry instance
@@ -203,7 +202,7 @@ void View::ConfigureGeometry(const DisplayConfiguration::ViewConfig& config)    
 }
 
 /// Call to import geometry topics
-void View::ImportGeoTopics(const string& title)   {
+void View::ImportGeoTopics(const std::string& title)   {
   printout(INFO,"View","+++ %s: Import geometry topics.",c_name());
   for(Topics::iterator i=m_geoTopics.begin(); i!=m_geoTopics.end(); ++i)  {
     printout(INFO,"ViewConfiguration","+++     Add topic %s",(*i).second->GetName());
@@ -213,7 +212,7 @@ void View::ImportGeoTopics(const string& title)   {
 }
 
 /// Call to import geometry elements by topic
-void View::ImportGeo(const string& topic, TEveElement* element)  { 
+void View::ImportGeo(const std::string& topic, TEveElement* element)  { 
   ImportGeoElement(element,&GetGeoTopic(topic));
 }
 
@@ -248,7 +247,7 @@ void View::ConfigureEvent(const DisplayConfiguration::ViewConfig& config)  {
   DisplayConfiguration::Configurations::const_iterator ic;
   for( ic=config.subdetectors.begin(); ic != config.subdetectors.end(); ++ic)  {
     const DisplayConfiguration::Config& cfg = *ic;
-    string nam = cfg.name;
+    std::string nam = cfg.name;
     if ( nam == "global" )  {
       continue;
     }
@@ -293,7 +292,7 @@ void View::ImportEvent(TEveElement* el)  {
 }
 
 /// Access/Create a topic by name
-TEveElementList& View::GetGeoTopic(const string& nam)    {
+TEveElementList& View::GetGeoTopic(const std::string& nam)    {
   Topics::iterator i=m_geoTopics.find(nam);
   if ( i == m_geoTopics.end() )  {
     TEveElementList* topic = new ElementList(nam.c_str(), nam.c_str(), true, true);
@@ -314,8 +313,8 @@ View& View::CreateScenes()  {
 /// Create the event scene
 View& View::CreateEventScene()   {
   if ( 0 == m_eveScene ) {
-    string nam  = m_name+" - Event Data";
-    string tool = m_name+" - Scene holding projected event-data for the view.";
+    std::string nam  = m_name+" - Event Data";
+    std::string tool = m_name+" - Scene holding projected event-data for the view.";
     m_eveScene = m_eve->manager().SpawnNewScene(nam.c_str(), tool.c_str());
   }
   return *this;
@@ -324,8 +323,8 @@ View& View::CreateEventScene()   {
 /// Create the geometry scene
 View& View::CreateGeoScene()  {
   if ( 0 == m_geoScene )   {
-    string nam  = m_name+" - Geometry";
-    string tool = m_name+" - Scene holding projected geometry for the view.";
+    std::string nam  = m_name+" - Geometry";
+    std::string tool = m_name+" - Scene holding projected geometry for the view.";
     m_geoScene = m_eve->manager().SpawnNewScene(nam.c_str(), tool.c_str());
   }
   return *this;

--- a/DDEve/src/View3D.cpp
+++ b/DDEve/src/View3D.cpp
@@ -13,8 +13,8 @@
 //==========================================================================
 
 // Framework include files
-#include "DDEve/View3D.h"
-#include "DDEve/Factories.h"
+#include <DDEve/View3D.h>
+#include <DDEve/Factories.h>
 
 using namespace dd4hep;
 

--- a/DDEve/src/ViewMenu.cpp
+++ b/DDEve/src/ViewMenu.cpp
@@ -12,29 +12,29 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Plugins.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
 
-#include "DDEve/View.h"
-#include "DDEve/ViewMenu.h"
-#include "DDEve/PopupMenu.h"
+#include <DDEve/View.h>
+#include <DDEve/ViewMenu.h>
+#include <DDEve/PopupMenu.h>
 
 // ROOT include files
-#include "TEveBrowser.h"
-#include "TEveManager.h"
-#include "TEveElement.h"
-#include "TEveWindow.h"
-#include "TEveViewer.h"
-#include "TGLViewer.h"
-#include "TGClient.h"
-#include "TGTab.h"
+#include <TEveBrowser.h>
+#include <TEveManager.h>
+#include <TEveElement.h>
+#include <TEveWindow.h>
+#include <TEveViewer.h>
+#include <TGLViewer.h>
+#include <TGClient.h>
+#include <TGTab.h>
 
 // Forward declarations
 class TEveWindowSlot;
 
-using namespace std;
 using namespace dd4hep;
+using pair_t = std::pair<std::string, std::string>;
 
 ClassImp(ViewMenu)
 
@@ -52,27 +52,27 @@ ViewMenu::~ViewMenu()  {
 
 /// Add the menu to the menu bar
 void ViewMenu::Build(TGMenuBar* menubar, int hints)    {
-  pair<string,string>* p = 0;
+  pair_t* p = 0;
   PopupMenu* view_menu = this;
-  view_menu->AddEntry("3&D View", this, &ViewMenu::CreateView, p=new pair<string,string>("DD4hep_DDEve_View3D","3D"));
-  view_menu->AddEntry("Rho-&Z Projection", this, &ViewMenu::CreateView, p=new pair<string,string>("DD4hep_DDEve_RhoZProjection","Rho-Z"));
-  view_menu->AddEntry("Rho-&Phi Projection",this, &ViewMenu::CreateView, p=new pair<string,string>("DD4hep_DDEve_RhoPhiProjection","Rho-Phi"));
+  view_menu->AddEntry("3&D View", this, &ViewMenu::CreateView, p=new pair_t("DD4hep_DDEve_View3D","3D"));
+  view_menu->AddEntry("Rho-&Z Projection", this, &ViewMenu::CreateView, p=new pair_t("DD4hep_DDEve_RhoZProjection","Rho-Z"));
+  view_menu->AddEntry("Rho-&Phi Projection",this, &ViewMenu::CreateView, p=new pair_t("DD4hep_DDEve_RhoPhiProjection","Rho-Phi"));
   const Display::ViewConfigurations& vc = m_display->viewConfigurations();
   for(Display::ViewConfigurations::const_iterator i=vc.begin(); i!=vc.end(); ++i)  {
     const Display::ViewConfig& v = (*i).second;
-    view_menu->AddEntry(v.name.c_str(), this, &ViewMenu::CreateView,p=new pair<string,string>("DD4hep_DDEve_"+v.type,v.name));
+    view_menu->AddEntry(v.name.c_str(), this, &ViewMenu::CreateView,p=new pair_t("DD4hep_DDEve_"+v.type,v.name));
   }
   menubar->AddPopup(m_title.c_str(),*view_menu, new TGLayoutHints(hints, 0, 4, 0, 0));
 }
 
 /// Create a new generic view
 void ViewMenu::CreateView(TGMenuEntry*, void* ud)   {
-  pair<string,string>* args = (pair<string,string>*)ud;
+  pair_t* args = (pair_t*)ud;
   CreateView(args->first,args->second);
 }
 
 View* ViewMenu::CreateView(const std::string& type, const std::string& title)   {
-  pair<string,string> args("DD4hep_DDEve_"+type,title);
+  pair_t args("DD4hep_DDEve_"+type,title);
   View* v = PluginService::Create<View*>(type.c_str(),m_display,title.c_str());
   BuildView(v);
   return v;

--- a/DDG4/examples/initAClick.C
+++ b/DDG4/examples/initAClick.C
@@ -32,13 +32,9 @@ std::string make_str(const char* data)  {
 int processCommand(const char* command, bool end_process)   {
   int status;
   // Disabling auto-parse is a hack required by a bug in ROOT
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   gInterpreter->SetClassAutoparsing(false);
   status = gInterpreter->ProcessLine(command);
   gInterpreter->SetClassAutoparsing(true);
-#else
-  status = gInterpreter->ProcessLine(command);
-#endif
   ::printf("+++ Status(%s) = %d\n",command,status);
   if ( end_process )  {
     gInterpreter->ProcessLine("gSystem->Exit(0)");

--- a/DDG4/include/DDG4/Geant4Converter.h
+++ b/DDG4/include/DDG4/Geant4Converter.h
@@ -14,8 +14,8 @@
 #define DDG4_GEANT4CONVERTER_H
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DDG4/Geant4Mapping.h"
+#include <DD4hep/Printout.h>
+#include <DDG4/Geant4Mapping.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -72,7 +72,6 @@ namespace dd4hep {
       /// Create geometry conversion
       Geant4Converter& create(DetElement top);
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
       /// Convert the geometry type material into the corresponding Geant4 object(s).
       virtual void* handleMaterialProperties(TObject* matrix) const;
 
@@ -84,7 +83,7 @@ namespace dd4hep {
 
       /// Convert the border surface to Geant4
       void* handleBorderSurface(TObject* surface) const;
-#endif
+
       /// Convert the geometry type material into the corresponding Geant4 object(s).
       virtual void* handleMaterial(const std::string& name, Material medium) const;
 
@@ -128,5 +127,4 @@ namespace dd4hep {
     };
   }    // End namespace sim
 }      // End namespace dd4hep
-
 #endif // DDG4_GEANT4CONVERTER_H

--- a/DDG4/include/DDG4/Geant4GeometryInfo.h
+++ b/DDG4/include/DDG4/Geant4GeometryInfo.h
@@ -10,16 +10,15 @@
 // Author     : M.Frank
 //
 //==========================================================================
-
 #ifndef DDG4_GEANT4GEOMETRYINFO_H
 #define DDG4_GEANT4GEOMETRYINFO_H
 
 // Framework include files
-#include "DD4hep/Objects.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/GeoHandler.h"
-#include "DD4hep/PropertyTable.h"
-#include "DDG4/Geant4Primitives.h"
+#include <DD4hep/Objects.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/GeoHandler.h>
+#include <DD4hep/PropertyTable.h>
+#include <DDG4/Geant4Primitives.h>
 
 // C/C++ include files
 #include <map>
@@ -127,12 +126,10 @@ namespace dd4hep {
         PropertyVector() = default;
         ~PropertyVector() = default;
       };
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
       std::map<PropertyTable,  PropertyVector*>                g4OpticalProperties;
       std::map<OpticalSurface, G4OpticalSurface*>              g4OpticalSurfaces;
       std::map<SkinSurface,    G4LogicalSkinSurface*>          g4SkinSurfaces;
       std::map<BorderSurface,  G4LogicalBorderSurface*>        g4BorderSurfaces;
-#endif
       std::map<Region, G4Region*>                              g4Regions;
       std::map<VisAttr, G4VisAttributes*>                      g4Vis;
       std::map<LimitSet, G4UserLimits*>                        g4Limits;
@@ -160,5 +157,4 @@ namespace dd4hep {
 
   }    // End namespace sim
 }      // End namespace dd4hep
-
 #endif // DDG4_GEANT4GEOMETRYINFO_H

--- a/DDG4/plugins/Geant4CaloSmearShowerModel.cpp
+++ b/DDG4/plugins/Geant4CaloSmearShowerModel.cpp
@@ -24,8 +24,8 @@
 #include <DDG4/Geant4Random.h>
 
 // Geant4 include files
-#include "G4SystemOfUnits.hh"
-#include "G4FastStep.hh"
+#include <G4SystemOfUnits.hh>
+#include <G4FastStep.hh>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep  {
@@ -48,38 +48,38 @@ namespace dd4hep  {
       double            NoiseEnergyResolution     { -1e0 };
 
       double resolution(double momentum)   const    {
-	double res = -1e0;
-	double mom = momentum/CLHEP::GeV;
-	if ( this->StocasticEnergyResolution > 0 && 
-	     this->ConstantEnergyResolution  > 0 &&
-	     this->NoiseEnergyResolution > 0 )    {
-	  res = std::sqrt(std::pow( this->StocasticEnergyResolution / std::sqrt( mom ), 2 ) +  // stochastic
-			  std::pow( this->ConstantEnergyResolution, 2 ) +                      // constant
-			  std::pow( this->NoiseEnergyResolution / mom, 2 ) );                  // noise
-	}
-	else if ( this->StocasticEnergyResolution > 0 &&
-		  this->ConstantEnergyResolution > 0 )    {
-	  res = std::sqrt(std::pow( this->StocasticEnergyResolution / std::sqrt( mom ), 2 ) +  // stochastic
-			  std::pow( this->ConstantEnergyResolution, 2 ) );                     // constant
-	}
-	else if ( this->StocasticEnergyResolution > 0 )    {
-	  res = this->StocasticEnergyResolution / std::sqrt( mom );                            // stochastic
-	}
-	else if ( this->ConstantEnergyResolution > 0 )    {
-	  res = this->ConstantEnergyResolution;                                                // constant
-	}
-	return res;
+        double res = -1e0;
+        double mom = momentum/CLHEP::GeV;
+        if ( this->StocasticEnergyResolution > 0 && 
+             this->ConstantEnergyResolution  > 0 &&
+             this->NoiseEnergyResolution > 0 )    {
+          res = std::sqrt(std::pow( this->StocasticEnergyResolution / std::sqrt( mom ), 2 ) +  // stochastic
+                          std::pow( this->ConstantEnergyResolution, 2 ) +                      // constant
+                          std::pow( this->NoiseEnergyResolution / mom, 2 ) );                  // noise
+        }
+        else if ( this->StocasticEnergyResolution > 0 &&
+                  this->ConstantEnergyResolution > 0 )    {
+          res = std::sqrt(std::pow( this->StocasticEnergyResolution / std::sqrt( mom ), 2 ) +  // stochastic
+                          std::pow( this->ConstantEnergyResolution, 2 ) );                     // constant
+        }
+        else if ( this->StocasticEnergyResolution > 0 )    {
+          res = this->StocasticEnergyResolution / std::sqrt( mom );                            // stochastic
+        }
+        else if ( this->ConstantEnergyResolution > 0 )    {
+          res = this->ConstantEnergyResolution;                                                // constant
+        }
+        return res;
       }
 
       double smearEnergy(double mom)   const  {
-	double resolution = this->resolution(mom);
-	double smeared    = mom;
-	if ( resolution > 0e0 )  {
-	  for( smeared = -1e0; smeared < 0e0; ) {  // Ensure that the resulting value is not negative
-	    smeared = mom * Geant4Random::instance()->gauss(1e0, resolution);
-	  }
-	}
-	return smeared;
+        double resolution = this->resolution(mom);
+        double smeared    = mom;
+        if ( resolution > 0e0 )  {
+          for( smeared = -1e0; smeared < 0e0; ) {  // Ensure that the resulting value is not negative
+            smeared = mom * Geant4Random::instance()->gauss(1e0, resolution);
+          }
+        }
+        return smeared;
       }
     };
     
@@ -113,7 +113,7 @@ namespace dd4hep  {
       // Consider only primary tracks and smear according to the parametrized resolution
       // ELSE: simply set the value of the (initial) energy of the particle is deposited in the step
       if ( !spot.primary->GetParentID() ) {
-	deposit = locals.smearEnergy(deposit);
+        deposit = locals.smearEnergy(deposit);
       }
       hit.SetEnergy(deposit);
       step.ProposeTotalEnergyDeposited(deposit);

--- a/DDG4/plugins/Geant4DetectorGeometryConstruction.cpp
+++ b/DDG4/plugins/Geant4DetectorGeometryConstruction.cpp
@@ -126,13 +126,11 @@ namespace dd4hep {
 
 #include <cmath>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 DECLARE_GEANT4ACTION(Geant4DetectorGeometryConstruction)
 
 /// Initializing constructor for other clients
-Geant4DetectorGeometryConstruction::Geant4DetectorGeometryConstruction(Geant4Context* ctxt, const string& nam)
+Geant4DetectorGeometryConstruction::Geant4DetectorGeometryConstruction(Geant4Context* ctxt, const std::string& nam)
 : Geant4DetectorConstruction(ctxt,nam)
 {
   declareProperty("DebugMaterials",    m_debugMaterials);
@@ -194,9 +192,9 @@ void Geant4DetectorGeometryConstruction::constructGeo(Geant4DetectorConstruction
   enableUI();
 }
 
-pair<string, PlacedVolume>
+std::pair<std::string, dd4hep::PlacedVolume>
 Geant4DetectorGeometryConstruction::resolve_path(const char* vol_path)  const {
-  string       p   = vol_path;
+  std::string       p   = vol_path;
   Detector&    det = context()->kernel().detectorDescription();
   PlacedVolume top = det.world().placement();
   PlacedVolume pv  = detail::tools::findNode(top, p);
@@ -217,19 +215,19 @@ int Geant4DetectorGeometryConstruction::printMaterial(const char* mat_name)  {
     for ( auto it = g4map.begin(); it != g4map.end(); ++it )  {
       const auto* mat = (*it).second;
       if ( mat->GetName() == mat_name )   {
-	stringstream output;
+        std::stringstream output;
         const auto* ion = mat->GetIonisation();
         printP2("+++  Dump of GEANT4 material: %s", mat_name);
         output << mat;
         if ( ion )   {
           output << "          MEE:  ";
-          output << setprecision(12);
+          output << std::setprecision(12);
           output << ion->GetMeanExcitationEnergy()/CLHEP::eV;
           output << " [eV]";
         }
         else
           output << "          MEE: UNKNOWN";
-	always("+++ printMaterial: \n%s\n", output.str().c_str());
+        always("+++ printMaterial: \n%s\n", output.str().c_str());
         return 1;
       }
     }
@@ -254,51 +252,51 @@ int Geant4DetectorGeometryConstruction::printVolumeObj(const char* vol_path, Pla
       const auto* ion = mat->GetIonisation();
       Solid sh  = pv.volume().solid();
       if ( flg )  {
-	printP2("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-	printP2("+++  Dump of GEANT4 solid: %s", vol_path);
+        printP2("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+        printP2("+++  Dump of GEANT4 solid: %s", vol_path);
       }
-      stringstream output;
+      std::stringstream output;
       if ( flg )   {
-	output << mat;
-	if ( ion )   {
-	  output << "          MEE:  ";
-	  output << setprecision(12);
-	  output << ion->GetMeanExcitationEnergy()/CLHEP::eV;
-	  output << " [eV]";
-	}
-	else
-	  output << "          MEE: UNKNOWN";
+        output << mat;
+        if ( ion )   {
+          output << "          MEE:  ";
+          output << std::setprecision(12);
+          output << ion->GetMeanExcitationEnergy()/CLHEP::eV;
+          output << " [eV]";
+        }
+        else
+          output << "          MEE: UNKNOWN";
       }
       if ( flg )   {
-	output << endl << *sol;
-	printP2("%s", output.str().c_str());
-	printP2("+++  Dump of ROOT   solid: %s", vol_path);
-	sh->InspectShape();
-	if ( sh->IsA() == TGeoScaledShape::Class() )    {
-	  TGeoScaledShape* scaled = (TGeoScaledShape*)sh.ptr();
-	  const Double_t* scale = scaled->GetScale()->GetScale();
-	  double dot = scale[0]*scale[1]*scale[2];
-	  printP2("+++ TGeoScaledShape: %8.3g  %8.3g  %8.3g  [%s]", scale[0], scale[1], scale[2],
-		  dot > 0e0 ? "RIGHT handed" : "LEFT handed");
-	}
-	else if ( pit != g4map.g4Placements.end() )   {
-	  const G4VPhysicalVolume* pl = (*pit).second;
-	  const G4RotationMatrix* rot = pl->GetRotation();
-	  const G4ThreeVector& tr = pl->GetTranslation();
-	  G4Transform3D transform(rot ? *rot : G4RotationMatrix(), tr);
-	  HepGeom::Scale3D  sc;
-	  HepGeom::Rotate3D rr;
-	  G4Translate3D     tt;
-	  transform.getDecomposition(sc,rr,tt);
-	  double dot = sc(0,0)*sc(1,1)*sc(2,2);
-	  printP2("+++ TGeoShape:       %8.3g  %8.3g  %8.3g  [%s]", sc(0,0), sc(1,1), sc(2,2),
-		  dot > 0e0 ? "RIGHT handed" : "LEFT handed");
-	}
-	const TGeoMatrix* matrix = pv->GetMatrix();
-	printP2("+++ TGeoMatrix:      %s",
-		matrix->TestBit(TGeoMatrix::kGeoReflection) ? "LEFT handed" : "RIGHT handed");        
-	printP2("+++ Shape: %s  cubic volume: %8.3g mm^3  area: %8.3g mm^2",
-		sol->GetName().c_str(), sol->GetCubicVolume(), sol->GetSurfaceArea());
+        output << std::endl << *sol;
+        printP2("%s", output.str().c_str());
+        printP2("+++  Dump of ROOT   solid: %s", vol_path);
+        sh->InspectShape();
+        if ( sh->IsA() == TGeoScaledShape::Class() )    {
+          TGeoScaledShape* scaled = (TGeoScaledShape*)sh.ptr();
+          const Double_t* scale = scaled->GetScale()->GetScale();
+          double dot = scale[0]*scale[1]*scale[2];
+          printP2("+++ TGeoScaledShape: %8.3g  %8.3g  %8.3g  [%s]", scale[0], scale[1], scale[2],
+                  dot > 0e0 ? "RIGHT handed" : "LEFT handed");
+        }
+        else if ( pit != g4map.g4Placements.end() )   {
+          const G4VPhysicalVolume* pl = (*pit).second;
+          const G4RotationMatrix* rot = pl->GetRotation();
+          const G4ThreeVector& tr = pl->GetTranslation();
+          G4Transform3D transform(rot ? *rot : G4RotationMatrix(), tr);
+          HepGeom::Scale3D  sc;
+          HepGeom::Rotate3D rr;
+          G4Translate3D     tt;
+          transform.getDecomposition(sc,rr,tt);
+          double dot = sc(0,0)*sc(1,1)*sc(2,2);
+          printP2("+++ TGeoShape:       %8.3g  %8.3g  %8.3g  [%s]", sc(0,0), sc(1,1), sc(2,2),
+                  dot > 0e0 ? "RIGHT handed" : "LEFT handed");
+        }
+        const TGeoMatrix* matrix = pv->GetMatrix();
+        printP2("+++ TGeoMatrix:      %s",
+                matrix->TestBit(TGeoMatrix::kGeoReflection) ? "LEFT handed" : "RIGHT handed");        
+        printP2("+++ Shape: %s  cubic volume: %8.3g mm^3  area: %8.3g mm^2",
+                sol->GetName().c_str(), sol->GetCubicVolume(), sol->GetSurfaceArea());
       }
       return 1;
     }
@@ -309,7 +307,7 @@ int Geant4DetectorGeometryConstruction::printVolumeObj(const char* vol_path, Pla
         warning("+++ printVolume: volume %s is an assembly...need to resolve imprint",vol_path);
         for(Int_t i=0; i < v->GetNdaughters(); ++i)   {
           TGeoNode*   dau_nod = v->GetNode(i);
-          string p = vol_path + string("/") + dau_nod->GetName();
+          std::string p = vol_path + std::string("/") + dau_nod->GetName();
           printVolumeObj(p.c_str(), dau_nod, flg);
         }
         return 0;
@@ -340,13 +338,13 @@ int Geant4DetectorGeometryConstruction::printVolumeTree(const char* vol_path)  {
     auto [p, pv] = resolve_path(vol_path);
     if ( pv.isValid() )    {
       if ( printVolumeObj(p.c_str(), pv, ~0x0) )     {
-	TGeoVolume* vol = pv->GetVolume();
-	for(Int_t i=0; i < vol->GetNdaughters(); ++i)   {
-	  PlacedVolume dau_pv(vol->GetNode(i));
-	  string path = (p + "/") + dau_pv.name();
-	  if ( printVolumeTree(path.c_str()) )     {
-	  }
-	}
+        TGeoVolume* vol = pv->GetVolume();
+        for(Int_t i=0; i < vol->GetNdaughters(); ++i)   {
+          PlacedVolume dau_pv(vol->GetNode(i));
+          std::string path = (p + "/") + dau_pv.name();
+          if ( printVolumeTree(path.c_str()) )     {
+          }
+        }
       }
       return 1;
     }
@@ -360,13 +358,13 @@ int Geant4DetectorGeometryConstruction::printVolTree(const char* vol_path)  {
     auto [p, pv] = resolve_path(vol_path);
     if ( pv.isValid() )    {
       if ( printVolumeObj(p.c_str(), pv, 0) )     {
-	TGeoVolume* vol = pv->GetVolume();
-	for(Int_t i=0; i < vol->GetNdaughters(); ++i)   {
-	  PlacedVolume dau_pv(vol->GetNode(i));
-	  string path = (p + "/") + dau_pv.name();
-	  if ( printVolTree(path.c_str()) )     {
-	  }
-	}
+        TGeoVolume* vol = pv->GetVolume();
+        for(Int_t i=0; i < vol->GetNdaughters(); ++i)   {
+          PlacedVolume dau_pv(vol->GetNode(i));
+          std::string path = (p + "/") + dau_pv.name();
+          if ( printVolTree(path.c_str()) )     {
+          }
+        }
       }
       return 1;
     }
@@ -437,8 +435,8 @@ int Geant4DetectorGeometryConstruction::writeGDML(const char* output)  {
   return 0;
 }
 
-void Geant4DetectorGeometryConstruction::printG4(const string& prefix, const G4VPhysicalVolume* g4pv)    const   {
-  string path = prefix + "/";
+void Geant4DetectorGeometryConstruction::printG4(const std::string& prefix, const G4VPhysicalVolume* g4pv)    const   {
+  std::string path = prefix + "/";
   printP2(  "+++  GEANT4 volume: %s", prefix.c_str());
   auto* g4v = g4pv->GetLogicalVolume();
   for(size_t i=0, n=g4v->GetNoDaughters(); i<n; ++i)    {
@@ -454,7 +452,7 @@ int Geant4DetectorGeometryConstruction::printG4Tree(const char* vol_path)  {
       auto& g4map = Geant4Mapping::instance().data().g4Placements;
       auto it = g4map.find(pv);
       if ( it != g4map.end() )   {
-	printG4(p, (*it).second);
+        printG4(p, (*it).second);
       }
       return 1;
     }

--- a/DDG4/plugins/Geant4DetectorSensitivesConstruction.cpp
+++ b/DDG4/plugins/Geant4DetectorSensitivesConstruction.cpp
@@ -13,7 +13,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4DetectorConstruction.h"
+#include <DDG4/Geant4DetectorConstruction.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -46,31 +46,29 @@ namespace dd4hep {
 
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Plugins.h"
-#include "DD4hep/Detector.h"
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Detector.h>
 
-#include "DDG4/Geant4Mapping.h"
-#include "DDG4/Geant4Kernel.h"
-#include "DDG4/Factories.h"
+#include <DDG4/Geant4Mapping.h>
+#include <DDG4/Geant4Kernel.h>
+#include <DDG4/Factories.h>
 
 // ROOT include files
-#include "TGeoManager.h"
+#include <TGeoManager.h>
 // Geant4 include files
-#include "G4SDManager.hh"
-#include "G4PVPlacement.hh"
-#include "G4VSensitiveDetector.hh"
+#include <G4SDManager.hh>
+#include <G4PVPlacement.hh>
+#include <G4VSensitiveDetector.hh>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 DECLARE_GEANT4ACTION(Geant4DetectorSensitivesConstruction)
 
 /// Initializing constructor for other clients
-Geant4DetectorSensitivesConstruction::Geant4DetectorSensitivesConstruction(Geant4Context* ctxt, const string& nam)
-  : Geant4DetectorConstruction(ctxt,nam)
+Geant4DetectorSensitivesConstruction::Geant4DetectorSensitivesConstruction(Geant4Context* ctxt, const std::string& nam)
+: Geant4DetectorConstruction(ctxt,nam)
 {
   InstanceCount::increment(this);
 }
@@ -84,13 +82,13 @@ Geant4DetectorSensitivesConstruction::~Geant4DetectorSensitivesConstruction() {
 void Geant4DetectorSensitivesConstruction::constructSensitives(Geant4DetectorConstructionContext* ctxt)   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   const Geant4Kernel& kernel = context()->kernel();
-  const auto&   types = kernel.sensitiveDetectorTypes();
-  const string& dflt  = kernel.defaultSensitiveDetectorType();
-  for(const auto& iv : p->sensitives )  {
+  const auto&         types  = kernel.sensitiveDetectorTypes();
+  const std::string&  dflt   = kernel.defaultSensitiveDetectorType();
+  for( const auto& iv : p->sensitives )  {
     SensitiveDetector sd = iv.first;
-    string nam = sd.name();
-    auto   iter = types.find(nam);
-      string typ = (iter != types.end()) ? (*iter).second : dflt;
+    std::string nam = sd.name();
+    auto iter = types.find(nam);
+    std::string typ = (iter != types.end()) ? (*iter).second : dflt;
     G4VSensitiveDetector* g4sd = 
       PluginService::Create<G4VSensitiveDetector*>(typ, nam, &ctxt->description);
     if (g4sd) {
@@ -101,9 +99,9 @@ void Geant4DetectorSensitivesConstruction::constructSensitives(Geant4DetectorCon
       PluginDebug dbg;
       g4sd = PluginService::Create<G4VSensitiveDetector*>(typ, nam, &ctxt->description);
       if ( !g4sd )  {
-        throw runtime_error("ConstructSDandField: FATAL Failed to "
-                            "create Geant4 sensitive detector " + nam + 
-                            " (" + sd.type() + ") of type " + typ + ".");
+        throw std::runtime_error("ConstructSDandField: FATAL Failed to "
+                                 "create Geant4 sensitive detector " + nam + 
+                                 " (" + sd.type() + ") of type " + typ + ".");
       }
       print("Geant4SDConstruction", "+++ Subdetector: %-32s  type: %-16s factory: %s.",
             nam.c_str(), sd.type().c_str(), typ.c_str());
@@ -113,8 +111,8 @@ void Geant4DetectorSensitivesConstruction::constructSensitives(Geant4DetectorCon
     for(const TGeoVolume* vol : iv.second )  {
       G4LogicalVolume* g4v = p->g4Volumes[vol];
       if ( !g4v )  {
-        throw runtime_error("ConstructSDandField: Failed to access G4LogicalVolume for SD "+
-                            nam + " of type " + typ + ".");
+        throw std::runtime_error("ConstructSDandField: Failed to access G4LogicalVolume for SD "+
+                                 nam + " of type " + typ + ".");
       }
       ctxt->setSensitiveDetector(g4v,g4sd);
     }

--- a/DDG4/plugins/Geant4EscapeCounter.cpp
+++ b/DDG4/plugins/Geant4EscapeCounter.cpp
@@ -14,9 +14,9 @@
 #define DD4HEP_DDG4_GEANT4ESCAPECOUNTER_H
 
 // Framework include files
-#include "DD4hep/DetElement.h"
-#include "DDG4/Geant4SensDetAction.h"
-#include "DDG4/Geant4SteppingAction.h"
+#include <DD4hep/DetElement.h>
+#include <DDG4/Geant4SensDetAction.h>
+#include <DDG4/Geant4SteppingAction.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -63,27 +63,26 @@ namespace dd4hep {
 // Author     : M.Frank
 //
 //====================================================================
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
+// Framework include files
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
 
-#include "DDG4/Geant4TouchableHandler.h"
-#include "DDG4/Geant4TrackHandler.h"
-#include "DDG4/Geant4StepHandler.h"
-#include "DDG4/Geant4Mapping.h"
-#include "DDG4/Geant4Data.h"
+#include <DDG4/Geant4TouchableHandler.h>
+#include <DDG4/Geant4TrackHandler.h>
+#include <DDG4/Geant4StepHandler.h>
+#include <DDG4/Geant4Mapping.h>
+#include <DDG4/Geant4Data.h>
 
-#include "CLHEP/Units/SystemOfUnits.h"
-#include "G4VProcess.hh"
+#include <CLHEP/Units/SystemOfUnits.h>
+#include <G4VProcess.hh>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Standard constructor
-Geant4EscapeCounter::Geant4EscapeCounter(Geant4Context* ctxt, const string& nam, DetElement det, Detector& description_ref)
+Geant4EscapeCounter::Geant4EscapeCounter(Geant4Context* ctxt, const std::string& nam, DetElement det, Detector& description_ref)
   : Geant4Sensitive(ctxt, nam, det, description_ref)
 {
-  string coll_name = name()+"Hits";
+  std::string coll_name = name()+"Hits";
   m_needsControl = true;
   declareProperty("Shells",m_detectorNames);
   m_collectionID = defineCollection<SimpleTracker::Hit>(coll_name);
@@ -100,7 +99,7 @@ bool Geant4EscapeCounter::process(const G4Step* step, G4TouchableHistory* /* his
   Geant4StepHandler  h(step);
   Geant4TrackHandler th(h.track);
   Geant4TouchableHandler handler(step);
-  string   hdlr_path  = handler.path();
+  std::string hdlr_path  = handler.path();
   Position prePos     = h.prePos();
   Position postPos    = h.postPos();
   Geant4HitCollection* coll = collection(m_collectionID);
@@ -132,6 +131,6 @@ bool Geant4EscapeCounter::process(const G4Step* step, G4TouchableHistory* /* his
   return true;
 }
 
-#include "DDG4/Factories.h"
+#include <DDG4/Factories.h>
 DECLARE_GEANT4SENSITIVE(Geant4EscapeCounter)
 

--- a/DDG4/plugins/Geant4EventReaderGuineaPig.cpp
+++ b/DDG4/plugins/Geant4EventReaderGuineaPig.cpp
@@ -14,16 +14,16 @@
 /** \addtogroup Geant4EventReader
  *
  @{
-  \package Geant4EventReaderGuineaPig
+ \package Geant4EventReaderGuineaPig
  * \brief Reader for ascii files with e+e- pairs created from GuineaPig.
  *
  *
-@}
- */
+ @}
+*/
 
 
 // Framework include files
-#include "DDG4/Geant4InputAction.h"
+#include <DDG4/Geant4InputAction.h>
 
 // C/C++ include files
 #include <fstream>
@@ -71,15 +71,14 @@ namespace dd4hep {
 
 
 // Framework include files
-#include "DDG4/Factories.h"
-#include "DD4hep/Printout.h"
-#include "CLHEP/Units/SystemOfUnits.h"
-#include "CLHEP/Units/PhysicalConstants.h"
+#include <DDG4/Factories.h>
+#include <DD4hep/Printout.h>
+#include <CLHEP/Units/SystemOfUnits.h>
+#include <CLHEP/Units/PhysicalConstants.h>
 
 // C/C++ include files
 #include <cerrno>
 
-using namespace std;
 using namespace dd4hep::sim;
 typedef dd4hep::detail::ReferenceBitMask<int> PropertyMask;
 
@@ -87,15 +86,15 @@ typedef dd4hep::detail::ReferenceBitMask<int> PropertyMask;
 DECLARE_GEANT4_EVENT_READER(Geant4EventReaderGuineaPig)
 
 /// Initializing constructor
-Geant4EventReaderGuineaPig::Geant4EventReaderGuineaPig(const string& nam)
+Geant4EventReaderGuineaPig::Geant4EventReaderGuineaPig(const std::string& nam)
 : Geant4EventReader(nam), m_input(), m_part_num(-1) 
 {
   // Now open the input file:
-  m_input.open(nam.c_str(),ifstream::in);
+  m_input.open(nam.c_str(), std::ifstream::in);
   if ( !m_input.good() )   {
-    string err = "+++ Geant4EventReaderGuineaPig: Failed to open input stream:"+nam+
-      " Error:"+string(strerror(errno));
-    throw runtime_error(err);
+    std::string err = "+++ Geant4EventReaderGuineaPig: Failed to open input stream:"+nam+
+      " Error:"+std::string(strerror(errno));
+    throw std::runtime_error(err);
   }
 }
 
@@ -145,7 +144,7 @@ Geant4EventReaderGuineaPig::moveToEvent(int event_number) {
       }
 
       for (unsigned i = 0; i<nSkipParticles; ++i){
-        if (m_input.ignore(numeric_limits<streamsize>::max(), m_input.widen('\n'))){
+        if (m_input.ignore(std::numeric_limits<std::streamsize>::max(), m_input.widen('\n'))){
           //just skipping the line
         }
         else
@@ -162,14 +161,12 @@ Geant4EventReaderGuineaPig::moveToEvent(int event_number) {
 Geant4EventReader::EventReaderStatus
 Geant4EventReaderGuineaPig::readParticles(int /* event_number */, 
                                           Vertices& vertices,
-                                          vector<Particle*>& particles)   {
+                                          std::vector<Particle*>& particles)   {
 
 
   // if no number of particles per event set, we will read the whole file
   if ( m_part_num < 0 )
     m_part_num = std::numeric_limits<int>::max() ; 
-
-
 
   // First check the input file status
   if ( m_input.eof() )   {
@@ -212,8 +209,8 @@ Geant4EventReaderGuineaPig::readParticles(int /* event_number */,
     std::stringstream m_input_str( lineStr ) ;
 
     m_input_str  >> Energy
-		 >> betaX   >> betaY >> betaZ
-		 >> posX    >> posY  >> posZ ;
+                 >> betaX   >> betaY >> betaZ
+                 >> posX    >> posY  >> posZ ;
 
     
     //    printf(" ------- %e  %e  %e  %e  %e  %e  %e \n", Energy,betaX, betaY,betaZ,posX,posY,posZ ) ;

--- a/DDG4/plugins/Geant4EventReaderHepEvt.cpp
+++ b/DDG4/plugins/Geant4EventReaderHepEvt.cpp
@@ -88,9 +88,8 @@ namespace dd4hep {
 // C/C++ include files
 #include <cerrno>
 
-using namespace std;
 using namespace dd4hep::sim;
-typedef dd4hep::detail::ReferenceBitMask<int> PropertyMask;
+using PropertyMask = dd4hep::detail::ReferenceBitMask<int>;
 
 #define HEPEvtShort 1
 #define HEPEvtLong  2
@@ -100,14 +99,14 @@ namespace {
   class Geant4EventReaderHepEvtShort : public Geant4EventReaderHepEvt  {
   public:
     /// Initializing constructor
-    explicit Geant4EventReaderHepEvtShort(const string& nam) : Geant4EventReaderHepEvt(nam,HEPEvtShort) {}
+    explicit Geant4EventReaderHepEvtShort(const std::string& nam) : Geant4EventReaderHepEvt(nam,HEPEvtShort) {}
     /// Default destructor
     virtual ~Geant4EventReaderHepEvtShort() {}
   };
   class Geant4EventReaderHepEvtLong : public Geant4EventReaderHepEvt  {
   public:
     /// Initializing constructor
-    explicit Geant4EventReaderHepEvtLong(const string& nam) : Geant4EventReaderHepEvt(nam,HEPEvtLong) {}
+    explicit Geant4EventReaderHepEvtLong(const std::string& nam) : Geant4EventReaderHepEvt(nam,HEPEvtLong) {}
     /// Default destructor
     virtual ~Geant4EventReaderHepEvtLong() {}
   };
@@ -120,15 +119,14 @@ DECLARE_GEANT4_EVENT_READER(Geant4EventReaderHepEvtLong)
 
 
 /// Initializing constructor
-Geant4EventReaderHepEvt::Geant4EventReaderHepEvt(const string& nam, int format)
+Geant4EventReaderHepEvt::Geant4EventReaderHepEvt(const std::string& nam, int format)
 : Geant4EventReader(nam), m_input(), m_format(format)
 {
   // Now open the input file:
-  m_input.open(nam.c_str(),ifstream::in);
+  m_input.open(nam.c_str(), std::ifstream::in);
   if ( !m_input.good() )   {
-    string err = "+++ Geant4EventReaderHepEvt: Failed to open input stream:"+nam+
-      " Error:"+string(strerror(errno));
-    throw runtime_error(err);
+    except("Geant4EventReaderHepEvt","+++ Failed to open input stream: %s Error:%s",
+           nam.c_str(), ::strerror(errno));
   }
 }
 
@@ -147,8 +145,8 @@ Geant4EventReaderHepEvt::moveToEvent(int event_number) {
       std::vector<Particle*> particles;
       Vertices vertices ;
       EventReaderStatus sc = readParticles(m_currEvent,vertices,particles);
-      for_each(vertices.begin(),vertices.end(),detail::deleteObject<Vertex>);
-      for_each(particles.begin(),particles.end(),detail::deleteObject<Particle>);
+      for_each(vertices.begin(), vertices.end(), detail::deleteObject<Vertex>);
+      for_each(particles.begin(), particles.end(), detail::deleteObject<Particle>);
       if ( sc != EVENT_READER_OK ) return sc;
       //Current event is increased in readParticles already!
       // ++m_currEvent;
@@ -162,7 +160,7 @@ Geant4EventReaderHepEvt::moveToEvent(int event_number) {
 Geant4EventReader::EventReaderStatus
 Geant4EventReaderHepEvt::readParticles(int /* event_number */, 
                                        Vertices& vertices,
-                                       vector<Particle*>& particles)   {
+                                       std::vector<Particle*>& particles)   {
 
 
   // First check the input file status
@@ -208,8 +206,8 @@ Geant4EventReaderHepEvt::readParticles(int /* event_number */,
   double VHEP3(0); // z vertex position in mm
   double VHEP4(0); // production time in mm/c
 
-  vector<int> daughter1;
-  vector<int> daughter2;
+  std::vector<int> daughter1;
+  std::vector<int> daughter2;
 
   for( unsigned IHEP=0; IHEP<NHEP; IHEP++ )    {
     if ( m_format == HEPEvtShort )
@@ -360,7 +358,7 @@ Geant4EventReaderHepEvt::readParticles(int /* event_number */,
   //    based on the generator status, as this varies widely with different
   //    generators.
 
-  for(size_t i=0; i<particles.size(); ++i )   {
+  for(std::size_t i=0; i<particles.size(); ++i )   {
     Geant4ParticleHandle p(particles[i]);
     if ( p->parents.size() == 0 )  {
       Geant4Vertex* vtx = new Geant4Vertex ;

--- a/DDG4/plugins/Geant4EventReaderHepMC.cpp
+++ b/DDG4/plugins/Geant4EventReaderHepMC.cpp
@@ -93,9 +93,8 @@ namespace dd4hep {
 #include <cerrno>
 #include <algorithm>
 
-using namespace std;
 using namespace dd4hep::sim;
-typedef dd4hep::detail::ReferenceBitMask<int> PropertyMask;
+using PropertyMask = dd4hep::detail::ReferenceBitMask<int>;
 
 // Factory entry
 DECLARE_GEANT4_EVENT_READER(Geant4EventReaderHepMC)
@@ -126,8 +125,8 @@ namespace dd4hep {
         float scale;
         float alpha_qcd;
         float alpha_qed;
-        vector<float>      weights;
-        vector<long>       random;
+        std::vector<float>      weights;
+        std::vector<long>       random;
         /// Default constructor
         EventHeader() : id(0), num_vertices(0), bp1(0), bp2(0), 
                         signal_process_id(0), signal_process_vertex(0),
@@ -149,10 +148,10 @@ namespace dd4hep {
         typedef std::map<int,Geant4Vertex*> Vertices;
         typedef std::map<int,Geant4Particle*> Particles;
 
-        istream& instream;
+        std::istream& instream;
 
         // io information
-        string key;
+        std::string key;
         double mom_unit, pos_unit;
         int    io_type;
 
@@ -162,7 +161,7 @@ namespace dd4hep {
         Particles m_particles;
 
         /// Default constructor
-        EventStream(istream& in) : instream(in), mom_unit(0.0), pos_unit(0.0),
+        EventStream(std::istream& in) : instream(in), mom_unit(0.0), pos_unit(0.0),
                                    io_type(0), xsection(0.0), xsection_err(0.0)
         { use_default_units();                       }
         /// Check if data stream is in proper state and has data
@@ -170,7 +169,7 @@ namespace dd4hep {
         Geant4Vertex* vertex(int i);
         Particles& particles() { return m_particles; }
         Vertices&  vertices()  { return m_vertices;  }
-        void set_io(int typ, const string& k)
+        void set_io(int typ, const std::string& k)
         { io_type = typ;    key = k;                 }
         void use_default_units()
         { mom_unit = CLHEP::MeV;   pos_unit = CLHEP::mm;           }
@@ -178,16 +177,16 @@ namespace dd4hep {
         void clear();
       };
 
-      char get_input(istream& is, istringstream& iline);
-      int read_until_event_end(istream & is);
-      int read_weight_names(EventStream &, istringstream& iline);
-      int read_particle(EventStream &info, istringstream& iline, Geant4Particle * p);
-      int read_vertex(EventStream &info, istream& is, istringstream & iline);
-      int read_event_header(EventStream &info, istringstream & input, EventHeader& header);
-      int read_cross_section(EventStream &info, istringstream & input);
-      int read_units(EventStream &info, istringstream & input);
-      int read_heavy_ion(EventStream &, istringstream & input);
-      int read_pdf(EventStream &, istringstream & input);
+      char get_input(std::istream& is, std::istringstream& iline);
+      int read_until_event_end(std::istream & is);
+      int read_weight_names(EventStream &, std::istringstream& iline);
+      int read_particle(EventStream &info, std::istringstream& iline, Geant4Particle * p);
+      int read_vertex(EventStream &info, std::istream& is, std::istringstream & iline);
+      int read_event_header(EventStream &info, std::istringstream & input, EventHeader& header);
+      int read_cross_section(EventStream &info, std::istringstream & input);
+      int read_units(EventStream &info, std::istringstream & input);
+      int read_heavy_ion(EventStream &, std::istringstream & input);
+      int read_pdf(EventStream &, std::istringstream & input);
       Geant4Vertex* vertex(EventStream& info, int i);
       void fix_particles(EventStream &info);
     }
@@ -199,14 +198,13 @@ namespace dd4hep {
 //#define DD4HEP_DEBUG_HEP_MC_PARTICLE 418
 
 /// Initializing constructor
-Geant4EventReaderHepMC::Geant4EventReaderHepMC(const string& nam)
+Geant4EventReaderHepMC::Geant4EventReaderHepMC(const std::string& nam)
   : Geant4EventReader(nam), m_input(), m_events(0)
 {
   // Now open the input file:
-  m_input.open(nam.c_str(),BOOST_IOS::in|BOOST_IOS::binary);
+  m_input.open(nam.c_str(), BOOST_IOS::in|BOOST_IOS::binary);
   if ( not m_input.is_open() )   {
-    except("Geant4EventReaderHepMC","+++ Failed to open input stream: %s Error:%s.",
-           nam.c_str(), ::strerror(errno));
+    except("+++ Failed to open input stream: %s Error:%s.", nam.c_str(), ::strerror(errno));
   }
   m_events = new HepMC::EventStream(m_input);
 }
@@ -260,7 +258,7 @@ Geant4EventReaderHepMC::readParticles(int /* ev_id */,
     output.reserve(parts.size());
     transform(parts.begin(),parts.end(),back_inserter(output),detail::reference2nd(parts));
     m_events->clear();
-    if (pos.mag2() > numeric_limits<double>::epsilon() )  {
+    if (pos.mag2() > std::numeric_limits<double>::epsilon() )  {
       for(Particles::iterator k=output.begin(); k != output.end(); ++k) {
         Geant4ParticleHandle p(*k);
         p->vsx += pos.x();
@@ -311,7 +309,7 @@ void HepMC::fix_particles(EventStream& info)  {
     Geant4Vertex* v = vertex(info,end_vtx_id);
 #if defined(DD4HEP_DEBUG_HEP_MC_VERTEX)
     if ( end_vtx_id == DD4HEP_DEBUG_HEP_MC_VERTEX )   {
-      cout << "End-vertex:" << end_vtx_id << endl;
+      std::cout << "End-vertex:" << end_vtx_id << std::endl;
     }
 #endif
     if ( v )   {
@@ -323,7 +321,7 @@ void HepMC::fix_particles(EventStream& info)  {
         EventStream::Particles::iterator ipp = parts.find(*id);
         Geant4Particle* dau = ipp != parts.end() ? (*ipp).second : 0;
         if ( !dau )
-          cout << "ERROR: Invalid daughter particle: " << *id << endl;
+          std::cout << "ERROR: Invalid daughter particle: " << *id << std::endl;
         else
           dau->parents.insert(p->id);
         p->daughters.insert(*id);
@@ -342,7 +340,7 @@ void HepMC::fix_particles(EventStream& info)  {
   }
   /// Particles originating from the beam (=no parents) must be
   /// be stripped off their parents and the status set to G4PARTICLE_GEN_DECAYED!
-  vector<Geant4Particle*> beam;
+  std::vector<Geant4Particle*> beam;
   for(const auto& ipart : parts)   {
     Geant4ParticleHandle p(ipart.second);
     if ( p->parents.size() == 0 )  {
@@ -353,7 +351,7 @@ void HepMC::fix_particles(EventStream& info)  {
     }
   }
   for(auto* ipp : beam)   {
-    //cout << "Clear parents of " << (*ipp)->id << endl;
+    //std::cout << "Clear parents of " << (*ipp)->id << std::endl;
     ipp->parents.clear();
     ipp->status = G4PARTICLE_GEN_DECAYED;
   }
@@ -364,18 +362,18 @@ Geant4Vertex* HepMC::vertex(EventStream& info, int i)   {
   return (it==info.vertices().end()) ? 0 : (*it).second;
 }
 
-char HepMC::get_input(istream& is, istringstream& iline)  {
+char HepMC::get_input(std::istream& is, std::istringstream& iline)  {
   char value = is.peek();
   if ( !is ) {        // make sure the stream is valid
-    cerr << "StreamHelpers: setting badbit." << endl;
-    is.clear(ios::badbit);
+    std::cerr << "StreamHelpers: setting badbit." << std::endl;
+    is.clear(std::ios::badbit);
     return -1;
   }
-  string line, firstc;
+  std::string line, firstc;
   getline(is,line);
   if ( !is ) {        // make sure the stream is valid
-    cerr << "StreamHelpers: setting badbit." << endl;
-    is.clear(ios::badbit);
+    std::cerr << "StreamHelpers: setting badbit." << std::endl;
+    is.clear(std::ios::badbit);
     return -1;
   }
   iline.clear();
@@ -384,8 +382,8 @@ char HepMC::get_input(istream& is, istringstream& iline)  {
   return iline ? value : -1;
 }
 
-int HepMC::read_until_event_end(istream & is) {
-  string line;
+int HepMC::read_until_event_end(std::istream & is) {
+  std::string line;
   while ( is ) {
     char val = is.peek();
     if( val == 'E' ) {  // next event
@@ -397,23 +395,23 @@ int HepMC::read_until_event_end(istream & is) {
   return 0;
 }
 
-int HepMC::read_weight_names(EventStream&, istringstream&)   {
+int HepMC::read_weight_names(EventStream&, std::istringstream&)   {
 #if 0
-  int HepMC::read_weight_names(EventStream& info, istringstream& iline)
+  int HepMC::read_weight_names(EventStream& info, std::istringstream& iline)
     size_t name_size = 0;
   iline >> name_size;
   info.weights.names.clear();
   info.weights.weights.clear();
 
-  string name;
+  std::string name;
   WeightContainer namedWeight;
-  string::size_type i1 = line.find("\""), i2, len = line.size();
+  std::string::size_type i1 = line.find("\""), i2, len = line.size();
   for(size_t ii = 0; ii < name_size; ++ii) {
     // weight names may contain blanks
     if(i1 >= len) {
-      cout << "debug: attempting to read past the end of the named weight line " << endl;
-      cout << "debug: We should never get here" << endl;
-      cout << "debug: Looking for the end of this event" << endl;
+      std::cout << "debug: attempting to read past the end of the named weight line " << std::endl;
+      std::cout << "debug: We should never get here" << std::endl;
+      std::cout << "debug: Looking for the end of this event" << std::endl;
       read_until_event_end(is);
     }
     i2 = line.find("\"",i1+1);
@@ -430,7 +428,7 @@ int HepMC::read_weight_names(EventStream&, istringstream&)   {
   return 1;
 }
 
-int HepMC::read_particle(EventStream &info, istringstream& input, Geant4Particle * p)   {
+int HepMC::read_particle(EventStream &info, std::istringstream& input, Geant4Particle * p)   {
   float ene = 0., theta = 0., phi = 0;
   int   size = 0, stat=0;
   PropertyMask status(p->status);
@@ -440,7 +438,7 @@ int HepMC::read_particle(EventStream &info, istringstream& input, Geant4Particle
   p->id = info.particles().size();
 #if defined(DD4HEP_DEBUG_HEP_MC_PARTICLE)
   if ( p->id == DD4HEP_DEBUG_HEP_MC_PARTICLE )   {
-    cout << "Particle id: " << p->id << endl;
+    std::cout << "Particle id: " << p->id << std::endl;
   }
 #endif
   p->charge = 0;
@@ -481,7 +479,7 @@ int HepMC::read_particle(EventStream &info, istringstream& input, Geant4Particle
   p->genStatus = stat&G4PARTICLE_GEN_STATUS_MASK;
   
   // read flow patterns if any exist. Protect against tainted readings.
-  size = min(size,100);
+  size = std::min(size,100);
   for (int i = 0; i < size; ++i ) {
     input >> p->colorFlow[0] >> p->colorFlow[1];
     if(!input) return 0;
@@ -489,9 +487,9 @@ int HepMC::read_particle(EventStream &info, istringstream& input, Geant4Particle
   return 1;
 }
 
-int HepMC::read_vertex(EventStream &info, istream& is, istringstream & input)    {
+int HepMC::read_vertex(EventStream &info, std::istream& is, std::istringstream & input)    {
   int id=0, dummy = 0, num_orphans_in=0, num_particles_out=0, weights_size=0;
-  vector<float> weights;
+  std::vector<float> weights;
   Geant4Vertex* v = new Geant4Vertex();
   Geant4Particle* p;
 
@@ -561,13 +559,13 @@ int HepMC::read_vertex(EventStream &info, istream& is, istringstream & input)   
     }
     else  {
       delete p;
-      throw runtime_error("Invalid number of particles....");
+      except("HepMC", "Invalid number of particles....");
     }
   }
   return 1;
 }
 
-int HepMC::read_event_header(EventStream &info, istringstream & input, EventHeader& header)   {
+int HepMC::read_event_header(EventStream &info, std::istringstream & input, EventHeader& header)   {
   // read values into temp variables, then fill GenEvent
   int random_states_size = 0;
   input >> header.id;
@@ -599,7 +597,7 @@ int HepMC::read_event_header(EventStream &info, istringstream & input, EventHead
   input >> weights_size;
   if( input.fail() ) return 0;
 
-  vector<float> wgt(weights_size);
+  std::vector<float> wgt(weights_size);
   for(size_t ii = 0; ii < weights_size; ++ii )
     input >> wgt[ii];
   if( input.fail() ) return 0;
@@ -609,14 +607,14 @@ int HepMC::read_event_header(EventStream &info, istringstream & input, EventHead
   return 1;
 }
 
-int HepMC::read_cross_section(EventStream &info, istringstream & input)   {
+int HepMC::read_cross_section(EventStream &info, std::istringstream & input)   {
   input >> info.xsection >> info.xsection_err;
   return input.fail() ? 0 : 1;
 }
 
-int HepMC::read_units(EventStream &info, istringstream & input)   {
+int HepMC::read_units(EventStream &info, std::istringstream & input)   {
   if( info.io_type == gen )  {
-    string mom, pos;
+    std::string mom, pos;
     input >> mom >> pos;
     if ( !input.fail() )  {
       if ( mom == "KEV" ) info.mom_unit = CLHEP::keV;
@@ -632,7 +630,7 @@ int HepMC::read_units(EventStream &info, istringstream & input)   {
   return input.fail() ? 0 : 1;
 }
 
-int HepMC::read_heavy_ion(EventStream &, istringstream & input)  {
+int HepMC::read_heavy_ion(EventStream &, std::istringstream & input)  {
   // read values into temp variables, then create a new HeavyIon object
   int nh =0, np =0, nt =0, nc =0,
     neut = 0, prot = 0, nw =0, nwn =0, nwnw =0;
@@ -640,7 +638,7 @@ int HepMC::read_heavy_ion(EventStream &, istringstream & input)  {
   input >> nh >> np >> nt >> nc >> neut >> prot >> nw >> nwn >> nwnw;
   input >> impact >> plane >> xcen >> inel;
   /*
-    cerr << "Reading heavy ion, but igoring data!" << endl;
+    std::cerr << "Reading heavy ion, but igoring data!" << std::endl;
     ion->set_Ncoll_hard(nh);
     ion->set_Npart_proj(np);
     ion->set_Npart_targ(nt);
@@ -658,7 +656,7 @@ int HepMC::read_heavy_ion(EventStream &, istringstream & input)  {
   return input.fail() ? 0 : 1;
 }
 
-int HepMC::read_pdf(EventStream &, istringstream & input)  {
+int HepMC::read_pdf(EventStream &, std::istringstream & input)  {
   // read values into temp variables, then create a new PdfInfo object
   int id1 =0, id2 =0;
   double  x1 = 0., x2 = 0., scale = 0., pdf1 = 0., pdf2 = 0.;
@@ -673,7 +671,7 @@ int HepMC::read_pdf(EventStream &, istringstream & input)  {
   if ( input.fail()  )
     return 0;
   /*
-    cerr << "Reading pdf, but igoring data!" << endl;
+    std::cerr << "Reading pdf, but igoring data!" << std::endl;
     pdf->set_id1( id1 );
     pdf->set_id2( id2 );
     pdf->set_x1( x1 );
@@ -698,7 +696,7 @@ int HepMC::read_pdf(EventStream &, istringstream & input)  {
 bool HepMC::EventStream::ok()  const   {
   // make sure the stream is good
   if ( instream.eof() || instream.fail() )  {
-    instream.clear(ios::badbit);
+    instream.clear(std::ios::badbit);
     return false;
   }
   return true;
@@ -721,7 +719,7 @@ bool HepMC::EventStream::read()   {
   ++num_evt;
   while( instream.good() ) {
     char value = instream.peek();
-    istringstream input_line;
+    std::istringstream input_line;
     ++num_line;
     if      ( value == 'E' && event_read )
       break;
@@ -743,7 +741,7 @@ bool HepMC::EventStream::read()   {
     switch( value )   {
     case 'H':  {
       int iotype = 0;
-      string key_value;
+      std::string key_value;
       input_line >> key_value;
       // search for event listing key before first event only.
       key_value = key_value.substr(0,key_value.find('\r'));
@@ -773,9 +771,9 @@ bool HepMC::EventStream::read()   {
         iotype = extascii_pdt;
 
       if( iotype != 0 && this->io_type != iotype )  {
-        cerr << "GenEvent::find_end_key: iotype keys have changed. "
-             << "MALFORMED INPUT" << endl;
-        instream.clear(ios::badbit);
+        std::cerr << "GenEvent::find_end_key: iotype keys have changed. "
+                  << "MALFORMED INPUT" << std::endl;
+        instream.clear(std::ios::badbit);
         return false;
       }
       else if ( iotype != 0 )  {
@@ -815,7 +813,7 @@ bool HepMC::EventStream::read()   {
       continue;
 
     case 'P':           // we should not find this line
-      cerr << "streaming input: found unexpected Particle line." << endl;
+      std::cerr << "streaming input: found unexpected Particle line." << std::endl;
       continue;
 
     default:            // ignore everything else

--- a/DDG4/plugins/Geant4FastPhysics.cpp
+++ b/DDG4/plugins/Geant4FastPhysics.cpp
@@ -87,7 +87,6 @@ namespace dd4hep  {
 // Geant4 include files
 #include <G4FastSimulationPhysics.hh>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Standard constructor

--- a/DDG4/plugins/Geant4FastSimShowerModel.cpp
+++ b/DDG4/plugins/Geant4FastSimShowerModel.cpp
@@ -14,8 +14,7 @@
 // Framework include files
 #include <DDG4/Geant4FastSimShowerModel.h>
 
-using namespace dd4hep;
-using namespace dd4hep::sim;
+using dd4hep::sim::Geant4FastSimShowerModel;
 
 #include <DDG4/Factories.h>
 DECLARE_GEANT4ACTION(Geant4FastSimShowerModel)

--- a/DDG4/plugins/Geant4FieldTrackingSetup.cpp
+++ b/DDG4/plugins/Geant4FieldTrackingSetup.cpp
@@ -147,28 +147,26 @@ namespace dd4hep {
 #include <G4PropagatorInField.hh>
 #include <limits>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Local declaration in anonymous namespace
 namespace {
 
   struct Geant4SetupPropertyMap {
-    const map<string,string>& vals;
-    Geant4SetupPropertyMap(const map<string,string>& v) : vals(v) {}
-    string value(const string& key) const;
-    double toDouble(const string& key) const;
-    bool operator[](const string& key) const  { return vals.find(key) != vals.end(); }
+    const std::map<std::string,std::string>& vals;
+    Geant4SetupPropertyMap(const std::map<std::string,std::string>& v) : vals(v) {}
+    std::string value(const std::string& key) const;
+    double toDouble(const std::string& key) const;
+    bool operator[](const std::string& key) const  { return vals.find(key) != vals.end(); }
   };
   
-  string Geant4SetupPropertyMap::value(const string& key) const {
-    Detector::PropertyValues::const_iterator iV = vals.find(key);
+  std::string Geant4SetupPropertyMap::value(const std::string& key) const {
+    dd4hep::Detector::PropertyValues::const_iterator iV = vals.find(key);
     return iV == vals.end() ? "" : (*iV).second;
   }
 
-  double Geant4SetupPropertyMap::toDouble(const string& key) const {
-    return _toDouble(this->value(key));
+  double Geant4SetupPropertyMap::toDouble(const std::string& key) const {
+    return dd4hep::_toDouble(this->value(key));
   }
 
 }
@@ -238,14 +236,17 @@ int Geant4FieldTrackingSetup::execute(Detector& description)   {
   return 1;
 }
 
-static long setup_fields(Detector& description, const dd4hep::detail::GeoHandler& /* cnv */, const map<string,string>& vals) {
+static long setup_fields(dd4hep::Detector& description,
+                         const dd4hep::detail::GeoHandler& /* cnv */,
+                         const std::map<std::string,std::string>& vals)
+{
   struct XMLFieldTrackingSetup : public Geant4FieldTrackingSetup {
-    XMLFieldTrackingSetup(const map<string,string>& values) : Geant4FieldTrackingSetup() {
+    XMLFieldTrackingSetup(const std::map<std::string,std::string>& values) : Geant4FieldTrackingSetup() {
       Geant4SetupPropertyMap pm(values);
-      Detector::PropertyValues::const_iterator iV = values.find("min_chord_step");
+      dd4hep::Detector::PropertyValues::const_iterator iV = values.find("min_chord_step");
       eq_typ      = pm.value("equation");
       stepper_typ = pm.value("stepper");
-      min_chord_step = _toDouble((iV==values.end()) ? string("1e-2 * mm") : (*iV).second);
+      min_chord_step = dd4hep::_toDouble((iV==values.end()) ? std::string("1e-2 * mm") : (*iV).second);
       if ( pm["eps_min"] ) eps_min = pm.toDouble("eps_min");
       if ( pm["eps_max"] ) eps_max = pm.toDouble("eps_max");
       if ( pm["delta_chord"] ) delta_chord = pm.toDouble("delta_chord");

--- a/DDG4/plugins/Geant4GDMLWriteAction.cpp
+++ b/DDG4/plugins/Geant4GDMLWriteAction.cpp
@@ -100,12 +100,10 @@ namespace dd4hep {
 #include <unistd.h>
 #include <memory>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Standard constructor
-Geant4GDMLWriteAction::Geant4GDMLWriteAction(Geant4Context* ctxt, const string& nam)
+Geant4GDMLWriteAction::Geant4GDMLWriteAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam)
 {
   m_needsControl = true;
@@ -130,7 +128,7 @@ void Geant4GDMLWriteAction::installCommandMessenger()   {
 
 /// Write geometry to GDML
 void Geant4GDMLWriteAction::writeGDML()   {
-  string fname = m_output;
+  std::string fname = m_output;
   struct stat buff;
   if ( fname.empty() )   {
     error("+++ No GDML file name given. Please set the output file (property Output)");
@@ -148,7 +146,7 @@ void Geant4GDMLWriteAction::writeGDML()   {
 #ifdef GEANT4_NO_GDML
   warning("+++ writeGDML: GDML not found in the present Geant4 build! Output: %s not written", fname.c_str());
 #else
-  unique_ptr<G4GDMLParser> parser(new G4GDMLParser());
+  std::unique_ptr<G4GDMLParser> parser(new G4GDMLParser());
   parser->SetRegionExport(m_exportRegions != 0);
   parser->SetEnergyCutsExport(m_exportEnergyCuts != 0);
 #if G4VERSION_NUMBER>=1030

--- a/DDG4/plugins/Geant4GFlashShowerModel.cpp
+++ b/DDG4/plugins/Geant4GFlashShowerModel.cpp
@@ -123,7 +123,6 @@ namespace dd4hep  {
 // C/C++ include files
 #include <sstream>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Standard constructor

--- a/DDG4/plugins/Geant4GeometryScanner.cpp
+++ b/DDG4/plugins/Geant4GeometryScanner.cpp
@@ -96,7 +96,6 @@ namespace dd4hep {
 #include <G4Material.hh>
 #include <G4VSolid.hh>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 #include <DDG4/Factories.h>
@@ -106,7 +105,7 @@ DECLARE_GEANT4ACTION(Geant4GeometryScanner)
 Geant4GeometryScanner::StepInfo::StepInfo(const Position& prePos,
                                           const Position& postPos,
                                           const G4LogicalVolume* vol,
-                                          const string& p)
+                                          const std::string& p)
 : pre(prePos), post(postPos), path(p), volume(vol)
 {
 }
@@ -126,7 +125,7 @@ Geant4GeometryScanner::StepInfo& Geant4GeometryScanner::StepInfo::operator=(cons
 }
 
 /// Standard constructor
-Geant4GeometryScanner::Geant4GeometryScanner(Geant4Context* ctxt, const string& nam)
+Geant4GeometryScanner::Geant4GeometryScanner(Geant4Context* ctxt, const std::string& nam)
   : Geant4SteppingAction(ctxt,nam)
 {
   m_needsControl = true;

--- a/DDG4/plugins/Geant4HitDumpAction.cpp
+++ b/DDG4/plugins/Geant4HitDumpAction.cpp
@@ -83,12 +83,10 @@ namespace dd4hep {
 #include <G4HCofThisEvent.hh>
 #include <G4Event.hh>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Standard constructor
-Geant4HitDumpAction::Geant4HitDumpAction(Geant4Context* ctxt, const string& nam)
+Geant4HitDumpAction::Geant4HitDumpAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4EventAction(ctxt, nam), m_containers{"*"}
 {
   m_needsControl = true;
@@ -108,7 +106,7 @@ void Geant4HitDumpAction::begin(const G4Event* /* event */)   {
 /// Dump single container of hits
 void Geant4HitDumpAction::dumpCollection(G4VHitsCollection* collection)  {
   Geant4HitCollection* coll = dynamic_cast<Geant4HitCollection*>(collection);
-  string nam = collection->GetName();
+  std::string nam = collection->GetName();
   if ( coll )    {
     Geant4DataDump::CalorimeterHits cal_hits;
     Geant4DataDump::TrackerHits     trk_hits;

--- a/DDG4/plugins/Geant4HitExtractor.cpp
+++ b/DDG4/plugins/Geant4HitExtractor.cpp
@@ -14,7 +14,6 @@
 // Framework include files
 #include "DDG4/Geant4Data.h"
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Namespace for the AIDA detector description toolkit

--- a/DDG4/plugins/Geant4HitTruthHandler.cpp
+++ b/DDG4/plugins/Geant4HitTruthHandler.cpp
@@ -14,7 +14,7 @@
 #define DD4HEP_DDG4_GEANT4HITTRUTHHANDLER_H
 
 // Framework include files
-#include "DDG4/Geant4EventAction.h"
+#include <DDG4/Geant4EventAction.h>
 
 // Forward declarations
 class G4VHitsCollection;
@@ -72,20 +72,18 @@ namespace dd4hep {
 //====================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4DataDump.h"
-#include "DDG4/Geant4HitCollection.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4DataDump.h>
+#include <DDG4/Geant4HitCollection.h>
 
 // Geant 4 includes
-#include "G4HCofThisEvent.hh"
-#include "G4Event.hh"
+#include <G4HCofThisEvent.hh>
+#include <G4Event.hh>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Standard constructor
-Geant4HitTruthHandler::Geant4HitTruthHandler(Geant4Context* ctxt, const string& nam)
+Geant4HitTruthHandler::Geant4HitTruthHandler(Geant4Context* ctxt, const std::string& nam)
   : Geant4EventAction(ctxt, nam)
 {
   m_needsControl = true;
@@ -152,6 +150,6 @@ void Geant4HitTruthHandler::end(const G4Event* event)    {
           event->GetEventID());
 }
 
-#include "DDG4/Factories.h"
+#include <DDG4/Factories.h>
 DECLARE_GEANT4ACTION(Geant4HitTruthHandler)
 

--- a/DDG4/plugins/Geant4MaterialScanner.cpp
+++ b/DDG4/plugins/Geant4MaterialScanner.cpp
@@ -12,9 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Objects.h"
-#include "DDG4/Defs.h"
-#include "DDG4/Geant4SteppingAction.h"
+#include <DD4hep/Objects.h>
+#include <DDG4/Defs.h>
+#include <DDG4/Geant4SteppingAction.h>
 
 // Forward declarations
 class G4LogicalVolume;
@@ -84,20 +84,19 @@ namespace dd4hep {
 //====================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Printout.h"
-#include "DDG4/Geant4TouchableHandler.h"
-#include "DDG4/Geant4StepHandler.h"
-#include "DDG4/Geant4EventAction.h"
-#include "DDG4/Geant4TrackingAction.h"
-#include "CLHEP/Units/SystemOfUnits.h"
-#include "G4LogicalVolume.hh"
-#include "G4Material.hh"
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Printout.h>
+#include <DDG4/Geant4TouchableHandler.h>
+#include <DDG4/Geant4StepHandler.h>
+#include <DDG4/Geant4EventAction.h>
+#include <DDG4/Geant4TrackingAction.h>
+#include <CLHEP/Units/SystemOfUnits.h>
+#include <G4LogicalVolume.hh>
+#include <G4Material.hh>
 
-using namespace std;
 using namespace dd4hep::sim;
 
-#include "DDG4/Factories.h"
+#include <DDG4/Factories.h>
 DECLARE_GEANT4ACTION(Geant4MaterialScanner)
 
 /// Initializing constructor
@@ -108,7 +107,7 @@ Geant4MaterialScanner::StepInfo::StepInfo(const Position& prePos, const Position
 
 /// Copy constructor
 Geant4MaterialScanner::StepInfo::StepInfo(const StepInfo& c)
-: pre(c.pre), post(c.post), volume(c.volume)
+  : pre(c.pre), post(c.post), volume(c.volume)
 {
 }
 
@@ -121,7 +120,7 @@ Geant4MaterialScanner::StepInfo& Geant4MaterialScanner::StepInfo::operator=(cons
 }
 
 /// Standard constructor
-Geant4MaterialScanner::Geant4MaterialScanner(Geant4Context* ctxt, const string& nam)
+Geant4MaterialScanner::Geant4MaterialScanner(Geant4Context* ctxt, const std::string& nam)
   : Geant4SteppingAction(ctxt,nam)
 {
   m_needsControl = true;
@@ -141,9 +140,9 @@ void Geant4MaterialScanner::operator()(const G4Step* step, G4SteppingManager*) {
   Geant4StepHandler h(step);
 #if 0
   Geant4TouchableHandler pre_handler(step);
-  string prePath = pre_handler.path();
+  std::string prePath = pre_handler.path();
   Geant4TouchableHandler post_handler(step);
-  string postPath = post_handler.path();
+  std::string postPath = post_handler.path();
 #endif
   G4LogicalVolume* logVol = h.logvol(h.pre);
   m_steps.emplace_back(new StepInfo(h.prePos(), h.postPos(), logVol));

--- a/DDG4/plugins/Geant4ParticleDumpAction.cpp
+++ b/DDG4/plugins/Geant4ParticleDumpAction.cpp
@@ -14,7 +14,7 @@
 #define DD4HEP_DDG4_GEANT4PARTICLEDUMPACTION_H
 
 // Framework include files
-#include "DDG4/Geant4EventAction.h"
+#include <DDG4/Geant4EventAction.h>
 
 // Forward declarations
 class G4VHitsCollection;
@@ -67,20 +67,18 @@ namespace dd4hep {
 //====================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4DataDump.h"
-#include "DDG4/Geant4HitCollection.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4DataDump.h>
+#include <DDG4/Geant4HitCollection.h>
 
 // Geant 4 includes
-#include "G4HCofThisEvent.hh"
-#include "G4Event.hh"
+#include <G4HCofThisEvent.hh>
+#include <G4Event.hh>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Standard constructor
-Geant4ParticleDumpAction::Geant4ParticleDumpAction(Geant4Context* ctxt, const string& nam)
+Geant4ParticleDumpAction::Geant4ParticleDumpAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4EventAction(ctxt, nam)
 {
   m_needsControl = true;
@@ -107,5 +105,5 @@ void Geant4ParticleDumpAction::end(const G4Event* event)    {
   warning("+++ [Event:%d] No particle map available!",event->GetEventID());
 }
 
-#include "DDG4/Factories.h"
+#include <DDG4/Factories.h>
 DECLARE_GEANT4ACTION(Geant4ParticleDumpAction)

--- a/DDG4/plugins/Geant4SensDetFilters.cpp
+++ b/DDG4/plugins/Geant4SensDetFilters.cpp
@@ -12,8 +12,8 @@
 //==========================================================================
 
 /// Framework include files
-#include "DDG4/Geant4SensDetAction.h"
-#include "DDG4/Geant4FastSimSpot.h"
+#include <DDG4/Geant4SensDetAction.h>
+#include <DDG4/Geant4FastSimSpot.h>
 
 /// Geant4 include files
 
@@ -51,15 +51,15 @@ namespace dd4hep {
       bool isGeantino(const G4Track* track) const;
       /// Access to the track from step
       const G4Track* getTrack(const G4Step* step)   const   {
-	return step->GetTrack();
+        return step->GetTrack();
       }
       /// Access to the track from step
       const G4Track* getTrack(const Geant4FastSimSpot* spot)   const   {
-	return spot->primary;
+        return spot->primary;
       }
       /// Access originator track from G4 fast track
       const G4Track* getTrack(const G4FastTrack* fast)   const   {
-	return fast->GetPrimaryTrack();
+        return fast->GetPrimaryTrack();
       }
     };
 
@@ -76,11 +76,11 @@ namespace dd4hep {
       virtual ~ParticleRejectFilter();
       /// Filter action. Return true if hits should be processed
       virtual bool operator()(const G4Step* step) const  override  final   {
-	return !isSameType(getTrack(step));
+        return !isSameType(getTrack(step));
       }
       /// GFlash/FastSim interface: Filter action. Return true if hits should be processed
       virtual bool operator()(const Geant4FastSimSpot* spot) const  override  final   {
-	return !isSameType(getTrack(spot));
+        return !isSameType(getTrack(spot));
       }
     };
 
@@ -97,11 +97,11 @@ namespace dd4hep {
       virtual ~ParticleSelectFilter();
       /// Filter action. Return true if hits should be processed
       virtual bool operator()(const G4Step* step) const  override  final   {
-	return isSameType(getTrack(step));
+        return isSameType(getTrack(step));
       }
       /// GFlash/FastSim interface: Filter action. Return true if hits should be processed
       virtual bool operator()(const Geant4FastSimSpot* spot) const  override  final   {
-	return isSameType(getTrack(spot));
+        return isSameType(getTrack(spot));
       }
     };
 
@@ -118,11 +118,11 @@ namespace dd4hep {
       virtual ~GeantinoRejectFilter();
       /// Filter action. Return true if hits should be processed
       virtual bool operator()(const G4Step* step) const  override  final   {
-	return !isGeantino(getTrack(step));
+        return !isGeantino(getTrack(step));
       }
       /// GFlash/FastSim interface: Filter action. Return true if hits should be processed
       virtual bool operator()(const Geant4FastSimSpot* spot) const  override  final   {
-	return !isGeantino(getTrack(spot));
+        return !isGeantino(getTrack(spot));
       }
     };
 
@@ -142,30 +142,28 @@ namespace dd4hep {
       virtual ~EnergyDepositMinimumCut();
       /// Filter action. Return true if hits should be processed
       virtual bool operator()(const G4Step* step) const  override  final  {
-	return step->GetTotalEnergyDeposit() > m_energyCut;
+        return step->GetTotalEnergyDeposit() > m_energyCut;
       }
       /// GFlash/FastSim interface: Filter action. Return true if hits should be processed
       virtual bool operator()(const Geant4FastSimSpot* spot) const  override  final  {
-	return spot->energy() > m_energyCut;
+        return spot->energy() > m_energyCut;
       }
     };
   }
 }
 
 /// Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Factories.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Factories.h>
 
 // Geant4 include files
-#include "G4ParticleTable.hh"
-#include "G4ChargedGeantino.hh"
-#include "G4Geantino.hh"
-#include "G4Track.hh"
-#include "G4Step.hh"
+#include <G4ParticleTable.hh>
+#include <G4ChargedGeantino.hh>
+#include <G4Geantino.hh>
+#include <G4Track.hh>
+#include <G4Step.hh>
 
 using namespace dd4hep::sim;
-using namespace dd4hep;
-using namespace std;
 
 //DECLARE_GEANT4ACTION()
 DECLARE_GEANT4ACTION(GeantinoRejectFilter)
@@ -191,7 +189,7 @@ const G4ParticleDefinition* ParticleFilter::definition() const  {
   if ( m_definition ) return m_definition;
   m_definition = G4ParticleTable::GetParticleTable()->FindParticle(m_particle);
   if ( 0 == m_definition )  {
-    throw runtime_error("Invalid particle name:'"+m_particle+"' [Not-in-particle-table]");
+    throw std::runtime_error("Invalid particle name:'"+m_particle+"' [Not-in-particle-table]");
   }
   return m_definition;
 }

--- a/DDG4/plugins/Geant4TrackerWeightedSD.cpp
+++ b/DDG4/plugins/Geant4TrackerWeightedSD.cpp
@@ -12,19 +12,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/DD4hepUnits.h"
-#include "DDG4/Geant4SensDetAction.inl"
-#include "DDG4/Geant4SteppingAction.h"
-#include "DDG4/Geant4TrackingAction.h"
-#include "DDG4/Geant4EventAction.h"
-#include "G4Event.hh"
-#include "G4VSolid.hh"
+#include <DD4hep/DD4hepUnits.h>
+#include <DDG4/Geant4SensDetAction.inl>
+#include <DDG4/Geant4SteppingAction.h>
+#include <DDG4/Geant4TrackingAction.h>
+#include <DDG4/Geant4EventAction.h>
+#include <G4Event.hh>
+#include <G4VSolid.hh>
 
 #include <map>
 #include <limits>
 #include <sstream>
-
-using namespace std;
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -224,7 +222,7 @@ namespace dd4hep {
             break;
           }
 
-          if ( ended == kSurface || distance_to_outside < numeric_limits<float>::epsilon() )
+          if ( ended == kSurface || distance_to_outside < std::numeric_limits<float>::epsilon() )
             hit_flag |= Geant4Tracker::Hit::HIT_ENDED_SURFACE;
           else if ( ended == kInside )
             hit_flag |= Geant4Tracker::Hit::HIT_ENDED_INSIDE;
@@ -477,5 +475,5 @@ namespace dd4hep {
 
 using namespace dd4hep::sim;
 
-#include "DDG4/Factories.h"
+#include <DDG4/Factories.h>
 DECLARE_GEANT4SENSITIVE(Geant4TrackerWeightedAction)

--- a/DDG4/plugins/Geant4UserActionInitialization.cpp
+++ b/DDG4/plugins/Geant4UserActionInitialization.cpp
@@ -15,7 +15,7 @@
 #define DD4HEP_DDG4_GEANT4USERACTIONINITIALIZATION_H
 
 // Framework include files
-#include "DDG4/Geant4UserInitialization.h"
+#include <DDG4/Geant4UserInitialization.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -60,19 +60,16 @@ namespace dd4hep {
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Factories.h"
-//#include "DDG4/Geant4UserActionInitialization.h"
-#include "DDG4/Geant4Context.h"
+#include <DDG4/Factories.h>
+//#include <DDG4/Geant4UserActionInitialization.h>
+#include <DDG4/Geant4Context.h>
 
-// C/C++ include files
-
-using namespace std;
 using namespace dd4hep::sim;
 
 //DECLARE_GEANT4ACTION(Geant4UserActionInitialization)
 
 /// Standard constructor, initializes variables
-Geant4UserActionInitialization::Geant4UserActionInitialization(Geant4Context* ctxt, const string& nam)
+Geant4UserActionInitialization::Geant4UserActionInitialization(Geant4Context* ctxt, const std::string& nam)
   : Geant4UserInitialization(ctxt,nam)
 {
 }

--- a/DDG4/plugins/Geant4XMLSetup.cpp
+++ b/DDG4/plugins/Geant4XMLSetup.cpp
@@ -12,18 +12,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/DetFactoryHelper.h"
-#include "XML/Conversions.h"
-#include "DDG4/Geant4Config.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/DetFactoryHelper.h>
+#include <XML/Conversions.h>
+#include <DDG4/Geant4Config.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
 
   // Forward declarations
   class ActionSequence;
-  using namespace std;
   using namespace dd4hep::sim;
   using namespace dd4hep::sim::Setup;
 
@@ -47,10 +46,10 @@ namespace dd4hep {
     template <typename T> static void _setAttributes(const T& handle, xml_h& e)  {
       xml::Handle_t props(e);
       // Now we set the object properties
-      vector<xml::Attribute> attrs = props.attributes();
-      for(vector<xml::Attribute>::iterator i=attrs.begin(); i!=attrs.end(); ++i)   {
+      std::vector<xml::Attribute> attrs = props.attributes();
+      for(std::vector<xml::Attribute>::iterator i=attrs.begin(); i!=attrs.end(); ++i)   {
         xml::Attribute a = *i;
-        handle[xml::_toString(props.attr_name(a))].str(props.attr<string>(a));
+        handle[xml::_toString(props.attr_name(a))].str(props.attr<std::string>(a));
       }
     }
 
@@ -63,20 +62,20 @@ namespace dd4hep {
         _setAttributes(handle, props);
       }
       if ( action.hasAttr(_Unicode(Control)) )   {
-        handle["Control"].str(props.attr<string>(_Unicode(Control)));
+        handle["Control"].str(props.attr<std::string>(_Unicode(Control)));
       }
     }
 
     /// Create/Configure Geant4 sensitive action object from XML
-    static Action _convertSensitive(Detector& description, xml_h e, const string& detector)  {
+    static Action _convertSensitive(Detector& description, xml_h e, const std::string& detector)  {
       xml_comp_t action(e);
       Kernel& kernel = Kernel::instance(description);
-      TypeName tn = TypeName::split(action.attr<string>(_U(name)));
+      TypeName tn = TypeName::split(action.attr<std::string>(_U(name)));
       // Create the object using the factory method
-      Sensitive handle(kernel,action.attr<string>(_U(name)),detector);
+      Sensitive handle(kernel,action.attr<std::string>(_U(name)),detector);
       _setProperties(Action(handle.get()),e);
       for(xml_coll_t f(e,_Unicode(filter)); f; ++f)  {
-        string nam = f.attr<string>(_U(name));
+        std::string nam = f.attr<std::string>(_U(name));
         Filter filter(kernel.globalFilter(nam,false));
         handle->adopt(filter);
       }
@@ -90,15 +89,15 @@ namespace dd4hep {
     static Action _convertAction(Detector& description, xml_h e)  {
       xml_comp_t action(e);
       Kernel& kernel = Kernel::instance(description);
-      TypeName tn = TypeName::split(action.attr<string>(_U(name)));
+      TypeName tn = TypeName::split(action.attr<std::string>(_U(name)));
       // Create the object using the factory method
-      Action handle(kernel,action.attr<string>(_U(name)));
+      Action handle(kernel,action.attr<std::string>(_U(name)));
       _setProperties(handle,e);
       printout(INFO,"Geant4Setup","+++ Added action %s of type %s",tn.second.c_str(),tn.first.c_str());
       installMessenger(handle);
 
       if ( action.hasChild(_Unicode(adopt)) )  {
-        xml_comp_t child = action.child(_Unicode(adopt));
+        xml_comp_t   child = action.child(_Unicode(adopt));
         Geant4Action* user = kernel.globalAction(child.nameStr());
         Geant4ParticleHandler* ph = dynamic_cast<Geant4ParticleHandler*>(handle.get());
         if ( ph )  {
@@ -110,8 +109,8 @@ namespace dd4hep {
 
     enum { SENSITIVE, ACTION, FILTER };
     /// Create/Configure Action object from XML
-    Action _createAction(Detector& description, xml_h a, const string& seqType, int what)  {
-      string   nam = a.attr<string>(_U(name));
+    Action _createAction(Detector& description, xml_h a, const std::string& seqType, int what)  {
+      std::string nam = a.attr<std::string>(_U(name));
       TypeName typ    = TypeName::split(nam);
       Kernel&  kernel = Kernel::instance(description);
       Action action((what==FILTER) ? (Geant4Action*)kernel.globalFilter(typ.second,false)
@@ -125,366 +124,366 @@ namespace dd4hep {
           : (what==FILTER) ? _convertAction(description, a)
           : Action();
         if ( !action )  {
-          throw runtime_error(format("Geant4ActionSequence","DDG4: The action '%s'"
-                                     " cannot be created. [Action-Missing]",nam.c_str()));
-        }
+          except("Geant4ActionSequence",
+                 "DDG4: The action '%s' cannot be created. [Action-Missing]",nam.c_str());
       }
-      return action;
     }
+    return action;
   }
+}
 
-  /// Convert Geant4Action objects
-  /**
-   *  <actions>
-   *    <action name="Geant4PostTrackingAction/PostTrackAction"
-   *      <properties
-   *         NAME1="Value1"
-   *         NAME2="Value2" />
-   *    </action>
-   *  </actions>
-   */
-  template <> void Converter<Action>::operator()(xml_h e)  const  {
-    Action a = _convertAction(description, e);
-    Kernel::instance(description).registerGlobalAction(a);
+/// Convert Geant4Action objects
+/**
+ *  <actions>
+ *    <action name="Geant4PostTrackingAction/PostTrackAction"
+ *      <properties
+ *         NAME1="Value1"
+ *         NAME2="Value2" />
+ *    </action>
+ *  </actions>
+ */
+template <> void Converter<Action>::operator()(xml_h e)  const  {
+  Action a = _convertAction(description, e);
+  Kernel::instance(description).registerGlobalAction(a);
+}
+
+/// Convert Sensitive detector filters
+/**
+ *  Note: Filters are Geant4Actions and - if global - may also receive properties!
+ *
+ *  <filters>
+ *    <filter name="GeantinoRejector"/>
+ *    <filter name="EnergyDepositMinimumCut">
+ *      <properties cut="10*MeV"/>
+ *    </filter>
+ *  </filters>
+ */
+template <> void Converter<Filter>::operator()(xml_h e)  const  {
+  Action a = _convertAction(description, e);
+  Kernel::instance(description).registerGlobalFilter(a);
+}
+
+/// Convert Geant4Phase objects
+/**
+ *  <phases>
+ *    <phase name="Geant4PostTrackingPhase/PostTrackPhase"
+ *      <properties
+ *         NAME1="Value1"
+ *         NAME2="Value2" />
+ *    </phase>
+ *  </phases>
+ */
+template <> void Converter<Phase>::operator()(xml_h e)  const  {
+  xml_comp_t x_phase(e);
+  Kernel&  kernel = Kernel::instance(description);
+  std::string nam = x_phase.attr<std::string>(_U(type));
+  typedef Geant4ActionPhase PH;
+  Phase p;
+
+  if ( nam == "RunAction/begin" )  {
+    void (Geant4ActionPhase::*func)(const G4Run*) = &Geant4ActionPhase::call;
+    kernel.runAction().callAtBegin((p=kernel.addPhase<const G4Run*>(nam)).get(),func);
+    //&Geant4ActionPhase::call<const G4Run*>);
   }
-
-  /// Convert Sensitive detector filters
-  /**
-   *  Note: Filters are Geant4Actions and - if global - may also receive properties!
-   *
-   *  <filters>
-   *    <filter name="GeantinoRejector"/>
-   *    <filter name="EnergyDepositMinimumCut">
-   *      <properties cut="10*MeV"/>
-   *    </filter>
-   *  </filters>
-   */
-  template <> void Converter<Filter>::operator()(xml_h e)  const  {
-    Action a = _convertAction(description, e);
-    Kernel::instance(description).registerGlobalFilter(a);
+  else if ( nam == "RunAction/end" )  {
+    void (Geant4ActionPhase::*func)(const G4Run*) = &Geant4ActionPhase::call;
+    kernel.runAction().callAtEnd((p=kernel.addPhase<const G4Run*>(nam)).get(),func);
+    //&PH::call<const G4Run*>);
   }
+  else if ( nam == "EventAction/begin" )  {
+    void (Geant4ActionPhase::*func)(const G4Event*) = &Geant4ActionPhase::call;
+    kernel.eventAction().callAtBegin((p=kernel.addPhase<const G4Event*>(nam)).get(),func);
+    //&PH::call<const G4Event*>);
+  }
+  else if ( nam == "EventAction/end" )  {
+    void (Geant4ActionPhase::*func)(const G4Event*) = &Geant4ActionPhase::call;
+    kernel.eventAction().callAtEnd((p=kernel.addPhase<const G4Event*>(nam)).get(),func);
+    //&PH::call<const G4Event*>);
+  }
+  else if ( nam == "TrackingAction/begin" )  {
+    void (Geant4ActionPhase::*func)(const G4Track*) = &Geant4ActionPhase::call;
+    kernel.trackingAction().callAtBegin((p=kernel.addPhase<const G4Track*>(nam)).get(),func);
+    //&PH::call<const G4Track*>);
+  }
+  else if ( nam == "TrackingAction/end" )  {
+    void (Geant4ActionPhase::*func)(const G4Track*) = &Geant4ActionPhase::call;
+    kernel.trackingAction().callAtEnd((p=kernel.addPhase<const G4Track*>(nam,false)).get(),func);
+    //&PH::call<const G4Track*>);
+  }
+  else if ( nam == "StackingAction/newStage" )  {
+    kernel.stackingAction().callAtNewStage((p=kernel.addPhase<void>(nam,false)).get(),&PH::call);
+  }
+  else if ( nam == "StackingAction/prepare" )  {
+    kernel.stackingAction().callAtPrepare((p=kernel.addPhase<void>(nam,false)).get(),&PH::call);
+  }
+  else if ( nam == "SteppingAction" )  {
+    void (Geant4ActionPhase::*func)(const G4Step*,G4SteppingManager*) = &Geant4ActionPhase::call;
+    kernel.steppingAction().call((p=kernel.addPhase<const G4Step*>(nam)).get(),func);
+    //&PH::call<const G4Step*,G4SteppingManager*>);
+  }
+  else if ( nam == "GeneratorAction/primaries" )  {
+    void (Geant4ActionPhase::*func)(G4Event*) = &Geant4ActionPhase::call;
+    kernel.generatorAction().call((p=kernel.addPhase<G4Event*>(nam)).get(),func);
+    //&PH::call<G4Event*>);
+  }
+  else   {
+    TypeName tn = TypeName::split(nam);
+    DetElement det = description.detector(tn.first);
+    if ( !det.isValid() )   {
+      except("Phase","DDG4: The phase '%s' of type SensitiveSeq"
+             " cannot be attached to a non-existing detector"
+             " [Detector-Missing]",nam.c_str());
+    }
 
-  /// Convert Geant4Phase objects
-  /**
-   *  <phases>
-   *    <phase name="Geant4PostTrackingPhase/PostTrackPhase"
-   *      <properties
-   *         NAME1="Value1"
-   *         NAME2="Value2" />
-   *    </phase>
-   *  </phases>
-   */
-  template <> void Converter<Phase>::operator()(xml_h e)  const  {
-    xml_comp_t x_phase(e);
-    Kernel& kernel = Kernel::instance(description);
-    string nam = x_phase.attr<string>(_U(type));
-    typedef Geant4ActionPhase PH;
-    Phase p;
-
-    if ( nam == "RunAction/begin" )  {
-      void (Geant4ActionPhase::*func)(const G4Run*) = &Geant4ActionPhase::call;
-      kernel.runAction().callAtBegin((p=kernel.addPhase<const G4Run*>(nam)).get(),func);
-      //&Geant4ActionPhase::call<const G4Run*>);
+    SensitiveDetector sd = description.sensitiveDetector(tn.first);
+    if ( !sd.isValid() )  {
+      except("Phase","DDG4: The phase '%s' of type SensitiveSeq"
+             " cannot be attached to a non-existing sensitive detector"
+             " [Sensitive-Missing]",nam.c_str());
     }
-    else if ( nam == "RunAction/end" )  {
-      void (Geant4ActionPhase::*func)(const G4Run*) = &Geant4ActionPhase::call;
-      kernel.runAction().callAtEnd((p=kernel.addPhase<const G4Run*>(nam)).get(),func);
-      //&PH::call<const G4Run*>);
-    }
-    else if ( nam == "EventAction/begin" )  {
-      void (Geant4ActionPhase::*func)(const G4Event*) = &Geant4ActionPhase::call;
-      kernel.eventAction().callAtBegin((p=kernel.addPhase<const G4Event*>(nam)).get(),func);
-      //&PH::call<const G4Event*>);
-    }
-    else if ( nam == "EventAction/end" )  {
-      void (Geant4ActionPhase::*func)(const G4Event*) = &Geant4ActionPhase::call;
-      kernel.eventAction().callAtEnd((p=kernel.addPhase<const G4Event*>(nam)).get(),func);
-      //&PH::call<const G4Event*>);
-    }
-    else if ( nam == "TrackingAction/begin" )  {
-      void (Geant4ActionPhase::*func)(const G4Track*) = &Geant4ActionPhase::call;
-      kernel.trackingAction().callAtBegin((p=kernel.addPhase<const G4Track*>(nam)).get(),func);
-      //&PH::call<const G4Track*>);
-    }
-    else if ( nam == "TrackingAction/end" )  {
-      void (Geant4ActionPhase::*func)(const G4Track*) = &Geant4ActionPhase::call;
-      kernel.trackingAction().callAtEnd((p=kernel.addPhase<const G4Track*>(nam,false)).get(),func);
-      //&PH::call<const G4Track*>);
-    }
-    else if ( nam == "StackingAction/newStage" )  {
-      kernel.stackingAction().callAtNewStage((p=kernel.addPhase<void>(nam,false)).get(),&PH::call);
-    }
-    else if ( nam == "StackingAction/prepare" )  {
-      kernel.stackingAction().callAtPrepare((p=kernel.addPhase<void>(nam,false)).get(),&PH::call);
-    }
-    else if ( nam == "SteppingAction" )  {
-      void (Geant4ActionPhase::*func)(const G4Step*,G4SteppingManager*) = &Geant4ActionPhase::call;
-      kernel.steppingAction().call((p=kernel.addPhase<const G4Step*>(nam)).get(),func);
-      //&PH::call<const G4Step*,G4SteppingManager*>);
-    }
-    else if ( nam == "GeneratorAction/primaries" )  {
-      void (Geant4ActionPhase::*func)(G4Event*) = &Geant4ActionPhase::call;
-      kernel.generatorAction().call((p=kernel.addPhase<G4Event*>(nam)).get(),func);
-      //&PH::call<G4Event*>);
-    }
-    else   {
-      TypeName tn = TypeName::split(nam);
-      DetElement det = description.detector(tn.first);
-      if ( !det.isValid() )   {
-        throw runtime_error(format("Phase","DDG4: The phase '%s' of type SensitiveSeq"
-                                   " cannot be attached to a non-existing detector"
-                                   " [Detector-Missing]",nam.c_str()));
-      }
-
-      SensitiveDetector sd = description.sensitiveDetector(tn.first);
-      if ( !sd.isValid() )  {
-        throw runtime_error(format("Phase","DDG4: The phase '%s' of type SensitiveSeq"
-                                   " cannot be attached to a non-existing sensitive detector"
-                                   " [Sensitive-Missing]",nam.c_str()));
-      }
-      SensitiveSeq sdSeq = SensitiveSeq(kernel,tn.first);
-      if ( tn.second == "begin" )
-        sdSeq->callAtBegin((p=kernel.addPhase<G4HCofThisEvent*>(tn.second)).get(),
-                           &PH::call<G4HCofThisEvent*>);
-      else if ( tn.second == "end" )
-        sdSeq->callAtEnd((p=kernel.addPhase<G4HCofThisEvent*>(tn.second)).get(),
+    SensitiveSeq sdSeq = SensitiveSeq(kernel,tn.first);
+    if ( tn.second == "begin" )
+      sdSeq->callAtBegin((p=kernel.addPhase<G4HCofThisEvent*>(tn.second)).get(),
                          &PH::call<G4HCofThisEvent*>);
-      else if ( tn.second == "clear" )
-        sdSeq->callAtClear((p=kernel.addPhase<G4HCofThisEvent*>(tn.second)).get(),
-                           &PH::call<G4HCofThisEvent*>);
-      else if ( tn.second == "process" )
-        sdSeq->callAtProcess((p=kernel.addPhase<G4Step*>(tn.second)).get(),
-                             &PH::call<G4Step*,G4TouchableHistory*>);
-      else
-        throw runtime_error(format("Phase","DDG4: The phase '%s' of type SensitiveSeq"
-                                   " cannot be attached to the call '%s'."
-                                   " [Callback-Missing]",tn.first.c_str(), tn.second.c_str()));
+    else if ( tn.second == "end" )
+      sdSeq->callAtEnd((p=kernel.addPhase<G4HCofThisEvent*>(tn.second)).get(),
+                       &PH::call<G4HCofThisEvent*>);
+    else if ( tn.second == "clear" )
+      sdSeq->callAtClear((p=kernel.addPhase<G4HCofThisEvent*>(tn.second)).get(),
+                         &PH::call<G4HCofThisEvent*>);
+    else if ( tn.second == "process" )
+      sdSeq->callAtProcess((p=kernel.addPhase<G4Step*>(tn.second)).get(),
+                           &PH::call<G4Step*,G4TouchableHistory*>);
+    else
+      except("Phase","DDG4: The phase '%s' of type SensitiveSeq"
+             " cannot be attached to the call '%s'."
+             " [Callback-Missing]",tn.first.c_str(), tn.second.c_str());
+  }
+}
+
+/// Convert Action sequences into objects
+/**
+ *  <sequences>
+ *    <sequence name="Geant4EventActionSequence/EventAction"
+ *      <member name="" type="Geant4TrackerEventMonitor/TrackerEvtAction"/>
+ *    </sequence>
+ *    <sequence name="Geant4SensdetActionSequence/SiVertexBarrel"
+ *      <member type="Geant4TrackerSensitiveMonitor/TrackerHitMonitor">
+ *        <properties
+ *           NAME1="Value1"
+ *           NAME2="Value2" />
+ *      </member>
+ *    </sequence>
+ *  </sequences>
+ */
+template <> void Converter<ActionSequence>::operator()(xml_h e)  const  {
+  xml_comp_t   seq(e);
+  SensitiveSeq sdSeq;
+  std::string  seqNam;
+  TypeName     seqType;
+  int          what = ACTION;
+  Kernel&      kernel = Kernel::instance(description);
+
+  if ( seq.hasAttr(_U(sd)) )   {
+    std::string sd_nam = seq.attr<std::string>(_U(sd));
+    SensitiveDetector sensitive = description.sensitiveDetector(sd_nam);
+    seqNam  = seq.attr<std::string>(_U(type))+"/"+sd_nam;
+    if ( !sensitive.isValid() )  {
+      printout(ALWAYS,"Geant4Setup","+++ ActionSequence %s is defined, "
+               "but no sensitive detector present.",seqNam.c_str());
+      printout(ALWAYS,"Geant4Setup","+++ ---> Sequence for detector %s IGNORED on popular request!",
+               sd_nam.c_str());
+      return;
     }
+    seqType = TypeName::split(seqNam);
+    sdSeq   = SensitiveSeq(kernel,seqNam);
+    what    = SENSITIVE;
+  }
+  else {
+    seqNam = seq.attr<std::string>(_U(name));
+    seqType = TypeName::split(seqNam);
+  }
+  printout(INFO,"Geant4Setup","+++ ActionSequence %s of type %s added.",
+           seqType.second.c_str(),seqType.first.c_str());
+
+  if ( seqType.second == "PhysicsList" )  {
+    PhysicsActionSeq pl(&kernel.physicsList());
+    PropertyManager& props = kernel.physicsList().properties();
+    props.dump();
+    _setAttributes(pl,e);
+    props.dump();
   }
 
-  /// Convert Action sequences into objects
-  /**
-   *  <sequences>
-   *    <sequence name="Geant4EventActionSequence/EventAction"
-   *      <member name="" type="Geant4TrackerEventMonitor/TrackerEvtAction"/>
-   *    </sequence>
-   *    <sequence name="Geant4SensdetActionSequence/SiVertexBarrel"
-   *      <member type="Geant4TrackerSensitiveMonitor/TrackerHitMonitor">
-   *        <properties
-   *           NAME1="Value1"
-   *           NAME2="Value2" />
-   *      </member>
-   *    </sequence>
-   *  </sequences>
-   */
-  template <> void Converter<ActionSequence>::operator()(xml_h e)  const  {
-    xml_comp_t seq(e);
-    SensitiveSeq sdSeq;
-    string       seqNam;
-    TypeName     seqType;
-    int          what = ACTION;
-    Kernel& kernel = Kernel::instance(description);
-
-    if ( seq.hasAttr(_U(sd)) )   {
-      string sd_nam = seq.attr<string>(_U(sd));
-      SensitiveDetector sensitive = description.sensitiveDetector(sd_nam);
-      seqNam  = seq.attr<string>(_U(type))+"/"+sd_nam;
-      if ( !sensitive.isValid() )  {
-        printout(ALWAYS,"Geant4Setup","+++ ActionSequence %s is defined, "
-                 "but no sensitive detector present.",seqNam.c_str());
-        printout(ALWAYS,"Geant4Setup","+++ ---> Sequence for detector %s IGNORED on popular request!",
-                 sd_nam.c_str());
-        return;
-      }
-      seqType = TypeName::split(seqNam);
-      sdSeq   = SensitiveSeq(kernel,seqNam);
-      what    = SENSITIVE;
+  for(xml_coll_t a(seq,_Unicode(action)); a; ++a)  {
+    std::string  nam = a.attr<std::string>(_U(name));
+    Action action(_createAction(description,a,seqType.second,what));
+    if ( seqType.second == "RunAction" )
+      kernel.runAction().adopt(_action<Geant4RunAction>(action.get()));
+    else if ( seqType.second == "EventAction" )
+      kernel.eventAction().adopt(_action<Geant4EventAction>(action.get()));
+    else if ( seqType.second == "GeneratorAction" )
+      kernel.generatorAction().adopt(_action<Geant4GeneratorAction>(action.get()));
+    else if ( seqType.second == "TrackingAction" )
+      kernel.trackingAction().adopt(_action<Geant4TrackingAction>(action.get()));
+    else if ( seqType.second == "StackingAction" )
+      kernel.stackingAction().adopt(_action<Geant4StackingAction>(action.get()));
+    else if ( seqType.second == "SteppingAction" )
+      kernel.steppingAction().adopt(_action<Geant4SteppingAction>(action.get()));
+    else if ( seqType.second == "PhysicsList" )
+      kernel.physicsList().adopt(_action<Geant4PhysicsList>(action.get()));
+    else if ( sdSeq.get() )
+      sdSeq->adopt(_action<Geant4Sensitive>(action.get()));
+    else   {
+      except("ActionSequence","DDG4: The action '%s'"
+             " cannot be attached to any sequence '%s'."
+             " [Sequence-Missing]",nam.c_str(), seqNam.c_str());
     }
-    else {
-      seqNam = seq.attr<string>(_U(name));
-      seqType = TypeName::split(seqNam);
-    }
-    printout(INFO,"Geant4Setup","+++ ActionSequence %s of type %s added.",
-             seqType.second.c_str(),seqType.first.c_str());
-
-    if ( seqType.second == "PhysicsList" )  {
-      PhysicsActionSeq pl(&kernel.physicsList());
-      PropertyManager& props = kernel.physicsList().properties();
-      props.dump();
-      _setAttributes(pl,e);
-      props.dump();
-    }
-
-    for(xml_coll_t a(seq,_Unicode(action)); a; ++a)  {
-      string   nam = a.attr<string>(_U(name));
-      Action action(_createAction(description,a,seqType.second,what));
-      if ( seqType.second == "RunAction" )
-        kernel.runAction().adopt(_action<Geant4RunAction>(action.get()));
-      else if ( seqType.second == "EventAction" )
-        kernel.eventAction().adopt(_action<Geant4EventAction>(action.get()));
-      else if ( seqType.second == "GeneratorAction" )
-        kernel.generatorAction().adopt(_action<Geant4GeneratorAction>(action.get()));
-      else if ( seqType.second == "TrackingAction" )
-        kernel.trackingAction().adopt(_action<Geant4TrackingAction>(action.get()));
-      else if ( seqType.second == "StackingAction" )
-        kernel.stackingAction().adopt(_action<Geant4StackingAction>(action.get()));
-      else if ( seqType.second == "SteppingAction" )
-        kernel.steppingAction().adopt(_action<Geant4SteppingAction>(action.get()));
-      else if ( seqType.second == "PhysicsList" )
-        kernel.physicsList().adopt(_action<Geant4PhysicsList>(action.get()));
-      else if ( sdSeq.get() )
-        sdSeq->adopt(_action<Geant4Sensitive>(action.get()));
-      else   {
-        throw runtime_error(format("ActionSequence","DDG4: The action '%s'"
-                                   " cannot be attached to any sequence '%s'."
-                                   " [Sequence-Missing]",nam.c_str(), seqNam.c_str()));
-      }
+    printout(INFO,"Geant4Setup","+++ ActionSequence %s added filter object:%s",
+             seqType.second.c_str(),action->name().c_str());
+  }
+  if ( what == SENSITIVE )  {
+    for(xml_coll_t a(seq,_Unicode(filter)); a; ++a)  {
+      std::string  nam = a.attr<std::string>(_U(name));
+      Action action(_createAction(description,a,"",FILTER));
+      installMessenger(action);
       printout(INFO,"Geant4Setup","+++ ActionSequence %s added filter object:%s",
                seqType.second.c_str(),action->name().c_str());
-    }
-    if ( what == SENSITIVE )  {
-      for(xml_coll_t a(seq,_Unicode(filter)); a; ++a)  {
-        string   nam = a.attr<string>(_U(name));
-        Action action(_createAction(description,a,"",FILTER));
-        installMessenger(action);
-        printout(INFO,"Geant4Setup","+++ ActionSequence %s added filter object:%s",
-                 seqType.second.c_str(),action->name().c_str());
-        if ( sdSeq.get() )
-          sdSeq->adopt(_action<Geant4Filter>(action.get()));
-        else   {
-          throw runtime_error(format("ActionSequence","DDG4: The action '%s'"
-                                     " cannot be attached to any sequence '%s'."
-                                     " [Sequence-Missing]",nam.c_str(), seqNam.c_str()));
-        }
+      if ( sdSeq.get() )
+        sdSeq->adopt(_action<Geant4Filter>(action.get()));
+      else   {
+        except("ActionSequence","DDG4: The action '%s'"
+               " cannot be attached to any sequence '%s'."
+               " [Sequence-Missing]",nam.c_str(), seqNam.c_str());
       }
     }
   }
+}
 
-  /// Create/Configure PhysicsList objects
-  /**
-   *  <physicslist>
-   *    <processes>
-   *      <particle name="'e-'">
-   *        <process name="G4eMultipleScattering" ordAtRestDoIt="-1" ordAlongSteptDoIt="1" ordPostStepDoIt="1"/>
-   *        <process name="G4eIonisation"         ordAtRestDoIt="-1" ordAlongSteptDoIt="2" ordPostStepDoIt="2"/>
-   *      </particle>
-   *    </processes>
-   *  </physicslist>
-   */
-  template <> void Converter<Geant4PhysicsList::ParticleProcesses>::operator()(xml_h e) const {
-    xml_comp_t part(e);
-    string part_name = part.nameStr();
-    Geant4PhysicsList::ParticleProcesses& procs =
-      _object<Geant4PhysicsList>().processes(part_name);
-    for(xml_coll_t q(part,_Unicode(process)); q; ++q)  {
-      xml_comp_t proc(q);
-      Geant4PhysicsList::Process p;
-      p.name = proc.nameStr();
-      p.ordAtRestDoIt     = proc.attr<int>(_Unicode(ordAtRestDoIt));
-      p.ordAlongSteptDoIt = proc.attr<int>(_Unicode(ordAlongSteptDoIt));
-      p.ordPostStepDoIt   = proc.attr<int>(_Unicode(ordPostStepDoIt));
-      procs.emplace_back(p);
-      printout(INFO,"Geant4Setup","+++ Converter<ParticleProcesses: Particle:%s add process %s %d %d %d",
-               part_name.c_str(),p.name.c_str(),p.ordAtRestDoIt,p.ordAlongSteptDoIt,p.ordPostStepDoIt);
-    }
+/// Create/Configure PhysicsList objects
+/**
+ *  <physicslist>
+ *    <processes>
+ *      <particle name="'e-'">
+ *        <process name="G4eMultipleScattering" ordAtRestDoIt="-1" ordAlongSteptDoIt="1" ordPostStepDoIt="1"/>
+ *        <process name="G4eIonisation"         ordAtRestDoIt="-1" ordAlongSteptDoIt="2" ordPostStepDoIt="2"/>
+ *      </particle>
+ *    </processes>
+ *  </physicslist>
+ */
+template <> void Converter<Geant4PhysicsList::ParticleProcesses>::operator()(xml_h e) const {
+  xml_comp_t part(e);
+  std::string part_name = part.nameStr();
+  Geant4PhysicsList::ParticleProcesses& procs =
+    _object<Geant4PhysicsList>().processes(part_name);
+  for(xml_coll_t q(part,_Unicode(process)); q; ++q)  {
+    xml_comp_t proc(q);
+    Geant4PhysicsList::Process p;
+    p.name = proc.nameStr();
+    p.ordAtRestDoIt     = proc.attr<int>(_Unicode(ordAtRestDoIt));
+    p.ordAlongSteptDoIt = proc.attr<int>(_Unicode(ordAlongSteptDoIt));
+    p.ordPostStepDoIt   = proc.attr<int>(_Unicode(ordPostStepDoIt));
+    procs.emplace_back(p);
+    printout(INFO,"Geant4Setup","+++ Converter<ParticleProcesses: Particle:%s add process %s %d %d %d",
+             part_name.c_str(),p.name.c_str(),p.ordAtRestDoIt,p.ordAlongSteptDoIt,p.ordPostStepDoIt);
   }
+}
 
-  /// Create/Configure PhysicsList objects: Particle constructors
-  /**
-   *  <physicslist>
-   *    <particles>
-   *      <construct name="G4Electron"/>
-   *      <construct name="G4Gamma"/>
-   *      <construct name="G4BosonConstructor"/>
-   *      <construct name="G4LeptonConstructor"/>
-   *      <construct name="G4BaryonConstructor"/>
-   *    </particles>
-   *  </physicslist>
-   */
-  template <> void Converter<Geant4PhysicsList::ParticleConstructor>::operator()(xml_h e) const {
-    Geant4PhysicsList::ParticleConstructors& parts = _object<Geant4PhysicsList>().particles();
-    xml_comp_t part(e);
-    string n = part.nameStr();
-    parts.emplace_back(n);
-    printout(INFO,"Geant4Setup","+++ ParticleConstructor: Add Geant4 particle constructor '%s'",n.c_str());
-  }
+/// Create/Configure PhysicsList objects: Particle constructors
+/**
+ *  <physicslist>
+ *    <particles>
+ *      <construct name="G4Electron"/>
+ *      <construct name="G4Gamma"/>
+ *      <construct name="G4BosonConstructor"/>
+ *      <construct name="G4LeptonConstructor"/>
+ *      <construct name="G4BaryonConstructor"/>
+ *    </particles>
+ *  </physicslist>
+ */
+template <> void Converter<Geant4PhysicsList::ParticleConstructor>::operator()(xml_h e) const {
+  Geant4PhysicsList::ParticleConstructors& parts = _object<Geant4PhysicsList>().particles();
+  xml_comp_t  part(e);
+  std::string n = part.nameStr();
+  parts.emplace_back(n);
+  printout(INFO,"Geant4Setup","+++ ParticleConstructor: Add Geant4 particle constructor '%s'",n.c_str());
+}
 
-  /// Create/Configure PhysicsList objects: Physics constructors
-  /**
-   *  <physicslist>
-   *    <physics>
-   *      <construct name="G4EmStandardPhysics"/>
-   *      <construct name="HadronPhysicsQGSP"/>
-   *    </physics>
-   *  </physicslist>
-   */
-  template <> void Converter<Geant4PhysicsList::PhysicsConstructor>::operator()(xml_h e) const {
-    Geant4PhysicsList::PhysicsConstructors& parts = _object<Geant4PhysicsList>().physics();
-    xml_comp_t part(e);
-    string n = part.nameStr();
-    parts.emplace_back(n);
-    printout(INFO,"Geant4Setup","+++ PhysicsConstructor: Add Geant4 physics constructor '%s'",n.c_str());
-  }
+/// Create/Configure PhysicsList objects: Physics constructors
+/**
+ *  <physicslist>
+ *    <physics>
+ *      <construct name="G4EmStandardPhysics"/>
+ *      <construct name="HadronPhysicsQGSP"/>
+ *    </physics>
+ *  </physicslist>
+ */
+template <> void Converter<Geant4PhysicsList::PhysicsConstructor>::operator()(xml_h e) const {
+  Geant4PhysicsList::PhysicsConstructors& parts = _object<Geant4PhysicsList>().physics();
+  xml_comp_t  part(e);
+  std::string n = part.nameStr();
+  parts.emplace_back(n);
+  printout(INFO,"Geant4Setup","+++ PhysicsConstructor: Add Geant4 physics constructor '%s'",n.c_str());
+}
 
-  /// Create/Configure PhysicsList extension objects: Predefined Geant4 Physics lists
-  /**
-   *  <physicslist>
-   *    <list name="TQGSP_FTFP_BERT_95"/>
-   *  </physicslist>
-   *  Note: list items are Geant4Actions and - if global - may receive properties!
-   */
-  struct PhysicsListExtension;
-  template <> void Converter<PhysicsListExtension>::operator()(xml_h e) const {
-    Kernel& kernel = Kernel::instance(description);
-    string ext = xml_comp_t(e).nameStr();
-    kernel.physicsList().properties()["extends"].str(ext);
-    printout(INFO,"Geant4Setup","+++ PhysicsListExtension: Set predefined Geant4 physics list to '%s'",ext.c_str());
-  }
+/// Create/Configure PhysicsList extension objects: Predefined Geant4 Physics lists
+/**
+ *  <physicslist>
+ *    <list name="TQGSP_FTFP_BERT_95"/>
+ *  </physicslist>
+ *  Note: list items are Geant4Actions and - if global - may receive properties!
+ */
+struct PhysicsListExtension;
+template <> void Converter<PhysicsListExtension>::operator()(xml_h e) const {
+  Kernel& kernel = Kernel::instance(description);
+  std::string ext = xml_comp_t(e).nameStr();
+  kernel.physicsList().properties()["extends"].str(ext);
+  printout(INFO,"Geant4Setup","+++ PhysicsListExtension: Set predefined Geant4 physics list to '%s'",ext.c_str());
+}
 
-  /// Create/Configure PhysicsList objects: Predefined Geant4 Physics lists
-  template <> void Converter<PhysicsList>::operator()(xml_h e)  const  {
-    string name = e.attr<string>(_U(name));
-    Kernel& kernel = Kernel::instance(description);
-    PhysicsList handle(kernel,name);
-    _setAttributes(handle,e);
-    xml_coll_t(e,_Unicode(particles)).for_each(_Unicode(construct),Converter<Geant4PhysicsList::ParticleConstructor>(description,handle.get()));
-    xml_coll_t(e,_Unicode(processes)).for_each(_Unicode(particle),Converter<Geant4PhysicsList::ParticleProcesses>(description,handle.get()));
-    xml_coll_t(e,_Unicode(physics)).for_each(_Unicode(construct),Converter<Geant4PhysicsList::PhysicsConstructor>(description,handle.get()));
-    xml_coll_t(e,_Unicode(extends)).for_each(Converter<PhysicsListExtension>(description,handle.get()));
-    kernel.physicsList().adopt(handle);
-  }
+/// Create/Configure PhysicsList objects: Predefined Geant4 Physics lists
+template <> void Converter<PhysicsList>::operator()(xml_h e)  const  {
+  std::string name = e.attr<std::string>(_U(name));
+  Kernel& kernel = Kernel::instance(description);
+  PhysicsList handle(kernel,name);
+  _setAttributes(handle,e);
+  xml_coll_t(e,_Unicode(particles)).for_each(_Unicode(construct),Converter<Geant4PhysicsList::ParticleConstructor>(description,handle.get()));
+  xml_coll_t(e,_Unicode(processes)).for_each(_Unicode(particle),Converter<Geant4PhysicsList::ParticleProcesses>(description,handle.get()));
+  xml_coll_t(e,_Unicode(physics)).for_each(_Unicode(construct),Converter<Geant4PhysicsList::PhysicsConstructor>(description,handle.get()));
+  xml_coll_t(e,_Unicode(extends)).for_each(Converter<PhysicsListExtension>(description,handle.get()));
+  kernel.physicsList().adopt(handle);
+}
 
-  /// Create/Configure Geant4Kernel objects
-  template <> void Converter<Kernel>::operator()(xml_h e) const {
-    Kernel& kernel = Kernel::instance(description);
-    xml_comp_t k(e);
-    if ( k.hasAttr(_Unicode(NumEvents)) )
-      kernel.property("NumEvents").str(k.attr<string>(_Unicode(NumEvents)));
-    if ( k.hasAttr(_Unicode(UI)) )
-      kernel.property("UI").str(k.attr<string>(_Unicode(UI)));
-  }
+/// Create/Configure Geant4Kernel objects
+template <> void Converter<Kernel>::operator()(xml_h e) const {
+  Kernel& kernel = Kernel::instance(description);
+  xml_comp_t k(e);
+  if ( k.hasAttr(_Unicode(NumEvents)) )
+    kernel.property("NumEvents").str(k.attr<std::string>(_Unicode(NumEvents)));
+  if ( k.hasAttr(_Unicode(UI)) )
+    kernel.property("UI").str(k.attr<std::string>(_Unicode(UI)));
+}
 
-  /// Main entry point to configure Geant4 with XML
-  template <> void Converter<XMLSetup>::operator()(xml_h seq)  const  {
-    xml_elt_t compact(seq);
-    // First execute the basic setup from the plugins module
-    long result = PluginService::Create<long>("geant4_XML_reader",&description,&seq);
-    if ( 0 == result )  {
-      throw runtime_error("dd4hep: Failed to locate plugin to interprete files of type"
-                          " \"" + seq.tag() + "\" - no factory of type geant4_XML_reader.");
-    }
-    result = *(long*) result;
-    if (result != 1) {
-      throw runtime_error("dd4hep: Failed to parse the XML tag " + seq.tag() + " with the plugin geant4_XML_reader");
-    }
-    xml_coll_t(compact,_Unicode(kernel)).for_each(Converter<Kernel>(description,param));
-    // Now deal with the new stuff.....
-    xml_coll_t(compact,_Unicode(actions) ).for_each(_Unicode(action),Converter<Action>(description,param));
-    xml_coll_t(compact,_Unicode(filters) ).for_each(_Unicode(filter),Converter<Filter>(description,param));
-    xml_coll_t(compact,_Unicode(sequences) ).for_each(_Unicode(sequence),Converter<ActionSequence>(description,param));
-    xml_coll_t(compact,_Unicode(phases) ).for_each(_Unicode(phase),Converter<Phase>(description,param));
-    xml_coll_t(compact,_Unicode(physicslist)).for_each(Converter<PhysicsList>(description,param));
+/// Main entry point to configure Geant4 with XML
+template <> void Converter<XMLSetup>::operator()(xml_h seq)  const  {
+  xml_elt_t compact(seq);
+  // First execute the basic setup from the plugins module
+  long result = PluginService::Create<long>("geant4_XML_reader",&description,&seq);
+  if ( 0 == result )  {
+    except("PhysicsList", "dd4hep: Failed to locate plugin to interprete files of type"
+           " \"" + seq.tag() + "\" - no factory of type geant4_XML_reader.");
   }
+  result = *(long*) result;
+  if (result != 1) {
+    except("PhysicsList", "dd4hep: Failed to parse the XML tag %s with the plugin geant4_XML_reader", seq.tag().c_str());
+  }
+  xml_coll_t(compact,_Unicode(kernel)).for_each(Converter<Kernel>(description,param));
+  // Now deal with the new stuff.....
+  xml_coll_t(compact,_Unicode(actions) ).for_each(_Unicode(action),Converter<Action>(description,param));
+  xml_coll_t(compact,_Unicode(filters) ).for_each(_Unicode(filter),Converter<Filter>(description,param));
+  xml_coll_t(compact,_Unicode(sequences) ).for_each(_Unicode(sequence),Converter<ActionSequence>(description,param));
+  xml_coll_t(compact,_Unicode(phases) ).for_each(_Unicode(phase),Converter<Phase>(description,param));
+  xml_coll_t(compact,_Unicode(physicslist)).for_each(Converter<PhysicsList>(description,param));
+}
 }
 
 /// Factory method

--- a/DDG4/reco/Geant4SurfaceTest.cpp
+++ b/DDG4/reco/Geant4SurfaceTest.cpp
@@ -15,7 +15,7 @@
 
 // Framework include files
 //#include "Geant4SurfaceTest.h"
-#include "DDG4/Geant4EventAction.h"
+#include <DDG4/Geant4EventAction.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -48,32 +48,31 @@ namespace dd4hep {
 #endif // DD4HEP_DDG4_GEANT4SURFACETEST_H
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/InstanceCount.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/InstanceCount.h>
 
-#include "DDG4/Factories.h"
-#include "DDG4/Geant4Data.h"
-#include "DDG4/Geant4Context.h"
-#include "DDG4/Geant4SensDetAction.h"
-#include "DDG4/Geant4HitCollection.h"
+#include <DDG4/Factories.h>
+#include <DDG4/Geant4Data.h>
+#include <DDG4/Geant4Context.h>
+#include <DDG4/Geant4SensDetAction.h>
+#include <DDG4/Geant4HitCollection.h>
 
-#include "DDRec/Surface.h"
-#include "DDRec/DetectorSurfaces.h"
-#include "DDRec/SurfaceManager.h"
-#include "DDRec/SurfaceHelper.h"
+#include <DDRec/Surface.h>
+#include <DDRec/DetectorSurfaces.h>
+#include <DDRec/SurfaceManager.h>
+#include <DDRec/SurfaceHelper.h>
 
 // Geant 4 includes
-#include "G4VHitsCollection.hh"
-#include "G4HCofThisEvent.hh"
-#include "G4Event.hh"
+#include <G4VHitsCollection.hh>
+#include <G4HCofThisEvent.hh>
+#include <G4Event.hh>
 
 // C/C++ include files
 #include <stdexcept>
 #include <map>
 #include <sstream>
 
-using namespace std;
 using namespace dd4hep::DDRec;
 using namespace dd4hep::detail;
 using namespace dd4hep::sim;

--- a/DDG4/src/EventParameters.cpp
+++ b/DDG4/src/EventParameters.cpp
@@ -10,8 +10,10 @@
 //
 //====================================================================
 
+/// Framework include files
 #include "DDG4/EventParameters.h"
 
+/// C/C++ include files
 #include <map>
 #include <string>
 

--- a/DDG4/src/Geant4Action.cpp
+++ b/DDG4/src/Geant4Action.cpp
@@ -25,7 +25,6 @@
 // C/C++ include files
 #include <algorithm>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 TypeName TypeName::split(const std::string& type_name, const std::string& delim) {
@@ -86,7 +85,7 @@ long Geant4Action::release() {
 }
 
 /// Set the output level; returns previous value
-PrintLevel Geant4Action::setOutputLevel(PrintLevel new_level)  {
+dd4hep::PrintLevel Geant4Action::setOutputLevel(PrintLevel new_level)  {
   int old = m_outputLevel;
   m_outputLevel = new_level;
   return (PrintLevel)old;
@@ -98,7 +97,7 @@ bool Geant4Action::hasProperty(const std::string& nam) const    {
 }
 
 /// Access single property
-Property& Geant4Action::property(const std::string& nam)   {
+dd4hep::Property& Geant4Action::property(const std::string& nam)   {
   return properties()[nam];
 }
 

--- a/DDG4/src/Geant4Action.cpp
+++ b/DDG4/src/Geant4Action.cpp
@@ -12,34 +12,33 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Context.h"
-#include "DDG4/Geant4Action.h"
-#include "DDG4/Geant4Kernel.h"
-#include "DDG4/Geant4UIMessenger.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Context.h>
+#include <DDG4/Geant4Action.h>
+#include <DDG4/Geant4Kernel.h>
+#include <DDG4/Geant4UIMessenger.h>
 
 // Geant4 include files
-#include "G4UIdirectory.hh"
+#include <G4UIdirectory.hh>
 
 // C/C++ include files
 #include <algorithm>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::sim;
 
-TypeName TypeName::split(const string& type_name, const string& delim) {
+TypeName TypeName::split(const std::string& type_name, const std::string& delim) {
   size_t idx = type_name.find(delim);
-  string typ = type_name, nam = type_name;
-  if (idx != string::npos) {
+  std::string typ = type_name, nam = type_name;
+  if (idx != std::string::npos) {
     typ = type_name.substr(0, idx);
     nam = type_name.substr(idx + 1);
   }
   return TypeName(typ, nam);
 }
 
-TypeName TypeName::split(const string& type_name) {
+TypeName TypeName::split(const std::string& type_name) {
   return split(type_name,"/");
 }
 #if 0
@@ -53,7 +52,7 @@ void Geant4Action::ContextUpdate::operator()(Geant4Action* action) const  {
 }
 #endif
 /// Standard constructor
-Geant4Action::Geant4Action(Geant4Context* ctxt, const string& nam)
+Geant4Action::Geant4Action(Geant4Context* ctxt, const std::string& nam)
   : m_context(ctxt), m_control(0), m_outputLevel(INFO), m_needsControl(false), m_name(nam), 
     m_refCount(1) 
 {
@@ -94,12 +93,12 @@ PrintLevel Geant4Action::setOutputLevel(PrintLevel new_level)  {
 }
 
 /// Check property for existence
-bool Geant4Action::hasProperty(const string& nam) const    {
+bool Geant4Action::hasProperty(const std::string& nam) const    {
   return m_properties.exists(nam);
 }
 
 /// Access single property
-Property& Geant4Action::property(const string& nam)   {
+Property& Geant4Action::property(const std::string& nam)   {
   return properties()[nam];
 }
 
@@ -107,7 +106,7 @@ Property& Geant4Action::property(const string& nam)   {
 void Geant4Action::installMessengers() {
   //m_needsControl = true;
   if (m_needsControl && !m_control) {
-    string path = context()->kernel().directoryName();
+    std::string path = context()->kernel().directoryName();
     path += name() + "/";
     m_control = new Geant4UIMessenger(name(), path);
     installPropertyMessenger();
@@ -145,7 +144,7 @@ void Geant4Action::configureFiber(Geant4Context* /* thread_context */)   {
 
 /// Support for messages with variable output level using output level
 void Geant4Action::print(const char* fmt, ...) const   {
-  int level = max(int(outputLevel()),(int)VERBOSE);
+  int level = std::max(int(outputLevel()),(int)VERBOSE);
   if ( level >= printLevel() )  {
     va_list args;
     va_start(args, fmt);
@@ -156,7 +155,7 @@ void Geant4Action::print(const char* fmt, ...) const   {
 
 /// Support for messages with variable output level using output level-1
 void Geant4Action::printM1(const char* fmt, ...) const   {
-  int level = max(outputLevel()-1,(int)VERBOSE);
+  int level = std::max(outputLevel()-1,(int)VERBOSE);
   if ( level >= printLevel() )  {
     va_list args;
     va_start(args, fmt);
@@ -167,7 +166,7 @@ void Geant4Action::printM1(const char* fmt, ...) const   {
 
 /// Support for messages with variable output level using output level-2
 void Geant4Action::printM2(const char* fmt, ...) const   {
-  int level = max(outputLevel()-2,(int)VERBOSE);
+  int level = std::max(outputLevel()-2,(int)VERBOSE);
   if ( level >= printLevel() )  {
     va_list args;
     va_start(args, fmt);
@@ -178,7 +177,7 @@ void Geant4Action::printM2(const char* fmt, ...) const   {
 
 /// Support for messages with variable output level using output level-1
 void Geant4Action::printP1(const char* fmt, ...) const   {
-  int level = min(outputLevel()+1,(int)FATAL);
+  int level = std::min(outputLevel()+1,(int)FATAL);
   if ( level >= printLevel() )  {
     va_list args;
     va_start(args, fmt);
@@ -189,7 +188,7 @@ void Geant4Action::printP1(const char* fmt, ...) const   {
 
 /// Support for messages with variable output level using output level-2
 void Geant4Action::printP2(const char* fmt, ...) const   {
-  int level = min(outputLevel()+2,(int)FATAL);
+  int level = std::min(outputLevel()+2,(int)FATAL);
   if ( level >= printLevel() )  {
     va_list args;
     va_start(args, fmt);
@@ -259,22 +258,22 @@ void Geant4Action::fatal(const char* fmt, ...) const {
 void Geant4Action::except(const char* fmt, ...) const {
   va_list args;
   va_start(args, fmt);
-  string err = dd4hep::format(m_name, fmt, args);
+  std::string err = dd4hep::format(m_name, fmt, args);
   dd4hep::printout(dd4hep::FATAL, m_name, err.c_str());
   va_end(args);
-  throw runtime_error(err);
+  throw std::runtime_error(err);
 }
 
 /// Abort Geant4 Run by throwing a G4Exception with type RunMustBeAborted
-void Geant4Action::abortRun(const string& exception, const char* fmt, ...) const {
-  string desc, typ = typeName(typeid(*this));
-  string issuer = name()+" ["+typ+"]";
+void Geant4Action::abortRun(const std::string& exception, const char* fmt, ...) const {
+  std::string desc, typ = typeName(typeid(*this));
+  std::string issuer = name()+" ["+typ+"]";
   va_list args;
   va_start(args, fmt);
   desc = dd4hep::format("*** Geant4Action:", fmt, args);
   va_end(args);
   G4Exception(issuer.c_str(),exception.c_str(),RunMustBeAborted,desc.c_str());
-  //throw runtime_error(issuer+"> "+desc);
+  //throw std::runtime_error(issuer+"> "+desc);
 }
 
 /// Access to the main run action sequence from the kernel object

--- a/DDG4/src/Geant4ActionContainer.cpp
+++ b/DDG4/src/Geant4ActionContainer.cpp
@@ -12,27 +12,26 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
-#include "DD4hep/InstanceCount.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
+#include <DD4hep/InstanceCount.h>
 
-#include "DDG4/Geant4ActionContainer.h"
-#include "DDG4/Geant4RunAction.h"
-#include "DDG4/Geant4PhysicsList.h"
-#include "DDG4/Geant4EventAction.h"
-#include "DDG4/Geant4SteppingAction.h"
-#include "DDG4/Geant4TrackingAction.h"
-#include "DDG4/Geant4StackingAction.h"
-#include "DDG4/Geant4GeneratorAction.h"
-#include "DDG4/Geant4DetectorConstruction.h"
-#include "DDG4/Geant4UserInitialization.h"
-#include "DDG4/Geant4SensDetAction.h"
+#include <DDG4/Geant4ActionContainer.h>
+#include <DDG4/Geant4RunAction.h>
+#include <DDG4/Geant4PhysicsList.h>
+#include <DDG4/Geant4EventAction.h>
+#include <DDG4/Geant4SteppingAction.h>
+#include <DDG4/Geant4TrackingAction.h>
+#include <DDG4/Geant4StackingAction.h>
+#include <DDG4/Geant4GeneratorAction.h>
+#include <DDG4/Geant4DetectorConstruction.h>
+#include <DDG4/Geant4UserInitialization.h>
+#include <DDG4/Geant4SensDetAction.h>
 
 // C/C++ include files
 #include <stdexcept>
 #include <algorithm>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 /// Standard constructor
@@ -69,7 +68,7 @@ int Geant4ActionContainer::terminate() {
 
 Geant4Context* Geant4ActionContainer::workerContext()   {
   if ( m_context ) return m_context;
-  throw runtime_error(format("Geant4Kernel", "DDG4: Master kernel object has no thread context! [Invalid Handle]"));
+  throw std::runtime_error(format("Geant4Kernel", "DDG4: Master kernel object has no thread context! [Invalid Handle]"));
 }
 
 /// Set the thread's context
@@ -83,7 +82,7 @@ template <class C> bool Geant4ActionContainer::registerSequence(C*& seq, const s
     seq->installMessengers();
     return true;
   }
-  throw runtime_error(format("Geant4ActionContainer", "DDG4: The action '%s' not found. [Action-NotFound]", name.c_str()));
+  throw std::runtime_error(format("Geant4ActionContainer", "DDG4: The action '%s' not found. [Action-NotFound]", name.c_str()));
 }
 
 /// Access generator action sequence
@@ -141,7 +140,7 @@ Geant4SensDetSequences& Geant4ActionContainer::sensitiveActions() const {
 }
 
 /// Access to the sensitive detector action from the kernel object
-Geant4SensDetActionSequence* Geant4ActionContainer::sensitiveAction(const string& nam) {
+Geant4SensDetActionSequence* Geant4ActionContainer::sensitiveAction(const std::string& nam) {
   Geant4SensDetActionSequence* ptr = m_sensDetActions->find(nam);
   if (ptr)   {
     return ptr;

--- a/DDG4/src/Geant4ActionPhase.cpp
+++ b/DDG4/src/Geant4ActionPhase.cpp
@@ -12,10 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4ActionPhase.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4ActionPhase.h>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 /// Standard constructor
@@ -37,8 +36,8 @@ dd4hep::Callback Geant4PhaseAction::callback()    {
 }
 
 /// Standard constructor
-Geant4ActionPhase::Geant4ActionPhase(Geant4Context* ctxt, const string& nam, const type_info& arg_type0,
-                                     const type_info& arg_type1, const type_info& arg_type2)
+Geant4ActionPhase::Geant4ActionPhase(Geant4Context* ctxt, const std::string& nam, const std::type_info& arg_type0,
+                                     const std::type_info& arg_type1, const std::type_info& arg_type2)
   : Geant4Action(ctxt, nam) {
   m_argTypes[0] = &arg_type0;
   m_argTypes[1] = &arg_type1;
@@ -64,7 +63,7 @@ bool Geant4ActionPhase::add(Geant4Action* action, Callback callback) {
 /// Remove an existing member from the phase. If not existing returns false
 bool Geant4ActionPhase::remove(Geant4Action* action, Callback callback) {
   if (action && callback.func.first) {
-    Members::iterator i = find(m_members.begin(), m_members.end(), make_pair(action,callback));
+    Members::iterator i = find(m_members.begin(), m_members.end(), std::make_pair(action,callback));
     if (i != m_members.end()) {
       (*i).first->release();
       m_members.erase(i);
@@ -92,12 +91,12 @@ void Geant4ActionPhase::execute(void* argument) {
 
 class G4HCofThisEvent;
 class G4TouchableHistory;
-#include "DDG4/Geant4RunAction.h"
-#include "DDG4/Geant4EventAction.h"
-#include "DDG4/Geant4TrackingAction.h"
-#include "DDG4/Geant4SteppingAction.h"
-#include "DDG4/Geant4StackingAction.h"
-#include "DDG4/Geant4GeneratorAction.h"
+#include <DDG4/Geant4RunAction.h>
+#include <DDG4/Geant4EventAction.h>
+#include <DDG4/Geant4TrackingAction.h>
+#include <DDG4/Geant4SteppingAction.h>
+#include <DDG4/Geant4StackingAction.h>
+#include <DDG4/Geant4GeneratorAction.h>
 namespace dd4hep {
   namespace sim {
     /// Callback in Begin stacking action

--- a/DDG4/src/Geant4AssemblyVolume.cpp
+++ b/DDG4/src/Geant4AssemblyVolume.cpp
@@ -12,19 +12,19 @@
 //==========================================================================
 
 /// Geant4 include files
-#include "G4LogicalVolume.hh"
-#include "G4VPhysicalVolume.hh"
-#include "G4ReflectionFactory.hh"
+#include <G4LogicalVolume.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4ReflectionFactory.hh>
 
 /// C/C++ include files
 #include <sstream>
 #include <string>
 
 /// Framework include files
-#include "DD4hep/DetectorTools.h"
-#include "DDG4/Geant4Converter.h"
-#include "DDG4/Geant4GeometryInfo.h"
-#include "DDG4/Geant4AssemblyVolume.h"
+#include <DD4hep/DetectorTools.h>
+#include <DDG4/Geant4Converter.h>
+#include <DDG4/Geant4GeometryInfo.h>
+#include <DDG4/Geant4AssemblyVolume.h>
 
 using namespace dd4hep::sim;
 

--- a/DDG4/src/Geant4Call.cpp
+++ b/DDG4/src/Geant4Call.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4Call.h"
+#include <DDG4/Geant4Call.h>
 
 /// Default destructor (keep here to avoid weak linkage to vtable)
 dd4hep::sim::Geant4Call::~Geant4Call()   {

--- a/DDG4/src/Geant4Context.cpp
+++ b/DDG4/src/Geant4Context.cpp
@@ -12,15 +12,14 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Context.h"
-#include "DDG4/Geant4Kernel.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Context.h>
+#include <DDG4/Geant4Kernel.h>
 
 // C/C++ include files
 #include <algorithm>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::sim;
 
@@ -101,9 +100,9 @@ Geant4Context::UserFramework& Geant4Context::userFramework() const  {
 
 /// Create a user trajectory
 G4VTrajectory* Geant4Context::createTrajectory(const G4Track* /* track */) const {
-  string err = dd4hep::format("Geant4Kernel", "createTrajectory: Purely virtual method. requires overloading!");
+  std::string err = dd4hep::format("Geant4Kernel", "createTrajectory: Purely virtual method. requires overloading!");
   dd4hep::printout(dd4hep::FATAL, "Geant4Kernel", "createTrajectory: Purely virtual method. requires overloading!");
-  throw runtime_error(err);
+  throw std::runtime_error(err);
 }
 
 /// Access the tracking manager

--- a/DDG4/src/Geant4Context.cpp
+++ b/DDG4/src/Geant4Context.cpp
@@ -20,7 +20,6 @@
 // C/C++ include files
 #include <algorithm>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Intializing constructor
@@ -89,7 +88,7 @@ Geant4Event& Geant4Context::event()  const   {
 }
 
 /// Access to detector description
-Detector& Geant4Context::detectorDescription() const {
+dd4hep::Detector& Geant4Context::detectorDescription() const {
   return m_kernel->detectorDescription();
 }
 

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -1435,7 +1435,8 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
              TGeoOpticalSurface::ModelToString(optSurf->GetModel()),
              TGeoOpticalSurface::FinishToString(optSurf->GetFinish()),
              optSurf->GetSigmaAlpha(), optSurf->GetPolish());
-
+    ///
+    /// Convert non-scalar properties from GDML tables
     G4MaterialPropertiesTable* tab = nullptr;
     TListIter itp(&optSurf->GetProperties());
     for(TObject* obj = itp.Next(); obj; obj = itp.Next())  {
@@ -1488,6 +1489,9 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
                  "  Geant4: %8.3g [MeV]  TGeo: %8.3g [GeV] Conversion: %8.3g",
                  bins[i], v->bins[i], conv.first);
     }
+    ///
+    /// Convert scalar properties
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,31,1)
     TListIter itc(&optSurf->GetConstProperties());
     for(TObject* obj = itc.Next(); obj; obj = itc.Next())  {
       string  exc_str;
@@ -1536,6 +1540,7 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
                named->GetName(), value, conv, value * conv);
       tab->AddConstProperty(named->GetName(), value * conv);
     }
+#endif  // ROOT_VERSION >= 6.31.1
     info.g4OpticalSurfaces[optSurf] = g4;
   }
   return g4;

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -12,13 +12,14 @@
 //==========================================================================
 
 // Framework include files
-#include <DD4hep/Detector.h>
-#include <DD4hep/Plugins.h>
 #include <DD4hep/Shapes.h>
 #include <DD4hep/Volumes.h>
+#include <DD4hep/Plugins.h>
 #include <DD4hep/Printout.h>
+#include <DD4hep/Detector.h>
 #include <DD4hep/DD4hepUnits.h>
 #include <DD4hep/PropertyTable.h>
+#include <DD4hep/DetectorTools.h>
 #include <DD4hep/detail/ShapesInterna.h>
 #include <DD4hep/detail/ObjectsInterna.h>
 #include <DD4hep/detail/DetectorInterna.h>
@@ -27,6 +28,7 @@
 #include <DDG4/Geant4Helpers.h>
 #include <DDG4/Geant4Converter.h>
 #include <DDG4/Geant4UserLimits.h>
+#include <DDG4/Geant4AssemblyVolume.h>
 #include <DDG4/Geant4PlacementParameterisation.h>
 #include "Geant4ShapeConverter.h"
 
@@ -77,23 +79,59 @@
 #include <limits>
 
 namespace units = dd4hep;
-using namespace dd4hep::detail;
 using namespace dd4hep::sim;
 using namespace dd4hep;
 using namespace std;
 
-#include <DDG4/Geant4AssemblyVolume.h>
-#include <DD4hep/DetectorTools.h>
-
-static constexpr const double CM_2_MM = (CLHEP::centimeter/dd4hep::centimeter);
-static constexpr const char* GEANT4_TAG_IGNORE = "Geant4-ignore";
-static constexpr const char* GEANT4_TAG_PLUGIN = "Geant4-plugin";
-static constexpr const char* GEANT4_TAG_BIRKSCONSTANT    = "BirksConstant";
-static constexpr const char* GEANT4_TAG_MEE              = "MeanExcitationEnergy";
-static constexpr const char* GEANT4_TAG_ENE_PER_ION_PAIR = "MeanEnergyPerIonPair";
-
 namespace {
+
+  static constexpr const double CM_2_MM = (CLHEP::centimeter/dd4hep::centimeter);
+  static constexpr const char* GEANT4_TAG_IGNORE = "Geant4-ignore";
+  static constexpr const char* GEANT4_TAG_PLUGIN = "Geant4-plugin";
+  static constexpr const char* GEANT4_TAG_BIRKSCONSTANT    = "BirksConstant";
+  static constexpr const char* GEANT4_TAG_MEE              = "MeanExcitationEnergy";
+  static constexpr const char* GEANT4_TAG_ENE_PER_ION_PAIR = "MeanEnergyPerIonPair";
+
   static string indent = "";
+
+  template <typename O, typename C, typename F> void handleRefs(const O* o, const C& c, F pmf) {
+    for (typename C::const_iterator i = c.begin(); i != c.end(); ++i) {
+      //(o->*pmf)((*i)->GetName(), *i);
+      (o->*pmf)("", *i);
+    }
+  }
+
+  template <typename O, typename C, typename F> void handle(const O* o, const C& c, F pmf) {
+    for (typename C::const_iterator i = c.begin(); i != c.end(); ++i) {
+      (o->*pmf)((*i)->GetName(), *i);
+    }
+  }
+
+  template <typename O, typename F> void handleArray(const O* o, const TObjArray* c, F pmf) {
+    TObjArrayIter arr(c);
+    for(TObject* i = arr.Next(); i; i=arr.Next())
+      (o->*pmf)(i);
+  }
+
+  template <typename O, typename C, typename F> void handleMap(const O* o, const C& c, F pmf) {
+    for (typename C::const_iterator i = c.begin(); i != c.end(); ++i)
+      (o->*pmf)((*i).first, (*i).second);
+  }
+
+  template <typename O, typename C, typename F> void handleRMap(const O* o, const C& c, F pmf) {
+    for (typename C::const_reverse_iterator i = c.rbegin(); i != c.rend(); ++i)  {
+      //cout << "Handle RMAP [ " << (*i).first << " ]" << endl;
+      handle(o, (*i).second, pmf);
+    }
+  }
+  template <typename O, typename C, typename F> void handleRMap_(const O* o, const C& c, F pmf) {
+    for (typename C::const_iterator i = c.begin(); i != c.end(); ++i)  {
+      const auto& cc = (*i).second;
+      for (const auto& j : cc)   {
+        (o->*pmf)(j);
+      }
+    }
+  }
 
   string make_NCName(const string& in)   {
     string res = detail::str_replace(in, "/", "_");
@@ -367,8 +405,8 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
                            material->GetTemperature(), material->GetPressure());
     }
 
-    string plugin_name;
-    double value;
+    string plugin_name { };
+    double value = 0e0;
     double ionisation_mee = -2e100;
     double ionisation_birks_constant = -2e100;
     double ionisation_ene_per_ion_pair = -2e100;
@@ -459,33 +497,33 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
       if ( nullptr != cptr )   {
         printout(INFO, name, "++ Ignore CONST property %s [%s]  --> Plugin.",
                  named->GetName(), named->GetTitle());
-	plugin_name = named->GetTitle();
+        plugin_name = named->GetTitle();
         continue;
       }
       cptr = ::strstr(named->GetName(), GEANT4_TAG_BIRKSCONSTANT);
       if ( nullptr != cptr )   {
-	err = kFALSE;
-	value = material->GetConstProperty(GEANT4_TAG_BIRKSCONSTANT,&err);
-	if ( err == kFALSE ) ionisation_birks_constant = value * (CLHEP::mm/CLHEP::MeV)/(units::mm/units::MeV);
+        err = kFALSE;
+        value = material->GetConstProperty(GEANT4_TAG_BIRKSCONSTANT,&err);
+        if ( err == kFALSE ) ionisation_birks_constant = value * (CLHEP::mm/CLHEP::MeV)/(units::mm/units::MeV);
         continue;
       }
       cptr = ::strstr(named->GetName(), GEANT4_TAG_MEE);
       if ( nullptr != cptr )   {
-	err = kFALSE;
-	value = material->GetConstProperty(GEANT4_TAG_MEE,&err);
-	if ( err == kFALSE ) ionisation_mee = value * (CLHEP::MeV/units::MeV);
+        err = kFALSE;
+        value = material->GetConstProperty(GEANT4_TAG_MEE, &err);
+        if ( err == kFALSE ) ionisation_mee = value * (CLHEP::MeV/units::MeV);
         continue;
       }
       cptr = ::strstr(named->GetName(), GEANT4_TAG_ENE_PER_ION_PAIR);
       if ( nullptr != cptr )   {
-	err = kFALSE;
-	value = material->GetConstProperty(GEANT4_TAG_ENE_PER_ION_PAIR,&err);
-	if ( err == kFALSE ) ionisation_ene_per_ion_pair = value * (CLHEP::MeV/units::MeV);
+        err = kFALSE;
+        value = material->GetConstProperty(GEANT4_TAG_ENE_PER_ION_PAIR,&err);
+        if ( err == kFALSE ) ionisation_ene_per_ion_pair = value * (CLHEP::MeV/units::MeV);
         continue;
       }
 
       err = kFALSE;
-      value = info.manager->GetProperty(named->GetTitle(),&err);
+      value = info.manager->GetProperty(named->GetTitle(), &err);
       if ( err != kFALSE )   {
         except(name,
                "++ FAILED to create G4 material %s [Cannot convert const property: %s]",
@@ -524,19 +562,19 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
     str << (*mat);
     if ( ionisation )   {
       if ( ionisation_birks_constant > 0e0 )   {
-	ionisation->SetBirksConstant(ionisation_birks_constant);
+        ionisation->SetBirksConstant(ionisation_birks_constant);
       }
       if ( ionisation_mee > -1e100 )   {
-	ionisation->SetMeanExcitationEnergy(ionisation_mee);
+        ionisation->SetMeanExcitationEnergy(ionisation_mee);
       }
       if ( ionisation_ene_per_ion_pair > 0e0 )   {
-	ionisation->SetMeanEnergyPerIonPair(ionisation_ene_per_ion_pair);
+        ionisation->SetMeanEnergyPerIonPair(ionisation_ene_per_ion_pair);
       }
       str << "          log(MEE): " << std::setprecision(4) << ionisation->GetLogMeanExcEnergy();
       if ( ionisation_birks_constant > 0e0 )
-	str << "  Birk's constant: " << std::setprecision(4) << ionisation->GetBirksConstant() << " [mm/MeV]";
+        str << "  Birk's constant: " << std::setprecision(4) << ionisation->GetBirksConstant() << " [mm/MeV]";
       if ( ionisation_ene_per_ion_pair > 0e0 )
-	str << "  Mean Energy Per Ion Pair: " << std::setprecision(4) << ionisation->GetMeanEnergyPerIonPair()/CLHEP::eV << " [eV]";
+        str << "  Mean Energy Per Ion Pair: " << std::setprecision(4) << ionisation->GetMeanEnergyPerIonPair()/CLHEP::eV << " [eV]";
     }
     else  {
       str << "          No ionisation parameters availible.";
@@ -548,7 +586,7 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
       Detector* det = const_cast<Detector*>(&m_detDesc);
       G4Material* extended_mat = PluginService::Create<G4Material*>(plugin_name, det, medium, mat);
       if ( !extended_mat )   {
-	except("G4Cnv::material["+name+"]","++ FATAL Failed to call plugin to create material.");
+        except("G4Cnv::material["+name+"]","++ FATAL Failed to call plugin to create material.");
       }
       mat = extended_mat;
     }
@@ -620,7 +658,7 @@ void* Geant4Converter::handleSolid(const string& name, const TGeoShape* shape) c
       TGeoScaledShape* sh   = (TGeoScaledShape*) shape;
       TGeoShape*       sol  = sh->GetShape();
       if ( sol->IsA() == TGeoShapeAssembly::Class() )  {
-	return solid;
+        return solid;
       }
       const double*    vals = sh->GetScale()->GetScale();
       G4Scale3D        scal(vals[0], vals[1], vals[2]);
@@ -674,7 +712,7 @@ void* Geant4Converter::handleSolid(const string& name, const TGeoShape* shape) c
 
       if ( matrix->IsRotation() ) {
         G4Transform3D transform;
-	g4Transform(matrix, transform);
+        g4Transform(matrix, transform);
         if (oper == TGeoBoolNode::kGeoSubtraction)
           solid = new G4SubtractionSolid(name, left, right, transform);
         else if (oper == TGeoBoolNode::kGeoUnion)
@@ -756,7 +794,7 @@ void* Geant4Converter::handleVolume(const string& name, const TGeoVolume* volume
       string plugin = _v.getProperty(GEANT4_TAG_PLUGIN,"");
       g4vol = PluginService::Create<G4LogicalVolume*>(plugin, det, _v, g4solid, g4medium);
       if ( !g4vol )    {
-	except("G4Cnv::volume["+name+"]","++ FATAL Failed to call plugin to create logical volume.");
+        except("G4Cnv::volume["+name+"]","++ FATAL Failed to call plugin to create logical volume.");
       }
     }
     else  {
@@ -769,30 +807,30 @@ void* Geant4Converter::handleVolume(const string& name, const TGeoVolume* volume
     if ( g4region )   {
       PrintLevel plevel = (debugVolumes||debugRegions||debugLimits) ? ALWAYS : outputLevel;
       printout(plevel, "Geant4Converter", "++ Volume     + Apply REGION settings: %-24s to volume %s.",
-	       reg.name(), vnam);
+               reg.name(), vnam);
       // Handle the region settings for the world volume seperately.
       // Geant4 does NOT WANT any regions assigned to the workd volume.
       // The world's region is created in the G4RunManagerKernel!
       if ( _v == m_detDesc.worldVolume() )   {
-	const char* wrd_nam = "DefaultRegionForTheWorld";
-	const char* src_nam = g4region->GetName().c_str();
-	auto* world_region  = G4RegionStore::GetInstance()->GetRegion(wrd_nam, false);
-	if ( auto* cuts = g4region->GetProductionCuts() )   {
-	  world_region->SetProductionCuts(cuts);
-	  printout(plevel, "Geant4Converter",
-		   "++ Volume %s Region: %s. Apply production cuts from %s", 
-		   vnam, wrd_nam, src_nam);
-	}
-	if ( auto* lims = g4region->GetUserLimits() )   {
-	  world_region->SetUserLimits(lims);
-	  printout(plevel, "Geant4Converter",
-		   "++ Volume %s Region: %s. Apply user limits from %s", 
-		   vnam, wrd_nam, src_nam);
-	}
+        const char* wrd_nam = "DefaultRegionForTheWorld";
+        const char* src_nam = g4region->GetName().c_str();
+        auto* world_region  = G4RegionStore::GetInstance()->GetRegion(wrd_nam, false);
+        if ( auto* cuts = g4region->GetProductionCuts() )   {
+          world_region->SetProductionCuts(cuts);
+          printout(plevel, "Geant4Converter",
+                   "++ Volume %s Region: %s. Apply production cuts from %s", 
+                   vnam, wrd_nam, src_nam);
+        }
+        if ( auto* lims = g4region->GetUserLimits() )   {
+          world_region->SetUserLimits(lims);
+          printout(plevel, "Geant4Converter",
+                   "++ Volume %s Region: %s. Apply user limits from %s", 
+                   vnam, wrd_nam, src_nam);
+        }
       }
       else   {
-	g4vol->SetRegion(g4region);
-	g4region->AddRootLogicalVolume(g4vol);
+        g4vol->SetRegion(g4region);
+        g4region->AddRootLogicalVolume(g4vol);
       }
     }
     G4VisAttributes* g4vattr = vis.isValid()
@@ -802,7 +840,7 @@ void* Geant4Converter::handleVolume(const string& name, const TGeoVolume* volume
     }
     info.g4Volumes[volume] = g4vol;
     printout(lvl, "Geant4Converter",
-	     "++ Volume     + %s converted: %p ---> G4: %p", vnam, volume, g4vol);
+             "++ Volume     + %s converted: %p ---> G4: %p", vnam, volume, g4vol);
   }
   return nullptr;
 }
@@ -979,69 +1017,69 @@ void* Geant4Converter::handlePlacement(const string& name, const TGeoNode* node)
       G4PhysicalVolumesPair pvPlaced  { nullptr, nullptr };
 
       if ( pv_data && pv_data->params && (pv_data->params->flags&Volume::REPLICATED) )   {
-	EAxis  axis = kUndefined;
-	double width = 0e0, offset = 0e0;
-	auto flags = pv_data->params->flags;
-	auto count = pv_data->params->trafo1D.second;
-	auto start = pv_data->params->start.Translation().Vect();
-	auto delta = pv_data->params->trafo1D.first.Translation().Vect();
+        EAxis  axis = kUndefined;
+        double width = 0e0, offset = 0e0;
+        auto flags = pv_data->params->flags;
+        auto count = pv_data->params->trafo1D.second;
+        auto start = pv_data->params->start.Translation().Vect();
+        auto delta = pv_data->params->trafo1D.first.Translation().Vect();
 
-	if ( flags&Volume::X_axis )
-	  { axis = kXAxis; width = delta.X(); offset = start.X(); }
-	else if ( flags&Volume::Y_axis )
-	  { axis = kYAxis; width = delta.Y(); offset = start.Y(); }
-	else if ( flags&Volume::Z_axis )
-	  { axis = kZAxis; width = delta.Z(); offset = start.Z(); }
-	else
-	  except("Geant4Converter",
-		 "++ Replication around unknown axis is not implemented. flags: %16X", flags);
-	printout(INFO,"Geant4Converter","++ Replicate: Axis: %ld Count: %ld offset: %f width: %f",
-		 axis, count, offset, width);
-	auto* g4pv = new G4PVReplica(name,      // its name
-				     g4vol,     // its logical volume
-				     g4mot,     // its mother (logical) volume
-				     axis,      // its replication axis
-				     count,     // Number of replicas
-				     width,     // Distance between 2 replicas
-				     offset);   // Placement offset in axis direction
-	pvPlaced = { g4pv, nullptr };
+        if ( flags&Volume::X_axis )
+        { axis = kXAxis; width = delta.X(); offset = start.X(); }
+        else if ( flags&Volume::Y_axis )
+        { axis = kYAxis; width = delta.Y(); offset = start.Y(); }
+        else if ( flags&Volume::Z_axis )
+        { axis = kZAxis; width = delta.Z(); offset = start.Z(); }
+        else
+          except("Geant4Converter",
+                 "++ Replication around unknown axis is not implemented. flags: %16X", flags);
+        printout(INFO,"Geant4Converter","++ Replicate: Axis: %ld Count: %ld offset: %f width: %f",
+                 axis, count, offset, width);
+        auto* g4pv = new G4PVReplica(name,      // its name
+                                     g4vol,     // its logical volume
+                                     g4mot,     // its mother (logical) volume
+                                     axis,      // its replication axis
+                                     count,     // Number of replicas
+                                     width,     // Distance between 2 replicas
+                                     offset);   // Placement offset in axis direction
+        pvPlaced = { g4pv, nullptr };
 #if 0
-	pvPlaced =
-	  G4ReflectionFactory::Instance()->Replicate(name,      // its name
-						     g4vol,     // its logical volume
-						     g4mot,     // its mother (logical) volume
-						     axis,      // its replication axis
-						     count,     // Number of replicas
-						     width,     // Distance between 2 replicas
-						     offset);   // Placement offset in axis direction
-	/// Update replica list to avoid additional conversions...
-	auto* g4pv = pvPlaced.second ? pvPlaced.second : pvPlaced.first;
+        pvPlaced =
+          G4ReflectionFactory::Instance()->Replicate(name,      // its name
+                                                     g4vol,     // its logical volume
+                                                     g4mot,     // its mother (logical) volume
+                                                     axis,      // its replication axis
+                                                     count,     // Number of replicas
+                                                     width,     // Distance between 2 replicas
+                                                     offset);   // Placement offset in axis direction
+        /// Update replica list to avoid additional conversions...
+        auto* g4pv = pvPlaced.second ? pvPlaced.second : pvPlaced.first;
 #endif
-	for( auto& handle : pv_data->params->placements )
-	  info.g4Placements[handle.ptr()] = g4pv;
+        for( auto& handle : pv_data->params->placements )
+          info.g4Placements[handle.ptr()] = g4pv;
       }
       else if ( pv_data && pv_data->params )   {
-	auto*  g4par = new Geant4PlacementParameterisation(pv);
-	auto*  g4pv  = new G4PVParameterised(name,              // its name
-					     g4vol,             // its logical volume
-					     g4mot,             // its mother (logical) volume
-					     g4par->axis(),     // its replication axis
-					     g4par->count(),    // Number of replicas
-					     g4par);            // G4 parametrization
-	pvPlaced = { g4pv, nullptr };
-	/// Update replica list to avoid additional conversions...
-	for( auto& handle : pv_data->params->placements )
-	  info.g4Placements[handle.ptr()] = g4pv;
+        auto*  g4par = new Geant4PlacementParameterisation(pv);
+        auto*  g4pv  = new G4PVParameterised(name,              // its name
+                                             g4vol,             // its logical volume
+                                             g4mot,             // its mother (logical) volume
+                                             g4par->axis(),     // its replication axis
+                                             g4par->count(),    // Number of replicas
+                                             g4par);            // G4 parametrization
+        pvPlaced = { g4pv, nullptr };
+        /// Update replica list to avoid additional conversions...
+        for( auto& handle : pv_data->params->placements )
+          info.g4Placements[handle.ptr()] = g4pv;
       }
       else    {
-	pvPlaced =
-	  G4ReflectionFactory::Instance()->Place(transform,     // no rotation
-						 name,          // its name
-						 g4vol,         // its logical volume
-						 g4mot,         // its mother (logical) volume
-						 false,         // no boolean operations
-						 copy,          // its copy number
-						 checkOverlaps);
+        pvPlaced =
+          G4ReflectionFactory::Instance()->Place(transform,     // no rotation
+                                                 name,          // its name
+                                                 g4vol,         // its logical volume
+                                                 g4mot,         // its mother (logical) volume
+                                                 false,         // no boolean operations
+                                                 copy,          // its copy number
+                                                 checkOverlaps);
       }
       printout(debugReflections||debugPlacements ? ALWAYS : lvl, "Geant4Converter",
                "++ Place %svolume %-12s in mother %-12s "
@@ -1096,47 +1134,47 @@ void* Geant4Converter::handleRegion(Region region, const set<const TGeoVolume*>&
       cuts = new G4ProductionCuts();
       cuts->SetProductionCut(r.cut()*CLHEP::mm/units::mm);
       printout(lvl, "Geant4Converter", "++ %s: Using default cut: %f [mm]",
-	       r.name(), r.cut()*CLHEP::mm/units::mm);
+               r.name(), r.cut()*CLHEP::mm/units::mm);
     }
     for( const auto& nam : limits )  {
       LimitSet ls = m_detDesc.limitSet(nam);
       if ( ls.isValid() ) {
-	const LimitSet::Set& cts = ls.cuts();
-	for (const auto& c : cts )   {
-	  int pid = 0;
-	  if ( c.particles == "*" ) pid = -1;
-	  else if ( c.particles == "e-"     ) pid = idxG4ElectronCut;
-	  else if ( c.particles == "e+"     ) pid = idxG4PositronCut;
-	  else if ( c.particles == "e[+-]"  ) pid = -idxG4PositronCut-idxG4ElectronCut;
-	  else if ( c.particles == "e[-+]"  ) pid = -idxG4PositronCut-idxG4ElectronCut;
-	  else if ( c.particles == "gamma"  ) pid = idxG4GammaCut;
-	  else if ( c.particles == "proton" ) pid = idxG4ProtonCut;
-	  else throw runtime_error("G4Region: Invalid production cut particle-type:" + c.particles);
-	  if ( !cuts ) cuts = new G4ProductionCuts();
-	  if ( pid == -(idxG4PositronCut+idxG4ElectronCut) )  {
-	    cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, idxG4PositronCut);
-	    cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, idxG4ElectronCut);
-	  }
-	  else  {
-	    cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, pid);
-	  }
-	  printout(lvl, "Geant4Converter", "++ %s: Set cut  [%s/%d] = %f [mm]",
-		   r.name(), c.particles.c_str(), pid, c.value*CLHEP::mm/units::mm);
-	}
-	bool found = false;
-	const auto& lm = data().g4Limits;
-	for (const auto& j : lm )   {
-	  if (nam == j.first->GetName()) {
-	    g4->SetUserLimits(j.second);
-	    printout(lvl, "Geant4Converter", "++ %s: Set limits %s to region type %s",
-		     r.name(), nam.c_str(), j.second->GetType().c_str());
-	    found = true;
-	    break;
-	  }
-	}
-	if ( found )   {
-	  continue;
-	}
+        const LimitSet::Set& cts = ls.cuts();
+        for (const auto& c : cts )   {
+          int pid = 0;
+          if ( c.particles == "*" ) pid = -1;
+          else if ( c.particles == "e-"     ) pid = idxG4ElectronCut;
+          else if ( c.particles == "e+"     ) pid = idxG4PositronCut;
+          else if ( c.particles == "e[+-]"  ) pid = -idxG4PositronCut-idxG4ElectronCut;
+          else if ( c.particles == "e[-+]"  ) pid = -idxG4PositronCut-idxG4ElectronCut;
+          else if ( c.particles == "gamma"  ) pid = idxG4GammaCut;
+          else if ( c.particles == "proton" ) pid = idxG4ProtonCut;
+          else throw runtime_error("G4Region: Invalid production cut particle-type:" + c.particles);
+          if ( !cuts ) cuts = new G4ProductionCuts();
+          if ( pid == -(idxG4PositronCut+idxG4ElectronCut) )  {
+            cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, idxG4PositronCut);
+            cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, idxG4ElectronCut);
+          }
+          else  {
+            cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, pid);
+          }
+          printout(lvl, "Geant4Converter", "++ %s: Set cut  [%s/%d] = %f [mm]",
+                   r.name(), c.particles.c_str(), pid, c.value*CLHEP::mm/units::mm);
+        }
+        bool found = false;
+        const auto& lm = data().g4Limits;
+        for (const auto& j : lm )   {
+          if (nam == j.first->GetName()) {
+            g4->SetUserLimits(j.second);
+            printout(lvl, "Geant4Converter", "++ %s: Set limits %s to region type %s",
+                     r.name(), nam.c_str(), j.second->GetType().c_str());
+            found = true;
+            break;
+          }
+        }
+        if ( found )   {
+          continue;
+        }
       }
       except("Geant4Converter", "++ G4Region: Failed to resolve limitset: " + nam);
     }
@@ -1166,7 +1204,7 @@ void* Geant4Converter::handleLimitSet(LimitSet limitset, const set<const TGeoVol
         else if ( h.defaultValue > std::numeric_limits<double>::epsilon() )  {
           printout(ALWAYS,"Geant4Converter",
                    "+++ LimitSet: Implicit Limit %s.%s for wildcard particles: %f",
-		   ls.name(), pref.c_str(), float(h.defaultValue));
+                   ls.name(), pref.c_str(), float(h.defaultValue));
         }
         return *this;
       }
@@ -1175,7 +1213,7 @@ void* Geant4Converter::handleLimitSet(LimitSet limitset, const set<const TGeoVol
     g4 = limits;
     printout(lvl, "Geant4Converter",
              "++ Successfully converted LimitSet: %s [%ld cuts, %ld limits]",
-	     limitset.name(), limitset.cuts().size(), limitset.limits().size());
+             limitset.name(), limitset.cuts().size(), limitset.limits().size());
     if ( debugRegions || debugLimits )    {
       LimitPrint print(limitset);
       print("maxTime",    limits->maxTime)
@@ -1385,11 +1423,12 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
     G4OpticalSurfaceModel  model  = geant4_surface_model(optSurf->GetModel());
     G4OpticalSurfaceFinish finish = geant4_surface_finish(optSurf->GetFinish());
     string name = make_NCName(optSurf->GetName());
+    PrintLevel lvl = debugSurfaces ? ALWAYS : DEBUG;
     g4 = new G4OpticalSurface(name, model, finish, type, optSurf->GetValue());
     g4->SetSigmaAlpha(optSurf->GetSigmaAlpha());
     g4->SetPolish(optSurf->GetPolish());
 
-    printout(debugSurfaces ? ALWAYS : DEBUG, "Geant4Converter",
+    printout(lvl, "Geant4Converter",
              "++ Created OpticalSurface: %-18s type:%s model:%s finish:%s SigmaAlphs: %.3e Polish: %.3e",
              optSurf->GetName(),
              TGeoOpticalSurface::TypeToString(optSurf->GetType()),
@@ -1398,8 +1437,8 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
              optSurf->GetSigmaAlpha(), optSurf->GetPolish());
 
     G4MaterialPropertiesTable* tab = nullptr;
-    TListIter it(&optSurf->GetProperties());
-    for(TObject* obj = it.Next(); obj; obj = it.Next())  {
+    TListIter itp(&optSurf->GetProperties());
+    for(TObject* obj = itp.Next(); obj; obj = itp.Next())  {
       string exc_str;
       TNamed*      named  = (TNamed*)obj;
       TGDMLMatrix* matrix = info.manager->GetGDMLMatrix(named->GetTitle());
@@ -1424,10 +1463,8 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
       }
       catch(const std::exception& e)   {
         exc_str = e.what();
-        idx = -1;
       }
       catch(...)   {
-        idx = -1;
       }
       if ( idx < 0 )   {
         printout(ERROR, "Geant4Converter",
@@ -1443,13 +1480,61 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
       G4MaterialPropertyVector* vec = new G4MaterialPropertyVector(&bins[0], &vals[0], bins.size());
       tab->AddProperty(named->GetName(), vec);
       
-      printout(debugSurfaces ? ALWAYS : DEBUG, "Geant4Converter",
+      printout(lvl, "Geant4Converter",
                "++       Property: %-20s [%ld x %ld] -->  %s",
                named->GetName(), matrix->GetRows(), matrix->GetCols(), named->GetTitle());
       for(std::size_t i=0, count=v->bins.size(); i<count; ++i)
-        printout(debugSurfaces ? ALWAYS : DEBUG, named->GetName(),
+        printout(lvl, named->GetName(),
                  "  Geant4: %8.3g [MeV]  TGeo: %8.3g [GeV] Conversion: %8.3g",
                  bins[i], v->bins[i], conv.first);
+    }
+    TListIter itc(&optSurf->GetConstProperties());
+    for(TObject* obj = itc.Next(); obj; obj = itc.Next())  {
+      string  exc_str;
+      TNamed* named  = (TNamed*)obj;
+      const char* cptr = ::strstr(named->GetName(), GEANT4_TAG_IGNORE);
+      if ( nullptr != cptr )   {
+        printout(INFO, name, "++ Ignore CONST property %s [%s].",
+                 named->GetName(), named->GetTitle());
+        continue;
+      }
+      cptr = ::strstr(named->GetTitle(), GEANT4_TAG_IGNORE);
+      if ( nullptr != cptr )   {
+        printout(INFO, name,"++ Ignore CONST property %s [%s].",
+                 named->GetName(), named->GetTitle());
+        continue;
+      }
+      Bool_t   err = kFALSE;
+      Double_t value = info.manager->GetProperty(named->GetTitle(),&err);
+      if ( err != kFALSE )   {
+        except(name,
+               "++ FAILED to create G4 material %s [Cannot convert const property: %s]",
+               optSurf->GetName(), named->GetName());
+      }
+      if ( nullptr == tab )  {
+        tab = new G4MaterialPropertiesTable();
+        g4->SetMaterialPropertiesTable(tab);
+      }
+      int idx = -1;
+      try   {
+        idx = tab->GetConstPropertyIndex(named->GetName());
+      }
+      catch(const std::exception& e)   {
+        exc_str = e.what();
+      }
+      catch(...)   {
+      }
+      if ( idx < 0 )   {
+        printout(ERROR, name,
+                 "++ UNKNOWN Geant4 CONST Property: %-20s %s [IGNORED]",
+                 exc_str.c_str(), named->GetName());
+        continue;
+      }
+      // We need to convert the property from TGeo units to Geant4 units
+      double conv = g4ConstPropertyConversion(idx);
+      printout(lvl, name, "++      CONST Property: %-20s %g * %g --> %g ",
+               named->GetName(), value, conv, value * conv);
+      tab->AddConstProperty(named->GetName(), value * conv);
     }
     info.g4OpticalSurfaces[optSurf] = g4;
   }
@@ -1564,47 +1649,6 @@ void* Geant4Converter::printPlacement(const string& name, const TGeoNode* node) 
   str << "                  |" << " SD:" << sd->GetName();
   printout(outputLevel, "G4Placement", str.str().c_str());
   return g4;
-}
-
-namespace  {
-  template <typename O, typename C, typename F> void handleRefs(const O* o, const C& c, F pmf) {
-    for (typename C::const_iterator i = c.begin(); i != c.end(); ++i) {
-      //(o->*pmf)((*i)->GetName(), *i);
-      (o->*pmf)("", *i);
-    }
-  }
-
-  template <typename O, typename C, typename F> void handle(const O* o, const C& c, F pmf) {
-    for (typename C::const_iterator i = c.begin(); i != c.end(); ++i) {
-      (o->*pmf)((*i)->GetName(), *i);
-    }
-  }
-
-  template <typename O, typename F> void handleArray(const O* o, const TObjArray* c, F pmf) {
-    TObjArrayIter arr(c);
-    for(TObject* i = arr.Next(); i; i=arr.Next())
-      (o->*pmf)(i);
-  }
-
-  template <typename O, typename C, typename F> void handleMap(const O* o, const C& c, F pmf) {
-    for (typename C::const_iterator i = c.begin(); i != c.end(); ++i)
-      (o->*pmf)((*i).first, (*i).second);
-  }
-
-  template <typename O, typename C, typename F> void handleRMap(const O* o, const C& c, F pmf) {
-    for (typename C::const_reverse_iterator i = c.rbegin(); i != c.rend(); ++i)  {
-      //cout << "Handle RMAP [ " << (*i).first << " ]" << endl;
-      handle(o, (*i).second, pmf);
-    }
-  }
-  template <typename O, typename C, typename F> void handleRMap_(const O* o, const C& c, F pmf) {
-    for (typename C::const_iterator i = c.begin(); i != c.end(); ++i)  {
-      const auto& cc = (*i).second;
-      for (const auto& j : cc)   {
-        (o->*pmf)(j);
-      }
-    }
-  }
 }
 
 /// Create geometry conversion

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -81,7 +81,6 @@
 namespace units = dd4hep;
 using namespace dd4hep::sim;
 using namespace dd4hep;
-using namespace std;
 
 namespace {
 
@@ -92,7 +91,7 @@ namespace {
   static constexpr const char* GEANT4_TAG_MEE              = "MeanExcitationEnergy";
   static constexpr const char* GEANT4_TAG_ENE_PER_ION_PAIR = "MeanEnergyPerIonPair";
 
-  static string indent = "";
+  static std::string indent = "";
 
   template <typename O, typename C, typename F> void handleRefs(const O* o, const C& c, F pmf) {
     for (typename C::const_iterator i = c.begin(); i != c.end(); ++i) {
@@ -120,7 +119,7 @@ namespace {
 
   template <typename O, typename C, typename F> void handleRMap(const O* o, const C& c, F pmf) {
     for (typename C::const_reverse_iterator i = c.rbegin(); i != c.rend(); ++i)  {
-      //cout << "Handle RMAP [ " << (*i).first << " ]" << endl;
+      //cout << "Handle RMAP [ " << (*i).first << " ]" << std::endl;
       handle(o, (*i).second, pmf);
     }
   }
@@ -133,8 +132,8 @@ namespace {
     }
   }
 
-  string make_NCName(const string& in)   {
-    string res = detail::str_replace(in, "/", "_");
+  std::string make_NCName(const std::string& in)   {
+    std::string res = detail::str_replace(in, "/", "_");
     res = detail::str_replace(res, "#", "_");
     return res;
   }
@@ -154,7 +153,7 @@ namespace {
   public:
     Region region;
     double threshold;
-    bool storeSecondaries;
+    bool   storeSecondaries;
     G4UserRegionInformation()
       : threshold(0.0), storeSecondaries(false) {
     }
@@ -166,40 +165,40 @@ namespace {
     }
   };
 
-  pair<double,double> g4PropertyConversion(int index)   {
+  std::pair<double,double> g4PropertyConversion(int index)   {
 #if G4VERSION_NUMBER >= 1040
     switch(index)  {
-    case kRINDEX:                         return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kREFLECTIVITY:                   return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kREALRINDEX:                     return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kIMAGINARYRINDEX:                return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kEFFICIENCY:                     return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kTRANSMITTANCE:                  return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kSPECULARLOBECONSTANT:           return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kSPECULARSPIKECONSTANT:          return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kBACKSCATTERCONSTANT:            return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kGROUPVEL:                       return make_pair(CLHEP::keV/units::keV, (CLHEP::m/CLHEP::s)/(units::m/units::s));  // meter/second
-    case kMIEHG:                          return make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);
-    case kRAYLEIGH:                       return make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);  // ??? says its a length
-    case kWLSCOMPONENT:                   return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kWLSABSLENGTH:                   return make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);
-    case kABSLENGTH:                      return make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);
+    case kRINDEX:                         return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kREFLECTIVITY:                   return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kREALRINDEX:                     return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kIMAGINARYRINDEX:                return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kEFFICIENCY:                     return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kTRANSMITTANCE:                  return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kSPECULARLOBECONSTANT:           return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kSPECULARSPIKECONSTANT:          return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kBACKSCATTERCONSTANT:            return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kGROUPVEL:                       return std::make_pair(CLHEP::keV/units::keV, (CLHEP::m/CLHEP::s)/(units::m/units::s));  // meter/second
+    case kMIEHG:                          return std::make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);
+    case kRAYLEIGH:                       return std::make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);  // ??? says its a length
+    case kWLSCOMPONENT:                   return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kWLSABSLENGTH:                   return std::make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);
+    case kABSLENGTH:                      return std::make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);
 #if G4VERSION_NUMBER >= 1100
-    case kWLSCOMPONENT2:                  return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kWLSABSLENGTH2:                  return make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);
-    case kSCINTILLATIONCOMPONENT1:        return make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
-    case kSCINTILLATIONCOMPONENT2:        return make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
-    case kSCINTILLATIONCOMPONENT3:        return make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
+    case kWLSCOMPONENT2:                  return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kWLSABSLENGTH2:                  return std::make_pair(CLHEP::keV/units::keV, CLHEP::m/units::m);
+    case kSCINTILLATIONCOMPONENT1:        return std::make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
+    case kSCINTILLATIONCOMPONENT2:        return std::make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
+    case kSCINTILLATIONCOMPONENT3:        return std::make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
 #else
-    case kFASTCOMPONENT:                  return make_pair(CLHEP::keV/units::keV, 1.0);
-    case kSLOWCOMPONENT:                  return make_pair(CLHEP::keV/units::keV, 1.0);
+    case kFASTCOMPONENT:                  return std::make_pair(CLHEP::keV/units::keV, 1.0);
+    case kSLOWCOMPONENT:                  return std::make_pair(CLHEP::keV/units::keV, 1.0);
 #endif
-    case kPROTONSCINTILLATIONYIELD:       return make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV); // Yields: 1/energy
-    case kDEUTERONSCINTILLATIONYIELD:     return make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
-    case kTRITONSCINTILLATIONYIELD:       return make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
-    case kALPHASCINTILLATIONYIELD:        return make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
-    case kIONSCINTILLATIONYIELD:          return make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
-    case kELECTRONSCINTILLATIONYIELD:     return make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
+    case kPROTONSCINTILLATIONYIELD:       return std::make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV); // Yields: 1/energy
+    case kDEUTERONSCINTILLATIONYIELD:     return std::make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
+    case kTRITONSCINTILLATIONYIELD:       return std::make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
+    case kALPHASCINTILLATIONYIELD:        return std::make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
+    case kIONSCINTILLATIONYIELD:          return std::make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
+    case kELECTRONSCINTILLATIONYIELD:     return std::make_pair(CLHEP::keV/units::keV, units::keV/CLHEP::keV);
     default:
       break;
     }
@@ -207,7 +206,7 @@ namespace {
 #else
     printout(FATAL,"Geant4Converter", "+++ Cannot convert material property with index: %d [Need Geant4 > 10.03]", index);
 #endif
-    return make_pair(0e0,0e0);
+    return std::make_pair(0e0,0e0);
   }
 
   double g4ConstPropertyConversion(int index)   {
@@ -306,7 +305,7 @@ Geant4Converter::~Geant4Converter() {
 }
 
 /// Handle the conversion of isotopes
-void* Geant4Converter::handleIsotope(const string& /* name */, const TGeoIsotope* iso) const {
+void* Geant4Converter::handleIsotope(const std::string& /* name */, const TGeoIsotope* iso) const {
   G4Isotope* g4i = data().g4Isotopes[iso];
   if ( !g4i )  {
     double a_conv = (CLHEP::g / CLHEP::mole);
@@ -320,7 +319,7 @@ void* Geant4Converter::handleIsotope(const string& /* name */, const TGeoIsotope
 }
 
 /// Handle the conversion of elements
-void* Geant4Converter::handleElement(const string& name, const Atom element) const {
+void* Geant4Converter::handleElement(const std::string& name, const Atom element) const {
   G4Element* g4e = data().g4Elements[element];
   if ( !g4e ) {
     PrintLevel lvl = debugElements ? ALWAYS : outputLevel;
@@ -339,8 +338,8 @@ void* Geant4Converter::handleElement(const string& name, const Atom element) con
       printout(lvl, "Geant4Converter", "++ Created G4 Isotope %s from data: Z=%d N=%d A=%.3f [g/mole]",
                element->GetName(), element->Z(), element->N(), element->A());
     }
-    stringstream str;
-    str << (*g4e) << endl;
+    std::stringstream str;
+    str << (*g4e) << std::endl;
     printout(lvl, "Geant4Converter", "++ Created G4 element %s", str.str().c_str());
     data().g4Elements[element] = g4e;
   }
@@ -348,7 +347,7 @@ void* Geant4Converter::handleElement(const string& name, const Atom element) con
 }
 
 /// Dump material in GDML format to output stream
-void* Geant4Converter::handleMaterial(const string& name, Material medium) const {
+void* Geant4Converter::handleMaterial(const std::string& name, Material medium) const {
   Geant4GeometryInfo& info = data();
   G4Material*         mat  = info.g4Materials[medium];
   if ( !mat )  {
@@ -405,18 +404,17 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
                            material->GetTemperature(), material->GetPressure());
     }
 
-    string plugin_name { };
+    std::string plugin_name { };
     double value = 0e0;
     double ionisation_mee = -2e100;
     double ionisation_birks_constant = -2e100;
     double ionisation_ene_per_ion_pair = -2e100;
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
     /// Attach the material properties if any
     G4MaterialPropertiesTable* tab = 0;
     TListIter propIt(&material->GetProperties());
     for(TObject* obj=propIt.Next(); obj; obj = propIt.Next())  {
-      string       exc_str;
+      std::string       exc_str;
       TNamed*      named  = (TNamed*)obj;
       TGDMLMatrix* matrix = info.manager->GetGDMLMatrix(named->GetTitle());
       const char*  cptr   = ::strstr(matrix->GetName(), GEANT4_TAG_IGNORE);
@@ -460,7 +458,7 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
       }
       // We need to convert the property from TGeo units to Geant4 units
       auto conv = g4PropertyConversion(idx);
-      vector<double> bins(v->bins), vals(v->values);
+      std::vector<double> bins(v->bins), vals(v->values);
       for(std::size_t i=0, count=bins.size(); i<count; ++i)
         bins[i] *= conv.first, vals[i] *= conv.second;
 
@@ -477,7 +475,7 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
     /// Attach the material properties if any
     TListIter cpropIt(&material->GetConstProperties());
     for(TObject* obj=cpropIt.Next(); obj; obj = cpropIt.Next())  {
-      string  exc_str;
+      std::string  exc_str;
       Bool_t     err = kFALSE;
       TNamed*  named = (TNamed*)obj;
 
@@ -555,10 +553,10 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
       printout(lvl, name, "++      CONST Property: %-20s %g ", named->GetName(), value);
       tab->AddConstProperty(named->GetName(), value * conv);
     }
-#endif
+    //
     // Set Birk's constant if it was supplied in the material table of the TGeoMaterial
     auto* ionisation = mat->GetIonisation();
-    stringstream str;
+    std::stringstream str;
     str << (*mat);
     if ( ionisation )   {
       if ( ionisation_birks_constant > 0e0 )   {
@@ -596,7 +594,7 @@ void* Geant4Converter::handleMaterial(const string& name, Material medium) const
 }
 
 /// Dump solid in GDML format to output stream
-void* Geant4Converter::handleSolid(const string& name, const TGeoShape* shape) const {
+void* Geant4Converter::handleSolid(const std::string& name, const TGeoShape* shape) const {
   G4VSolid* solid = nullptr;
   if ( shape ) {
     if ( nullptr != (solid = data().g4Solids[shape]) )   {
@@ -650,10 +648,8 @@ void* Geant4Converter::handleSolid(const string& name, const TGeoShape* shape) c
       solid = convertShape<TGeoArb8>(shape);
     else if (isa == TGeoPara::Class())
       solid = convertShape<TGeoPara>(shape);
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
     else if (isa == TGeoTessellated::Class()) 
       solid = convertShape<TGeoTessellated>(shape);
-#endif
     else if (isa == TGeoScaledShape::Class())  {
       TGeoScaledShape* sh   = (TGeoScaledShape*) shape;
       TGeoShape*       sol  = sh->GetShape();
@@ -743,7 +739,7 @@ void* Geant4Converter::handleSolid(const string& name, const TGeoShape* shape) c
 }
 
 /// Dump logical volume in GDML format to output stream
-void* Geant4Converter::handleVolume(const string& name, const TGeoVolume* volume) const {
+void* Geant4Converter::handleVolume(const std::string& name, const TGeoVolume* volume) const {
   Volume _v(volume);
   Geant4GeometryInfo& info = data();
   PrintLevel lvl = debugVolumes ? ALWAYS : outputLevel;
@@ -791,7 +787,7 @@ void* Geant4Converter::handleVolume(const string& name, const TGeoVolume* volume
     G4LogicalVolume* g4vol = nullptr;
     if ( _v.hasProperties() && !_v.getProperty(GEANT4_TAG_PLUGIN,"").empty() )   {
       Detector* det = const_cast<Detector*>(&m_detDesc); 
-      string plugin = _v.getProperty(GEANT4_TAG_PLUGIN,"");
+      std::string plugin = _v.getProperty(GEANT4_TAG_PLUGIN,"");
       g4vol = PluginService::Create<G4LogicalVolume*>(plugin, det, _v, g4solid, g4medium);
       if ( !g4vol )    {
         except("G4Cnv::volume["+name+"]","++ FATAL Failed to call plugin to create logical volume.");
@@ -846,7 +842,7 @@ void* Geant4Converter::handleVolume(const string& name, const TGeoVolume* volume
 }
 
 /// Dump logical volume in GDML format to output stream
-void* Geant4Converter::collectVolume(const string& /* name */, const TGeoVolume* volume) const {
+void* Geant4Converter::collectVolume(const std::string& /* name */, const TGeoVolume* volume) const {
   Geant4GeometryInfo& info = data();
   Volume              _v(volume);
   Region              reg = _v.region();
@@ -866,7 +862,7 @@ void* Geant4Converter::collectVolume(const string& /* name */, const TGeoVolume*
 }
 
 /// Dump volume placement in GDML format to output stream
-void* Geant4Converter::handleAssembly(const string& name, const TGeoNode* node) const {
+void* Geant4Converter::handleAssembly(const std::string& name, const TGeoNode* node) const {
   TGeoVolume* mot_vol = node->GetVolume();
   PrintLevel lvl = debugVolumes ? ALWAYS : outputLevel;
   if ( mot_vol->IsA() != TGeoVolumeAssembly::Class() )    {
@@ -939,7 +935,7 @@ void* Geant4Converter::handleAssembly(const string& name, const TGeoNode* node) 
 }
 
 /// Dump volume placement in GDML format to output stream
-void* Geant4Converter::handlePlacement(const string& name, const TGeoNode* node) const {
+void* Geant4Converter::handlePlacement(const std::string& name, const TGeoNode* node) const {
   Geant4GeometryInfo& info = data();
   PrintLevel lvl = debugPlacements ? ALWAYS : outputLevel;
   Geant4GeometryMaps::PlacementMap::const_iterator g4it = info.g4Placements.find(node);
@@ -1008,7 +1004,7 @@ void* Geant4Converter::handlePlacement(const string& name, const TGeoNode* node)
         return nullptr;
       }
       else if ( node != info.manager->GetTopNode() && volIt == info.g4Volumes.end() )  {
-        throw logic_error("Geant4Converter: Invalid mother volume found!");
+        throw std::logic_error("Geant4Converter: Invalid mother volume found!");
       }
       PlacedVolume pv(node);
       const auto*  pv_data = pv.data();
@@ -1108,7 +1104,7 @@ void* Geant4Converter::handlePlacement(const string& name, const TGeoNode* node)
 }
 
 /// Convert the geometry type region into the corresponding Geant4 object(s).
-void* Geant4Converter::handleRegion(Region region, const set<const TGeoVolume*>& /* volumes */) const {
+void* Geant4Converter::handleRegion(Region region, const std::set<const TGeoVolume*>& /* volumes */) const {
   G4Region* g4 = data().g4Regions[region];
   if ( !g4 ) {
     PrintLevel lvl = debugRegions ? ALWAYS : outputLevel;
@@ -1117,7 +1113,7 @@ void* Geant4Converter::handleRegion(Region region, const set<const TGeoVolume*>&
 
     // create region info with storeSecondaries flag
     if( not r.wasThresholdSet() and r.storeSecondaries() ) {
-      throw runtime_error("G4Region: StoreSecondaries is True, but no explicit threshold set:");
+      throw std::runtime_error("G4Region: StoreSecondaries is True, but no explicit threshold set:");
     }
     printout(lvl, "Geant4Converter", "++ Setting up region: %s", r.name());
     G4UserRegionInformation* info = new G4UserRegionInformation();
@@ -1127,7 +1123,7 @@ void* Geant4Converter::handleRegion(Region region, const set<const TGeoVolume*>&
     g4->SetUserInformation(info);
 
     printout(lvl, "Geant4Converter", "++ Converted region settings of:%s.", r.name());
-    vector < string > &limits = r.limits();
+    std::vector < std::string > &limits = r.limits();
     G4ProductionCuts* cuts = 0;
     // set production cut
     if( not r.useDefaultCut() ) {
@@ -1149,7 +1145,7 @@ void* Geant4Converter::handleRegion(Region region, const set<const TGeoVolume*>&
           else if ( c.particles == "e[-+]"  ) pid = -idxG4PositronCut-idxG4ElectronCut;
           else if ( c.particles == "gamma"  ) pid = idxG4GammaCut;
           else if ( c.particles == "proton" ) pid = idxG4ProtonCut;
-          else throw runtime_error("G4Region: Invalid production cut particle-type:" + c.particles);
+          else throw std::runtime_error("G4Region: Invalid production cut particle-type:" + c.particles);
           if ( !cuts ) cuts = new G4ProductionCuts();
           if ( pid == -(idxG4PositronCut+idxG4ElectronCut) )  {
             cuts->SetProductionCut(c.value*CLHEP::mm/units::mm, idxG4PositronCut);
@@ -1186,7 +1182,7 @@ void* Geant4Converter::handleRegion(Region region, const set<const TGeoVolume*>&
 }
 
 /// Convert the geometry type LimitSet into the corresponding Geant4 object(s).
-void* Geant4Converter::handleLimitSet(LimitSet limitset, const set<const TGeoVolume*>& /* volumes */) const {
+void* Geant4Converter::handleLimitSet(LimitSet limitset, const std::set<const TGeoVolume*>& /* volumes */) const {
   G4UserLimits* g4 = data().g4Limits[limitset];
   if ( !g4 ) {
     PrintLevel lvl = debugLimits || debugRegions ? ALWAYS : outputLevel;
@@ -1228,7 +1224,7 @@ void* Geant4Converter::handleLimitSet(LimitSet limitset, const set<const TGeoVol
 }
 
 /// Convert the geometry visualisation attributes to the corresponding Geant4 object(s).
-void* Geant4Converter::handleVis(const string& /* name */, VisAttr attr) const {
+void* Geant4Converter::handleVis(const std::string& /* name */, VisAttr attr) const {
   Geant4GeometryInfo& info = data();
   G4VisAttributes*    g4   = info.g4Vis[attr];
   if ( !g4 ) {
@@ -1255,35 +1251,34 @@ void* Geant4Converter::handleVis(const string& /* name */, VisAttr attr) const {
 
 /// Handle the geant 4 specific properties
 void Geant4Converter::handleProperties(Detector::Properties& prp) const {
-  map < string, string > processors;
+  std::map < std::string, std::string > processors;
   static int s_idd = 9999999;
   for( const auto& [nam, vals] : prp ) {
     if ( nam.substr(0, 6) == "geant4" ) {
       auto id_it = vals.find("id");
-      string id = (id_it == vals.end()) ? _toString(++s_idd,"%d") : (*id_it).second;
+      std::string id = (id_it == vals.end()) ? _toString(++s_idd,"%d") : (*id_it).second;
       processors.emplace(id, nam);
     }
   }
   for( const auto& p : processors ) {
     const GeoHandler* hdlr = this;
     const Detector::PropertyValues& vals = prp[p.second];
-    string type = vals.find("type")->second;
-    string tag  = type + "_Geant4_action";
+    std::string type = vals.find("type")->second;
+    std::string tag  = type + "_Geant4_action";
     Detector* det = const_cast<Detector*>(&m_detDesc);
     long      res = PluginService::Create<long>(tag, det, hdlr, &vals);
     if ( 0 == res ) {
-      throw runtime_error("Failed to locate plugin to interprete files of type"
-                          " \"" + tag + "\" - no factory:" + type);
+      throw std::runtime_error("Failed to locate plugin to interprete files of type"
+                               " \"" + tag + "\" - no factory:" + type);
     }
     res = *(long*)res;
     if ( res != 1 ) {
-      throw runtime_error("Failed to invoke the plugin " + tag + " of type " + type);
+      throw std::runtime_error("Failed to invoke the plugin " + tag + " of type " + type);
     }
     printout(outputLevel, "Geant4Converter", "+++++ Executed Successfully Geant4 setup module *%s*.", type.c_str());
   }
 }
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
 /// Convert the geometry type material into the corresponding Geant4 object(s).
 void* Geant4Converter::handleMaterialProperties(TObject* mtx) const    {
   Geant4GeometryInfo& info   = data();
@@ -1422,7 +1417,7 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
     G4SurfaceType          type   = geant4_surface_type(optSurf->GetType());
     G4OpticalSurfaceModel  model  = geant4_surface_model(optSurf->GetModel());
     G4OpticalSurfaceFinish finish = geant4_surface_finish(optSurf->GetFinish());
-    string name = make_NCName(optSurf->GetName());
+    std::string name = make_NCName(optSurf->GetName());
     PrintLevel lvl = debugSurfaces ? ALWAYS : DEBUG;
     g4 = new G4OpticalSurface(name, model, finish, type, optSurf->GetValue());
     g4->SetSigmaAlpha(optSurf->GetSigmaAlpha());
@@ -1440,7 +1435,7 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
     G4MaterialPropertiesTable* tab = nullptr;
     TListIter itp(&optSurf->GetProperties());
     for(TObject* obj = itp.Next(); obj; obj = itp.Next())  {
-      string exc_str;
+      std::string exc_str;
       TNamed*      named  = (TNamed*)obj;
       TGDMLMatrix* matrix = info.manager->GetGDMLMatrix(named->GetTitle());
       const char*  cptr   = ::strstr(matrix->GetName(), GEANT4_TAG_IGNORE);
@@ -1475,7 +1470,7 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
       }
       // We need to convert the property from TGeo units to Geant4 units
       auto conv = g4PropertyConversion(idx);
-      vector<double> bins(v->bins), vals(v->values);
+      std::vector<double> bins(v->bins), vals(v->values);
       for(std::size_t i=0, count=v->bins.size(); i<count; ++i)
         bins[i] *= conv.first, vals[i] *= conv.second;
       G4MaterialPropertyVector* vec = new G4MaterialPropertyVector(&bins[0], &vals[0], bins.size());
@@ -1494,7 +1489,7 @@ void* Geant4Converter::handleOpticalSurface(TObject* surface) const    {
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,31,1)
     TListIter itc(&optSurf->GetConstProperties());
     for(TObject* obj = itc.Next(); obj; obj = itc.Next())  {
-      string  exc_str;
+      std::string  exc_str;
       TNamed* named  = (TNamed*)obj;
       const char* cptr = ::strstr(named->GetName(), GEANT4_TAG_IGNORE);
       if ( nullptr != cptr )   {
@@ -1554,7 +1549,7 @@ void* Geant4Converter::handleSkinSurface(TObject* surface) const   {
   if ( !g4 ) {
     G4OpticalSurface* optSurf  = info.g4OpticalSurfaces[OpticalSurface(surf->GetSurface())];
     G4LogicalVolume*  v = info.g4Volumes[surf->GetVolume()];
-    string name = make_NCName(surf->GetName());
+    std::string name = make_NCName(surf->GetName());
     g4 = new G4LogicalSkinSurface(name, v, optSurf);
     printout(debugSurfaces ? ALWAYS : DEBUG, "Geant4Converter",
              "++ Created SkinSurface: %-18s  optical:%s",
@@ -1573,7 +1568,7 @@ void* Geant4Converter::handleBorderSurface(TObject* surface) const   {
     G4OpticalSurface*  optSurf = info.g4OpticalSurfaces[OpticalSurface(surf->GetSurface())];
     G4VPhysicalVolume* n1 = info.g4Placements[surf->GetNode1()];
     G4VPhysicalVolume* n2 = info.g4Placements[surf->GetNode2()];
-    string name = make_NCName(surf->GetName());
+    std::string name = make_NCName(surf->GetName());
     g4 = new G4LogicalBorderSurface(name, n1, n2, optSurf);
     printout(debugSurfaces ? ALWAYS : DEBUG, "Geant4Converter",
              "++ Created BorderSurface: %-18s  optical:%s",
@@ -1582,38 +1577,38 @@ void* Geant4Converter::handleBorderSurface(TObject* surface) const   {
   }
   return g4;
 }
-#endif
 
 /// Convert the geometry type SensitiveDetector into the corresponding Geant4 object(s).
-void Geant4Converter::printSensitive(SensitiveDetector sens_det, const set<const TGeoVolume*>& /* volumes */) const {
-  Geant4GeometryInfo&     info = data();
-  set<const TGeoVolume*>& volset = info.sensitives[sens_det];
-  SensitiveDetector       sd = sens_det;
-  stringstream str;
+void Geant4Converter::printSensitive(SensitiveDetector sens_det, const std::set<const TGeoVolume*>& /* volumes */) const {
+  Geant4GeometryInfo&          info = data();
+  std::set<const TGeoVolume*>& volset = info.sensitives[sens_det];
+  SensitiveDetector            sd = sens_det;
+  std::stringstream str;
 
   printout(INFO, "Geant4Converter", "++ SensitiveDetector: %-18s %-20s Hits:%-16s", sd.name(), ("[" + sd.type() + "]").c_str(),
            sd.hitsCollection().c_str());
-  str << "                    | " << "Cutoff:" << setw(6) << left << sd.energyCutoff() << setw(5) << right << volset.size()
+  str << "                    | " << "Cutoff:" << std::setw(6) << std::left
+      << sd.energyCutoff() << std::setw(5) << std::right << volset.size()
       << " volumes ";
   if (sd.region().isValid())
-    str << " Region:" << setw(12) << left << sd.region().name();
+    str << " Region:" << std::setw(12) << std::left << sd.region().name();
   if (sd.limits().isValid())
-    str << " Limits:" << setw(12) << left << sd.limits().name();
+    str << " Limits:" << std::setw(12) << std::left << sd.limits().name();
   str << ".";
   printout(INFO, "Geant4Converter", str.str().c_str());
 
   for (const auto i : volset )  {
-    map<Volume, G4LogicalVolume*>::iterator v = info.g4Volumes.find(i);
+    std::map<Volume, G4LogicalVolume*>::iterator v = info.g4Volumes.find(i);
     G4LogicalVolume* vol = (*v).second;
     str.str("");
-    str << "                                   | " << "Volume:" << setw(24) << left << vol->GetName() << " "
+    str << "                                   | " << "Volume:" << std::setw(24) << std::left << vol->GetName() << " "
         << vol->GetNoDaughters() << " daughters.";
     printout(INFO, "Geant4Converter", str.str().c_str());
   }
 }
 
-string printSolid(G4VSolid* sol) {
-  stringstream str;
+std::string printSolid(G4VSolid* sol) {
+  std::stringstream str;
   if (typeid(*sol) == typeid(G4Box)) {
     const G4Box* b = (G4Box*) sol;
     str << "++ Box: x=" << b->GetXHalfLength() << " y=" << b->GetYHalfLength() << " z=" << b->GetZHalfLength();
@@ -1627,7 +1622,7 @@ string printSolid(G4VSolid* sol) {
 }
 
 /// Print G4 placement
-void* Geant4Converter::printPlacement(const string& name, const TGeoNode* node) const {
+void* Geant4Converter::printPlacement(const std::string& name, const TGeoNode* node) const {
   Geant4GeometryInfo& info = data();
   G4VPhysicalVolume*  g4   = info.g4Placements[node];
   G4LogicalVolume*    vol  = info.g4Volumes[node->GetVolume()];
@@ -1638,7 +1633,7 @@ void* Geant4Converter::printPlacement(const string& name, const TGeoNode* node) 
   if ( !sd )  {
     return g4;
   }
-  stringstream str;
+  std::stringstream str;
   str << "G4Cnv::placement: + " << name << " No:" << node->GetNumber() << " Vol:" << vol->GetName() << " Solid:"
       << sol->GetName();
   printout(outputLevel, "G4Placement", str.str().c_str());
@@ -1667,10 +1662,8 @@ Geant4Converter& Geant4Converter::create(DetElement top) {
   // We do not have to handle defines etc.
   // All positions and the like are not really named.
   // Hence, start creating the G4 objects for materials, solids and log volumes.
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   handleArray(this, geo.manager->GetListOfGDMLMatrices(), &Geant4Converter::handleMaterialProperties);
   handleArray(this, geo.manager->GetListOfOpticalSurfaces(), &Geant4Converter::handleOpticalSurface);
-#endif
   
   handle(this,     geo.volumes, &Geant4Converter::collectVolume);
   handle(this,     geo.solids,  &Geant4Converter::handleSolid);
@@ -1686,11 +1679,9 @@ Geant4Converter& Geant4Converter::create(DetElement top) {
   handleRMap(this, *m_data,     &Geant4Converter::handleAssembly);
   // Now place all this stuff appropriately
   handleRMap(this, *m_data,     &Geant4Converter::handlePlacement);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   /// Handle concrete surfaces
   handleArray(this, geo.manager->GetListOfSkinSurfaces(),   &Geant4Converter::handleSkinSurface);
   handleArray(this, geo.manager->GetListOfBorderSurfaces(), &Geant4Converter::handleBorderSurface);
-#endif
   //==================== Fields
   handleProperties(m_detDesc.properties());
   if ( printSensitives )  {

--- a/DDG4/src/Geant4Data.cpp
+++ b/DDG4/src/Geant4Data.cpp
@@ -24,7 +24,6 @@
 #include <G4Allocator.hh>
 #include <G4OpticalPhoton.hh>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Default constructor

--- a/DDG4/src/Geant4Data.cpp
+++ b/DDG4/src/Geant4Data.cpp
@@ -24,7 +24,6 @@
 #include <G4Allocator.hh>
 #include <G4OpticalPhoton.hh>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::sim;
 

--- a/DDG4/src/Geant4DataConversion.cpp
+++ b/DDG4/src/Geant4DataConversion.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4DataConversion.h"
+#include <DDG4/Geant4DataConversion.h>
 
 using namespace dd4hep::sim;
 

--- a/DDG4/src/Geant4DataDump.cpp
+++ b/DDG4/src/Geant4DataDump.cpp
@@ -15,10 +15,8 @@
 #include <DD4hep/Primitives.h>
 #include <DDG4/Geant4DataDump.h>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
-
-typedef detail::ReferenceBitMask<const int> PropertyMask;
+using PropertyMask = dd4hep::detail::ReferenceBitMask<const int>;
 
 /// Default constructor
 Geant4DataDump::Geant4DataDump(const std::string& tag) : m_tag(tag) {

--- a/DDG4/src/Geant4DataDump.cpp
+++ b/DDG4/src/Geant4DataDump.cpp
@@ -12,10 +12,9 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Primitives.h"
-#include "DDG4/Geant4DataDump.h"
+#include <DD4hep/Primitives.h>
+#include <DDG4/Geant4DataDump.h>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::sim;
 

--- a/DDG4/src/Geant4DetectorConstruction.cpp
+++ b/DDG4/src/Geant4DetectorConstruction.cpp
@@ -20,8 +20,6 @@
 #include <G4VUserDetectorConstruction.hh>
 #include <G4SDManager.hh>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Helper: Assign sensitive detector to logical volume
@@ -81,7 +79,7 @@ void Geant4DetectorConstructionSequence::adopt(Geant4DetectorConstruction* actio
     m_actors.add(action);
     return;
   }
-  except("Geant4RunActionSequence","++ Attempt to add an invalid actor!");
+  except("++ Attempt to add an invalid actor!");
 }
 
 /// Access an actor by name
@@ -91,8 +89,8 @@ Geant4DetectorConstruction* Geant4DetectorConstructionSequence::get(const std::s
       return i;
     }
   }
-  except("Geant4RunActionSequence","++ Attempt to access invalid actor %s!",nam.c_str());
-  return 0;
+  except("++ Attempt to access invalid actor %s!",nam.c_str());
+  return nullptr;
 }
 
 /// Geometry construction callback. Called at "Construct()"
@@ -111,49 +109,47 @@ void Geant4DetectorConstructionSequence::constructSensitives(Geant4DetectorConst
 }
 
 /// Access to the converted regions
-const map<Region, G4Region*>& Geant4DetectorConstructionSequence::regions() const   {
+const std::map<dd4hep::Region, G4Region*>&
+Geant4DetectorConstructionSequence::regions() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Regions;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::regions: Access not possible. Geometry is not yet converted!");
 }
-#if 0
-/// Access to the converted sensitive detectors
-const Geant4GeometryMaps::SensDetMap& Geant4DetectorConstructionSequence::sensitives() const   {
-  Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
-  if ( p ) return p->g4SensDets;
-  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::sensitives: Access not possible. Geometry is not yet converted!");
-}
-#endif
+
 /// Access to the converted volumes
-const map<Volume, G4LogicalVolume*>& Geant4DetectorConstructionSequence::volumes() const   {
+const std::map<dd4hep::Volume, G4LogicalVolume*>&
+Geant4DetectorConstructionSequence::volumes() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Volumes;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::volumes: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted shapes
-const map<const TGeoShape*, G4VSolid*>& Geant4DetectorConstructionSequence::shapes() const   {
+const std::map<const TGeoShape*, G4VSolid*>& Geant4DetectorConstructionSequence::shapes() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Solids;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::shapes: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted limit sets
-const map<LimitSet, G4UserLimits*>& Geant4DetectorConstructionSequence::limits() const   {
+const std::map<dd4hep::LimitSet, G4UserLimits*>&
+Geant4DetectorConstructionSequence::limits() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Limits;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::limits: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted assemblies
-const map<PlacedVolume, Geant4AssemblyVolume*>& Geant4DetectorConstructionSequence::assemblies() const   {
+const std::map<dd4hep::PlacedVolume, Geant4AssemblyVolume*>&
+Geant4DetectorConstructionSequence::assemblies() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4AssemblyVolumes;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::assemblies: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted placements
-const map<PlacedVolume, G4VPhysicalVolume*>& Geant4DetectorConstructionSequence::placements() const   {
+const std::map<dd4hep::PlacedVolume, G4VPhysicalVolume*>&
+Geant4DetectorConstructionSequence::placements() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Placements;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::placements: Access not possible. Geometry is not yet converted!");

--- a/DDG4/src/Geant4DetectorConstruction.cpp
+++ b/DDG4/src/Geant4DetectorConstruction.cpp
@@ -12,13 +12,13 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Mapping.h"
-#include "DDG4/Geant4GeometryInfo.h"
-#include "DDG4/Geant4DetectorConstruction.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Mapping.h>
+#include <DDG4/Geant4GeometryInfo.h>
+#include <DDG4/Geant4DetectorConstruction.h>
 
-#include "G4VUserDetectorConstruction.hh"
-#include "G4SDManager.hh"
+#include <G4VUserDetectorConstruction.hh>
+#include <G4SDManager.hh>
 
 using namespace std;
 using namespace dd4hep;
@@ -114,63 +114,63 @@ void Geant4DetectorConstructionSequence::constructSensitives(Geant4DetectorConst
 const map<Region, G4Region*>& Geant4DetectorConstructionSequence::regions() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Regions;
-  throw runtime_error("+++ Geant4DetectorConstructionSequence::regions: Access not possible. Geometry is not yet converted!");
+  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::regions: Access not possible. Geometry is not yet converted!");
 }
 #if 0
 /// Access to the converted sensitive detectors
 const Geant4GeometryMaps::SensDetMap& Geant4DetectorConstructionSequence::sensitives() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4SensDets;
-  throw runtime_error("+++ Geant4DetectorConstructionSequence::sensitives: Access not possible. Geometry is not yet converted!");
+  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::sensitives: Access not possible. Geometry is not yet converted!");
 }
 #endif
 /// Access to the converted volumes
 const map<Volume, G4LogicalVolume*>& Geant4DetectorConstructionSequence::volumes() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Volumes;
-  throw runtime_error("+++ Geant4DetectorConstructionSequence::volumes: Access not possible. Geometry is not yet converted!");
+  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::volumes: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted shapes
 const map<const TGeoShape*, G4VSolid*>& Geant4DetectorConstructionSequence::shapes() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Solids;
-  throw runtime_error("+++ Geant4DetectorConstructionSequence::shapes: Access not possible. Geometry is not yet converted!");
+  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::shapes: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted limit sets
 const map<LimitSet, G4UserLimits*>& Geant4DetectorConstructionSequence::limits() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Limits;
-  throw runtime_error("+++ Geant4DetectorConstructionSequence::limits: Access not possible. Geometry is not yet converted!");
+  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::limits: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted assemblies
 const map<PlacedVolume, Geant4AssemblyVolume*>& Geant4DetectorConstructionSequence::assemblies() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4AssemblyVolumes;
-  throw runtime_error("+++ Geant4DetectorConstructionSequence::assemblies: Access not possible. Geometry is not yet converted!");
+  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::assemblies: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted placements
 const map<PlacedVolume, G4VPhysicalVolume*>& Geant4DetectorConstructionSequence::placements() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Placements;
-  throw runtime_error("+++ Geant4DetectorConstructionSequence::placements: Access not possible. Geometry is not yet converted!");
+  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::placements: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted materials
 const Geant4GeometryMaps::MaterialMap& Geant4DetectorConstructionSequence::materials() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Materials;
-  throw runtime_error("+++ Geant4DetectorConstructionSequence::materials: Access not possible. Geometry is not yet converted!");
+  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::materials: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted elements
 const Geant4GeometryMaps::ElementMap& Geant4DetectorConstructionSequence::elements() const   {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Elements;
-  throw runtime_error("+++ Geant4DetectorConstructionSequence::elements: Access not possible. Geometry is not yet converted!");
+  throw std::runtime_error("+++ Geant4DetectorConstructionSequence::elements: Access not possible. Geometry is not yet converted!");
 }
 
 

--- a/DDG4/src/Geant4EventAction.cpp
+++ b/DDG4/src/Geant4EventAction.cpp
@@ -14,13 +14,11 @@
 // Framework include files
 #include "DD4hep/InstanceCount.h"
 #include "DDG4/Geant4EventAction.h"
+
 // Geant4 headers
 #include "G4Threading.hh"
 #include "G4AutoLock.hh"
-// C/C++ include files
-#include <stdexcept>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 namespace {
@@ -28,7 +26,7 @@ namespace {
 }
 
 /// Standard constructor
-Geant4EventAction::Geant4EventAction(Geant4Context* ctxt, const string& nam)
+Geant4EventAction::Geant4EventAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) 
 {
   InstanceCount::increment(this);
@@ -48,7 +46,7 @@ void Geant4EventAction::end(const G4Event* ) {
 }
 
 /// Standard constructor
-Geant4SharedEventAction::Geant4SharedEventAction(Geant4Context* ctxt, const string& nam)
+Geant4SharedEventAction::Geant4SharedEventAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4EventAction(ctxt, nam)
 {
   InstanceCount::increment(this);
@@ -73,7 +71,7 @@ void Geant4SharedEventAction::use(Geant4EventAction* action)   {
     m_action = action;
     return;
   }
-  throw runtime_error("Geant4SharedEventAction: Attempt to use invalid actor!");
+  except("Geant4SharedEventAction: Attempt to use invalid actor!");
 }
 
 /// Begin-of-event callback
@@ -97,7 +95,7 @@ void Geant4SharedEventAction::end(const G4Event* event)   {
 }
 
 /// Standard constructor
-Geant4EventActionSequence::Geant4EventActionSequence(Geant4Context* ctxt, const string& nam)
+Geant4EventActionSequence::Geant4EventActionSequence(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   m_needsControl = true;
   InstanceCount::increment(this);
@@ -125,7 +123,7 @@ void Geant4EventActionSequence::configureFiber(Geant4Context* thread_context)   
 }
 
 /// Get an action by name
-Geant4EventAction* Geant4EventActionSequence::get(const string& nam) const   {
+Geant4EventAction* Geant4EventActionSequence::get(const std::string& nam) const   {
   return m_actors.get(FindByName(TypeName::split(nam).second));
 }
 
@@ -137,7 +135,7 @@ void Geant4EventActionSequence::adopt(Geant4EventAction* action) {
     m_actors.add(action);
     return;
   }
-  throw runtime_error("Geant4EventActionSequence: Attempt to add invalid actor!");
+  except("Geant4EventActionSequence: Attempt to add invalid actor!");
 }
 
 /// Pre-track action callback

--- a/DDG4/src/Geant4Exec.cpp
+++ b/DDG4/src/Geant4Exec.cpp
@@ -12,35 +12,35 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Handle.h"
-#include "DDG4/Geant4RunAction.h"
-#include "DDG4/Geant4EventAction.h"
-#include "DDG4/Geant4SteppingAction.h"
-#include "DDG4/Geant4TrackingAction.h"
-#include "DDG4/Geant4StackingAction.h"
-#include "DDG4/Geant4GeneratorAction.h"
-#include "DDG4/Geant4UserInitialization.h"
-#include "DDG4/Geant4DetectorConstruction.h"
-#include "DDG4/Geant4PhysicsList.h"
-#include "DDG4/Geant4UIManager.h"
-#include "DDG4/Geant4Kernel.h"
-#include "DDG4/Geant4Random.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Handle.h>
+#include <DDG4/Geant4RunAction.h>
+#include <DDG4/Geant4EventAction.h>
+#include <DDG4/Geant4SteppingAction.h>
+#include <DDG4/Geant4TrackingAction.h>
+#include <DDG4/Geant4StackingAction.h>
+#include <DDG4/Geant4GeneratorAction.h>
+#include <DDG4/Geant4UserInitialization.h>
+#include <DDG4/Geant4DetectorConstruction.h>
+#include <DDG4/Geant4PhysicsList.h>
+#include <DDG4/Geant4UIManager.h>
+#include <DDG4/Geant4Kernel.h>
+#include <DDG4/Geant4Random.h>
 
 // Geant4 include files
-#include "G4Version.hh"
-#include "G4UserRunAction.hh"
-#include "G4UserEventAction.hh"
-#include "G4UserTrackingAction.hh"
-#include "G4UserStackingAction.hh"
-#include "G4UserSteppingAction.hh"
-#include "G4VUserPhysicsList.hh"
-#include "G4VModularPhysicsList.hh"
-#include "G4VUserPrimaryGeneratorAction.hh"
-#include "G4VUserActionInitialization.hh"
-#include "G4VUserDetectorConstruction.hh"
+#include <G4Version.hh>
+#include <G4UserRunAction.hh>
+#include <G4UserEventAction.hh>
+#include <G4UserTrackingAction.hh>
+#include <G4UserStackingAction.hh>
+#include <G4UserSteppingAction.hh>
+#include <G4VUserPhysicsList.hh>
+#include <G4VModularPhysicsList.hh>
+#include <G4VUserPrimaryGeneratorAction.hh>
+#include <G4VUserActionInitialization.hh>
+#include <G4VUserDetectorConstruction.hh>
 
 // C/C++ include files
 #include <memory>
@@ -56,6 +56,8 @@ namespace dd4hep {
   /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
   namespace sim {
 
+    class Geant4DetectorConstructionSequence;
+    
     /// Sequence handler implementing common actions to all sequences.
     /** @class SequenceHdl
      *
@@ -489,38 +491,36 @@ namespace dd4hep {
         m_sequence->buildMaster();
       }
     }
+    
+    /// Compatibility actions for running Geant4 in single threaded mode
+    /** @class Geant4Compatibility
+     *
+     * @author  M.Frank
+     * @version 1.0
+     */
+    class Geant4Compatibility {
+    public:
+      /// Default constructor
+      Geant4Compatibility() = default;
+      /// Default destructor
+      virtual ~Geant4Compatibility() = default;
+      /// Detector construction invocation in compatibility mode
+      Geant4DetectorConstructionSequence* buildDefaultDetectorConstruction(Geant4Kernel& kernel);
+    };
+
   }
 }
 
-#include "DD4hep/Detector.h"
-#include "DD4hep/Plugins.h"
-#include "DDG4/Geant4DetectorConstruction.h"
-#include "DDG4/Geant4Kernel.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Plugins.h>
+#include <DDG4/Geant4DetectorConstruction.h>
+#include <DDG4/Geant4Kernel.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 // Geant4 include files
-#include "G4RunManager.hh"
-#include "G4PhysListFactory.hh"
-
-
-/// Compatibility actions for running Geant4 in single threaded mode
-/** @class Geant4Compatibility
- *
- * @author  M.Frank
- * @version 1.0
- */
-class Geant4Compatibility {
-public:
-  /// Default constructor
-  Geant4Compatibility() = default;
-  /// Default destructor
-  virtual ~Geant4Compatibility() = default;
-  /// Detector construction invocation in compatibility mode
-  Geant4DetectorConstructionSequence* buildDefaultDetectorConstruction(Geant4Kernel& kernel);
-};
+#include <G4RunManager.hh>
+#include <G4PhysListFactory.hh>
 
 /// Detector construction invocation in compatibility mode
 Geant4DetectorConstructionSequence* Geant4Compatibility::buildDefaultDetectorConstruction(Geant4Kernel& kernel)  {
@@ -531,19 +531,19 @@ Geant4DetectorConstructionSequence* Geant4Compatibility::buildDefaultDetectorCon
   printout(WARNING, "Geant4Exec", "+++ Building default Geant4DetectorConstruction for single threaded compatibility.");
 
   /// Attach first the geometry converter from dd4hep to Geant4
-  cr = PluginService::Create<Geant4Action*>("Geant4DetectorGeometryConstruction",ctx,string("ConstructGeometry"));
+  cr = PluginService::Create<Geant4Action*>("Geant4DetectorGeometryConstruction",ctx,std::string("ConstructGeometry"));
   det_cr = dynamic_cast<Geant4DetectorConstruction*>(cr);
   if ( det_cr ) 
     seq->adopt(det_cr);
   else
-    throw runtime_error("Panic! Failed to build Geant4DetectorGeometryConstruction.");
+    throw std::runtime_error("Panic! Failed to build Geant4DetectorGeometryConstruction.");
   /// Attach the sensitive detector manipulator:
-  cr = PluginService::Create<Geant4Action*>("Geant4DetectorSensitivesConstruction",ctx,string("ConstructSensitives"));
+  cr = PluginService::Create<Geant4Action*>("Geant4DetectorSensitivesConstruction",ctx,std::string("ConstructSensitives"));
   det_cr = dynamic_cast<Geant4DetectorConstruction*>(cr);
   if ( det_cr )
     seq->adopt(det_cr);
   else
-    throw runtime_error("Panic! Failed to build Geant4DetectorSensitivesConstruction.");
+    throw std::runtime_error("Panic! Failed to build Geant4DetectorSensitivesConstruction.");
   return seq;
 }
 
@@ -574,7 +574,7 @@ int Geant4Exec::configure(Geant4Kernel& kernel) {
   /// Get the detector constructed
   Geant4DetectorConstructionSequence* user_det = kernel.detectorConstruction(false);
   if ( nullptr == user_det && kernel.isMultiThreaded() )   {
-    throw runtime_error("Panic! No valid detector construction sequencer present. [Mandatory MT]");
+    throw std::runtime_error("Panic! No valid detector construction sequencer present. [Mandatory MT]");
   }
   if ( nullptr == user_det && !kernel.isMultiThreaded() )   {
     user_det = Geant4Compatibility().buildDefaultDetectorConstruction(kernel);
@@ -585,13 +585,13 @@ int Geant4Exec::configure(Geant4Kernel& kernel) {
   /// Get the physics list constructed
   Geant4PhysicsListActionSequence* phys_seq = kernel.physicsList(false);
   if ( nullptr == phys_seq )   {
-    string phys_model = "QGSP_BERT";
+    std::string phys_model = "QGSP_BERT";
     phys_seq = kernel.physicsList(true);
     phys_seq->property("extends").set(phys_model);
   }
   G4VUserPhysicsList* physics = phys_seq->extensionList();
   if (nullptr == physics) {
-    throw runtime_error("Panic! No valid user physics list present!");
+    throw std::runtime_error("Panic! No valid user physics list present!");
   }
 #if 0
   /// Not here: Use seperate object to do this!
@@ -606,7 +606,7 @@ int Geant4Exec::configure(Geant4Kernel& kernel) {
   /// Construct the remaining user initialization in multi-threaded mode
   Geant4UserInitializationSequence* user_init = kernel.userInitialization(false);
   if ( nullptr == user_init && kernel.isMultiThreaded() )   {
-    throw runtime_error("Panic! No valid user initialization sequencer present. [Mandatory MT]");
+    throw std::runtime_error("Panic! No valid user initialization sequencer present. [Mandatory MT]");
   }
   else if ( nullptr == user_init && !kernel.isMultiThreaded() )  {
     /// Use default actions registered to the default kernel. Will do the right thing...
@@ -632,7 +632,7 @@ int Geant4Exec::initialize(Geant4Kernel& kernel) {
 /// Run the simulation
 int Geant4Exec::run(Geant4Kernel& kernel) {
   Property& p = kernel.property("UI");
-  string value = p.value<string>();
+  std::string value = p.value<std::string>();
 
   kernel.executePhase("start",0);
   if ( !value.empty() )  {
@@ -646,7 +646,7 @@ int Geant4Exec::run(Geant4Kernel& kernel) {
       }
       ui->except("++ Geant4Exec: Failed to start UI interface.");
     }
-    throw runtime_error(format("Geant4Exec","++ Failed to locate UI interface %s.",value.c_str()));
+    throw std::runtime_error(format("Geant4Exec","++ Failed to locate UI interface %s.",value.c_str()));
   }
   long nevt = kernel.property("NumEvents").value<long>();
   kernel.runManager().BeamOn(nevt);

--- a/DDG4/src/Geant4FastSimShowerModel.cpp
+++ b/DDG4/src/Geant4FastSimShowerModel.cpp
@@ -26,7 +26,6 @@
 // C/C++ include files
 #include <sstream>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Namespace for the AIDA detector description toolkit

--- a/DDG4/src/Geant4GDMLDetector.cpp
+++ b/DDG4/src/Geant4GDMLDetector.cpp
@@ -12,7 +12,7 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4GDMLDetector.h"
+#include <DDG4/Geant4GDMLDetector.h>
 
 // C/C++ include files
 #include <iostream>
@@ -22,9 +22,6 @@
 #ifdef GEANT4_HAS_GDML
 #include "G4GDMLParser.hh"
 #endif
-
-using namespace std;
-using namespace dd4hep;
 
 dd4hep::sim::Geant4GDMLDetector::Geant4GDMLDetector(const std::string& gdmlFile)
   : m_fileName(gdmlFile), m_world(0) {

--- a/DDG4/src/Geant4GeneratorAction.cpp
+++ b/DDG4/src/Geant4GeneratorAction.cpp
@@ -12,16 +12,14 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4GeneratorAction.h"
-#include "DDG4/Geant4Kernel.h"
-// Geant4 headers
-#include "G4Threading.hh"
-#include "G4AutoLock.hh"
-// C/C++ include files
-#include <stdexcept>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4GeneratorAction.h>
+#include <DDG4/Geant4Kernel.h>
 
-using namespace std;
+// Geant4 headers
+#include <G4Threading.hh>
+#include <G4AutoLock.hh>
+
 using namespace dd4hep::sim;
 
 namespace {
@@ -29,7 +27,7 @@ namespace {
 }
 
 /// Standard constructor
-Geant4GeneratorAction::Geant4GeneratorAction(Geant4Context* ctxt, const string& nam)
+Geant4GeneratorAction::Geant4GeneratorAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   InstanceCount::increment(this);
 }
@@ -40,7 +38,7 @@ Geant4GeneratorAction::~Geant4GeneratorAction() {
 }
 
 /// Standard constructor
-Geant4SharedGeneratorAction::Geant4SharedGeneratorAction(Geant4Context* ctxt, const string& nam)
+Geant4SharedGeneratorAction::Geant4SharedGeneratorAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4GeneratorAction(ctxt, nam), m_action(0)
 {
   InstanceCount::increment(this);
@@ -64,7 +62,7 @@ void Geant4SharedGeneratorAction::use(Geant4GeneratorAction* action)   {
     m_action = action;
     return;
   }
-  throw runtime_error("Geant4SharedGeneratorAction: Attempt to use invalid actor!");
+  throw std::runtime_error("Geant4SharedGeneratorAction: Attempt to use invalid actor!");
 }
 
 /// User generator callback
@@ -78,7 +76,7 @@ void Geant4SharedGeneratorAction::operator()(G4Event* event)  {
 }
 
 /// Standard constructor
-Geant4GeneratorActionSequence::Geant4GeneratorActionSequence(Geant4Context* ctxt, const string& nam)
+Geant4GeneratorActionSequence::Geant4GeneratorActionSequence(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   m_needsControl = true;
   InstanceCount::increment(this);
@@ -104,7 +102,7 @@ void Geant4GeneratorActionSequence::configureFiber(Geant4Context* thread_context
 }
 
 /// Get an action by name
-Geant4GeneratorAction* Geant4GeneratorActionSequence::get(const string& nam) const   {
+Geant4GeneratorAction* Geant4GeneratorActionSequence::get(const std::string& nam) const   {
   return m_actors.get(FindByName(TypeName::split(nam).second));
 }
 
@@ -116,7 +114,7 @@ void Geant4GeneratorActionSequence::adopt(Geant4GeneratorAction* action) {
     m_actors.add(action);
     return;
   }
-  throw runtime_error("Geant4GeneratorActionSequence: Attempt to add invalid actor!");
+  except("Attempt to add invalid actor!");
 }
 
 /// Generator callback

--- a/DDG4/src/Geant4GeneratorWrapper.cpp
+++ b/DDG4/src/Geant4GeneratorWrapper.cpp
@@ -12,30 +12,29 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4GeneratorWrapper.h"
+#include <DDG4/Geant4GeneratorWrapper.h>
 
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/Plugins.h"
-#include "DD4hep/Printout.h"
-#include "DDG4/Geant4Context.h"
-#include "DDG4/Geant4Primary.h"
-#include "DDG4/Geant4InputHandling.h"
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Printout.h>
+#include <DDG4/Geant4Context.h>
+#include <DDG4/Geant4Primary.h>
+#include <DDG4/Geant4InputHandling.h>
 
 // Geant4 include files
-#include "G4Event.hh"
-#include "G4PrimaryVertex.hh"
-#include "G4PrimaryParticle.hh"
-#include "G4VPrimaryGenerator.hh"
+#include <G4Event.hh>
+#include <G4PrimaryVertex.hh>
+#include <G4PrimaryParticle.hh>
+#include <G4VPrimaryGenerator.hh>
 
 // C/C++ include files
 #include <stdexcept>
 #include <set>
 
 using namespace dd4hep::sim;
-using namespace std;
 
 /// Standard constructor
-Geant4GeneratorWrapper::Geant4GeneratorWrapper(Geant4Context* ctxt, const string& nam)
+Geant4GeneratorWrapper::Geant4GeneratorWrapper(Geant4Context* ctxt, const std::string& nam)
   : Geant4GeneratorAction(ctxt,nam), m_generator(0)
 {
   declareProperty("Uses", m_generatorType);
@@ -56,8 +55,8 @@ G4VPrimaryGenerator* Geant4GeneratorWrapper::generator()   {
       PluginDebug dbg;
       m_generator = PluginService::Create<G4VPrimaryGenerator*>(m_generatorType);
       if ( !m_generator )  {
-        throw runtime_error("Geant4GeneratorWrapper: FATAL Failed to "
-                            "create G4VPrimaryGenerator of type " + m_generatorType + ".");
+        except("Geant4GeneratorWrapper: FATAL Failed to create G4VPrimaryGenerator of type %s.",
+               m_generatorType.c_str());
       }
     }
   }
@@ -68,7 +67,7 @@ G4VPrimaryGenerator* Geant4GeneratorWrapper::generator()   {
 void Geant4GeneratorWrapper::operator()(G4Event* event)  {
   Geant4PrimaryEvent* prim = context()->event().extension<Geant4PrimaryEvent>();
   Geant4PrimaryMap*   primaryMap = context()->event().extension<Geant4PrimaryMap>();
-  set<G4PrimaryVertex*> primaries;
+  std::set<G4PrimaryVertex*> primaries;
   
   // Now generate the new interaction
   generator()->GeneratePrimaryVertex(event);

--- a/DDG4/src/Geant4GeometryInfo.cpp
+++ b/DDG4/src/Geant4GeometryInfo.cpp
@@ -12,21 +12,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4GeometryInfo.h"
-#include "DDG4/Geant4AssemblyVolume.h"
+#include <DDG4/Geant4GeometryInfo.h>
+#include <DDG4/Geant4AssemblyVolume.h>
+#include <DD4hep/Printout.h>
 
 // Geant4 include files
-#include "G4VPhysicalVolume.hh"
+#include <G4VPhysicalVolume.hh>
 
-// C/C++ include files
-#include <stdexcept>
-
-using namespace std;
 using namespace dd4hep::sim;
 
-
-string Geant4GeometryInfo::placementPath(const Geant4PlacementPath& path, bool reverse)   {
-  string path_name;
+std::string Geant4GeometryInfo::placementPath(const Geant4PlacementPath& path, bool reverse)   {
+  std::string path_name;
   if ( reverse )  {
     for (Geant4PlacementPath::const_reverse_iterator pIt = path.rbegin(); pIt != path.rend(); ++pIt) {
       path_name += "/"; path_name += (*pIt)->GetName();
@@ -55,7 +51,8 @@ Geant4GeometryInfo::~Geant4GeometryInfo() {
 /// The world placement
 G4VPhysicalVolume* Geant4GeometryInfo::world() const   {
   if ( m_world ) return m_world;
-  throw runtime_error("Geant4GeometryInfo: Attempt to access invalid world placement");
+  except("Geant4GeometryInfo", "Attempt to access invalid world placement");
+  return m_world;
 }
 
 /// Set the world placement
@@ -63,7 +60,7 @@ void Geant4GeometryInfo::setWorld(const TGeoNode* node)    {
   Geant4GeometryMaps::PlacementMap::const_iterator g4it = g4Placements.find(node);
   G4VPhysicalVolume* g4 = (g4it == g4Placements.end()) ? 0 : (*g4it).second;
   if (!g4) {
-    throw runtime_error("Geant4GeometryInfo: Attempt to SET invalid world placement");
+    except("Geant4GeometryInfo", "Attempt to SET invalid world placement");
   }
   m_world = g4;
 }

--- a/DDG4/src/Geant4Handle.cpp
+++ b/DDG4/src/Geant4Handle.cpp
@@ -12,33 +12,28 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Plugins.h"
-#include "DD4hep/Printout.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Printout.h>
 
-#include "DDG4/Geant4Handle.h"
-#include "DDG4/Geant4Kernel.h"
-#include "DDG4/Geant4GeneratorAction.h"
-#include "DDG4/Geant4RunAction.h"
-#include "DDG4/Geant4EventAction.h"
-#include "DDG4/Geant4TrackingAction.h"
-#include "DDG4/Geant4SteppingAction.h"
-#include "DDG4/Geant4StackingAction.h"
-#include "DDG4/Geant4SensDetAction.h"
-#include "DDG4/Geant4PhysicsList.h"
-#include "DDG4/Geant4ActionPhase.h"
-#include "DDG4/Geant4UserInitialization.h"
-#include "DDG4/Geant4DetectorConstruction.h"
+#include <DDG4/Geant4Handle.h>
+#include <DDG4/Geant4Kernel.h>
+#include <DDG4/Geant4GeneratorAction.h>
+#include <DDG4/Geant4RunAction.h>
+#include <DDG4/Geant4EventAction.h>
+#include <DDG4/Geant4TrackingAction.h>
+#include <DDG4/Geant4SteppingAction.h>
+#include <DDG4/Geant4StackingAction.h>
+#include <DDG4/Geant4SensDetAction.h>
+#include <DDG4/Geant4PhysicsList.h>
+#include <DDG4/Geant4ActionPhase.h>
+#include <DDG4/Geant4UserInitialization.h>
+#include <DDG4/Geant4DetectorConstruction.h>
 
 // Geant4 include files
-#include "G4Threading.hh"
-#include "G4AutoLock.hh"
+#include <G4Threading.hh>
+#include <G4AutoLock.hh>
 
-// C/C++ include files
-#include <stdexcept>
-
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 namespace {
   G4Mutex creation_mutex=G4MUTEX_INITIALIZER;
@@ -46,7 +41,6 @@ namespace {
 
 namespace dd4hep {
   namespace sim {
-
 
     template <typename TYPE> static inline TYPE* checked_value(TYPE* p) {
       if (p) {
@@ -77,14 +71,14 @@ namespace dd4hep {
       Geant4Context* ctxt = kernel.workerContext();
       Geant4Action* object = PluginService::Create<Geant4Action*>(typ.first, ctxt, typ.second);
       if (!object && typ.first == typ.second) {
-        string _t = typeName(typeid(TYPE));
+        std::string _t = typeName(typeid(TYPE));
         printout(DEBUG, "Geant4Handle", "Object factory for %s not found. Try out %s",
                  typ.second.c_str(), _t.c_str());
         object = PluginService::Create<Geant4Action*>(_t, ctxt, typ.second);
         if (!object) {
           size_t idx = _t.rfind(':');
-          if (idx != string::npos)
-            _t = string(_t.substr(idx + 1));
+          if (idx != std::string::npos)
+            _t = std::string(_t.substr(idx + 1));
           printout(DEBUG, "Geant4Handle", "Try out object factory for %s",_t.c_str());
           object = PluginService::Create<Geant4Action*>(_t, ctxt, typ.second);
         }
@@ -104,8 +98,8 @@ namespace dd4hep {
     template <typename TYPE, typename CONT> 
     TYPE* _create_share(Geant4Kernel& kernel,
                         CONT& (Geant4ActionContainer::*pmf)(), 
-                        const string& type_name, 
-                        const string& shared_typ, 
+                        const std::string& type_name, 
+                        const std::string& shared_typ, 
                         bool shared, TYPE*)
     {
       TypeName typ = TypeName::split(type_name);
@@ -135,7 +129,7 @@ namespace dd4hep {
     }
 
     template <typename TYPE> 
-    Geant4Handle<TYPE>::Geant4Handle(Geant4Kernel& kernel, const string& type_name, bool /* shared */)  {
+    Geant4Handle<TYPE>::Geant4Handle(Geant4Kernel& kernel, const std::string& type_name, bool /* shared */)  {
       value = _create_object<TYPE>(kernel,TypeName::split(type_name));
     }
 
@@ -164,7 +158,7 @@ namespace dd4hep {
         value->addRef();
     }
 
-    template <typename TYPE> Property& Geant4Handle<TYPE>::operator[](const string& property_name) const {
+    template <typename TYPE> Property& Geant4Handle<TYPE>::operator[](const std::string& property_name) const {
       PropertyManager& pm = checked_value(value)->properties();
       return pm[property_name];
     }
@@ -238,7 +232,7 @@ namespace dd4hep {
     }
 
     template <> 
-    Geant4Handle<Geant4RunAction>::Geant4Handle(Geant4Kernel& kernel, const string& type_name, bool shared)  {
+    Geant4Handle<Geant4RunAction>::Geant4Handle(Geant4Kernel& kernel, const std::string& type_name, bool shared)  {
       value = _create_share(kernel,&Geant4ActionContainer::runAction, type_name,
                             "Geant4SharedRunAction", shared, null());
     }
@@ -249,7 +243,7 @@ namespace dd4hep {
     }
 
     template <> 
-    Geant4Handle<Geant4EventAction>::Geant4Handle(Geant4Kernel& kernel, const string& type_name, bool shared)  {
+    Geant4Handle<Geant4EventAction>::Geant4Handle(Geant4Kernel& kernel, const std::string& type_name, bool shared)  {
       value = _create_share(kernel,&Geant4ActionContainer::eventAction, type_name,
                             "Geant4SharedEventAction", shared, null());
     }
@@ -260,7 +254,7 @@ namespace dd4hep {
     }
 
     template <> 
-    Geant4Handle<Geant4GeneratorAction>::Geant4Handle(Geant4Kernel& kernel, const string& type_name, bool shared)  {
+    Geant4Handle<Geant4GeneratorAction>::Geant4Handle(Geant4Kernel& kernel, const std::string& type_name, bool shared)  {
       value = _create_share(kernel,&Geant4ActionContainer::generatorAction, type_name,
                             "Geant4SharedGeneratorAction", shared, null());
     }
@@ -271,7 +265,7 @@ namespace dd4hep {
     }
 
     template <> 
-    Geant4Handle<Geant4TrackingAction>::Geant4Handle(Geant4Kernel& kernel, const string& type_name, bool shared)  {
+    Geant4Handle<Geant4TrackingAction>::Geant4Handle(Geant4Kernel& kernel, const std::string& type_name, bool shared)  {
       value = _create_share(kernel,&Geant4ActionContainer::trackingAction, type_name,
                             "Geant4SharedTrackingAction", shared, null());
     }
@@ -282,7 +276,7 @@ namespace dd4hep {
     }
 
     template <> 
-    Geant4Handle<Geant4SteppingAction>::Geant4Handle(Geant4Kernel& kernel, const string& type_name, bool shared)  {
+    Geant4Handle<Geant4SteppingAction>::Geant4Handle(Geant4Kernel& kernel, const std::string& type_name, bool shared)  {
       value = _create_share(kernel,&Geant4ActionContainer::steppingAction, type_name,
                             "Geant4SharedSteppingAction", shared, null());
     }
@@ -293,7 +287,7 @@ namespace dd4hep {
     }
 
     template <> 
-    Geant4Handle<Geant4StackingAction>::Geant4Handle(Geant4Kernel& kernel, const string& type_name, bool shared)  {
+    Geant4Handle<Geant4StackingAction>::Geant4Handle(Geant4Kernel& kernel, const std::string& type_name, bool shared)  {
       value = _create_share(kernel,&Geant4ActionContainer::stackingAction, type_name,
                             "Geant4SharedStackingAction", shared, null());
     }
@@ -303,8 +297,8 @@ namespace dd4hep {
                             "Geant4SharedStackingAction", shared, null());
     }
 
-    template <> Geant4Handle<Geant4Sensitive>::Geant4Handle(Geant4Kernel& kernel, const string& type_name,
-                                                            const string& detector, bool /* shared */) {
+    template <> Geant4Handle<Geant4Sensitive>::Geant4Handle(Geant4Kernel& kernel, const std::string& type_name,
+                                                            const std::string& detector, bool /* shared */) {
       try {
         Geant4Context*  ctxt = kernel.workerContext();
         TypeName         typ = TypeName::split(type_name);
@@ -316,7 +310,7 @@ namespace dd4hep {
           return;
         }
       }
-      catch (const exception& e) {
+      catch (const std::exception& e) {
         printout(ERROR, "Geant4Handle<Geant4Sensitive>", "Exception: %s", e.what());
       }
       catch (...) {

--- a/DDG4/src/Geant4HierarchyDump.cpp
+++ b/DDG4/src/Geant4HierarchyDump.cpp
@@ -12,47 +12,47 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Detector.h"
-#include "DD4hep/Plugins.h"
-#include "DD4hep/Volumes.h"
-#include "DD4hep/Printout.h"
-#include "DDG4/Geant4HierarchyDump.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Volumes.h>
+#include <DD4hep/Printout.h>
+#include <DDG4/Geant4HierarchyDump.h>
 
 // Geant4 include files
-#include "G4Version.hh"
-#include "G4VisAttributes.hh"
-#include "G4ProductionCuts.hh"
-#include "G4VUserRegionInformation.hh"
-#include "G4Element.hh"
-#include "G4SDManager.hh"
+#include <G4Version.hh>
+#include <G4VisAttributes.hh>
+#include <G4ProductionCuts.hh>
+#include <G4VUserRegionInformation.hh>
+#include <G4Element.hh>
+#include <G4SDManager.hh>
 
-#include "G4AssemblyVolume.hh"
-#include "G4Box.hh"
-#include "G4Trd.hh"
-#include "G4Tubs.hh"
-#include "G4Cons.hh"
-#include "G4Torus.hh"
-#include "G4Sphere.hh"
-#include "G4Polycone.hh"
-#include "G4Polyhedra.hh"
-#include "G4UnionSolid.hh"
-#include "G4Paraboloid.hh"
-#include "G4SubtractionSolid.hh"
-#include "G4IntersectionSolid.hh"
+#include <G4AssemblyVolume.hh>
+#include <G4Box.hh>
+#include <G4Trd.hh>
+#include <G4Tubs.hh>
+#include <G4Cons.hh>
+#include <G4Torus.hh>
+#include <G4Sphere.hh>
+#include <G4Polycone.hh>
+#include <G4Polyhedra.hh>
+#include <G4UnionSolid.hh>
+#include <G4Paraboloid.hh>
+#include <G4SubtractionSolid.hh>
+#include <G4IntersectionSolid.hh>
 
-#include "G4Region.hh"
-#include "G4UserLimits.hh"
-#include "G4VSensitiveDetector.hh"
+#include <G4Region.hh>
+#include <G4UserLimits.hh>
+#include <G4VSensitiveDetector.hh>
 
-#include "G4LogicalVolume.hh"
-#include "G4Material.hh"
-#include "G4Element.hh"
-#include "G4Isotope.hh"
-#include "G4Transform3D.hh"
-#include "G4ThreeVector.hh"
-#include "G4PVPlacement.hh"
-#include "G4ElectroMagneticField.hh"
-#include "G4FieldManager.hh"
+#include <G4LogicalVolume.hh>
+#include <G4Material.hh>
+#include <G4Element.hh>
+#include <G4Isotope.hh>
+#include <G4Transform3D.hh>
+#include <G4ThreeVector.hh>
+#include <G4PVPlacement.hh>
+#include <G4ElectroMagneticField.hh>
+#include <G4FieldManager.hh>
 
 // C/C++ include files
 #include <iostream>
@@ -60,8 +60,6 @@
 #include <sstream>
 
 using namespace dd4hep::sim;
-using namespace dd4hep;
-using namespace std;
 
 static const char* _T(const std::string& str) {
   return str.c_str();
@@ -78,7 +76,7 @@ Geant4HierarchyDump::Geant4HierarchyDump(Detector& description, unsigned long fl
 Geant4HierarchyDump::~Geant4HierarchyDump() {
 }
 
-void Geant4HierarchyDump::dump(const string& indent, const G4VPhysicalVolume* v) const {
+void Geant4HierarchyDump::dump(const std::string& indent, const G4VPhysicalVolume* v) const {
   G4LogicalVolume*      lv   = v->GetLogicalVolume();
   G4VSensitiveDetector* sd   = lv->GetSensitiveDetector();
   G4RotationMatrix*     rot  = v->GetObjectRotation();
@@ -87,7 +85,7 @@ void Geant4HierarchyDump::dump(const string& indent, const G4VPhysicalVolume* v)
   G4Region*             rg   = lv->GetRegion();
   G4UserLimits*         ul   = lv->GetUserLimits();
   G4int                 ndau = lv->GetNoDaughters();
-  stringstream str;
+  std::stringstream str;
   char text[32];
 
   printout(INFO, "Geant4Hierarchy", "%s -> Placement:%s LV:%s Material:%s Solid:%s # of Daughters:%d CopyNo:%d",

--- a/DDG4/src/Geant4HitCollection.cpp
+++ b/DDG4/src/Geant4HitCollection.cpp
@@ -12,12 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4HitCollection.h"
-#include "DDG4/Geant4Data.h"
-#include "G4Allocator.hh"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4HitCollection.h>
+#include <DDG4/Geant4Data.h>
+#include <G4Allocator.hh>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 G4ThreadLocal G4Allocator<Geant4HitWrapper>* HitWrapperAllocator = 0;
@@ -85,12 +84,12 @@ Geant4HitCollection::~Geant4HitCollection() {
 }
 
 /// Type information of the object stored
-const ComponentCast& Geant4HitCollection::type() const {
+const dd4hep::ComponentCast& Geant4HitCollection::type() const {
   return m_manipulator->cast;
 }
 
 /// Type information of the vector type for extracting data
-const ComponentCast& Geant4HitCollection::vector_type() const {
+const dd4hep::ComponentCast& Geant4HitCollection::vector_type() const {
   return m_manipulator->vec_type;
 }
 

--- a/DDG4/src/Geant4HitHandler.cpp
+++ b/DDG4/src/Geant4HitHandler.cpp
@@ -19,44 +19,43 @@
 // Geant4 include files
 #include <G4NavigationHistory.hh>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Coordinate transformation to global coordinate.
-Position Geant4HitHandler::localToGlobal(const DDSegmentation::Vector3D& local)  const   {
+dd4hep::Position Geant4HitHandler::localToGlobal(const DDSegmentation::Vector3D& local)  const   {
   return localToGlobal(G4ThreeVector(local.X / dd4hep::mm,local.Y / dd4hep::mm,local.Z / dd4hep::mm));
 }
 
 /// Coordinate transformation to global coordinates.
-Position Geant4HitHandler::localToGlobal(const Position& local)  const   {
+dd4hep::Position Geant4HitHandler::localToGlobal(const Position& local)  const   {
   return localToGlobal(G4ThreeVector(local.X(),local.Y(),local.Z()));
 }
 
 /// Coordinate transformation to global coordinates
-Position Geant4HitHandler::localToGlobal(double x, double y, double z)  const    {
+dd4hep::Position Geant4HitHandler::localToGlobal(double x, double y, double z)  const    {
   return localToGlobal(G4ThreeVector(x,y,z));
 }
 
 /// Coordinate transformation to global coordinates
-Position Geant4HitHandler::localToGlobal(const G4ThreeVector& loc)  const    {
+dd4hep::Position Geant4HitHandler::localToGlobal(const G4ThreeVector& loc)  const    {
   G4ThreeVector p = touchable_ptr->GetHistory()->GetTopTransform().Inverse().TransformPoint(loc);
   return Position(p.x(),p.y(),p.z());
 }
 
 /// Coordinate transformation to local coordinates
-Position Geant4HitHandler::globalToLocal(double x, double y, double z)  const    {
+dd4hep::Position Geant4HitHandler::globalToLocal(double x, double y, double z)  const    {
   G4ThreeVector p = globalToLocalG4(G4ThreeVector(x,y,z));
   return Position(p.x(),p.y(),p.z());
 }
 
 /// Coordinate transformation to local coordinates
-Position Geant4HitHandler::globalToLocal(const Position& global)  const    {
+dd4hep::Position Geant4HitHandler::globalToLocal(const Position& global)  const    {
   G4ThreeVector p = globalToLocalG4(G4ThreeVector(global.X(),global.Y(),global.Z()));
   return Position(p.x(),p.y(),p.z());
 }
 
 /// Coordinate transformation to local coordinates
-Position Geant4HitHandler::globalToLocal(const G4ThreeVector& global)  const    {
+dd4hep::Position Geant4HitHandler::globalToLocal(const G4ThreeVector& global)  const    {
   G4ThreeVector p = globalToLocalG4(global);
   return Position(p.x(),p.y(),p.z());
 }

--- a/DDG4/src/Geant4InputAction.cpp
+++ b/DDG4/src/Geant4InputAction.cpp
@@ -13,20 +13,19 @@
 //====================================================================
 
 // Framework include files
-#include "DD4hep/Memory.h"
-#include "DD4hep/Plugins.h"
-#include "DDG4/Geant4Primary.h"
-#include "DDG4/Geant4Context.h"
-#include "DDG4/Geant4Kernel.h"
-#include "DDG4/Geant4InputAction.h"
-#include "DDG4/Geant4RunAction.h"
+#include <DD4hep/Memory.h>
+#include <DD4hep/Plugins.h>
+#include <DDG4/Geant4Primary.h>
+#include <DDG4/Geant4Context.h>
+#include <DDG4/Geant4Kernel.h>
+#include <DDG4/Geant4InputAction.h>
+#include <DDG4/Geant4RunAction.h>
 
-#include "G4Event.hh"
+#include <G4Event.hh>
 
-using namespace std;
 using namespace dd4hep::sim;
-typedef dd4hep::detail::ReferenceBitMask<int> PropertyMask;
-typedef Geant4InputAction::Vertices Vertices ;
+using Vertices = Geant4InputAction::Vertices;
+using PropertyMask = dd4hep::detail::ReferenceBitMask<int>;
 
 
 /// Initializing constructor
@@ -118,7 +117,7 @@ Geant4EventReader::moveToEvent(int /* event_number */)   {
 #endif
 
 /// Standard constructor
-Geant4InputAction::Geant4InputAction(Geant4Context* ctxt, const string& nam)
+Geant4InputAction::Geant4InputAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4GeneratorAction(ctxt,nam), m_reader(0), m_currentEventNumber(0)
 {
   declareProperty("Input",          m_input);
@@ -148,7 +147,7 @@ void Geant4InputAction::createReader() {
   if ( m_input.empty() )  {
     except("InputAction: No input file declared!");
   }
-  string err;
+  std::string err;
   TypeName tn = TypeName::split(m_input,"|");
   try  {
     m_reader = PluginService::Create<Geant4EventReader*>(tn.first,tn.second);
@@ -163,7 +162,7 @@ void Geant4InputAction::createReader() {
     m_reader->checkParameters( m_parameters );
     m_reader->setInputAction( this );
     m_reader->registerRunParameters();
-  } catch(const exception& e)  {
+  } catch(const std::exception& e)  {
     err = e.what();
   }
   if ( !err.empty() )  {
@@ -173,8 +172,8 @@ void Geant4InputAction::createReader() {
 
 
 /// helper to report Geant4 exceptions
-string Geant4InputAction::issue(int i)  const  {
-  stringstream str;
+std::string Geant4InputAction::issue(int i)  const  {
+  std::stringstream str;
   str << "Geant4InputAction[" << name() << "]: Event " << i << " ";
   return str.str();
 }
@@ -197,7 +196,7 @@ int Geant4InputAction::readParticles(int evt_number,
   }
 
   if ( Geant4EventReader::EVENT_READER_OK != status )  {
-    string msg = issue(evid)+"Error when moving to event - ";
+    std::string msg = issue(evid)+"Error when moving to event - ";
     if ( status == Geant4EventReader::EVENT_READER_EOF ) msg += " EOF: [end of file].";
     else msg += " Unknown error condition";
     if ( m_abort )  {
@@ -217,9 +216,8 @@ int Geant4InputAction::readParticles(int evt_number,
     }
   }
 
-
   if ( Geant4EventReader::EVENT_READER_OK != status )  {
-    string msg = issue(evid)+"Error when moving to event - ";
+    std::string msg = issue(evid)+"Error when moving to event - ";
     if ( status == Geant4EventReader::EVENT_READER_EOF ) msg += " EOF: [end of file].";
     else msg += " Unknown error condition";
     if ( m_abort )  {
@@ -234,7 +232,7 @@ int Geant4InputAction::readParticles(int evt_number,
 
 /// Callback to generate primary particles
 void Geant4InputAction::operator()(G4Event* event)   {
-  vector<Particle*>         primaries;
+  std::vector<Particle*>    primaries;
   Geant4Event&              evt = context()->event();
   Geant4PrimaryEvent*       prim = evt.extension<Geant4PrimaryEvent>();
   Vertices                  vertices ;

--- a/DDG4/src/Geant4IsotropeGenerator.cpp
+++ b/DDG4/src/Geant4IsotropeGenerator.cpp
@@ -12,16 +12,15 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Random.h"
-#include "DDG4/Geant4IsotropeGenerator.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Random.h>
+#include <DDG4/Geant4IsotropeGenerator.h>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 /// Standard constructor
-Geant4IsotropeGenerator::Geant4IsotropeGenerator(Geant4Context* ctxt, const string& nam)
+Geant4IsotropeGenerator::Geant4IsotropeGenerator(Geant4Context* ctxt, const std::string& nam)
   : Geant4ParticleGenerator(ctxt, nam)
 {
   InstanceCount::increment(this);

--- a/DDG4/src/Geant4Mapping.cpp
+++ b/DDG4/src/Geant4Mapping.cpp
@@ -12,16 +12,12 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4Mapping.h"
-
-#include "DD4hep/Printout.h"
-#include "DD4hep/VolumeManager.h"
-#include "G4PVPlacement.hh"
-#include <stdexcept>
+#include <DDG4/Geant4Mapping.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/VolumeManager.h>
+#include <G4PVPlacement.hh>
 
 using namespace dd4hep::sim;
-using namespace dd4hep;
-using namespace std;
 
 /// Initializing Constructor
 Geant4Mapping::Geant4Mapping(const Detector& description_ref)
@@ -45,7 +41,7 @@ Geant4Mapping& Geant4Mapping::instance() {
 void Geant4Mapping::checkValidity() const {
   if (m_dataPtr)
     return;
-  throw runtime_error("Geant4Mapping: Attempt to access an invalid data block!");
+  except("Geant4Mapping", "Attempt to access an invalid data block!");
 }
 
 /// Create new data block. Delete old data block if present.
@@ -77,11 +73,12 @@ Geant4VolumeManager Geant4Mapping::volumeManager() const {
     }
     return Geant4VolumeManager(Handle < Geant4GeometryInfo > (m_dataPtr));
   }
-  throw runtime_error(format("Geant4Mapping", "Cannot create volume manager without Geant4 geometry info [Invalid-Info]"));
+  except("Geant4Mapping", "Cannot create volume manager without Geant4 geometry info [Invalid-Info]");
+  return {};
 }
 
 /// Accessor to resolve geometry placements
-PlacedVolume Geant4Mapping::placement(const G4VPhysicalVolume* node) const {
+dd4hep::PlacedVolume Geant4Mapping::placement(const G4VPhysicalVolume* node) const {
   checkValidity();
   const Geant4GeometryMaps::PlacementMap& pm = m_dataPtr->g4Placements;
   for( const auto& entry : pm )  {

--- a/DDG4/src/Geant4OutputAction.cpp
+++ b/DDG4/src/Geant4OutputAction.cpp
@@ -12,22 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Particle.h"
-#include "DDG4/Geant4RunAction.h"
-#include "DDG4/Geant4OutputAction.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Particle.h>
+#include <DDG4/Geant4RunAction.h>
+#include <DDG4/Geant4OutputAction.h>
 
 // Geant 4 includes
-#include "G4HCofThisEvent.hh"
-#include "G4Event.hh"
+#include <G4HCofThisEvent.hh>
+#include <G4Event.hh>
 
 using namespace dd4hep::sim;
-using namespace dd4hep;
-using namespace std;
 
 /// Standard constructor
-Geant4OutputAction::Geant4OutputAction(Geant4Context* ctxt, const string& nam)
+Geant4OutputAction::Geant4OutputAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4EventAction(ctxt, nam), m_truth(0)
 {
   InstanceCount::increment(this);
@@ -73,7 +71,7 @@ void Geant4OutputAction::end(const G4Event* evt) {
           saveCollection(ctxt, hc);
         }
       }
-      catch(const exception& e)   {
+      catch(const std::exception& e)   {
         printout(ERROR,name(),"+++ [Event:%d] Exception while saving event:%s",
                  evt->GetEventID(),e.what());
         if ( m_errorFatal ) throw;
@@ -85,7 +83,7 @@ void Geant4OutputAction::end(const G4Event* evt) {
       }
       commit(ctxt);
     }
-    catch(const exception& e)   {
+    catch(const std::exception& e)   {
       printout(ERROR,name(),"+++ [Event:%d] Exception while saving event:%s",
                evt->GetEventID(),e.what());
       if ( m_errorFatal ) throw;

--- a/DDG4/src/Geant4Particle.cpp
+++ b/DDG4/src/Geant4Particle.cpp
@@ -27,13 +27,12 @@
 #include <TDatabasePDG.h>
 #include <TParticlePDG.h>
 
+// C/C++ include files
 #include <sstream>
 #include <iostream>
 #include <regex.h>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
-typedef detail::ReferenceBitMask<int> PropertyMask;
 
 /// Default destructor
 ParticleExtension::~ParticleExtension() {
@@ -385,6 +384,7 @@ void Geant4ParticleHandle::header4(int level, const std::string& src, const char
 }
 
 void Geant4ParticleHandle::dump4(int level, const std::string& src, const char* tag) const  {
+  using PropertyMask = dd4hep::detail::ReferenceBitMask<int>;
   Geant4ParticleHandle p(*this);
   //char equiv[32];
   PropertyMask mask(p->reason);
@@ -495,32 +495,31 @@ void Geant4ParticleMap::clear()    {
 void Geant4ParticleMap::dump()  const  {
   int cnt;
   char text[64];
-  using namespace std;
   const Geant4ParticleMap* m = this;
 
   cnt = 0;
-  cout << "Particle map:" << endl;
+  std::cout << "Particle map:" << std::endl;
   for( const auto& p : m->particleMap )  {
-    ::snprintf(text,sizeof(text)," [%-4d:%p]",p.second->id,(void*)p.second);
-    cout << text;
+    std::snprintf(text,sizeof(text)," [%-4d:%p]",p.second->id,(void*)p.second);
+    std::cout << text;
     if ( ++cnt == 8 ) {
-      cout << endl;
+      std::cout << std::endl;
       cnt = 0;
     }
   }
-  cout << endl;
+  std::cout << std::endl;
 
   cnt = 0;
-  cout << "Equivalents:" << endl;
+  std::cout << "Equivalents:" << std::endl;
   for( const auto& p : m->equivalentTracks )  {
-    ::snprintf(text,sizeof(text)," [%-5d : %-5d]",p.first,p.second);
-    cout << text;
+    std::snprintf(text,sizeof(text)," [%-5d : %-5d]",p.first,p.second);
+    std::cout << text;
     if ( ++cnt == 8 ) {
-      cout << endl;
+      std::cout << std::endl;
       cnt = 0;
     }
   }
-  cout << endl;
+  std::cout << std::endl;
 }
 
 /// Adopt particle maps

--- a/DDG4/src/Geant4ParticleGenerator.cpp
+++ b/DDG4/src/Geant4ParticleGenerator.cpp
@@ -12,27 +12,26 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Context.h"
-#include "DDG4/Geant4Primary.h"
-#include "DDG4/Geant4ParticleGenerator.h"
-#include "DDG4/Geant4Random.h"
-#include "CLHEP/Units/SystemOfUnits.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Context.h>
+#include <DDG4/Geant4Primary.h>
+#include <DDG4/Geant4ParticleGenerator.h>
+#include <DDG4/Geant4Random.h>
+#include <CLHEP/Units/SystemOfUnits.h>
 
 // Geant4 include files
-#include "G4ParticleTable.hh"
-#include "G4ParticleDefinition.hh"
+#include <G4ParticleTable.hh>
+#include <G4ParticleDefinition.hh>
 
 // C/C++ include files
 #include <stdexcept>
 #include <cmath>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 /// Standard constructor
-Geant4ParticleGenerator::Geant4ParticleGenerator(Geant4Context* ctxt, const string& nam)
+Geant4ParticleGenerator::Geant4ParticleGenerator(Geant4Context* ctxt, const std::string& nam)
   : Geant4GeneratorAction(ctxt, nam), m_direction(0,1,0), m_position(0,0,0), m_particle(0)
 {
   InstanceCount::increment(this);
@@ -125,7 +124,7 @@ void Geant4ParticleGenerator::operator()(G4Event*) {
     G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
     m_particle = particleTable->FindParticle(m_particleName);
     if (0 == m_particle) {
-      throw runtime_error("Geant4ParticleGenerator: Bad particle type:"+m_particleName+"!");
+      except("Geant4ParticleGenerator: Bad particle type: %s!", m_particleName.c_str());
     }
   }
   Geant4Event& evt = context()->event();
@@ -177,6 +176,5 @@ void Geant4ParticleGenerator::operator()(G4Event*) {
              p->id, m_particleName.c_str(), momentum/CLHEP::GeV,
 	     vtx->x/CLHEP::mm, vtx->y/CLHEP::mm, vtx->z/CLHEP::mm,
 	     direction.X(), direction.Y(), direction.Z());
-
   }
 }

--- a/DDG4/src/Geant4ParticleGun.cpp
+++ b/DDG4/src/Geant4ParticleGun.cpp
@@ -12,22 +12,21 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Context.h"
-#include "DDG4/Geant4Primary.h"
-#include "DDG4/Geant4ParticleGun.h"
-#include "DDG4/Geant4InputHandling.h"
-#include "CLHEP/Units/SystemOfUnits.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Context.h>
+#include <DDG4/Geant4Primary.h>
+#include <DDG4/Geant4ParticleGun.h>
+#include <DDG4/Geant4InputHandling.h>
+#include <CLHEP/Units/SystemOfUnits.h>
 
 // C/C++ include files
 #include <limits>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 /// Standard constructor
-Geant4ParticleGun::Geant4ParticleGun(Geant4Context* ctxt, const string& nam)
+Geant4ParticleGun::Geant4ParticleGun(Geant4Context* ctxt, const std::string& nam)
   : Geant4IsotropeGenerator(ctxt,nam), m_shotNo(0)
 {
   InstanceCount::increment(this);
@@ -59,7 +58,7 @@ void Geant4ParticleGun::getParticleDirection(int num, ROOT::Math::XYZVector& dir
 
 /// Callback to generate primary particles
 void Geant4ParticleGun::operator()(G4Event* event)   {
-  double r = m_direction.R(), eps = numeric_limits<float>::epsilon();
+  double r = m_direction.R(), eps = std::numeric_limits<float>::epsilon();
   if ( r > eps )  {
     m_direction.SetXYZ(m_direction.X()/r, m_direction.Y()/r, m_direction.Z()/r);
   }

--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -40,14 +40,11 @@
 #include <stdexcept>
 #include <algorithm>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
-
-typedef detail::ReferenceBitMask<int> PropertyMask;
+using PropertyMask = dd4hep::detail::ReferenceBitMask<int>;
 
 /// Standard constructor
-Geant4ParticleHandler::Geant4ParticleHandler(Geant4Context* ctxt, const string& nam)
+Geant4ParticleHandler::Geant4ParticleHandler(Geant4Context* ctxt, const std::string& nam)
   : Geant4GeneratorAction(ctxt,nam), Geant4MonteCarloTruth(),
     m_ownsParticles(false), m_userHandler(0), m_primaryMap(0)
 {
@@ -159,7 +156,7 @@ void Geant4ParticleHandler::mark(const G4Track* track)   {
   G4LogicalVolume*       vol = track->GetVolume()->GetLogicalVolume();
   G4VSensitiveDetector*   g4 = vol->GetSensitiveDetector();
   Geant4ActionSD* sd = dynamic_cast<Geant4ActionSD*>(g4);
-  string typ = sd ? sd->sensitiveType() : string();
+  std::string typ = sd ? sd->sensitiveType() : std::string();
   if ( typ == "calorimeter" )
     mask.set(G4PARTICLE_CREATED_CALORIMETER_HIT);
   else if ( typ == "tracker" )
@@ -184,7 +181,7 @@ void Geant4ParticleHandler::operator()(G4Event* event)  {
 
 /// User stepping callback
 void Geant4ParticleHandler::step(const G4Step* step_value, G4SteppingManager* mgr)   {
-  typedef vector<const G4Track*> _Sec;
+  typedef std::vector<const G4Track*> _Sec;
   ++m_currTrack.steps;
   if ( (m_currTrack.reason&G4PARTICLE_ABOVE_ENERGY_THRESHOLD) )  {
     //
@@ -428,7 +425,7 @@ void Geant4ParticleHandler::beginEvent(const G4Event* event)  {
 
 /// Debugging: Dump Geant4 particle map
 void Geant4ParticleHandler::dumpMap(const char* tag)  const  {
-  const string& n = name();
+  const std::string& n = name();
   Geant4ParticleHandle::header4(INFO,n,tag);
   for(ParticleMap::const_iterator iend=m_particleMap.end(), i=m_particleMap.begin(); i!=iend; ++i)  {
     Geant4ParticleHandle((*i).second).dump4(INFO,n,tag);
@@ -621,7 +618,7 @@ bool Geant4ParticleHandler::defaultKeepParticle(Particle& particle)   {
 /// Clean the monte carlo record. Remove all unwanted stuff.
 /// This is the core of the object executed at the end of each event action.
 int Geant4ParticleHandler::recombineParents()  {
-  set<int> remove;
+  std::set<int> remove;
 
   /// Need to start from BACK, to clean first the latest produced stuff.
   for(ParticleMap::reverse_iterator i=m_particleMap.rbegin(); i!=m_particleMap.rend(); ++i)  {
@@ -705,7 +702,7 @@ void Geant4ParticleHandler::checkConsistency()  const   {
     Geant4ParticleHandle p(particle);
     PropertyMask mask(p->reason);
     PropertyMask status(p->status);
-    set<int>& daughters = p->daughters;
+    std::set<int>& daughters = p->daughters;
     ParticleMap::const_iterator j;
     // For all particles, the set of daughters must be contained in the record.
     for( int id_dau : daughters )   {

--- a/DDG4/src/Geant4ParticlePrint.cpp
+++ b/DDG4/src/Geant4ParticlePrint.cpp
@@ -12,24 +12,21 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4ParticlePrint.h"
-#include "DDG4/Geant4Data.h"
-#include "DDG4/Geant4HitCollection.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4ParticlePrint.h>
+#include <DDG4/Geant4Data.h>
+#include <DDG4/Geant4HitCollection.h>
 
 // Geant4 include files
-#include "G4Event.hh"
+#include <G4Event.hh>
 
 // C/C++ include files
 #include <cstring>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
-
-typedef detail::ReferenceBitMask<const int> PropertyMask;
+using PropertyMask = dd4hep::detail::ReferenceBitMask<const int>;
 
 /// Standard constructor
 Geant4ParticlePrint::Geant4ParticlePrint(Geant4Context* ctxt, const std::string& nam)
@@ -80,8 +77,8 @@ void Geant4ParticlePrint::printParticle(const std::string& prefix, const G4Event
   char equiv[32];
   PropertyMask mask(p->reason);
   PropertyMask status(p->status);
-  string proc_name = p.processName();
-  string proc_type = p.processTypeName();
+  std::string proc_name = p.processName();
+  std::string proc_type = p.processTypeName();
   int parent_id = p->parents.empty() ? -1 : *(p->parents.begin());
 
   equiv[0] = 0;
@@ -207,10 +204,8 @@ void Geant4ParticlePrint::printParticleTree(const G4Event* e,
   }
   
   printParticle(txt, e, p);
-  const set<int>& daughters = p->daughters;
   // For all particles, the set of daughters must be contained in the record.
-  for(set<int>::const_iterator id=daughters.begin(); id!=daughters.end(); ++id)   {
-    int id_dau = *id;
+  for( int id_dau : p->daughters )  {
     Geant4ParticleHandle dau = (*particles.find(id_dau)).second;
     printParticleTree(e, particles, level+1, dau);
   }

--- a/DDG4/src/Geant4PhysicsConstructor.cpp
+++ b/DDG4/src/Geant4PhysicsConstructor.cpp
@@ -12,12 +12,12 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4PhysicsConstructor.h"
-#include "G4VModularPhysicsList.hh"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4PhysicsConstructor.h>
+#include <G4VModularPhysicsList.hh>
 
 // Geant4 include files
-#include "G4Version.hh"
+#include <G4Version.hh>
 
 using namespace dd4hep::sim;
 
@@ -58,7 +58,6 @@ namespace  {
     }
   };
 }
-
 
 
 /// Standard action constructor

--- a/DDG4/src/Geant4Primary.cpp
+++ b/DDG4/src/Geant4Primary.cpp
@@ -12,19 +12,18 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Primary.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Primary.h>
 
 // Geant4 include files
-#include "G4PrimaryParticle.hh"
+#include <G4PrimaryParticle.hh>
 
 // C/C++ include files
 #include <stdexcept>
 #include <cstdio>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Default destructor

--- a/DDG4/src/Geant4Random.cpp
+++ b/DDG4/src/Geant4Random.cpp
@@ -12,21 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Random.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Random.h>
 
-#include "CLHEP/Random/EngineFactory.h"
-#include "CLHEP/Random/RandGamma.h"
-#include "CLHEP/Random/Random.h"
+#include <CLHEP/Random/EngineFactory.h>
+#include <CLHEP/Random/RandGamma.h>
+#include <CLHEP/Random/Random.h>
 
 // ROOT include files
-#include "TRandom1.h"
+#include <TRandom1.h>
 
 // C/C++ include files
 #include <cmath>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 namespace CLHEP   {
@@ -113,7 +112,7 @@ Geant4Random::~Geant4Random()  {
 /// Access the main Geant4 random generator instance. Must be created before used!
 Geant4Random* Geant4Random::instance(bool throw_exception)   {
   if ( !s_instance && throw_exception )  {
-    throw runtime_error("No global random number generator defined!");
+    dd4hep::except("Geant4Random", "No global random number generator defined!");
   }  
   return s_instance;
 }
@@ -125,10 +124,10 @@ Geant4Random* Geant4Random::setMainInstance(Geant4Random* ptr)   {
   }
   if ( s_instance != ptr )   {
     if ( !ptr )  {
-      throw runtime_error("Attempt to declare invalid Geant4Random instance.");
+      dd4hep::except("Geant4Random","Attempt to declare invalid Geant4Random instance.");
     }
     if ( !ptr->m_inited )  {  
-      throw runtime_error("Attempt to declare uninitialized Geant4Random instance.");
+      dd4hep::except("Geant4Random","Attempt to declare uninitialized Geant4Random instance.");
     }
     Geant4Random* old = s_instance;
     CLHEP::HepRandomEngine* curr = CLHEP::HepRandom::getTheEngine();
@@ -146,19 +145,19 @@ Geant4Random* Geant4Random::setMainInstance(Geant4Random* ptr)   {
   return 0;
 }
 
-#include "CLHEP/Random/DualRand.h"
-#include "CLHEP/Random/JamesRandom.h"
-#include "CLHEP/Random/MTwistEngine.h"
-#include "CLHEP/Random/RanecuEngine.h"
-#include "CLHEP/Random/Ranlux64Engine.h"
-#include "CLHEP/Random/RanluxEngine.h"
-#include "CLHEP/Random/RanshiEngine.h"
-#include "CLHEP/Random/NonRandomEngine.h"
+#include <CLHEP/Random/DualRand.h>
+#include <CLHEP/Random/JamesRandom.h>
+#include <CLHEP/Random/MTwistEngine.h>
+#include <CLHEP/Random/RanecuEngine.h>
+#include <CLHEP/Random/Ranlux64Engine.h>
+#include <CLHEP/Random/RanluxEngine.h>
+#include <CLHEP/Random/RanshiEngine.h>
+#include <CLHEP/Random/NonRandomEngine.h>
 
 /// Initialize the instance. 
 void Geant4Random::initialize()   {
   if ( !m_file.empty() )  {
-    ifstream in(m_file.c_str(), std::ios::in);
+    std::ifstream in(m_file.c_str(), std::ios::in);
     m_engine = CLHEP::EngineFactory::newEngine(in);
     if ( !m_engine )    {
       except("Failed to create CLHEP random engine from file:%s.",m_file.c_str());

--- a/DDG4/src/Geant4RunAction.cpp
+++ b/DDG4/src/Geant4RunAction.cpp
@@ -12,15 +12,13 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4RunAction.h"
-// Geant4 headers
-#include "G4Threading.hh"
-#include "G4AutoLock.hh"
-// C/C++ include files
-#include <stdexcept>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4RunAction.h>
 
-using namespace std;
+// Geant4 headers
+#include <G4Threading.hh>
+#include <G4AutoLock.hh>
+
 using namespace dd4hep::sim;
 
 namespace {
@@ -29,7 +27,7 @@ namespace {
 }
 
 /// Standard constructor
-Geant4RunAction::Geant4RunAction(Geant4Context* ctxt, const string& nam)
+Geant4RunAction::Geant4RunAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   InstanceCount::increment(this);
 }
@@ -48,7 +46,7 @@ void Geant4RunAction::end(const G4Run*) {
 }
 
 /// Standard constructor
-Geant4SharedRunAction::Geant4SharedRunAction(Geant4Context* ctxt, const string& nam)
+Geant4SharedRunAction::Geant4SharedRunAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4RunAction(ctxt, nam)
 {
   InstanceCount::increment(this);
@@ -73,7 +71,7 @@ void Geant4SharedRunAction::use(Geant4RunAction* action)   {
     m_action = action;
     return;
   }
-  throw runtime_error("Geant4SharedRunAction: Attempt to use invalid actor!");
+  except("Geant4SharedRunAction: Attempt to use invalid actor!");
 }
 
 /// Begin-of-run callback
@@ -97,7 +95,7 @@ void Geant4SharedRunAction::end(const G4Run* run)   {
 }
 
 /// Standard constructor
-Geant4RunActionSequence::Geant4RunActionSequence(Geant4Context* ctxt, const string& nam)
+Geant4RunActionSequence::Geant4RunActionSequence(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   m_needsControl = true;
   InstanceCount::increment(this);
@@ -124,7 +122,7 @@ void Geant4RunActionSequence::configureFiber(Geant4Context* thread_context)   {
 }
 
 /// Get an action by name
-Geant4RunAction* Geant4RunActionSequence::get(const string& nam) const   {
+Geant4RunAction* Geant4RunActionSequence::get(const std::string& nam) const   {
   return m_actors.get(FindByName(TypeName::split(nam).second));
 }
 
@@ -136,7 +134,7 @@ void Geant4RunActionSequence::adopt(Geant4RunAction* action) {
     m_actors.add(action);
     return;
   }
-  throw runtime_error("Geant4RunActionSequence: Attempt to add invalid actor!");
+  except("Geant4RunActionSequence: Attempt to add invalid actor!");
 }
 
 /// Pre-track action callback

--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -43,6 +43,9 @@
 #include <G4GenericTrap.hh>
 #include <G4ExtrudedSolid.hh>
 #include <G4EllipticalTube.hh>
+#include <G4TessellatedSolid.hh>
+#include <G4TriangularFacet.hh>
+#include <G4QuadrangularFacet.hh>
 
 // C/C++ include files
 
@@ -237,18 +240,6 @@ namespace dd4hep {
         vertices.emplace_back(vtx_xy[0] * CM_2_MM, vtx_xy[1] * CM_2_MM);
       return new G4GenericTrap(sh->GetName(), sh->GetDz() * CM_2_MM, vertices);
     }
-  }    // End namespace sim
-}      // End namespace dd4hep
-
-#if ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
-#include <G4TessellatedSolid.hh>
-#include <G4TriangularFacet.hh>
-#include <G4QuadrangularFacet.hh>
-
-/// Namespace for the AIDA detector description toolkit
-namespace dd4hep {
-  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
-  namespace sim {
 
     template <> G4VSolid* convertShape<TGeoTessellated>(const TGeoShape* shape)  {
       TGeoTessellated*   sh  = (TGeoTessellated*) shape;
@@ -299,5 +290,3 @@ namespace dd4hep {
     
   }    // End namespace sim
 }      // End namespace dd4hep
-#endif // ROOT_VERSION_CODE > ROOT_VERSION(6,21,0)
-

--- a/DDG4/src/Geant4StackingAction.cpp
+++ b/DDG4/src/Geant4StackingAction.cpp
@@ -12,23 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4StackingAction.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4StackingAction.h>
+
 // Geant4 headers
-#include "G4Threading.hh"
-#include "G4AutoLock.hh"
+#include <G4Threading.hh>
+#include <G4AutoLock.hh>
 
-// C/C++ include files
-#include <stdexcept>
-
-using namespace std;
 using namespace dd4hep::sim;
 namespace {
   G4Mutex action_mutex=G4MUTEX_INITIALIZER;
 }
 
 /// Standard constructor
-Geant4StackingAction::Geant4StackingAction(Geant4Context* ctxt, const string& nam)
+Geant4StackingAction::Geant4StackingAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   InstanceCount::increment(this);
 }
@@ -40,13 +37,12 @@ Geant4StackingAction::~Geant4StackingAction() {
 
 /// Classify new track: The first call in the sequence returning non-null pointer wins!
 TrackClassification 
-Geant4StackingAction::classifyNewTrack(G4StackManager* /* manager */,
-				       const G4Track* /* track */)  {
+Geant4StackingAction::classifyNewTrack(G4StackManager* /* manager */, const G4Track* /* track */)  {
   return TrackClassification();
 }
 
 /// Standard constructor
-Geant4SharedStackingAction::Geant4SharedStackingAction(Geant4Context* ctxt, const string& nam)
+Geant4SharedStackingAction::Geant4SharedStackingAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4StackingAction(ctxt, nam), m_action(0)
 {
   InstanceCount::increment(this);
@@ -71,7 +67,7 @@ void Geant4SharedStackingAction::use(Geant4StackingAction* action)   {
     m_action = action;
     return;
   }
-  throw runtime_error("Geant4SharedStackingAction: Attempt to use invalid actor!");
+  except("Attempt to use invalid actor!");
 }
 
 /// Begin-of-stacking callback
@@ -97,7 +93,7 @@ void Geant4SharedStackingAction::prepare(G4StackManager* stackManager)  {
 /// Classify new track with delegation
 TrackClassification 
 Geant4SharedStackingAction::classifyNewTrack(G4StackManager* stackManager,
-					     const G4Track* track)   {
+                                             const G4Track* track)   {
   if ( m_action )  {
     G4AutoLock protection_lock(&action_mutex);  {
       ContextSwap swap(m_action,context());
@@ -108,7 +104,7 @@ Geant4SharedStackingAction::classifyNewTrack(G4StackManager* stackManager,
 }
 
 /// Standard constructor
-Geant4StackingActionSequence::Geant4StackingActionSequence(Geant4Context* ctxt, const string& nam)
+Geant4StackingActionSequence::Geant4StackingActionSequence(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   m_needsControl = true;
   InstanceCount::increment(this);
@@ -130,7 +126,7 @@ void Geant4StackingActionSequence::adopt(Geant4StackingAction* action) {
     m_actors.add(action);
     return;
   }
-  throw runtime_error("Geant4StackingActionSequence: Attempt to add invalid actor!");
+  except("Attempt to add invalid actor!");
 }
 
 /// Set or update client context
@@ -145,7 +141,7 @@ void Geant4StackingActionSequence::configureFiber(Geant4Context* thread_context)
 }
 
 /// Get an action by name
-Geant4StackingAction* Geant4StackingActionSequence::get(const string& nam) const   {
+Geant4StackingAction* Geant4StackingActionSequence::get(const std::string& nam) const   {
   return m_actors.get(FindByName(TypeName::split(nam).second));
 }
 
@@ -164,7 +160,7 @@ void Geant4StackingActionSequence::prepare(G4StackManager* stackManager) {
 /// Classify new track: The first call in the sequence returning non-null pointer wins!
 TrackClassification 
 Geant4StackingActionSequence::classifyNewTrack(G4StackManager* stackManager,
-					       const G4Track* track)   {
+                                               const G4Track* track)   {
   for( auto a : m_actors )   {
     auto ret = a->classifyNewTrack(stackManager, track);
     if ( ret.type != NoTrackClassification )  {

--- a/DDG4/src/Geant4StepHandler.cpp
+++ b/DDG4/src/Geant4StepHandler.cpp
@@ -12,16 +12,15 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4StepHandler.h"
-#include "DDSegmentation/Segmentation.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "CLHEP/Units/SystemOfUnits.h"
+#include <DDG4/Geant4StepHandler.h>
+#include <DDSegmentation/Segmentation.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <CLHEP/Units/SystemOfUnits.h>
 
 // Geant4 include files
-#include "G4Version.hh"
+#include <G4Version.hh>
 
 namespace units = dd4hep;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Returns the step status in form of a string

--- a/DDG4/src/Geant4SteppingAction.cpp
+++ b/DDG4/src/Geant4SteppingAction.cpp
@@ -12,22 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4SteppingAction.h"
-// Geant4 headers
-#include "G4Threading.hh"
-#include "G4AutoLock.hh"
-// C/C++ include files
-#include <stdexcept>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4SteppingAction.h>
 
-using namespace std;
+// Geant4 headers
+#include <G4Threading.hh>
+#include <G4AutoLock.hh>
+
 using namespace dd4hep::sim;
 namespace {
   G4Mutex action_mutex=G4MUTEX_INITIALIZER;
 }
 
 /// Standard constructor
-Geant4SteppingAction::Geant4SteppingAction(Geant4Context* ctxt, const string& nam)
+Geant4SteppingAction::Geant4SteppingAction(Geant4Context* ctxt, const std::string& nam)
 : Geant4Action(ctxt, nam) {
   InstanceCount::increment(this);
 }
@@ -42,7 +40,7 @@ void Geant4SteppingAction::operator()(const G4Step*, G4SteppingManager*) {
 }
 
 /// Standard constructor
-Geant4SharedSteppingAction::Geant4SharedSteppingAction(Geant4Context* ctxt, const string& nam)
+Geant4SharedSteppingAction::Geant4SharedSteppingAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4SteppingAction(ctxt, nam), m_action(0)
 {
   InstanceCount::increment(this);
@@ -62,7 +60,7 @@ void Geant4SharedSteppingAction::use(Geant4SteppingAction* action)   {
     m_action = action;
     return;
   }
-  throw runtime_error("Geant4SharedSteppingAction: Attempt to use invalid actor!");
+  except("Attempt to use invalid actor!");
 }
 
 /// Set or update client for the use in a new thread fiber
@@ -81,7 +79,7 @@ void Geant4SharedSteppingAction::operator()(const G4Step* s, G4SteppingManager* 
 }
 
 /// Standard constructor
-Geant4SteppingActionSequence::Geant4SteppingActionSequence(Geant4Context* ctxt, const string& nam)
+Geant4SteppingActionSequence::Geant4SteppingActionSequence(Geant4Context* ctxt, const std::string& nam)
 : Geant4Action(ctxt, nam) {
   m_needsControl = true;
   InstanceCount::increment(this);
@@ -107,7 +105,7 @@ void Geant4SteppingActionSequence::updateContext(Geant4Context* ctxt)    {
 }
 
 /// Get an action by name
-Geant4SteppingAction* Geant4SteppingActionSequence::get(const string& nam) const   {
+Geant4SteppingAction* Geant4SteppingActionSequence::get(const std::string& nam) const   {
   return m_actors.get(FindByName(TypeName::split(nam).second));
 }
 
@@ -125,5 +123,5 @@ void Geant4SteppingActionSequence::adopt(Geant4SteppingAction* action) {
     m_actors.add(action);
     return;
   }
-  throw runtime_error("Geant4SteppingActionSequence: Attempt to add invalid actor!");
+  except("Attempt to add invalid actor!");
 }

--- a/DDG4/src/Geant4TestActions.cpp
+++ b/DDG4/src/Geant4TestActions.cpp
@@ -12,19 +12,17 @@
 //=========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4TestActions.h"
-#include "G4Run.hh"
-#include "G4Event.hh"
-#include "G4Step.hh"
-#include "G4Track.hh"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4TestActions.h>
+#include <G4Run.hh>
+#include <G4Event.hh>
+#include <G4Step.hh>
+#include <G4Track.hh>
 
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
-using namespace dd4hep::sim;
 using namespace dd4hep::sim::Test;
 
 namespace {

--- a/DDG4/src/Geant4TouchableHandler.cpp
+++ b/DDG4/src/Geant4TouchableHandler.cpp
@@ -12,14 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4TouchableHandler.h"
-#include "DDG4/Geant4GeometryInfo.h"
+#include <DDG4/Geant4TouchableHandler.h>
+#include <DDG4/Geant4GeometryInfo.h>
 
-#include "G4Step.hh"
-#include "G4VTouchable.hh"
-
-// C/C++ include files
-#include <stdexcept>
+#include <G4Step.hh>
+#include <G4VTouchable.hh>
 
 using namespace dd4hep::sim;
 
@@ -52,7 +49,7 @@ Geant4TouchableHandler::Geant4PlacementPath Geant4TouchableHandler::placementPat
     return path_val;
   }
   if ( exception )   {
-    throw std::runtime_error("Attempt to access invalid G4 touchable object.");
+    except("Geant4TouchableHandler", "Attempt to access invalid G4 touchable object.");
   }
   return path_val;
 }

--- a/DDG4/src/Geant4TrackInformation.cpp
+++ b/DDG4/src/Geant4TrackInformation.cpp
@@ -12,10 +12,8 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4TrackInformation.h"
+#include <DDG4/Geant4TrackInformation.h>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Default constructor

--- a/DDG4/src/Geant4TrackingAction.cpp
+++ b/DDG4/src/Geant4TrackingAction.cpp
@@ -12,24 +12,20 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4TrackingAction.h"
-#include "DDG4/Geant4MonteCarloTruth.h"
-#include "DDG4/Geant4TrackInformation.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4TrackingAction.h>
+#include <DDG4/Geant4MonteCarloTruth.h>
+#include <DDG4/Geant4TrackInformation.h>
 
 // Geant4 include files
-#include "G4Track.hh"
-#include "G4Threading.hh"
-#include "G4AutoLock.hh"
-#include "G4TrackingManager.hh"
-#include "G4VUserTrackInformation.hh"
+#include <G4Track.hh>
+#include <G4Threading.hh>
+#include <G4AutoLock.hh>
+#include <G4TrackingManager.hh>
+#include <G4VUserTrackInformation.hh>
 
-// C/C++ include files
-#include <stdexcept>
-
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
+
 class G4Step;
 class G4TouchableHistory;
 namespace {
@@ -37,7 +33,7 @@ namespace {
 }
 
 /// Standard constructor
-Geant4TrackingActionSequence::Geant4TrackingActionSequence(Geant4Context* ctxt, const string& nam)
+Geant4TrackingActionSequence::Geant4TrackingActionSequence(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   m_needsControl = true;
   InstanceCount::increment(this);
@@ -66,7 +62,7 @@ void Geant4TrackingActionSequence::configureFiber(Geant4Context* thread_context)
 }
 
 /// Get an action by name
-Geant4TrackingAction* Geant4TrackingActionSequence::get(const string& nam) const   {
+Geant4TrackingAction* Geant4TrackingActionSequence::get(const std::string& nam) const   {
   return m_actors.get(FindByName(TypeName::split(nam).second));
 }
 
@@ -78,7 +74,7 @@ void Geant4TrackingActionSequence::adopt(Geant4TrackingAction* action) {
     m_actors.add(action);
     return;
   }
-  throw runtime_error("Geant4TrackingActionSequence: Attempt to add invalid actor!");
+  throw std::runtime_error("Geant4TrackingActionSequence: Attempt to add invalid actor!");
 }
 
 /// Pre-track action callback
@@ -96,7 +92,7 @@ void Geant4TrackingActionSequence::end(const G4Track* track) {
 }
 
 /// Standard constructor
-Geant4TrackingAction::Geant4TrackingAction(Geant4Context* ctxt, const string& nam)
+Geant4TrackingAction::Geant4TrackingAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   InstanceCount::increment(this);
 }
@@ -121,7 +117,7 @@ void Geant4TrackingAction::mark(const G4Track* track) const    {
 }
 
 /// Standard constructor
-Geant4SharedTrackingAction::Geant4SharedTrackingAction(Geant4Context* ctxt, const string& nam)
+Geant4SharedTrackingAction::Geant4SharedTrackingAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4TrackingAction(ctxt, nam), m_action(0)
 {
   InstanceCount::increment(this);
@@ -146,7 +142,7 @@ void Geant4SharedTrackingAction::use(Geant4TrackingAction* action)   {
     m_action = action;
     return;
   }
-  throw runtime_error("Geant4SharedTrackingAction: Attempt to use invalid actor!");
+  except("Attempt to use invalid actor!");
 }
 
 /// Begin-of-track callback

--- a/DDG4/src/Geant4TrackingPostAction.cpp
+++ b/DDG4/src/Geant4TrackingPostAction.cpp
@@ -12,17 +12,16 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4TrackingPostAction.h"
-#include "DDG4/Geant4TrackHandler.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4TrackingPostAction.h>
+#include <DDG4/Geant4TrackHandler.h>
 
 // Geant4 include files
-#include "G4TrackingManager.hh"
+#include <G4TrackingManager.hh>
 
 // C/C++ include files
 #include <algorithm>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 /// Helper class to manipulate strings
@@ -81,7 +80,7 @@ void Geant4TrackingPostAction::end(const G4Track* tr) {
 
   Geant4TrackHandler track(tr);
   //Geant4TrackInformation* info = track.info<Geant4TrackInformation>();
-  const string& proc = track.creatorProcess()->GetProcessName();
+  const std::string& proc = track.creatorProcess()->GetProcessName();
   StringV::const_iterator trIt = find_if(m_ignoredProcs.begin(), m_ignoredProcs.end(), FindString(proc));
   if (trIt != m_ignoredProcs.end()) {
     warning("Particles created by processes of type %s are not kept!", (*trIt).c_str());

--- a/DDG4/src/Geant4TrackingPreAction.cpp
+++ b/DDG4/src/Geant4TrackingPreAction.cpp
@@ -12,11 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4TrackingPreAction.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4TrackingPreAction.h>
 
 // Geant4 include files
-#include "G4TrackingManager.hh"
+#include <G4TrackingManager.hh>
 
 using namespace dd4hep::sim;
 

--- a/DDG4/src/Geant4UIManager.cpp
+++ b/DDG4/src/Geant4UIManager.cpp
@@ -31,16 +31,15 @@
 #include <functional>
 
 using namespace dd4hep::sim;
-using namespace std;
 
 namespace   {
-  string make_cmd(const string& cmd)  {
-    return string( "/control/execute "+cmd);
+  std::string make_cmd(const std::string& cmd)  {
+    return std::string( "/control/execute "+cmd);
   }
 }
 
 /// Initializing constructor
-Geant4UIManager::Geant4UIManager(Geant4Context* ctxt, const string& nam)
+Geant4UIManager::Geant4UIManager(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt,nam), m_vis(0), m_ui(0)
 {
   declareProperty("SetupUI",            m_uiSetup="");
@@ -56,9 +55,9 @@ Geant4UIManager::Geant4UIManager(Geant4Context* ctxt, const string& nam)
   declareProperty("HaveVIS",            m_haveVis=false);
   declareProperty("HaveUI",             m_haveUI=true);
   declareProperty("Prompt",             m_prompt);
-  context()->kernel().register_configure(bind(&Geant4UIManager::configure,this));
-  context()->kernel().register_initialize(bind(&Geant4UIManager::initialize,this));
-  context()->kernel().register_terminate(bind(&Geant4UIManager::terminate,this));
+  context()->kernel().register_configure(std::bind(&Geant4UIManager::configure,this));
+  context()->kernel().register_initialize(std::bind(&Geant4UIManager::initialize,this));
+  context()->kernel().register_terminate(std::bind(&Geant4UIManager::terminate,this));
   enableUI();
 }
 
@@ -113,7 +112,7 @@ void Geant4UIManager::terminate() {
 }
 
 /// Apply single command
-void Geant4UIManager::applyCommand(const string& command)   {
+void Geant4UIManager::applyCommand(const std::string& command)   {
   /// Get the pointer to the User Interface manager
   G4UImanager* mgr = G4UImanager::GetUIpointer();
   if ( mgr )    {
@@ -248,7 +247,7 @@ void Geant4UIManager::start() {
 
   /// No UI. Pure batch mode: Simply execute requested number of events
   long numEvent = context()->kernel().property("NumEvents").value<long>();
-  if(numEvent < 0) numEvent = numeric_limits<int>::max();
+  if(numEvent < 0) numEvent = std::numeric_limits<int>::max();
   info("++ Start run with %d events.",numEvent);
   try {
     context()->kernel().runManager().BeamOn(numEvent);

--- a/DDG4/src/Geant4UIMessenger.cpp
+++ b/DDG4/src/Geant4UIMessenger.cpp
@@ -12,19 +12,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/Primitives.h"
-#include "DDG4/Geant4UIMessenger.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/Primitives.h>
+#include <DDG4/Geant4UIMessenger.h>
 
 // Geant4 include files
-#include "G4UIcmdWithoutParameter.hh"
-#include "G4UIcmdWithAString.hh"
+#include <G4UIcmdWithoutParameter.hh>
+#include <G4UIcmdWithAString.hh>
 
 // C/C++ include files
 #include <algorithm>
 
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 namespace {
@@ -35,8 +33,8 @@ namespace {
     InstallProperties(Geant4UIMessenger::Commands& c, const std::string& p, G4UImessenger* m)
       : cmds(c), path(p), msg(m) {
     }
-    void operator()(const pair<string, Property>& o) {
-      string n = path + o.first;
+    void operator()(const std::pair<std::string, dd4hep::Property>& o) {
+      std::string n = path + o.first;
       G4UIcmdWithAString* cmd = new G4UIcmdWithAString(n.c_str(), msg);
       cmd->SetParameterName(o.first.c_str(), true);
       cmd->SetGuidance(("Property item of type " + o.second.type()).c_str());
@@ -45,7 +43,7 @@ namespace {
   };
 }
 
-Geant4UIMessenger::Geant4UIMessenger(const string& name, const string& path)
+Geant4UIMessenger::Geant4UIMessenger(const std::string& name, const std::string& path)
   : G4UImessenger(), m_directory(0), m_properties(0), m_name(name), m_path(path) {
   m_directory = new G4UIdirectory(path.c_str());
   printout(INFO, "Geant4UI", "+++ %s> Install Geant4 control directory:%s", name.c_str(), path.c_str());
@@ -89,7 +87,7 @@ void Geant4UIMessenger::exportProperties(PropertyManager& mgr) {
 G4String Geant4UIMessenger::GetCurrentValue(G4UIcommand * c) {
   Commands::iterator i = m_propertyCmd.find(c);
   if (m_properties && i != m_propertyCmd.end()) {
-    const string& n = (*i).second;
+    const std::string& n = (*i).second;
     return (*m_properties)[n].str();
   }
   printout(INFO, "Geant4UI",
@@ -101,7 +99,7 @@ G4String Geant4UIMessenger::GetCurrentValue(G4UIcommand * c) {
 void Geant4UIMessenger::SetNewValue(G4UIcommand *c, G4String v) {
   Commands::iterator i = m_propertyCmd.find(c);
   if (m_properties && i != m_propertyCmd.end()) {
-    const string& n = (*i).second;
+    const std::string& n = (*i).second;
     try  {
       if (!v.empty()) {
         Property& p = (*m_properties)[n];
@@ -111,12 +109,12 @@ void Geant4UIMessenger::SetNewValue(G4UIcommand *c, G4String v) {
                  m_name.c_str(), n.c_str(), v.c_str(), p.str().c_str());
       }
       else {
-        string value = (*m_properties)[n].str();
+        std::string value = (*m_properties)[n].str();
         printout(INFO, "Geant4UI", "+++ %s> Unchanged property value %s = %s.",
                  m_name.c_str(), n.c_str(), value.c_str());
       }
     }
-    catch(const exception& e)   {
+    catch(const std::exception& e)   {
       printout(INFO, "Geant4UI", "+++ %s> Exception: Failed to change property %s = '%s'.",
                m_name.c_str(), n.c_str(), v.c_str());
       printout(INFO, "Geant4UI", "+++ %s> Exception: %s", m_name.c_str(), e.what());
@@ -134,7 +132,7 @@ void Geant4UIMessenger::SetNewValue(G4UIcommand *c, G4String v) {
         const void* args[] = {v.c_str(), 0};
         (*j).second.execute(args);
       }
-      catch(const exception& e)   {
+      catch(const std::exception& e)   {
         printout(INFO, "Geant4UI", "+++ %s> Exception: Failed to exec action '%s' [%s].",
                  m_name.c_str(), c->GetCommandName().c_str(), c->GetCommandPath().c_str());
         printout(INFO, "Geant4UI", "+++ %s> Exception: %s",e.what());

--- a/DDG4/src/Geant4UserInitialization.cpp
+++ b/DDG4/src/Geant4UserInitialization.cpp
@@ -12,17 +12,13 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4UserInitialization.h"
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4UserInitialization.h>
 
-// C/C++ include files
-#include <stdexcept>
-
-using namespace std;
 using namespace dd4hep::sim;
 
 /// Standard constructor
-Geant4UserInitialization::Geant4UserInitialization(Geant4Context* ctxt, const string& nam)
+Geant4UserInitialization::Geant4UserInitialization(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt, nam) {
   m_needsControl = false;
   InstanceCount::increment(this);
@@ -42,7 +38,7 @@ void Geant4UserInitialization::buildMaster()  const  {
 }
 
 /// Standard constructor
-Geant4UserInitializationSequence::Geant4UserInitializationSequence(Geant4Context* ctxt, const string& nam)
+Geant4UserInitializationSequence::Geant4UserInitializationSequence(Geant4Context* ctxt, const std::string& nam)
   : Geant4UserInitialization(ctxt, nam) {
   m_needsControl = false;
   InstanceCount::increment(this);
@@ -64,7 +60,7 @@ void Geant4UserInitializationSequence::adopt(Geant4UserInitialization* action)  
     m_actors.add(action);
     return;
   }
-  throw runtime_error("Geant4UserInitializationSequence: Attempt to add invalid actor!");
+  except("Attempt to add invalid actor!");
 }
 
 /// Callback function to build setup for the MT worker thread

--- a/DDG4/src/Geant4UserLimits.cpp
+++ b/DDG4/src/Geant4UserLimits.cpp
@@ -12,29 +12,25 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Geant4UserLimits.h"
-#include "DDG4/Geant4Particle.h"
-#include "DD4hep/InstanceCount.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/Primitives.h"
-#include "DD4hep/Printout.h"
+#include <DDG4/Geant4UserLimits.h>
+#include <DDG4/Geant4Particle.h>
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Primitives.h>
+#include <DD4hep/Printout.h>
 
 // Geant 4 include files
-#include "G4Track.hh"
-#include "G4ParticleDefinition.hh"
-#include "CLHEP/Units/SystemOfUnits.h"
+#include <G4Track.hh>
+#include <G4ParticleDefinition.hh>
+#include <CLHEP/Units/SystemOfUnits.h>
 
-// C/C++ include files
-#include <stdexcept>
-
-using namespace std;
 using namespace dd4hep::sim;
 
 namespace  {
   bool user_limit_debug = false;
 }
 
-      /// Allow for debugging user limits (very verbose)
+/// Allow for debugging user limits (very verbose)
 bool Geant4UserLimits::enable_debug(bool value)   {
   bool tmp = user_limit_debug;
   user_limit_debug = value;
@@ -48,21 +44,21 @@ double Geant4UserLimits::Handler::value(const G4Track& track) const    {
     auto i = particleLimits.find(track.GetDefinition());
     if ( i != particleLimits.end() )  {
       if ( user_limit_debug )   {
-	dd4hep::printout(dd4hep::INFO,"Geant4UserLimits", "Apply explicit limit %f to track: %s",
-			 def->GetParticleName().c_str());
+        dd4hep::printout(dd4hep::INFO,"Geant4UserLimits", "Apply explicit limit %f to track: %s",
+                         def->GetParticleName().c_str());
       }
       return (*i).second;
     }
   }
   if ( user_limit_debug )   {
     dd4hep::printout(dd4hep::INFO,"Geant4UserLimits", "Apply default limit %f to track: %s",
-		     def->GetParticleName().c_str());
+                     def->GetParticleName().c_str());
   }
   return defaultValue;
 }
 
 /// Set the handler value(s)
-void Geant4UserLimits::Handler::set(const string& particles, double val)   {
+void Geant4UserLimits::Handler::set(const std::string& particles, double val)   {
   if ( particles == "*" || particles == ".(.*)" )   {
     defaultValue = val;
     return;
@@ -108,28 +104,28 @@ void Geant4UserLimits::update(LimitSet limitset)    {
     else if (l.name == "range_min")
       minRange.set(l.particles, l.value);
     else
-      throw runtime_error("Unknown Geant4 user limit: " + l.toString());
+      except("Geant4UserLimits", "Unknown Geant4 user limit: %s ", l.toString().c_str());
   }
 }
 
 /// Setters may not be called!
 void Geant4UserLimits::SetMaxAllowedStep(G4double /* ustepMax */)  {
-  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+  dd4hep::notImplemented(std::string(__PRETTY_FUNCTION__)+" May not be called!");
 }
 
 void Geant4UserLimits::SetUserMaxTrackLength(G4double /* utrakMax */)  {
-  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+  dd4hep::notImplemented(std::string(__PRETTY_FUNCTION__)+" May not be called!");
 }
 
 void Geant4UserLimits::SetUserMaxTime(G4double /* utimeMax */)  {
-  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+  dd4hep::notImplemented(std::string(__PRETTY_FUNCTION__)+" May not be called!");
 }
 
 void Geant4UserLimits::SetUserMinEkine(G4double /* uekinMin */)  {
-  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+  dd4hep::notImplemented(std::string(__PRETTY_FUNCTION__)+" May not be called!");
 }
 
 void Geant4UserLimits::SetUserMinRange(G4double /* urangMin */)  {
-  dd4hep::notImplemented(string(__PRETTY_FUNCTION__)+" May not be called!");
+  dd4hep::notImplemented(std::string(__PRETTY_FUNCTION__)+" May not be called!");
 }
 

--- a/DDG4/src/Geant4Vertex.cpp
+++ b/DDG4/src/Geant4Vertex.cpp
@@ -12,11 +12,10 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Printout.h"
-#include "DD4hep/InstanceCount.h"
-#include "DDG4/Geant4Vertex.h"
+#include <DD4hep/Printout.h>
+#include <DD4hep/InstanceCount.h>
+#include <DDG4/Geant4Vertex.h>
 
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Default destructor

--- a/DDG4/src/Geant4VolumeManager.cpp
+++ b/DDG4/src/Geant4VolumeManager.cpp
@@ -29,20 +29,17 @@
 #include <sstream>
 
 using namespace dd4hep::sim::Geant4GeometryMaps;
-using namespace dd4hep::detail::tools;
-using namespace dd4hep::detail;
 using namespace dd4hep::sim;
 using namespace dd4hep;
-using namespace std;
 
 #include <DDG4/Geant4AssemblyVolume.h>
-typedef pair<VolumeID,vector<pair<const BitFieldElement*, VolumeID> > > VolIDDescriptor;
+typedef std::pair<VolumeID,std::vector<std::pair<const BitFieldElement*, VolumeID> > > VolIDDescriptor;
 namespace {
 
   /// Helper class to populate the Geant4 volume manager
   struct Populator {
-    typedef vector<const TGeoNode*> Chain;
-    typedef map<VolumeID,Geant4GeometryInfo::Geant4PlacementPath> Registries;
+    typedef std::vector<const TGeoNode*> Chain;
+    typedef std::map<VolumeID,Geant4GeometryInfo::Geant4PlacementPath> Registries;
     /// Reference to the Detector instance
     const Detector& m_detDesc;
     /// Set of already added entries
@@ -74,10 +71,10 @@ namespace {
       }
       /// Needed to compute the cellID of parameterized volumes
       for( const auto& pv : m_geo.g4Placements )   {
-	if ( pv.second->IsParameterised() )
-	  m_geo.g4Parameterised[pv.second] = pv.first;
-	if ( pv.second->IsReplicated() )
-	  m_geo.g4Replicated[pv.second] = pv.first;
+        if ( pv.second->IsParameterised() )
+          m_geo.g4Parameterised[pv.second] = pv.first;
+        if ( pv.second->IsReplicated() )
+          m_geo.g4Replicated[pv.second] = pv.first;
       }
     }
 
@@ -133,14 +130,14 @@ namespace {
           node = *(k);
           PlacementMap::const_iterator g4pit = m_geo.g4Placements.find(node);
           if (g4pit != m_geo.g4Placements.end()) {
-	    G4VPhysicalVolume* phys = (*g4pit).second;
-	    if ( phys->IsParameterised() )   {
-	      PlacedVolume pv(n);
-	      PlacedVolumeExtension* ext = pv.data();
-	      if ( nullptr == ext->params->field )   {
-		ext->params->field = iddesc.field(ext->volIDs.at(0).first);
-	      }
-	    }
+            G4VPhysicalVolume* phys = (*g4pit).second;
+            if ( phys->IsParameterised() )   {
+              PlacedVolume pv(n);
+              PlacedVolumeExtension* ext = pv.data();
+              if ( nullptr == ext->params->field )   {
+                ext->params->field = iddesc.field(ext->volIDs.at(0).first);
+              }
+            }
             path.emplace_back(phys);
             printout(print_chain, "Geant4VolumeManager", "+++     Chain: Node OK: %s [%s]",
                      node->GetName(), phys->GetName().c_str());
@@ -171,21 +168,21 @@ namespace {
           printout(print_res, "Geant4VolumeManager", "+++     Map %016X to Geant4 Path:%s",
                    (void*)code, Geant4GeometryInfo::placementPath(path).c_str());
           if ( m_geo.g4Paths.find(path) == m_geo.g4Paths.end() ) {
-	    Geant4GeometryInfo::PlacementFlags opt;
-	    for(const auto* phys : path)   {
-	      opt.flags.path_has_parametrised = phys->IsParameterised() ? 1 : 0;
-	      opt.flags.path_has_replicated   = phys->IsReplicated()    ? 1 : 0;
-	    }
-	    opt.flags.parametrised = path.front()->IsParameterised() ? 1 : 0;
-	    opt.flags.replicated   = path.front()->IsReplicated()    ? 1 : 0;
+            Geant4GeometryInfo::PlacementFlags opt;
+            for(const auto* phys : path)   {
+              opt.flags.path_has_parametrised = phys->IsParameterised() ? 1 : 0;
+              opt.flags.path_has_replicated   = phys->IsReplicated()    ? 1 : 0;
+            }
+            opt.flags.parametrised = path.front()->IsParameterised() ? 1 : 0;
+            opt.flags.replicated   = path.front()->IsReplicated()    ? 1 : 0;
             m_geo.g4Paths[path] = { code, opt.value };
             m_entries.emplace(code,path);
             return;
           }
-	  /// This is a normal case for parametrized volumes and no error
-	  if ( !path.empty() && (path.front()->IsParameterised() || path.front()->IsReplicated()) )   {
-	    return;
-	  }
+          /// This is a normal case for parametrized volumes and no error
+          if ( !path.empty() && (path.front()->IsParameterised() || path.front()->IsReplicated()) )   {
+            return;
+          }
           printout(ERROR, "Geant4VolumeManager", "populate: Severe error: Duplicated Geant4 path!!!! %s %s",
                    " [THIS SHOULD NEVER HAPPEN]",Geant4GeometryInfo::placementPath(path).c_str());
           goto Err;
@@ -195,10 +192,10 @@ namespace {
         goto Err;
       }
       else  {
-	/// This is a normal case for parametrized volumes and no error
-	if ( !path.empty() && (path.front()->IsParameterised() || path.front()->IsReplicated()) )   {
-	  return;
-	}
+        /// This is a normal case for parametrized volumes and no error
+        if ( !path.empty() && (path.front()->IsParameterised() || path.front()->IsReplicated()) )   {
+          return;
+        }
       }
       printout(ERROR, "Geant4VolumeManager", "populate: Severe error: Duplicated Volume entry: 0x%X"
                " [THIS SHOULD NEVER HAPPEN]", code);
@@ -211,7 +208,7 @@ namespace {
       if ( !nodes.empty() )
         printout(ERROR,"Geant4VolumeManager","     TGeo path: %s",detail::tools::placementPath(nodes,false).c_str());
       printout(ERROR,"Geant4VolumeManager",  " Offend.VolIDs: %s",detail::tools::toString(ro.idSpec(),ids,code).c_str());
-      throw runtime_error("Failed to populate Geant4 volume manager!");
+      throw std::runtime_error("Failed to populate Geant4 volume manager!");
     }
   };
 }
@@ -224,11 +221,11 @@ Geant4VolumeManager::Geant4VolumeManager(const Detector& description, Geant4Geom
     p.populate(description.world());
     return;
   }
-  throw runtime_error(format("Geant4VolumeManager", "Attempt populate from invalid Geant4 geometry info [Invalid-Info]"));
+  except("Geant4VolumeManager", "Attempt populate from invalid Geant4 geometry info [Invalid-Info]");
 }
 
 /// Helper: Generate placement path from touchable object
-vector<const G4VPhysicalVolume*>
+std::vector<const G4VPhysicalVolume*>
 Geant4VolumeManager::placementPath(const G4VTouchable* touchable, bool exception) const {
   Geant4TouchableHandler handler(touchable);
   return handler.placementPath(exception);
@@ -237,17 +234,17 @@ Geant4VolumeManager::placementPath(const G4VTouchable* touchable, bool exception
 /// Check the validity of the information before accessing it.
 bool Geant4VolumeManager::checkValidity() const {
   if (!isValid()) {
-    throw runtime_error(format("Geant4VolumeManager", "Attempt to use invalid Geant4 volume manager [Invalid-Handle]"));
+    except("Geant4VolumeManager", "Attempt to use invalid Geant4 volume manager [Invalid-Handle]");
   }
   else if (!ptr()->valid) {
-    throw runtime_error(format("Geant4VolumeManager", "Attempt to use invalid Geant4 geometry info [Invalid-Info]"));
+    except("Geant4VolumeManager", "Attempt to use invalid Geant4 geometry info [Invalid-Info]");
   }
   return true;
 }
 
 #if 0
 /// Access CELLID by placement path
-VolumeID Geant4VolumeManager::volumeID(const vector<const G4VPhysicalVolume*>& path) const {
+VolumeID Geant4VolumeManager::volumeID(const std::vector<const G4VPhysicalVolume*>& path) const {
   if (!path.empty() && checkValidity()) {
     const auto& mapping = ptr()->g4Paths;
     auto i = mapping.find(path);
@@ -268,7 +265,7 @@ VolumeID Geant4VolumeManager::volumeID(const vector<const G4VPhysicalVolume*>& p
 /// Access CELLID by Geant4 touchable object
 VolumeID Geant4VolumeManager::volumeID(const G4VTouchable* touchable) const {
   Geant4TouchableHandler handler(touchable);
-  vector<const G4VPhysicalVolume*> path = handler.placementPath();
+  std::vector<const G4VPhysicalVolume*> path = handler.placementPath();
   if (!path.empty() && checkValidity()) {
     const auto& mapping = ptr()->g4Paths;
     auto i = mapping.find(path);
@@ -276,36 +273,36 @@ VolumeID Geant4VolumeManager::volumeID(const G4VTouchable* touchable) const {
       const auto& e = (*i).second;
       /// No parametrization or replication.
       if ( e.flags == 0 )  {
-	return e.volumeID;
+        return e.volumeID;
       }
       VolumeID volid = e.volumeID;
       const auto& paramterised = ptr()->g4Parameterised;
       const auto& replicated   = ptr()->g4Replicated;
       /// This is incredibly slow .... but what can I do ? Need a better idea.
       for ( std::size_t j=0; j < path.size(); ++j )   {
-	const auto* phys = path[j];
-	if ( phys->IsParameterised() )   {
-	  int copy_no = touchable->GetCopyNumber(j);
-	  const auto it = paramterised.find(phys);
-	  if ( it != paramterised.end() )   {
-	    //printout(INFO,"Geant4VolumeManager",
-	    //         "Copy number:   %ld  <--> %ld", copy_no, long(phys->GetCopyNo()));
-	    const auto* field = (*it).second.data()->params->field;
-	    volid |= IDDescriptor::encode(field, copy_no);
-	    continue;
-	  }
-	  except("Geant4VolumeManager","Error  Geant4VolumeManager::volumeID(const G4VTouchable* touchable)");
-	}
-	else if ( phys->IsReplicated() )    {
-	  int copy_no = touchable->GetCopyNumber(j);
-	  const auto it = replicated.find(phys);
-	  if ( it != replicated.end() )   {
-	    const auto* field = (*it).second.data()->params->field;
-	    volid |= IDDescriptor::encode(field, copy_no);
-	    continue;
-	  }
-	  except("Geant4VolumeManager","Error  Geant4VolumeManager::volumeID(const G4VTouchable* touchable)");
-	}
+        const auto* phys = path[j];
+        if ( phys->IsParameterised() )   {
+          int copy_no = touchable->GetCopyNumber(j);
+          const auto it = paramterised.find(phys);
+          if ( it != paramterised.end() )   {
+            //printout(INFO,"Geant4VolumeManager",
+            //         "Copy number:   %ld  <--> %ld", copy_no, long(phys->GetCopyNo()));
+            const auto* field = (*it).second.data()->params->field;
+            volid |= IDDescriptor::encode(field, copy_no);
+            continue;
+          }
+          except("Geant4VolumeManager","Error  Geant4VolumeManager::volumeID(const G4VTouchable* touchable)");
+        }
+        else if ( phys->IsReplicated() )    {
+          int copy_no = touchable->GetCopyNumber(j);
+          const auto it = replicated.find(phys);
+          if ( it != replicated.end() )   {
+            const auto* field = (*it).second.data()->params->field;
+            volid |= IDDescriptor::encode(field, copy_no);
+            continue;
+          }
+          except("Geant4VolumeManager","Error  Geant4VolumeManager::volumeID(const G4VTouchable* touchable)");
+        }
       }
       return volid;
     }
@@ -320,7 +317,7 @@ VolumeID Geant4VolumeManager::volumeID(const G4VTouchable* touchable) const {
 }
 
 /// Accessfully decoded volume fields  by placement path
-void Geant4VolumeManager::volumeDescriptor(const vector<const G4VPhysicalVolume*>& path,
+void Geant4VolumeManager::volumeDescriptor(const std::vector<const G4VPhysicalVolume*>& path,
                                            VolIDDescriptor& vol_desc) const
 {
   vol_desc.second.clear();

--- a/DDG4/src/IoStreams.cpp
+++ b/DDG4/src/IoStreams.cpp
@@ -12,18 +12,16 @@
 //==========================================================================
 
 // Framework includes
-#include "DDG4/IoStreams.h"
+#include <DDG4/IoStreams.h>
+
+// ROOT include files
+#include <TFile.h>
 
 // C/C++ include files
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <cstdio>
-
-// ROOT include files
-#include "TFile.h"
-
-using namespace dd4hep;
 
 namespace {
   /// Anonymous cast class to get access to protected members of TFile ;-)

--- a/DDG4/src/python/Geant4PythonAction.cpp
+++ b/DDG4/src/python/Geant4PythonAction.cpp
@@ -13,23 +13,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Factories.h"
-#include "DDG4/Python/Geant4PythonAction.h"
-#include "DDG4/Python/Geant4PythonCall.h"
-#include "DDG4/Python/DDPython.h"
+#include <DDG4/Factories.h>
+#include <DDG4/Python/Geant4PythonAction.h>
+#include <DDG4/Python/Geant4PythonCall.h>
+#include <DDG4/Python/DDPython.h>
 
-// C/C++ include files
-#include <stdexcept>
-#include <fstream>
-
-using namespace std;
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 DECLARE_GEANT4ACTION(Geant4PythonAction)
 
 /// Standard constructor, initializes variables
-Geant4PythonAction::Geant4PythonAction(Geant4Context* ctxt, const string& nam)
+Geant4PythonAction::Geant4PythonAction(Geant4Context* ctxt, const std::string& nam)
   : Geant4Action(ctxt,nam)
 {
   m_needsControl = true;

--- a/DDG4/src/python/Geant4PythonCall.cpp
+++ b/DDG4/src/python/Geant4PythonCall.cpp
@@ -13,14 +13,13 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Python/Geant4PythonCall.h"
-#include "DDG4/Python/DDPython.h"
-#include "TPyReturn.h"
+#include <DDG4/Python/Geant4PythonCall.h>
+#include <DDG4/Python/DDPython.h>
+#include <TPyReturn.h>
 
 // C/C++ include files
 #include <stdexcept>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::sim;
 
@@ -87,9 +86,7 @@ namespace dd4hep { namespace sim {
     INSTANTIATE(unsigned long);
     INSTANTIATE(float);
     INSTANTIATE(double);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
     INSTANTIATE(char*);
-#endif
     INSTANTIATE(const char*);
     INSTANTIATE(PyObject*);
     INSTANTIATE(void*);

--- a/DDG4/src/python/Geant4PythonCall.cpp
+++ b/DDG4/src/python/Geant4PythonCall.cpp
@@ -17,10 +17,6 @@
 #include <DDG4/Python/DDPython.h>
 #include <TPyReturn.h>
 
-// C/C++ include files
-#include <stdexcept>
-
-using namespace dd4hep;
 using namespace dd4hep::sim;
 
 /// Standard constructor, initializes variables

--- a/DDG4/src/python/Geant4PythonDetectorConstruction.cpp
+++ b/DDG4/src/python/Geant4PythonDetectorConstruction.cpp
@@ -12,21 +12,20 @@
 //
 //==========================================================================
 // Framework include files
-#include "DDG4/Geant4Context.h"
-#include "DDG4/Geant4Kernel.h"
+#include <DDG4/Geant4Context.h>
+#include <DDG4/Geant4Kernel.h>
 
-#include "DDG4/Python/DDPython.h"
-#include "DDG4/Python/Geant4PythonAction.h"
-#include "DDG4/Python/Geant4PythonDetectorConstruction.h"
+#include <DDG4/Python/DDPython.h>
+#include <DDG4/Python/Geant4PythonAction.h>
+#include <DDG4/Python/Geant4PythonDetectorConstruction.h>
 
-using namespace std;
 using namespace dd4hep::sim;
 
-#include "DDG4/Factories.h"
+#include <DDG4/Factories.h>
 DECLARE_GEANT4ACTION(Geant4PythonDetectorConstruction)
 
 /// Standard constructor, initializes variables
-Geant4PythonDetectorConstruction::Geant4PythonDetectorConstruction(Geant4Context* ctxt, const string& nam)
+Geant4PythonDetectorConstruction::Geant4PythonDetectorConstruction(Geant4Context* ctxt, const std::string& nam)
 : Geant4DetectorConstruction(ctxt,nam), 
   m_constructSD(), m_constructFLD(), m_constructGEO()
 {
@@ -49,7 +48,7 @@ void Geant4PythonDetectorConstruction::setConstructSensitives(PyObject* callable
 }
 
 /// Execute command in the python interpreter
-void Geant4PythonDetectorConstruction::exec(const string& desc, const Geant4PythonCall& cmd)  const   {
+void Geant4PythonDetectorConstruction::exec(const std::string& desc, const Geant4PythonCall& cmd)  const   {
   if ( cmd.isValid() )  {
     int ret = cmd.execute<int>();
     if ( ret != 1 )  {

--- a/DDG4/src/python/Geant4PythonDetectorConstructionLast.cpp
+++ b/DDG4/src/python/Geant4PythonDetectorConstructionLast.cpp
@@ -15,8 +15,8 @@
 #define DD4HEP_DDG4_GEANT4PYTHONDETECTORCONSTRUCTIONLAST_H
 
 // Framework include files
-#include "DDG4/Geant4DetectorConstruction.h"
-#include "DDG4/Python/DDPython.h"
+#include <DDG4/Geant4DetectorConstruction.h>
+#include <DDG4/Python/DDPython.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDG4/src/python/Geant4PythonInitialization.cpp
+++ b/DDG4/src/python/Geant4PythonInitialization.cpp
@@ -13,18 +13,17 @@
 //==========================================================================
 
 // Framework include files
-#include "DDG4/Factories.h"
-#include "DDG4/Geant4Kernel.h"
-#include "DDG4/Python/DDPython.h"
-#include "DDG4/Python/Geant4PythonInitialization.h"
+#include <DDG4/Factories.h>
+#include <DDG4/Geant4Kernel.h>
+#include <DDG4/Python/DDPython.h>
+#include <DDG4/Python/Geant4PythonInitialization.h>
 
-using namespace std;
 using namespace dd4hep::sim;
 
 DECLARE_GEANT4ACTION(Geant4PythonInitialization)
 
 /// Standard constructor, initializes variables
-Geant4PythonInitialization::Geant4PythonInitialization(Geant4Context* ctxt, const string& nam)
+Geant4PythonInitialization::Geant4PythonInitialization(Geant4Context* ctxt, const std::string& nam)
 : Geant4UserInitialization(ctxt,nam), m_masterSetup(), m_workerSetup()
 {
   m_needsControl = true;
@@ -41,7 +40,7 @@ void Geant4PythonInitialization::setWorkerSetup(PyObject* callable, PyObject* ar
 }
 
 /// Execute command in the python interpreter
-void Geant4PythonInitialization::exec(const string& desc, const Geant4PythonCall& cmd)  const   {
+void Geant4PythonInitialization::exec(const std::string& desc, const Geant4PythonCall& cmd)  const   {
   if ( cmd.isValid() )  { 
     int ret = cmd.execute<int>();
     if ( ret != 1 )  {

--- a/DDParsers/include/Evaluator/DD4hepUnits.h
+++ b/DDParsers/include/Evaluator/DD4hepUnits.h
@@ -29,16 +29,6 @@
 
 #include "RVersion.h"
 
-// We use the ROOT system units if they are avalible (FAILS SOME TESTS FOR NOW)
-#if 0
-/// ROOT_VERSION_CODE >= ROOT_VERSION(6,12,0)
-#include "TGeoSystemOfUnits.h"
-/// Main dd4hep namespace. We must import here the ROOT TGeo units
-namespace dd4hep {
-  using namespace TGeoUnit;
-}
-#else
-
 /// Main dd4hep namespace. We must import here the ROOT TGeo units
 namespace dd4hep {
 
@@ -423,6 +413,4 @@ namespace dd4hep {
     static constexpr double universe_mean_density = 1.e-25 * g / cm3;
   //}
 }
-#endif
-
 #endif // EVALUATOR_DD4HEPUNITS_H

--- a/UtilityApps/src/teve_display.cpp
+++ b/UtilityApps/src/teve_display.cpp
@@ -12,49 +12,48 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/Factories.h"
-#include "DD4hep/Detector.h"
-#include "DDRec/SurfaceHelper.h"
+#include <DD4hep/Factories.h>
+#include <DD4hep/Detector.h>
+#include <DDRec/SurfaceHelper.h>
 
 #include "EvNavHandler.h"
 #include "MultiView.h"
 
 #include "run_plugin.h"
-#include "TRint.h"
+#include <TRint.h>
 
-#include "TROOT.h"
-#include "TEveGeoNode.h"
-#include "TEveBrowser.h"
-#include "TGNumberEntry.h"
-#include "TGButton.h"
-#include "TGLabel.h"
-#include "TStyle.h"
-#include "TGComboBox.h"
-#include "TEveManager.h"
-#include "TSystem.h"
-#include "TGLViewer.h"
-#include "TEveViewer.h"
-#include "TGLPerspectiveCamera.h"
-#include "TGLCamera.h"
-#include "TEveStraightLineSet.h"
-#include "TSysEvtHandler.h"
+#include <TROOT.h>
+#include <TEveGeoNode.h>
+#include <TEveBrowser.h>
+#include <TGNumberEntry.h>
+#include <TGButton.h>
+#include <TGLabel.h>
+#include <TStyle.h>
+#include <TGComboBox.h>
+#include <TEveManager.h>
+#include <TSystem.h>
+#include <TGLViewer.h>
+#include <TEveViewer.h>
+#include <TGLPerspectiveCamera.h>
+#include <TGLCamera.h>
+#include <TEveStraightLineSet.h>
+#include <TSysEvtHandler.h>
 #include <TEveScene.h>
 #include <TEveProjectionManager.h>
 #include <TEveProjectionAxes.h>
 #include <TEveWindow.h>
 
-#include "TGeoManager.h"
-#include "TGLClip.h"
-#include "TMap.h"
-#include "TObjString.h"
-#include "TGeoShape.h"
-#include "TGLScenePad.h"
+#include <TGeoManager.h>
+#include <TGLClip.h>
+#include <TMap.h>
+#include <TObjString.h>
+#include <TGeoShape.h>
+#include <TGLScenePad.h>
 
 
 using namespace dd4hep ;
 using namespace rec ;
 using namespace detail ;
-
 
 //=====================================================================================
 // function declarations: 
@@ -295,12 +294,7 @@ void make_gui() {
 
   TGHorizontalFrame* hf = new TGHorizontalFrame(frmMain);
   {
-      
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,9,2)
     TString icondir( Form("%s/", TROOT::GetIconPath().Data()) );
-#else
-    TString icondir( Form("%s/icons/", gSystem->Getenv("ROOTSYS")) );
-#endif
     TGPictureButton* b = 0;
     EvNavHandler    *fh = new EvNavHandler;
 

--- a/examples/ClientTests/src/Assemblies_VXD_geo.cpp
+++ b/examples/ClientTests/src/Assemblies_VXD_geo.cpp
@@ -14,13 +14,11 @@
 // Framework includes
 #include "DD4hep/DetFactoryHelper.h"
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 static Ref_t create_element(Detector& description, xml_h e, SensitiveDetector sens)  {
   xml_det_t    x_det = e;
-  string       name  = x_det.nameStr();
+  std::string  name  = x_det.nameStr();
   Assembly     assembly(name+"_assembly");
   DetElement   vxd(name, x_det.typeStr(), x_det.id());
   PlacedVolume pv;
@@ -32,7 +30,7 @@ static Ref_t create_element(Detector& description, xml_h e, SensitiveDetector se
     xml_comp_t  x_ladder  (x_layer.child(_U(ladder)));
     int         layer_id   = x_layer.id();
     int         nLadders   = x_ladder.number();
-    string      layername  = name+_toString(layer_id,"_layer%d");
+    std::string layername  = name+_toString(layer_id,"_layer%d");
     double      dphi       = 2.*M_PI/double(nLadders);
     // --- create an assembly and DetElement for the layer 
     Assembly     layer_assembly(layername);
@@ -81,7 +79,7 @@ static Ref_t create_element(Detector& description, xml_h e, SensitiveDetector se
     for(int j=0; j<nLadders; ++j) {
       double dj = double(j);
       double phi = phi0 + dj*dphi;
-      string laddername = layername + _toString(j,"_ladder%d");
+      std::string laddername = layername + _toString(j,"_ladder%d");
       double lthick = sens_thick + supp_thick;
       RotationZYX rot( phi,0,0);
       double pos_x = (radius + lthick/2.)*cos(phi)  - offset * sin( phi );

--- a/examples/ClientTests/src/MaterialTester_geo.cpp
+++ b/examples/ClientTests/src/MaterialTester_geo.cpp
@@ -11,29 +11,23 @@
 //
 //==========================================================================
 
-#include "RVersion.h"
-
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,20,0)
-
 // Framework include files
-#include "DD4hep/DetFactoryHelper.h"
-#include "DD4hep/DD4hepUnits.h"
-#include "DD4hep/Printout.h"
+#include <DD4hep/DetFactoryHelper.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Printout.h>
 
 // ROOT include file
-#include "TGeoElement.h"
-#include "TGeoPhysicalConstants.h"
-#include "TGeant4PhysicalConstants.h"
-#include "TMath.h"
+#include <TGeoElement.h>
+#include <TGeoPhysicalConstants.h>
+#include <TGeant4PhysicalConstants.h>
+#include <TMath.h>
 
 namespace units = dd4hep;
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 static Ref_t create_element(Detector& description, xml_h xml_det, SensitiveDetector /* sens */)  {
   xml_det_t    x_det = xml_det;
-  string       det_name = x_det.nameStr();
+  std::string  det_name = x_det.nameStr();
   Assembly     assembly(det_name+"_assembly");
   DetElement   det(det_name,x_det.typeStr(), x_det.id());
 
@@ -41,7 +35,7 @@ static Ref_t create_element(Detector& description, xml_h xml_det, SensitiveDetec
     xml_det_t xbox = x_det.child(_U(box));
     Volume box = Volume(det_name+"_box",
                         Box(xbox.x(), xbox.y(), xbox.z()),
-                        description.material(xbox.attr<string>(_U(material))));
+                        description.material(xbox.attr<std::string>(_U(material))));
     PlacedVolume place = assembly.placeVolume(box);
     place.addPhysVolID("box",0);
   }
@@ -140,4 +134,4 @@ static Ref_t create_element(Detector& description, xml_h xml_det, SensitiveDetec
 }
 
 DECLARE_DETELEMENT(MaterialTester,create_element)
-#endif
+

--- a/examples/ClientTests/src/MiniTel.cpp
+++ b/examples/ClientTests/src/MiniTel.cpp
@@ -16,14 +16,14 @@
 #include "DD4hep/Printout.h"
 #include "DD4hep/Detector.h"
 
+// C/C++ include files
 #include <iostream>
 #include <map>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 namespace  {
+
   struct MyDetExtension  {
     int idD, Ni, Nj;
     double dimDX, dimDY, dimDZ;
@@ -45,14 +45,14 @@ namespace  {
 typedef MyDetExtension DetectorExtension;
 
 static Ref_t create_detector(Detector &description, xml_h e, SensitiveDetector sens)  {
-  xml_det_t  x_det    = e;	//xml-detelemnt of the detector taken as an argument
-  xml_comp_t det_dim  = x_det.child(_U(dimensions));
-  xml_comp_t det_mod  = x_det.child(_U(module));	    // considering the module-pixel of the detector
-  string     det_name = x_det.nameStr();	//det_name is the name of the xml-detelement
-  Assembly   assembly (det_name);
-  DetElement sdet(det_name,x_det.id());        //sdet is the detelement of the detector!!(actually is a Handle,already a pointer to m_element)
-  Volume     motherVol = description.pickMotherVolume(sdet); //the mothers volume of our detector
-  Material   mat = description.material("Silicon");
+  xml_det_t   x_det    = e;	//xml-detelemnt of the detector taken as an argument
+  xml_comp_t  det_dim  = x_det.child(_U(dimensions));
+  xml_comp_t  det_mod  = x_det.child(_U(module));	    // considering the module-pixel of the detector
+  std::string det_name = x_det.nameStr();	//det_name is the name of the xml-detelement
+  Assembly    assembly (det_name);
+  DetElement  sdet(det_name,x_det.id());        //sdet is the detelement of the detector!!(actually is a Handle,already a pointer to m_element)
+  Volume      motherVol = description.pickMotherVolume(sdet); //the mothers volume of our detector
+  Material    mat = description.material("Silicon");
 
   DetectorExtension* ext = new MyDetExtension(sdet);
   sdet.addExtension<MyDetExtension>(ext);

--- a/examples/ClientTests/src/PlacedVolumeScannerTest.cpp
+++ b/examples/ClientTests/src/PlacedVolumeScannerTest.cpp
@@ -19,7 +19,7 @@
    geoPluginRun -destroy -plugin DD4hep_VolumeScannerTest -opt [-opt]
 
 */
-// Framework include files
+/// Framework include files
 #include "DD4hep/Volumes.h"
 #include "DD4hep/Detector.h"
 #include "DD4hep/Printout.h"
@@ -27,6 +27,8 @@
 #include "DD4hep/DetectorTools.h"
 #include "DD4hep/VolumeProcessor.h"
 #include "TClass.h"
+
+/// C/C++ include files
 #include <iomanip>
 
 namespace   {
@@ -61,7 +63,6 @@ namespace   {
   };
 }
 
-using namespace std;
 using namespace dd4hep;
 
 /// Plugin function: Test example of the volume scanner using a customized callback functor
@@ -73,7 +74,7 @@ using namespace dd4hep;
  */
 static int scan_volumes (Detector& detector, int argc, char** argv)  {
   bool help = false;
-  string det_element_path, placed_vol_path;
+  std::string det_element_path, placed_vol_path;
   for(int i=0; i<argc && argv[i]; ++i)  {
     if ( 0 == ::strncmp("-help",argv[i],4) )
       help = true;
@@ -86,13 +87,13 @@ static int scan_volumes (Detector& detector, int argc, char** argv)  {
   }
   if ( help )   {
     /// Help printout describing the basic command line interface
-    cout <<
+    std::cout <<
       "Usage: -plugin <name> -arg [-arg]                                                  \n"
       "     name:   factory name     DD4hep_PlacedVolumeScannerTest                       \n"
       "     -detector <name>         Path to the detector element where to start the scan.\n"
       "     -path     <name>         Alternatively specify the physical volume path.      \n"
       "     -help                    Ahow this help.                                      \n"
-      "\tArguments given: " << arguments(argc,argv) << endl << flush;
+      "\tArguments given: " << arguments(argc,argv) << std::endl << std::flush;
     ::exit(EINVAL);
   }
 

--- a/examples/ClientTests/src/Property_test.cpp
+++ b/examples/ClientTests/src/Property_test.cpp
@@ -11,13 +11,14 @@
 //
 //==========================================================================
 
-// Framework include files
+/// Framework include files
 #include <DD4hep/ComponentProperties.h>
 #include <DD4hep/Factories.h>
+
+/// C/C++ include files
 #include <iostream>
 #include <deque>
 
-using namespace std;
 using namespace dd4hep;
 
 /// Plugin function: Condition program example
@@ -30,71 +31,77 @@ using namespace dd4hep;
  */
 #include <sstream>
 namespace   {
-  template <typename T> int _test_prop(const string& tag, const string& data)    {
+  template <typename T> int _test_prop(const std::string& tag, const std::string& data)    {
     T value;
-    stringstream log;
+    std::stringstream log;
     Property prop(value);
     try  {
       prop.str(data);
-      log << "| " << setw(32) << left << tag << " " << setw(6) << left << "" << "   " << setw(10) << left << value << "  ";
-      cout << log.str() << endl;
+      log << "| " << std::setw(32) << std::left << tag << " "
+          << std::setw(6) << std::left << "" << "   "
+          << std::setw(10) << std::left << value << "  ";
+      std::cout << log.str() << std::endl;
     }
-    catch(const exception& e)   {
-      cout << "Test FAILED: " << tag << " Exception: " << e.what() << endl;
+    catch(const std::exception& e)   {
+      std::cout << "Test FAILED: " << tag << " Exception: " << e.what() << std::endl;
       return 1;
     }
     return 0;
   }
-  template <typename T> int _test_cont(const string& tag, const string& data)    {
+  template <typename T> int _test_cont(const std::string& tag, const std::string& data)    {
     T value;
-    stringstream log;
+    std::stringstream log;
     Property prop(value);
     try  {
       prop.str(data);
-      log << "| " << setw(32) << left << tag << " ";
+      log << "| " << std::setw(32) << std::left << tag << " ";
       for(const auto& p : value)
-	log << setw(6) << left << "" << "   " << setw(10) << left << p << "  ";
-      cout << log.str() << endl;
+        log << std::setw(6) << std::left << "" << "   " << std::setw(10) << std::left << p << "  ";
+      std::cout << log.str() << std::endl;
     }
-    catch(const exception& e)   {
-      cout << "Test FAILED: " << tag << " Exception: " << e.what() << endl;
+    catch(const std::exception& e)   {
+      std::cout << "Test FAILED: " << tag << " Exception: " << e.what() << std::endl;
       return 1;
     }
     return 0;
   }
-  template <> int _test_cont<vector<bool> >(const string& tag, const string& data)    {
-    vector<bool> value;
-    stringstream log;
+  template <> int _test_cont<std::vector<bool> >(const std::string& tag, const std::string& data)    {
+    std::vector<bool> value;
+    std::stringstream log;
     Property prop(value);
     try  {
       prop.str(data);
-      log << "| " << setw(32) << left << tag << " ";
+      log << "| " << std::setw(32) << std::left << tag << " ";
       for(const auto p : value)
-	log << setw(6) << left << "" << "   " << setw(10) << left << p << "  ";
-      cout << log.str() << endl;
+        log << std::setw(6) << std::left << "" << "   " << std::setw(10) << std::left << p << "  ";
+      std::cout << log.str() << std::endl;
     }
-    catch(const exception& e)   {
-      cout << "Test FAILED: " << tag << " Exception: " << e.what() << endl;
+    catch(const std::exception& e)   {
+      std::cout << "Test FAILED: " << tag << " Exception: " << e.what() << std::endl;
       return 1;
     }
     return 0;
   }
-  template <typename T> int _test_map(const string& tag, const string& data)    {
+  template <typename T> int _test_map(const std::string& tag, const std::string& data)    {
     T value;
-    stringstream log;
+    std::stringstream log;
     Property prop(value);
     try  {
       prop.str(data);
-      log << "| " << setw(32) << left << tag << " ";
+      log << "| " << std::setw(32) << std::left << tag << " ";
       for(const auto& p : value)
-	log << setw(6) << left << p.first << " = " << setw(10) << left << p.second << "  ";
-      cout << log.str() << endl;
+        log << std::setw(6) << std::left << p.first << " = " << std::setw(10) << std::left << p.second << "  ";
+      std::cout << log.str() << std::endl;
     }
-    catch(const exception& e)   {
-      cout << "Test FAILED: " << tag << " Exception: " << e.what() << endl;
+    catch(const std::exception& e)   {
+      std::cout << "Test FAILED: " << tag << " Exception: " << e.what() << std::endl;
       return 1;
     }
     return 0;
+  }
+  void line()  {
+    std::cout << "+-----------------------------------------------------"
+              << "-----------------------------------------------------" << std::endl;
   }
 }
 
@@ -104,8 +111,8 @@ static int property_test(Detector& /* description */, int /* argc */, char** /* 
   using XYZVector = ROOT::Math::XYZVector;
   using PxPyPzE = ROOT::Math::PxPyPzEVector;
   int result = 0;
-  cout << "+----------------------------------------------------------------------------------------------------------" << endl;
-  result += _test_prop<string>                   ("prop_str",                "'a'");
+  line();
+  result += _test_prop<std::string>              ("prop_str",                "'a'");
   result += _test_prop<bool>                     ("prop_bool",               "true");
   result += _test_prop<int>                      ("prop_int",                "11");
   result += _test_prop<int>                      ("prop_int_eval",           "1*11");
@@ -123,119 +130,119 @@ static int property_test(Detector& /* description */, int /* argc */, char** /* 
   result += _test_prop<XYZVector>                ("prop_XYZVector_eval",     "(1*GeV, 2*GeV, 3*GeV)");
   result += _test_prop<PxPyPzE>                  ("prop_PxPyPzEVector",      "(1, 2, 3, 4)");
   result += _test_prop<PxPyPzE>                  ("prop_PxPyPzEVector_eval", "(1*GeV, 2*GeV, 3*GeV, 4*GeV)");
-  cout << "+----------------------------------------------------------------------------------------------------------" << endl;
-  result += _test_map <map<string, string> >     ("map_str_str",             "{'a':   'a',      'b':  'bb',       'c':  'ccc'}");
-  result += _test_map <map<string, bool> >       ("map_str_bool",            "{'a':   true,     'b': false,       'c':   true}");
-  result += _test_map <map<string, int> >        ("map_str_int",             "{'a':   11,       'b':   222,       'c':   3333}");
-  result += _test_map <map<string, int> >        ("map_str_int_eval",        "{'a':  1*11,      'b': 2*111,       'c': 3*1111}");
-  result += _test_map <map<string, long> >       ("map_str_long",            "{'a':   111,      'b':   222,       'c':   3333}");
-  result += _test_map <map<string, long> >       ("map_str_long_eval",       "{'a': 1*111,      'b': 2*111,       'c': 3*1111}");
-  result += _test_map <map<string, float> >      ("map_str_float",           "{'a':   1.11,     'b': 22.22,       'c':   333.33}");
-  result += _test_map <map<string, float> >      ("map_str_float_eval",      "{'a':  '1.11*GeV','b':'22.22*MeV',  'c':  '333.3*TeV'}");
-  result += _test_map <map<string, double> >     ("map_str_double",          "{'a':   1.11,     'b': 22.22,       'c':   333.33}");
-  result += _test_map <map<string, double> >     ("map_str_double_eval",     "{'a':  '1.11*GeV','b':'22.22*MeV',  'c':  '333.3*TeV'}");
-  //result += _test_map <map<string, XYZPoint> >   ("map_str_XYZPoint",        "{['a', (1, 2, 3)]}");//, 'b': (10,20,30), 'c': (100,200,300)}");
-  //result += _test_map <map<string, XYZVector> >  ("map_str_XYZVector",       "{'a': (1, 2, 3), 'b': (10,20,30), 'c': (100,200,300)}");
-  //result += _test_map <map<string, PxPyPzE> >    ("map_str_PxPyPzEVector",   "{'a': (1, 2, 3, 4), 'b': (10,20,30,40), 'c': (100,200,300,400)}");
-  cout << "+----------------------------------------------------------------------------------------------------------" << endl;
-  result += _test_map <map<int, string> >        ("map_int_str",             "{ 10:   'a',        200:   'bb',        3000: '    ccc'}");
-  result += _test_map <map<int, bool> >          ("map_int_bool",            "{ 10:   true,       200:  false,        3000:      true}");
-  result += _test_map <map<int, int> >           ("map_int_int",             "{ 10:   11,         200:  200,          3000:      3000}");
-  result += _test_map <map<int, int> >           ("map_int_int_eval",        "{ 10:   1*11,       200: 2*100,         3000:    3*1000}");
-  result += _test_map <map<int, long> >          ("map_int_long",            "{ 10:   111,        200:   222,         3000:   3333}");
-  result += _test_map <map<int, long> >          ("map_int_long_eval",       "{ 10: 1*111,        200: 2*111,         3000: 3*1111}");
-  result += _test_map <map<int, float> >         ("map_int_float",           "{ 10:   1.11,       200:   22.22,       3000:    333.33}");
-  result += _test_map <map<int, float> >         ("map_int_float_eval",      "{ 10:   1.11*GeV,   200:   22.22*MeV,   3000: 333.3*TeV}");
-  result += _test_map <map<int, double> >        ("map_int_double",          "{ 10:   1.11,       200:   22.22,       3000:    333.33}");
-  result += _test_map <map<int, double> >        ("map_int_double_eval",     "{ 10:   1.11*GeV,   200:   22.22*MeV,   3000: 333.3*TeV}");
-  //result += _test_map <map<int, string> >        ("map_eval_int_str",        "{ 1*10: 'a',      2*100:   'bb',      3*1000:     'ccc'}");
-  result += _test_map <map<int, double> >        ("map_eval_int_double",     "{ 1*10: 1.11,     2*100: 22.22,       3*1000:    333.33}");
-  //result += _test_map <map<int, XYZPoint> >      ("map_int_XYZPoint",        "{ 10: (1, 2, 3),    200: (10,20,30),    3000: (100,200,300)}");
-  //result += _test_map <map<int, XYZVector> >     ("map_int_XYZVector",       "{ 10: (1, 2, 3),    200: (10,20,30),    3000: (100,200,300)}");
-  //result += _test_map <map<int, PxPyPzE> >       ("map_int_PxPyPzEVector",   "{ 10: (1, 2, 3, 4), 200: (10,20,30,40), 3000: (100,200,300,400)}");
+  line();
+  result += _test_map <std::map<std::string, std::string> >("map_str_str",             "{'a':   'a',      'b':  'bb',       'c':  'ccc'}");
+  result += _test_map <std::map<std::string, bool> >       ("map_str_bool",            "{'a':   true,     'b': false,       'c':   true}");
+  result += _test_map <std::map<std::string, int> >        ("map_str_int",             "{'a':   11,       'b':   222,       'c':   3333}");
+  result += _test_map <std::map<std::string, int> >        ("map_str_int_eval",        "{'a':  1*11,      'b': 2*111,       'c': 3*1111}");
+  result += _test_map <std::map<std::string, long> >       ("map_str_long",            "{'a':   111,      'b':   222,       'c':   3333}");
+  result += _test_map <std::map<std::string, long> >       ("map_str_long_eval",       "{'a': 1*111,      'b': 2*111,       'c': 3*1111}");
+  result += _test_map <std::map<std::string, float> >      ("map_str_float",           "{'a':   1.11,     'b': 22.22,       'c':   333.33}");
+  result += _test_map <std::map<std::string, float> >      ("map_str_float_eval",      "{'a':  '1.11*GeV','b':'22.22*MeV',  'c':  '333.3*TeV'}");
+  result += _test_map <std::map<std::string, double> >     ("map_str_double",          "{'a':   1.11,     'b': 22.22,       'c':   333.33}");
+  result += _test_map <std::map<std::string, double> >     ("map_str_double_eval",     "{'a':  '1.11*GeV','b':'22.22*MeV',  'c':  '333.3*TeV'}");
+  //result += _test_map <std::map<std::string, XYZPoint> >   ("map_str_XYZPoint",        "{['a', (1, 2, 3)]}");//, 'b': (10,20,30), 'c': (100,200,300)}");
+  //result += _test_map <std::map<std::string, XYZVector> >  ("map_str_XYZVector",       "{'a': (1, 2, 3), 'b': (10,20,30), 'c': (100,200,300)}");
+  //result += _test_map <std::map<std::string, PxPyPzE> >    ("map_str_PxPyPzEVector",   "{'a': (1, 2, 3, 4), 'b': (10,20,30,40), 'c': (100,200,300,400)}");
+  line();
+  result += _test_map <std::map<int, std::string> >        ("map_int_str",             "{ 10:   'a',        200:   'bb',        3000: '    ccc'}");
+  result += _test_map <std::map<int, bool> >          ("map_int_bool",            "{ 10:   true,       200:  false,        3000:      true}");
+  result += _test_map <std::map<int, int> >           ("map_int_int",             "{ 10:   11,         200:  200,          3000:      3000}");
+  result += _test_map <std::map<int, int> >           ("map_int_int_eval",        "{ 10:   1*11,       200: 2*100,         3000:    3*1000}");
+  result += _test_map <std::map<int, long> >          ("map_int_long",            "{ 10:   111,        200:   222,         3000:   3333}");
+  result += _test_map <std::map<int, long> >          ("map_int_long_eval",       "{ 10: 1*111,        200: 2*111,         3000: 3*1111}");
+  result += _test_map <std::map<int, float> >         ("map_int_float",           "{ 10:   1.11,       200:   22.22,       3000:    333.33}");
+  result += _test_map <std::map<int, float> >         ("map_int_float_eval",      "{ 10:   1.11*GeV,   200:   22.22*MeV,   3000: 333.3*TeV}");
+  result += _test_map <std::map<int, double> >        ("map_int_double",          "{ 10:   1.11,       200:   22.22,       3000:    333.33}");
+  result += _test_map <std::map<int, double> >        ("map_int_double_eval",     "{ 10:   1.11*GeV,   200:   22.22*MeV,   3000: 333.3*TeV}");
+  //result += _test_map <std::map<int, std::string> >  ("map_eval_int_str",        "{ 1*10: 'a',      2*100:   'bb',      3*1000:     'ccc'}");
+  result += _test_map <std::map<int, double> >        ("map_eval_int_double",     "{ 1*10: 1.11,     2*100: 22.22,       3*1000:    333.33}");
+  //result += _test_map <std::map<int, XYZPoint> >      ("map_int_XYZPoint",        "{ 10: (1, 2, 3),    200: (10,20,30),    3000: (100,200,300)}");
+  //result += _test_map <std::map<int, XYZVector> >     ("map_int_XYZVector",       "{ 10: (1, 2, 3),    200: (10,20,30),    3000: (100,200,300)}");
+  //result += _test_map <std::map<int, PxPyPzE> >       ("map_int_PxPyPzEVector",   "{ 10: (1, 2, 3, 4), 200: (10,20,30,40), 3000: (100,200,300,400)}");
 #if defined(DD4HEP_HAVE_ALL_PARSERS)
-  cout << "+----------------------------------------------------------------------------------------------------------" << endl;
-  result += _test_map <map<float, string> >      ("map_float_str",           "{ 10:   'a',      200:   'bb',        3000: 'ccc'}");
-  result += _test_map <map<float, bool> >        ("map_float_bool",          "{ 10:   true,     200:  false,        3000:  true}");
-  result += _test_map <map<float, int> >         ("map_float_int",           "{ 10:   11,       200:  200,          3000:  3000}");
-  result += _test_map <map<float, int> >         ("map_float_int_eval",      "{ 10:   1*11,     200: 2*100,         3000: 3*1000}");
-  result += _test_map <map<float, float> >       ("map_float_float",         "{ 10:   1.11,     200:   22.22,       3000: 333.33}");
-  result += _test_map <map<float, float> >       ("map_float_float_eval",    "{ 10:   1.11*GeV, 200:   22.22*MeV,   3000: 333.3*TeV}");
-  result += _test_map <map<float, double> >      ("map_float_double",        "{ 10:   1.11,     200:   22.22,       3000: 333.33}");
-  result += _test_map <map<float, double> >      ("map_float_double_eval",   "{ 10:   1.11*GeV, 200:   22.22*MeV,   3000: 333.3*TeV}");
+  line();
+  result += _test_map <std::map<float, std::string> > ("map_float_str",           "{ 10:   'a',      200:   'bb',        3000: 'ccc'}");
+  result += _test_map <std::map<float, bool> >        ("map_float_bool",          "{ 10:   true,     200:  false,        3000:  true}");
+  result += _test_map <std::map<float, int> >         ("map_float_int",           "{ 10:   11,       200:  200,          3000:  3000}");
+  result += _test_map <std::map<float, int> >         ("map_float_int_eval",      "{ 10:   1*11,     200: 2*100,         3000: 3*1000}");
+  result += _test_map <std::map<float, float> >       ("map_float_float",         "{ 10:   1.11,     200:   22.22,       3000: 333.33}");
+  result += _test_map <std::map<float, float> >       ("map_float_float_eval",    "{ 10:   1.11*GeV, 200:   22.22*MeV,   3000: 333.3*TeV}");
+  result += _test_map <std::map<float, double> >      ("map_float_double",        "{ 10:   1.11,     200:   22.22,       3000: 333.33}");
+  result += _test_map <std::map<float, double> >      ("map_float_double_eval",   "{ 10:   1.11*GeV, 200:   22.22*MeV,   3000: 333.3*TeV}");
 #endif
-  cout << "+----------------------------------------------------------------------------------------------------------" << endl;
-  result += _test_cont<set<string> >             ("set_str",                 "{'a',                    'bb',              'ccc'}");
-  result += _test_cont<set<bool> >               ("set_bool",                "{true,                   false,              true}");
-  result += _test_cont<set<int> >                ("set_int",                 "{11,                     222,               3333}");
-  result += _test_cont<set<int> >                ("set_int_eval",            "{1*11,                   2*111,           3*1111}");
-  result += _test_cont<set<int> >                ("set_int",                 "{11,                     222,               3333}");
-  result += _test_cont<set<long> >               ("set_long_eval",           "{1*11,                   2*111,           3*1111}");
-  result += _test_cont<set<long> >               ("set_long",                "{11,                     222,               3333}");
-  result += _test_cont<set<float> >              ("set_float",               "{1.11,                   22.22,             333.33}");
-  result += _test_cont<set<float> >              ("set_float_eval",          "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
-  result += _test_cont<set<double> >             ("set_double",              "{1.11,                   22.22,             333.33}");
-  result += _test_cont<set<double> >             ("set_double_eval",         "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
-  result += _test_cont<set<XYZPoint> >           ("set_XYZPoint",            "{(1, 2, 3),              (10,20,30),       (100,200,300)}");
-  result += _test_cont<set<XYZPoint> >           ("set_XYZPoint_eval",       "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
-  result += _test_cont<set<XYZVector> >          ("set_XYZVector",           "{(1, 2, 3),              (10,20,30),       (100,200,300)}");
-  result += _test_cont<set<XYZVector> >          ("set_XYZVector_eval",      "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
-  result += _test_cont<set<PxPyPzE> >            ("set_PxPyPzEVector",       "{(1, 2, 3,4),            (10,20,30,40),    (100,200,300,400)}");
-  result += _test_cont<set<PxPyPzE> >            ("set_PxPyPzEVector_eval",  "{(1*m, 2*m, 3*m, 4*m),   (10*m,20*m,30*m,40*m), (100*m,200*m,300*m,400*m)}");
-  cout << "+----------------------------------------------------------------------------------------------------------" << endl;
-  result += _test_cont<vector<string> >          ("vector_str",               "{'a',                    'bb',              'ccc'}");
-  result += _test_cont<vector<bool> >            ("vector_bool",              "{true,                   false,              true}");
-  result += _test_cont<vector<int> >             ("vector_int",               "{11,                     222,               3333}");
-  result += _test_cont<vector<int> >             ("vector_int_eval",          "{1*11,                   2*111,           3*1111}");
-  result += _test_cont<vector<long> >            ("vector_long_eval",         "{1*11,                   2*111,           3*1111}");
-  result += _test_cont<vector<long> >            ("vector_long",              "{11,                     222,               3333}");
-  result += _test_cont<vector<_ulong> >          ("vector_ulong_eval",        "{1*11,                   2*111,           3*1111}");
-  result += _test_cont<vector<_ulong> >          ("vector_ulong",             "{11,                     222,               3333}");
-  result += _test_cont<vector<float> >           ("vector_float",             "{1.11,                   22.22,             333.33}");
-  result += _test_cont<vector<float> >           ("vector_float_eval",        "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
-  result += _test_cont<vector<double> >          ("vector_double",            "{1.11,                   22.22,             333.33}");
-  result += _test_cont<vector<double> >          ("vector_double_eval",       "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
-  result += _test_cont<vector<XYZPoint> >        ("vector_XYZPoint",          "{(1, 2, 3),              (10,20,30), (100,200,300)}");
-  result += _test_cont<vector<XYZPoint> >        ("vector_XYZPoint_eval",     "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
-  result += _test_cont<vector<XYZVector> >       ("vector_XYZVector",         "{(1, 2, 3),              (10,20,30), (100,200,300)}");
-  result += _test_cont<vector<XYZVector> >       ("vector_XYZVector_eval",    "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
-  result += _test_cont<vector<PxPyPzE> >         ("vector_PxPyPzEVector",     "{(1, 2, 3,4),            (10,20,30,40),    (100,200,300,400)}");
-  result += _test_cont<vector<PxPyPzE> >         ("vector_PxPyPzEVector_eval","{(1*m, 2*m, 3*m, 4*m),   (10*m,20*m,30*m,40*m), (100*m,200*m,300*m,400*m)}");
-  cout << "+----------------------------------------------------------------------------------------------------------" << endl;
-  result += _test_cont<list<string> >            ("list_str",                 "{'a',                    'bb',              'ccc'}");
-  result += _test_cont<list<bool> >              ("list_bool",                "{true,                   false,              true}");
-  result += _test_cont<list<int> >               ("list_int",                 "{11,                     222,               3333}");
-  result += _test_cont<list<int> >               ("list_int_eval",            "{1*11,                   2*111,           3*1111}");
-  result += _test_cont<list<long> >              ("list_long_eval",           "{1*11,                   2*111,           3*1111}");
-  result += _test_cont<list<long> >              ("list_long",                "{11,                     222,               3333}");
-  result += _test_cont<list<_ulong> >            ("list_ulong_eval",          "{1*11,                   2*111,           3*1111}");
-  result += _test_cont<list<_ulong> >            ("list_ulong",               "{11,                     222,               3333}");
-  result += _test_cont<list<float> >             ("list_float",               "{1.11,                   22.22,             333.33}");
-  result += _test_cont<list<float> >             ("list_float_eval",          "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
-  result += _test_cont<list<double> >            ("list_double",              "{1.11,                   22.22,             333.33}");
-  result += _test_cont<list<double> >            ("list_double_eval",         "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
-  result += _test_cont<list<XYZPoint> >          ("list_XYZPoint",            "{(1, 2, 3),              (10,20,30), (100,200,300)}");
-  result += _test_cont<list<XYZVector> >         ("list_XYZVector",           "{(1, 2, 3),              (10,20,30), (100,200,300)}");
-  result += _test_cont<list<PxPyPzE> >           ("list_PxPyPzEVector",       "{(1, 2, 3,4),            (10,20,30,40), (100,200,300,400)}");
-  result += _test_cont<list<XYZVector> >         ("list_XYZVector_eval",      "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
-  result += _test_cont<list<PxPyPzE> >           ("list_PxPyPzEVector",       "{(1, 2, 3,4),            (10,20,30,40),    (100,200,300,400)}");
-  result += _test_cont<list<PxPyPzE> >           ("list_PxPyPzEVector_eval",  "{(1*m, 2*m, 3*m, 4*m),   (10*m,20*m,30*m,40*m), (100*m,200*m,300*m,400*m)}");
-  cout << "+----------------------------------------------------------------------------------------------------------" << endl;
+  line();
+  result += _test_cont<std::set<std::string> >        ("set_str",                 "{'a',                    'bb',              'ccc'}");
+  result += _test_cont<std::set<bool> >               ("set_bool",                "{true,                   false,              true}");
+  result += _test_cont<std::set<int> >                ("set_int",                 "{11,                     222,               3333}");
+  result += _test_cont<std::set<int> >                ("set_int_eval",            "{1*11,                   2*111,           3*1111}");
+  result += _test_cont<std::set<int> >                ("set_int",                 "{11,                     222,               3333}");
+  result += _test_cont<std::set<long> >               ("set_long_eval",           "{1*11,                   2*111,           3*1111}");
+  result += _test_cont<std::set<long> >               ("set_long",                "{11,                     222,               3333}");
+  result += _test_cont<std::set<float> >              ("set_float",               "{1.11,                   22.22,             333.33}");
+  result += _test_cont<std::set<float> >              ("set_float_eval",          "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
+  result += _test_cont<std::set<double> >             ("set_double",              "{1.11,                   22.22,             333.33}");
+  result += _test_cont<std::set<double> >             ("set_double_eval",         "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
+  result += _test_cont<std::set<XYZPoint> >           ("set_XYZPoint",            "{(1, 2, 3),              (10,20,30),       (100,200,300)}");
+  result += _test_cont<std::set<XYZPoint> >           ("set_XYZPoint_eval",       "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
+  result += _test_cont<std::set<XYZVector> >          ("set_XYZVector",           "{(1, 2, 3),              (10,20,30),       (100,200,300)}");
+  result += _test_cont<std::set<XYZVector> >          ("set_XYZVector_eval",      "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
+  result += _test_cont<std::set<PxPyPzE> >            ("set_PxPyPzEVector",       "{(1, 2, 3,4),            (10,20,30,40),    (100,200,300,400)}");
+  result += _test_cont<std::set<PxPyPzE> >            ("set_PxPyPzEVector_eval",  "{(1*m, 2*m, 3*m, 4*m),   (10*m,20*m,30*m,40*m), (100*m,200*m,300*m,400*m)}");
+  line();
+  result += _test_cont<std::vector<std::string> >     ("vector_str",               "{'a',                    'bb',              'ccc'}");
+  result += _test_cont<std::vector<bool> >            ("vector_bool",              "{true,                   false,              true}");
+  result += _test_cont<std::vector<int> >             ("vector_int",               "{11,                     222,               3333}");
+  result += _test_cont<std::vector<int> >             ("vector_int_eval",          "{1*11,                   2*111,           3*1111}");
+  result += _test_cont<std::vector<long> >            ("vector_long_eval",         "{1*11,                   2*111,           3*1111}");
+  result += _test_cont<std::vector<long> >            ("vector_long",              "{11,                     222,               3333}");
+  result += _test_cont<std::vector<_ulong> >          ("vector_ulong_eval",        "{1*11,                   2*111,           3*1111}");
+  result += _test_cont<std::vector<_ulong> >          ("vector_ulong",             "{11,                     222,               3333}");
+  result += _test_cont<std::vector<float> >           ("vector_float",             "{1.11,                   22.22,             333.33}");
+  result += _test_cont<std::vector<float> >           ("vector_float_eval",        "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
+  result += _test_cont<std::vector<double> >          ("vector_double",            "{1.11,                   22.22,             333.33}");
+  result += _test_cont<std::vector<double> >          ("vector_double_eval",       "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
+  result += _test_cont<std::vector<XYZPoint> >        ("vector_XYZPoint",          "{(1, 2, 3),              (10,20,30), (100,200,300)}");
+  result += _test_cont<std::vector<XYZPoint> >        ("vector_XYZPoint_eval",     "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
+  result += _test_cont<std::vector<XYZVector> >       ("vector_XYZVector",         "{(1, 2, 3),              (10,20,30), (100,200,300)}");
+  result += _test_cont<std::vector<XYZVector> >       ("vector_XYZVector_eval",    "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
+  result += _test_cont<std::vector<PxPyPzE> >         ("vector_PxPyPzEVector",     "{(1, 2, 3,4),            (10,20,30,40),    (100,200,300,400)}");
+  result += _test_cont<std::vector<PxPyPzE> >         ("vector_PxPyPzEVector_eval","{(1*m, 2*m, 3*m, 4*m),   (10*m,20*m,30*m,40*m), (100*m,200*m,300*m,400*m)}");
+  line();
+  result += _test_cont<std::list<std::string> >       ("list_str",                 "{'a',                    'bb',              'ccc'}");
+  result += _test_cont<std::list<bool> >              ("list_bool",                "{true,                   false,              true}");
+  result += _test_cont<std::list<int> >               ("list_int",                 "{11,                     222,               3333}");
+  result += _test_cont<std::list<int> >               ("list_int_eval",            "{1*11,                   2*111,           3*1111}");
+  result += _test_cont<std::list<long> >              ("list_long_eval",           "{1*11,                   2*111,           3*1111}");
+  result += _test_cont<std::list<long> >              ("list_long",                "{11,                     222,               3333}");
+  result += _test_cont<std::list<_ulong> >            ("list_ulong_eval",          "{1*11,                   2*111,           3*1111}");
+  result += _test_cont<std::list<_ulong> >            ("list_ulong",               "{11,                     222,               3333}");
+  result += _test_cont<std::list<float> >             ("list_float",               "{1.11,                   22.22,             333.33}");
+  result += _test_cont<std::list<float> >             ("list_float_eval",          "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
+  result += _test_cont<std::list<double> >            ("list_double",              "{1.11,                   22.22,             333.33}");
+  result += _test_cont<std::list<double> >            ("list_double_eval",         "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
+  result += _test_cont<std::list<XYZPoint> >          ("list_XYZPoint",            "{(1, 2, 3),              (10,20,30), (100,200,300)}");
+  result += _test_cont<std::list<XYZVector> >         ("list_XYZVector",           "{(1, 2, 3),              (10,20,30), (100,200,300)}");
+  result += _test_cont<std::list<PxPyPzE> >           ("list_PxPyPzEVector",       "{(1, 2, 3,4),            (10,20,30,40), (100,200,300,400)}");
+  result += _test_cont<std::list<XYZVector> >         ("list_XYZVector_eval",      "{(1*m, 2*m, 3*m),        (10*m,20*m,30*m), (100*m,200*m,300*m)}");
+  result += _test_cont<std::list<PxPyPzE> >           ("list_PxPyPzEVector",       "{(1, 2, 3,4),            (10,20,30,40),    (100,200,300,400)}");
+  result += _test_cont<std::list<PxPyPzE> >           ("list_PxPyPzEVector_eval",  "{(1*m, 2*m, 3*m, 4*m),   (10*m,20*m,30*m,40*m), (100*m,200*m,300*m,400*m)}");
+  line();
 #if defined(DD4HEP_HAVE_ALL_PARSERS)
-  result += _test_cont<deque<string> >           ("deque_str",                "{'a',                    'bb',              'ccc'}");
-  result += _test_cont<deque<bool> >             ("deque_bool",               "{true,                   false,              true}");
-  result += _test_cont<deque<int> >              ("deque_int",                "{11,                     222,               3333}");
-  result += _test_cont<deque<int> >              ("deque_int_eval",           "{1*11,                   2*111,           3*1111}");
-  result += _test_cont<deque<float> >            ("deque_float",              "{1.11,                   22.22,             333.33}");
-  result += _test_cont<deque<float> >            ("deque_float_eval",         "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
-  result += _test_cont<deque<double> >           ("deque_double",             "{1.11,                   22.22,             333.33}");
-  result += _test_cont<deque<double> >           ("deque_double_eval",        "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
-  cout << "+----------------------------------------------------------------------------------------------------------" << endl;
+  result += _test_cont<std::deque<std::string> >      ("deque_str",                "{'a',                    'bb',              'ccc'}");
+  result += _test_cont<std::deque<bool> >             ("deque_bool",               "{true,                   false,              true}");
+  result += _test_cont<std::deque<int> >              ("deque_int",                "{11,                     222,               3333}");
+  result += _test_cont<std::deque<int> >              ("deque_int_eval",           "{1*11,                   2*111,           3*1111}");
+  result += _test_cont<std::deque<float> >            ("deque_float",              "{1.11,                   22.22,             333.33}");
+  result += _test_cont<std::deque<float> >            ("deque_float_eval",         "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
+  result += _test_cont<std::deque<double> >           ("deque_double",             "{1.11,                   22.22,             333.33}");
+  result += _test_cont<std::deque<double> >           ("deque_double_eval",        "{1.11*GeV,               22.22*MeV,         333.3*TeV}");
+  line();
 #endif
   if ( 0 == result )
-    cout << endl << "Test PASSED" << endl << endl;
+    std::cout << std::endl << "Test PASSED" << std::endl << std::endl;
   else
-    cout << endl << "Test FAILED" << endl << "===> " << result << " Subtests FAILED" << endl;
+    std::cout << std::endl << "Test FAILED" << std::endl << "===> " << result << " Subtests FAILED" << std::endl;
 
   // All done.
   return 1;

--- a/examples/ClientTests/src/SectorBarrelCalorimeter_geo.cpp
+++ b/examples/ClientTests/src/SectorBarrelCalorimeter_geo.cpp
@@ -15,9 +15,7 @@
 #include "XML/Layering.h"
 #include <limits>
 
-using namespace std;
 using namespace dd4hep;
-using namespace dd4hep::detail;
 
 static void placeStaves(DetElement&   parent,
 			DetElement&   stave,
@@ -55,7 +53,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   Layering    layering(x_det);
   //xml_comp_t  staves      = x_det.staves();
   xml_dim_t   dim         = x_det.dimensions();
-  string      det_name    = x_det.nameStr();
+  std::string det_name    = x_det.nameStr();
   Material    air         = description.air();
   double      totalThickness = layering.totalThickness();
   int         numSides    = dim.numsides();
@@ -108,9 +106,9 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     const Layer* lay    = layering.layer(layer_num-1); // Get the layer from the layering engine.
     // Loop over repeats for this layer.
     for (int j = 0; j < repeat; j++)    {
-      string     layer_name      = det_name+_toString(layer_num,"_layer%d");
-      double     layer_thickness = lay->thickness();
-      DetElement layer(stave,_toString(layer_num,"layer%d"),x_det.id());
+      std::string layer_name      = det_name+_toString(layer_num,"_layer%d");
+      double      layer_thickness = lay->thickness();
+      DetElement  layer(stave,_toString(layer_num,"layer%d"),x_det.id());
 
       // Layer position in Z within the stave.
       layer_pos_z += layer_thickness / 2;
@@ -121,11 +119,11 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       double slice_pos_z = -(layer_thickness / 2);
       int slice_number = 1;
       for(xml_coll_t k(x_layer,_U(slice)); k; ++k)  {
-	xml_comp_t x_slice = k;
-	string   slice_name      = layer_name + _toString(slice_number,"_slice%d");
-	double   slice_thickness = x_slice.thickness();
-	Material slice_material  = description.material(x_slice.materialStr());
-	DetElement slice(layer,_toString(slice_number,"slice%d"),x_det.id());
+	xml_comp_t  x_slice = k;
+	std::string slice_name      = layer_name + _toString(slice_number,"_slice%d");
+	double      slice_thickness = x_slice.thickness();
+	Material    slice_material  = description.material(x_slice.materialStr());
+	DetElement  slice(layer,_toString(slice_number,"slice%d"),x_det.id());
 
 	slice_pos_z += slice_thickness / 2;
 	// Slice volume & box
@@ -159,7 +157,10 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
       // Increment the layer X dimension.
       layer_pos_x = (layerR-rmin)/tan_external;
       layer_dim_x =  (std::sqrt(rmax*rmax - layerR*layerR)+half_polyFace - layer_pos_x)/2.0;
-      cout<<"Rmin: "<< rmin<<" Rmax: "<<rmax<<" half_polyFace: "<<half_polyFace<<" Layer " <<layer_num<<" layerR: "<<layerR<<" layer_dim_x:" <<layer_dim_x<<endl;
+      std::cout << "Rmin: " <<  rmin << " Rmax: " << rmax
+                << " half_polyFace: " << half_polyFace
+                << " Layer "  << layer_num << " layerR: " << layerR << " layer_dim_x:"  << layer_dim_x
+                << std::endl;
       // Increment the layer Z position.
       layer_pos_z += layer_thickness / 2;
       // Increment the layer number.

--- a/examples/DDCMS/src/plugins/DDDefinitions2Objects.cpp
+++ b/examples/DDCMS/src/plugins/DDDefinitions2Objects.cpp
@@ -474,9 +474,7 @@ template <> void Converter<elementarymaterial>::operator()(xml_h element) const 
 #endif
     mix->AddElement(elt, 1.0);
     mix->SetRadLen(0e0);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,12,0)
     mix->ComputeDerivedQuantities();
-#endif
     /// Create medium from the material
     TGeoMedium* medium = mgr.GetMedium(matname);
     if (0 == medium) {
@@ -516,9 +514,7 @@ template <> void Converter<compositematerial>::operator()(xml_h element) const  
                fracname.c_str());
     }
     mix->SetRadLen(0e0);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,12,0)
     mix->ComputeDerivedQuantities();
-#endif
     printout(_ns.context->debug.materials ? ALWAYS : DEBUG, "DDCMS",
              "++  Converting material %-48s  Density: %8.3f [g/cm3] ROOT: %8.3f [g/cm3]",
              ('"'+nam+'"').c_str(), density, mix->GetDensity());

--- a/examples/LHeD/scripts/initAClick.C
+++ b/examples/LHeD/scripts/initAClick.C
@@ -32,13 +32,9 @@ std::string make_str(const char* data)  {
 int processCommand(const char* command, bool end_process)   {
   int status;
   // Disabling auto-parse is a hack required by a bug in ROOT
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   gInterpreter->SetClassAutoparsing(false);
   status = gInterpreter->ProcessLine(command);
   gInterpreter->SetClassAutoparsing(true);
-#else
-  status = gInterpreter->ProcessLine(command);
-#endif
   ::printf("+++ Status(%s) = %d\n",command,status);
   if ( end_process )  {
     gInterpreter->ProcessLine("gSystem->Exit(0)");

--- a/examples/OpticalSurfaces/compact/ReadOpticalSurfaces.xml
+++ b/examples/OpticalSurfaces/compact/ReadOpticalSurfaces.xml
@@ -63,10 +63,12 @@
     <opticalsurface finish="Rough_LUT" model="DAVIS" name="OpticalSurface#1" type="dielectric_LUTDAVIS" value="0">
       <property name="REFLECTIVITY" ref="REFLECTIVITY0x123aff00"/>
       <property name="EFFICIENCY"   ref="EFFICIENCY0x8b77240"/>
+      <constant name="SURFACEROUGHNESS" value="0.1*mm"/>
     </opticalsurface>
     <opticalsurface finish="ground" model="unified" name="OpticalSurface#2" type="dielectric_dielectric" value="1">
       <property name="REFLECTIVITY" ref="REFLECTIVITY0x123aff00"/>
       <property name="EFFICIENCY"   ref="EFFICIENCY0x8b77240"/>
+      <constant name="SURFACEROUGHNESS" value="0.1*mm"/>
     </opticalsurface>
   </surfaces>
 

--- a/examples/OpticalSurfaces/src/OpNovice_geo.cpp
+++ b/examples/OpticalSurfaces/src/OpNovice_geo.cpp
@@ -12,33 +12,33 @@
 //==========================================================================
 
 // Include files
-#include "DD4hep/DetFactoryHelper.h"
-#include "DD4hep/OpticalSurfaces.h"
-#include "DD4hep/Printout.h"
-#include "DD4hep/Detector.h"
+#include <DD4hep/DetFactoryHelper.h>
+#include <DD4hep/OpticalSurfaces.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Detector.h>
 
+// C/C++ include files
 #include <iostream>
 #include <map>
 
-using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::detail;
 
 /// Example of a water box with a box of air inside, the "bubble"
 static Ref_t create_detector(Detector &description, xml_h e, SensitiveDetector /* sens */)  {
-  xml_det_t x_det    = e;
-  string det_name    = x_det.nameStr();
-  DetElement sdet(det_name,x_det.id());
-  xml_det_t x_tank   = x_det.child(_Unicode(tank));
-  xml_det_t x_bubble = x_det.child(_Unicode(bubble));
+  xml_det_t   x_det    = e;
+  std::string det_name = x_det.nameStr();
+  DetElement  sdet(det_name,x_det.id());
+  xml_det_t   x_tank   = x_det.child(_Unicode(tank));
+  xml_det_t   x_bubble = x_det.child(_Unicode(bubble));
 
   Assembly hall_vol("Hall");
   Box    encl_box(_toDouble("world_x-2*cm"),_toDouble("world_y-2*cm"),_toDouble("world_z-2*cm"));
   Volume encl_vol("Enclosure",encl_box,description.air());
   Box    tank_box(x_tank.x(), x_tank.y(), x_tank.z());
-  Volume tank_vol("Tank",tank_box,description.material(x_tank.attr<string>(_U(material))));
+  Volume tank_vol("Tank",tank_box,description.material(x_tank.attr<std::string>(_U(material))));
   Box    bubble_box(x_bubble.x(), x_bubble.y(), x_bubble.z());
-  Volume bubble_vol("Bubble",bubble_box,description.material(x_bubble.attr<string>(_U(material))));
+  Volume bubble_vol("Bubble",bubble_box,description.material(x_bubble.attr<std::string>(_U(material))));
 
   encl_vol.setVisAttributes(description.invisible());
   tank_vol.setVisAttributes(description, x_tank.visStr());
@@ -53,7 +53,6 @@ static Ref_t create_detector(Detector &description, xml_h e, SensitiveDetector /
   hallPlace.addPhysVolID("system",x_det.id());
   sdet.setPlacement(hallPlace);
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,17,0)
   // Now attach the surface
   OpticalSurfaceManager surfMgr = description.surfaceManager();
   OpticalSurface waterSurf  = surfMgr.opticalSurface("/world/"+det_name+"#WaterSurface");
@@ -62,9 +61,6 @@ static Ref_t create_detector(Detector &description, xml_h e, SensitiveDetector /
   BorderSurface  bubbleSurf = BorderSurface(description, sdet, "TankBubble", airSurf,   bubblePlace, tankPlace);
   bubbleSurf.isValid();
   tankSurf.isValid();
-#else
-  bubblePlace.isValid();
-#endif
   return sdet;
 }
 DECLARE_DETELEMENT(DD4hep_OpNovice,create_detector)


### PR DESCRIPTION
BEGINRELEASENOTES
Multiple commits. Most important one (on user request):
- Implement CONST properties to optical sufaces. (Requires new release of ROOT)
  See issue: https://github.com/AIDASoft/DD4hep/issues/1223

Otherwise:
- Remove support for very old versions of ROOT < 6.10.0
- Remove support for very old versions of ROOT < 6.26.0. 
- Remove default use of std namespace from most implementation files.
ENDRELEASENOTES