### PR TITLE
XML: add std:: when building with tinyXML

### DIFF
--- a/DDCore/src/XML/DocumentHandler.cpp
+++ b/DDCore/src/XML/DocumentHandler.cpp
@@ -508,7 +508,7 @@ Document DocumentHandler::load(const std::string& fname, UriReader* reader) cons
       except("dd4hep:XML","++ Unknown error (TinyXML) while parsing:%s",fname.c_str());
     }
   }
-  catch(exception& e) {
+  catch(std::exception& e) {
     printout(ERROR,"DocumentHandler","+++ Exception (TinyXML): parse(path):%s",e.what());
   }
   if ( result ) {

--- a/DDCore/src/XML/XMLElements.cpp
+++ b/DDCore/src/XML/XMLElements.cpp
@@ -989,13 +989,13 @@ static unsigned int adler32(unsigned int adler, const XmlChar* xml_buff, size_t 
 typedef unsigned int (fcn_t)(unsigned int, const XmlChar*, size_t);
 unsigned int Handle_t::checksum(unsigned int param, fcn_t fcn) const {
 #ifdef DD4HEP_USE_TINYXML
-  typedef map<std::string, std::string> StringMap;
+  typedef std::map<std::string, std::string> StringMap;
   TiXmlNode* n = Xml(m_node).n;
   if ( n ) {
     if ( 0 == fcn ) fcn = adler32;
     switch (n->Type()) {
     case TiXmlNode::ELEMENT: {
-      map<std::string,std::string> m;
+      std::map<std::string,std::string> m;
       TiXmlElement* e = n->ToElement();
       TiXmlAttribute* p=e->FirstAttribute();
       for(; p; p=p->Next()) m.emplace(p->Name(),p->Value());

--- a/DDRec/src/DetectorSurfaces.cpp
+++ b/DDRec/src/DetectorSurfaces.cpp
@@ -35,8 +35,10 @@ namespace dd4hep {
       const VolSurfaceList* vsL = volSurfaceList(det) ;
 
       try {
-        _sL = det.extension< SurfaceList >() ;
-
+        _sL = det.extension< SurfaceList >(false) ;
+        if (not _sL) {
+          _sL = det.addExtension<SurfaceList >(  new SurfaceList( true )  ) ;
+        }
       } catch(const std::exception& e) { 
         _sL = det.addExtension<SurfaceList >(  new SurfaceList( true )  ) ; 
       }


### PR DESCRIPTION
BEGINRELEASENOTES
- XML: add missing std:: when building with TinyXML
- DetectorSurfaces: silence printout when creating SurfaceList, fixes #1229 

ENDRELEASENOTES