### PR TITLE
Add multithreading support to ddsim

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -25,7 +25,7 @@ jobs:
         release-platform: ${{ matrix.LCG }}
         run: |
           # clang-tidy does not work with the clang-wrapper, we setup the direct clang here
-          source /cvmfs/sft.cern.ch/lcg/contrib/clang/19/x86_64-el9/setup.sh
+          source /cvmfs/sft.cern.ch/lcg/contrib/clang/22/x86_64-el9/setup.sh
           mkdir build
           cd build
           unset CPATH

--- a/DDG4/include/DDG4/Geant4Kernel.h
+++ b/DDG4/include/DDG4/Geant4Kernel.h
@@ -159,6 +159,7 @@ namespace dd4hep {
 
       //bool isMultiThreaded() const { return m_multiThreaded; }
       bool isMultiThreaded() const { return m_numThreads > 0; }
+      int numThreads()       const { return m_numThreads; }
 
       /// Access thread identifier
       static unsigned long int thread_self();

--- a/DDG4/include/DDG4/Geant4Output2ROOT.h
+++ b/DDG4/include/DDG4/Geant4Output2ROOT.h
@@ -62,8 +62,6 @@ namespace dd4hep {
       bool m_filesByRun = false;
       /// Counter of worker endRun calls so that closeOutput fires only after all workers are done
       std::atomic<int> m_endRunCount { 0 };
-      /// G4 event ID of the current event, stored for each event for MT ordering
-      int m_currentEventID { -1 };
       /// Static mutex to protect ROOT I/O operations in multi-threaded mode
       static std::mutex s_rootMutex;
 

--- a/DDG4/include/DDG4/Geant4Output2ROOT.h
+++ b/DDG4/include/DDG4/Geant4Output2ROOT.h
@@ -17,6 +17,7 @@
 #include <DDG4/Geant4OutputAction.h>
 
 #include <memory>
+#include <mutex>
 
 class TFile;
 class TTree;
@@ -58,6 +59,8 @@ namespace dd4hep {
       bool m_handleMCTruth = true;
       /// Property: Flag to create a new output file for each run
       bool m_filesByRun = false;
+      /// Static mutex to protect ROOT I/O operations in multi-threaded mode
+      static std::mutex s_rootMutex;
 
     public:
       /// Standard constructor

--- a/DDG4/include/DDG4/Geant4Output2ROOT.h
+++ b/DDG4/include/DDG4/Geant4Output2ROOT.h
@@ -77,6 +77,9 @@ namespace dd4hep {
 
       /// Close current output file
       virtual void closeOutput();
+    private:
+      /// Close the current output file. Must be called with s_rootMutex held.
+      void closeOutputLocked();
       /// Callback to store the Geant4 run information
       void beginRun(const G4Run* run)  override;
       /// Callback at end of run: write and close the output file while DDG4 is still alive

--- a/DDG4/include/DDG4/Geant4Output2ROOT.h
+++ b/DDG4/include/DDG4/Geant4Output2ROOT.h
@@ -16,6 +16,7 @@
 // Framework include files
 #include <DDG4/Geant4OutputAction.h>
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 
@@ -59,6 +60,10 @@ namespace dd4hep {
       bool m_handleMCTruth = true;
       /// Property: Flag to create a new output file for each run
       bool m_filesByRun = false;
+      /// Counter of worker endRun calls so that closeOutput fires only after all workers are done
+      std::atomic<int> m_endRunCount { 0 };
+      /// G4 event ID of the current event, stored for each event for MT ordering
+      int m_currentEventID { -1 };
       /// Static mutex to protect ROOT I/O operations in multi-threaded mode
       static std::mutex s_rootMutex;
 
@@ -76,6 +81,8 @@ namespace dd4hep {
       virtual void closeOutput();
       /// Callback to store the Geant4 run information
       void beginRun(const G4Run* run)  override;
+      /// Callback at end of run: write and close the output file while DDG4 is still alive
+      void endRun(const G4Run* run)  override;
       /// Callback to store each Geant4 hit collection
       void saveCollection(OutputContext<G4Event>& ctxt, G4VHitsCollection* collection)  override;
       /// Callback to store the Geant4 event

--- a/DDG4/include/DDG4/Python/PyDDG4.h
+++ b/DDG4/include/DDG4/Python/PyDDG4.h
@@ -35,7 +35,11 @@ struct PyDDG4  {
 
   static int execute();
   static int process(const char* fname);
+  static int runAll(Kernel& kernel);
+  static int initialize(Kernel& kernel);
+  static int configure(Kernel& kernel);
   static int run(Kernel& kernel);
+  static int terminate(Kernel& kernel);
   static int run(const char* fname);
 };
 #endif // DDG4_PYTHON_PYDDG4_H

--- a/DDG4/plugins/Geant4EventSeed.cpp
+++ b/DDG4/plugins/Geant4EventSeed.cpp
@@ -19,6 +19,7 @@
 #include <DD4hep/Printout.h>
 
 #include <DDG4/Geant4EventAction.h>
+#include <DDG4/Geant4StackingAction.h>
 #include <DDG4/Geant4Random.h>
 #include <DDG4/Factories.h>
 
@@ -27,6 +28,8 @@
 //Geant includes
 #include <G4Run.hh>
 #include <G4Event.hh>
+#include <G4EventManager.hh>
+#include <G4StackManager.hh>
 
 using namespace dd4hep::sim;
 
@@ -39,6 +42,8 @@ Geant4EventSeed::Geant4EventSeed(Geant4Context* c, const std::string& typ) : Gea
 {
   Geant4Action::runAction().callAtBegin(this,&Geant4EventSeed::begin);
   Geant4Action::eventAction().callAtBegin(this,&Geant4EventSeed::beginEvent);
+  // Re-seed after GeneratePrimaries so file-based generators' SetEventID is visible.
+  Geant4Action::stackingAction().callAtPrepare(this,&Geant4EventSeed::prepareEvent);
   InstanceCount::increment(this);
 }
 
@@ -78,6 +83,25 @@ void Geant4EventSeed::beginEvent(const G4Event* evt) {
   if ( dd4hep::printLevel() <= dd4hep::DEBUG ) {
     rndm->showStatus();
   }
+
+}
+
+/// prepare-stacking callback: re-seed after GeneratePrimaries using the final event ID
+void Geant4EventSeed::prepareEvent(G4StackManager* /* stackMgr */) {
+
+  const G4Event* evt = G4EventManager::GetEventManager()->GetConstCurrentEvent();
+  if ( !evt ) return;
+
+  Geant4Random *rndm = Geant4Random::instance();
+
+  unsigned int eventID = evt->GetEventID();
+  unsigned int newSeed = hash( m_initialSeed, eventID, m_runID );
+
+  dd4hep::printout( dd4hep::INFO, m_type,
+		    "At prepareEvent: eventID=%u, runID=%u initialSeed=%u, newSeed=%u",
+		    eventID, m_runID, m_initialSeed, newSeed );
+
+  rndm->setSeed( newSeed );
 
 }
 

--- a/DDG4/plugins/Geant4EventSeed.h
+++ b/DDG4/plugins/Geant4EventSeed.h
@@ -16,6 +16,9 @@
 // Framework include files
 #include <DDG4/Geant4RunAction.h>
 
+// Forward declarations
+class G4StackManager;
+
 
 
 /// Namespace for the AIDA detector description toolkit
@@ -54,8 +57,10 @@ namespace dd4hep {
       virtual ~Geant4EventSeed();
       /// begin-of-run callback
       void begin(const G4Run*);
-      /// begin-of-event callback
+      /// begin-of-event callback: seeds based on pre-assigned Geant4 event ID
       void beginEvent(const G4Event*);
+      /// prepare-stacking callback: re-seeds after GeneratePrimaries using the final event ID
+      void prepareEvent(G4StackManager*);
     };
 
     /*

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -839,6 +839,7 @@ class Geant4:
     """
     # Only use shared=True in MT mode to avoid double-save in ST mode
     shared = self.master().NumberOfThreads > 1
+    
     evt_root = EventAction(self.kernel(), 'Geant4Output2ROOT/' + name, shared)
     evt_root.HandleMCTruth = mc_truth
     evt_root.Control = True

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -837,7 +837,9 @@ class Geant4:
 
     \author  M.Frank
     """
-    evt_root = EventAction(self.kernel(), 'Geant4Output2ROOT/' + name, True)
+    # Only use shared=True in MT mode to avoid double-save in ST mode
+    shared = self.master().NumberOfThreads > 1
+    evt_root = EventAction(self.kernel(), 'Geant4Output2ROOT/' + name, shared)
     evt_root.HandleMCTruth = mc_truth
     evt_root.Control = True
     if not output.endswith('.root'):
@@ -853,7 +855,9 @@ class Geant4:
 
     \author  M.Frank
     """
-    evt_lcio = EventAction(self.kernel(), 'Geant4Output2LCIO/' + name, True)
+    # Only use shared=True in MT mode to avoid double-save in ST mode
+    shared = self.master().NumberOfThreads > 1
+    evt_lcio = EventAction(self.kernel(), 'Geant4Output2LCIO/' + name, shared)
     evt_lcio.Control = True
     evt_lcio.Output = output
     evt_lcio.enableUI()
@@ -862,7 +866,9 @@ class Geant4:
 
   def setupEDM4hepOutput(self, name, output):
     """Configure EDM4hep root output for the simulated events."""
-    evt_edm4hep = EventAction(self.kernel(), 'Geant4Output2EDM4hep/' + name, True)
+    # Only use shared=True in MT mode to avoid double-save in ST mode
+    shared = self.master().NumberOfThreads > 1
+    evt_edm4hep = EventAction(self.kernel(), 'Geant4Output2EDM4hep/' + name, shared)
     evt_edm4hep.Control = True
     evt_edm4hep.Output = output
     evt_edm4hep.enableUI()

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -839,7 +839,7 @@ class Geant4:
     """
     # Only use shared=True in MT mode to avoid double-save in ST mode
     shared = self.master().NumberOfThreads > 1
-    
+
     evt_root = EventAction(self.kernel(), 'Geant4Output2ROOT/' + name, shared)
     evt_root.HandleMCTruth = mc_truth
     evt_root.Control = True

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -921,7 +921,7 @@ class Geant4:
     \author  M.Frank
     """
     from ROOT import PyDDG4
-    PyDDG4.run(self.master().get())
+    PyDDG4.runAll(self.master().get())
     return self
 
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -436,6 +436,8 @@ class DD4hepSimulation(object):
     if actionList:
       generationInit = self._buildInputStage(geant4, actionList, output_level=self.output.inputStage,
                                              have_mctruth=self._enablePrimaryHandler())
+    # Store on self so run() can read numberOfEvents before terminate() destroys it
+    self._generationInit = generationInit
 
     # ================================================================================================
 
@@ -635,12 +637,10 @@ class DD4hepSimulation(object):
     if not PyDDG4.run(master):
       logger.error("Simulation failed!")
       exitCode += 1
-    if not PyDDG4.terminate(master):
-      exitCode += 1
-      logger.error("Termination failed!")
 
     totalTimeUser, totalTimeSys, _cuTime, _csTime, _elapsedTime = os.times()
     processedEvents = self.numberOfEvents
+    generationInit = getattr(self, '_generationInit', None)
     if generationInit:
       processedEvents = int(generationInit.numberOfEvents)
       if self.numberOfEvents < 0:
@@ -655,6 +655,11 @@ class DD4hepSimulation(object):
         perEventTime = eventTime / processedEvents
         logger.info("StartUp Time: %3.2f s, Processing and Init: %3.2f s (~%3.2f s/Event @ %d threads) "
                     % (startUpTime, eventTime, perEventTime, self.numberOfThreads))
+
+    if not PyDDG4.terminate(master):
+      exitCode += 1
+      logger.error("Termination failed!")
+
     return exitCode
 
   def __setMagneticFieldOptions(self, geant4):

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -616,6 +616,12 @@ class DD4hepSimulation(object):
     from ROOT import PyDDG4
     master = geant4.master().get()
 
+    # Preload reader libraries on the master thread before workers start.
+    if self.inputFiles and self.numberOfThreads > 1:
+      from ROOT import gSystem
+      if any(f.endswith(tuple(EDM4HEP_INPUT_EXTENSIONS)) for f in self.inputFiles):
+        gSystem.Load("libDDG4EDM4HEPReader")
+
     PyDDG4.configure(master)
     PyDDG4.initialize(master)
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -563,9 +563,9 @@ class DD4hepSimulation(object):
 
     logger.info("# Configure G4 sensitive detectors: python setup callback")
     seq, act = geant4.addDetectorConstruction(
-      "Geant4PythonDetectorConstruction/SetupSD",
-      sensitives=self.__setupSensitives,
-      sensitives_args=(geant4, detectorDescription,))
+        "Geant4PythonDetectorConstruction/SetupSD",
+        sensitives=self.__setupSensitives,
+        sensitives_args=(geant4, detectorDescription,))
     logger.info("# Configure G4 sensitive detectors: atach'em to the sensitive volumes")
     seq, act = geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -610,6 +610,7 @@ class DD4hepSimulation(object):
 
     startUpTime, _sysTime, _cuTime, _csTime, _elapsedTime = os.times()
 
+    exitCode = 0
     if not PyDDG4.run(master):
       logger.error("Simulation failed!")
       exitCode += 1

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -326,6 +326,7 @@ class DD4hepSimulation(object):
     kernel.registerGlobalAction(run)
     kernel.runAction().add(run)
 
+    # ----------------------------------------------------------------------------------
     # Configure run, event, track, step, and stack actions, if present
     for action_list, DDG4_Action, kernel_Action in \
         [(self.action.run, DDG4.RunAction, kernel.runAction),
@@ -426,6 +427,8 @@ class DD4hepSimulation(object):
       generationInit = self._buildInputStage(geant4, actionList, output_level=self.output.inputStage,
                                              have_mctruth=self._enablePrimaryHandler())
 
+    # ================================================================================================
+
     # And handle the simulation particles.
     part = DDG4.GeneratorAction(kernel, "Geant4ParticleHandler/ParticleHandler")
     kernel.generatorAction().adopt(part)
@@ -446,6 +449,8 @@ class DD4hepSimulation(object):
 
     return 1
 
+    # =================================================================================
+
   def __setupSensitives(self, geant4, detectorDescription):
     kernel = geant4.kernel()
 
@@ -456,7 +461,9 @@ class DD4hepSimulation(object):
       logger.error("%s", e)
       return 1
 
+    # =================================================================================
     # get lists of trackers and calorimeters in detectorDescription
+
     trk, cal, unk = self.getDetectorLists(detectorDescription)
     for detectors, function, defFilter, defAction, abort in \
         [(trk, geant4.setupTracker, self.filter.tracker, self.action.tracker, False),

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -495,10 +495,12 @@ class DD4hepSimulation(object):
     kernel = geant4.kernel()
     logger.debug("Setting up actions")
     self.__setupActions(kernel)
+    import DDG4
+    logger.debug("Setting up Geant4Random for worker thread")
+    # Initialize a per-worker Geant4Random wrapping this thread's CLHEP engine
+    self.random.initializeWorker(DDG4, kernel, self.printLevel)
     logger.debug("Setting up EventSeeder for worker")
     # Setup EventSeeder for this worker
-    # Uses the shared Geant4Random instance from master
-    import DDG4
     self.random.setupEventSeeder(DDG4, kernel)
     logger.debug("Setting up generator actions")
     self.__setupGeneratorActions(kernel, geant4)

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -72,6 +72,7 @@ class DD4hepSimulation(object):
 
     self.numberOfEvents = 0
     self.skipNEvents = 0
+    self.numberOfThreads = 1
     self.physicsList = None  # deprecated use physics.list
     self.crossingAngleBoost = 0.0
     self.macroFile = ''
@@ -183,6 +184,9 @@ class DD4hepSimulation(object):
     parser.add_argument("--skipNEvents", action="store", dest="skipNEvents", default=self.skipNEvents, type=int,
                         help="Skip first N events when reading a file")
 
+    parser.add_argument("--numberOfThreads", "-j", action="store", dest="numberOfThreads", default=self.numberOfThreads,
+                        type=int, help="Number of threads for simulation")
+
     parser.add_argument("--physicsList", action="store", dest="physicsList", default=self.physicsList,
                         help="Physics list to use in simulation. Deprecated, use physics.list")
 
@@ -254,6 +258,7 @@ class DD4hepSimulation(object):
 
     self.numberOfEvents = parsed.numberOfEvents
     self.skipNEvents = parsed.skipNEvents
+    self.numberOfThreads = parsed.numberOfThreads
     self.physicsList = parsed.physicsList
     self.crossingAngleBoost = parsed.crossingAngleBoost
     self.macroFile = parsed.macroFile

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -79,6 +79,8 @@ class DD4hepSimulation(object):
     self.enableGun = False
     self.enableG4GPS = False
     self.enableG4Gun = False
+    self._g4gun = []
+    self._g4gps = []
     self.vertexSigma = [0.0, 0.0, 0.0, 0.0]
     self.vertexOffset = [0.0, 0.0, 0.0, 0.0]
     self.enableDetailedShowerMode = False
@@ -363,6 +365,7 @@ class DD4hepSimulation(object):
       g4gun.Mask = 2
       logger.info("++++ Adding Geant4 Particle Gun ++++")
       actionList.append(g4gun)
+      self._g4gun.append(g4gun)
 
     if self.enableG4GPS:
       # GPS Create something
@@ -371,6 +374,7 @@ class DD4hepSimulation(object):
       g4gps.Mask = 3
       logger.info("++++ Adding Geant4 General Particle Source ++++")
       actionList.append(g4gps)
+      self._g4gps.append(g4gps)
 
     start = 4
     for index, plugin in enumerate(self.inputConfig.userInputPlugin, start=start):
@@ -594,6 +598,15 @@ class DD4hepSimulation(object):
 
     PyDDG4.configure(master)
     PyDDG4.initialize(master)
+
+    # GPS
+    # FIXME this applies to only 1 thread, and Geant4GeneratorWrapper doesn't work as shared=True
+    if self._g4gun is not []:
+      for g4gun in self._g4gun:
+        g4gun.generator()
+    if self._g4gps is not []:
+      for g4gps in self._g4gps:
+        g4gps.generator()
 
     startUpTime, _sysTime, _cuTime, _csTime, _elapsedTime = os.times()
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -401,11 +401,11 @@ class DD4hepSimulation(object):
         gen.Input = "Geant4EventReaderHepEvtLong|" + inputFile
       elif inputFile.endswith(tuple([".hepmc"] + HEPMC3_SUPPORTED_EXTENSIONS)):
         if self.hepmc3.useHepMC3:
-          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index)
+          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=True)
           gen.Parameters = self.hepmc3.getParameters()
           gen.Input = "HEPMC3FileReader|" + inputFile
         else:
-          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index)
+          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=True)
           gen.Input = "Geant4EventReaderHepMC|" + inputFile
       elif inputFile.endswith(".pairs"):
         gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/GuineaPig%d" % index)

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -491,7 +491,6 @@ class DD4hepSimulation(object):
 
   def __setupMaster(self, geant4):
     logger.debug("Setting up master")
-    kernel = geant4.master()
     return 1
 
   def run(self):

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -347,6 +347,8 @@ class DD4hepSimulation(object):
   def __setupGeneratorActions(self, kernel, geant4):
     import DDG4
 
+    shared = (kernel.RunManagerType == "G4MTRunManager")
+
     actionList = []
 
     if self.enableGun:
@@ -360,7 +362,7 @@ class DD4hepSimulation(object):
 
     if self.enableG4Gun:
       # GPS Create something
-      g4gun = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/Gun")
+      g4gun = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/Gun", shared=shared)
       g4gun.Uses = 'G4ParticleGun'
       g4gun.Mask = 2
       logger.info("++++ Adding Geant4 Particle Gun ++++")
@@ -369,7 +371,7 @@ class DD4hepSimulation(object):
 
     if self.enableG4GPS:
       # GPS Create something
-      g4gps = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/GPS")
+      g4gps = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/GPS", shared=shared)
       g4gps.Uses = 'G4GeneralParticleSource'
       g4gps.Mask = 3
       logger.info("++++ Adding Geant4 General Particle Source ++++")
@@ -401,11 +403,11 @@ class DD4hepSimulation(object):
         gen.Input = "Geant4EventReaderHepEvtLong|" + inputFile
       elif inputFile.endswith(tuple([".hepmc"] + HEPMC3_SUPPORTED_EXTENSIONS)):
         if self.hepmc3.useHepMC3:
-          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=True)
+          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=shared)
           gen.Parameters = self.hepmc3.getParameters()
           gen.Input = "HEPMC3FileReader|" + inputFile
         else:
-          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=True)
+          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=shared)
           gen.Input = "Geant4EventReaderHepMC|" + inputFile
       elif inputFile.endswith(".pairs"):
         gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/GuineaPig%d" % index)
@@ -857,7 +859,8 @@ class DD4hepSimulation(object):
     ga = geant4.kernel().generatorAction()
 
     # Register Generation initialization action
-    gen = GeneratorAction(geant4.kernel(), "Geant4GeneratorActionInit/GenerationInit")
+    shared = (geant4.kernel().RunManagerType == "G4MTRunManager")
+    gen = GeneratorAction(geant4.kernel(), "Geant4GeneratorActionInit/GenerationInit", shared = shared)
     generationInit = gen
     if output_level is not None:
       gen.OutputLevel = output_level

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -666,7 +666,9 @@ class DD4hepSimulation(object):
 
   def __setMagneticFieldOptions(self, geant4):
     """ create and configure the magnetic tracking setup """
-    field = geant4.addConfig('Geant4FieldTrackingSetupAction/MagFieldTrackingSetup')
+    # Use Geant4FieldTrackingConstruction (a DetectorConstruction) so that
+    # constructField() is called on every worker thread via ConstructSDandField().
+    _seq, field = geant4.addDetectorConstruction('Geant4FieldTrackingConstruction/MagFieldTrackingSetup')
     field.stepper = self.field.stepper
     field.equation = self.field.equation
     field.eps_min = self.field.eps_min

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -347,7 +347,9 @@ class DD4hepSimulation(object):
   def __setupGeneratorActions(self, kernel, geant4):
     import DDG4
 
-    shared = (kernel.RunManagerType == "G4MTRunManager")
+    # Determine 'shared' based on the overall setting, not the worker kernel property
+    shared = (self.numberOfThreads > 1)
+    logger.debug(f"Determined shared={shared} based on self.numberOfThreads={self.numberOfThreads}")
 
     actionList = []
 
@@ -859,7 +861,8 @@ class DD4hepSimulation(object):
     ga = geant4.kernel().generatorAction()
 
     # Register Generation initialization action
-    shared = (geant4.kernel().RunManagerType == "G4MTRunManager")
+    shared = (self.numberOfThreads > 1)
+    logger.debug(f"Determined shared={shared} based on self.numberOfThreads={self.numberOfThreads}")
     gen = GeneratorAction(geant4.kernel(), "Geant4GeneratorActionInit/GenerationInit", shared = shared)
     generationInit = gen
     if output_level is not None:

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -79,8 +79,6 @@ class DD4hepSimulation(object):
     self.enableGun = False
     self.enableG4GPS = False
     self.enableG4Gun = False
-    self._g4gun = None
-    self._g4gps = None
     self.vertexSigma = [0.0, 0.0, 0.0, 0.0]
     self.vertexOffset = [0.0, 0.0, 0.0, 0.0]
     self.enableDetailedShowerMode = False
@@ -320,66 +318,14 @@ class DD4hepSimulation(object):
 
 # ==================================================================================
 
-  def run(self):
-    """setup the geometry and dd4hep and geant4 and do what was asked to be done"""
-    import ROOT
-    ROOT.PyConfig.IgnoreCommandLineOptions = True
-
+  def __setupActions(self, kernel):
     import DDG4
-    import dd4hep
 
-    self.printLevel = getOutputLevel(self.printLevel)
+    # Configure default run action
+    run = DDG4.RunAction(kernel, 'Geant4TestRunAction/RunInit')
+    kernel.registerGlobalAction(run)
+    kernel.runAction().add(run)
 
-    kernel = DDG4.Kernel()
-    dd4hep.setPrintLevel(self.printLevel)
-
-    for compactFile in self.compactFile:
-      kernel.loadGeometry(str("file:" + os.path.abspath(compactFile)))
-    detectorDescription = kernel.detectorDescription()
-
-    DDG4.importConstants(detectorDescription)
-
-  # ----------------------------------------------------------------------------------
-
-    # simple = DDG4.Geant4( kernel, tracker='Geant4TrackerAction',calo='Geant4CalorimeterAction')
-    # geant4 = DDG4.Geant4( kernel, tracker='Geant4TrackerCombineAction',calo='Geant4ScintillatorCalorimeterAction')
-    geant4 = DDG4.Geant4(kernel, tracker=self.action.tracker, calo=self.action.calo)
-    if not self.disableSignalHandler:
-      geant4.registerInterruptHandler()
-
-    geant4.printDetectors()
-
-    if self.runType == "vis":
-      uiaction = geant4.setupUI(typ="tcsh", vis=True, macro=self.macroFile)
-    elif self.runType == "qt":
-      uiaction = geant4.setupUI(typ="qt", vis=True, macro=self.macroFile)
-    elif self.runType == "run":
-      uiaction = geant4.setupUI(typ="tcsh", vis=False, macro=self.macroFile, ui=False)
-    elif self.runType == "shell":
-      uiaction = geant4.setupUI(typ="tcsh", vis=False, macro=None, ui=True)
-    elif self.runType == "batch":
-      uiaction = geant4.setupUI(typ="tcsh", vis=False, macro=None, ui=False)
-    else:
-      logger.error("unknown runType")
-      return 1
-
-    # User Configuration for the Geant4Phases
-    uiaction.ConfigureCommands = self.ui._commandsConfigure
-    uiaction.InitializeCommands = self.ui._commandsInitialize
-    uiaction.PostRunCommands = self.ui._commandsPostRun
-    uiaction.PreRunCommands = self.ui._commandsPreRun
-    uiaction.TerminateCommands = self.ui._commandsTerminate
-
-    kernel.NumEvents = self.numberOfEvents
-
-    # -----------------------------------------------------------------------------------
-    # setup the magnetic field:
-    self.__setMagneticFieldOptions(geant4)
-
-    # configure geometry creation
-    self.geometry.constructGeometry(kernel, geant4, self.output.geometry)
-
-    # ----------------------------------------------------------------------------------
     # Configure run, event, track, step, and stack actions, if present
     for action_list, DDG4_Action, kernel_Action in \
         [(self.action.run, DDG4.RunAction, kernel.runAction),
@@ -393,17 +339,10 @@ class DD4hepSimulation(object):
           setattr(action, parameter, value)
         kernel_Action().add(action)
 
-    # ----------------------------------------------------------------------------------
-    # Configure Run actions
-    run1 = DDG4.RunAction(kernel, 'Geant4TestRunAction/RunInit')
-    kernel.registerGlobalAction(run1)
-    kernel.runAction().add(run1)
+    return 1
 
-    # Configure the random seed, do it before the I/O because we might change the seed!
-    self.random.initialize(DDG4, kernel, self.output.random)
-
-    # Configure the output file format and plugin
-    self.outputConfig.initialize(dd4hepsimulation=self, geant4=geant4)
+  def __setupGeneratorActions(self, kernel, geant4):
+    import DDG4
 
     actionList = []
 
@@ -418,19 +357,19 @@ class DD4hepSimulation(object):
 
     if self.enableG4Gun:
       # GPS Create something
-      self._g4gun = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/Gun")
-      self._g4gun.Uses = 'G4ParticleGun'
-      self._g4gun.Mask = 2
+      g4gun = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/Gun")
+      g4gun.Uses = 'G4ParticleGun'
+      g4gun.Mask = 2
       logger.info("++++ Adding Geant4 Particle Gun ++++")
-      actionList.append(self._g4gun)
+      actionList.append(g4gun)
 
     if self.enableG4GPS:
       # GPS Create something
-      self._g4gps = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/GPS")
-      self._g4gps.Uses = 'G4GeneralParticleSource'
-      self._g4gps.Mask = 3
+      g4gps = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/GPS")
+      g4gps.Uses = 'G4GeneralParticleSource'
+      g4gps.Mask = 3
       logger.info("++++ Adding Geant4 General Particle Source ++++")
-      actionList.append(self._g4gps)
+      actionList.append(g4gps)
 
     start = 4
     for index, plugin in enumerate(self.inputConfig.userInputPlugin, start=start):
@@ -487,8 +426,6 @@ class DD4hepSimulation(object):
       generationInit = self._buildInputStage(geant4, actionList, output_level=self.output.inputStage,
                                              have_mctruth=self._enablePrimaryHandler())
 
-    # ================================================================================================
-
     # And handle the simulation particles.
     part = DDG4.GeneratorAction(kernel, "Geant4ParticleHandler/ParticleHandler")
     kernel.generatorAction().adopt(part)
@@ -507,31 +444,136 @@ class DD4hepSimulation(object):
 
     self.part.setupUserParticleHandler(part, kernel, DDG4)
 
-    # =================================================================================
+    return 1
+
+  def __setupSensitives(geant4, detectorDescription, sim):
+    kernel = geant4.kernel()
 
     # Setup global filters for use in sensitive detectors
     try:
-      self.filter.setupFilters(kernel)
+      sim.filter.setupFilters(kernel)
     except RuntimeError as e:
       logger.error("%s", e)
       return 1
 
-    # =================================================================================
     # get lists of trackers and calorimeters in detectorDescription
-
-    trk, cal, unk = self.getDetectorLists(detectorDescription)
+    trk, cal, unk = sim.getDetectorLists(detectorDescription)
     for detectors, function, defFilter, defAction, abort in \
-        [(trk, geant4.setupTracker, self.filter.tracker, self.action.tracker, False),
-         (cal, geant4.setupCalorimeter, self.filter.calo, self.action.calo, False),
+        [(trk, geant4.setupTracker, sim.filter.tracker, sim.action.tracker, False),
+         (cal, geant4.setupCalorimeter, sim.filter.calo, sim.action.calo, False),
          (unk, geant4.setupDetector, None, "No Default", True),
          ]:
       try:
-        self.__setupSensitiveDetectors(detectors, function, defFilter, defAction, abort)
+        sim.__setupSensitiveDetectors(detectors, function, defFilter, defAction, abort)
       except Exception as e:
         logger.error("Failed setting up sensitive detector %s", e)
         raise
 
-  # =================================================================================
+    return 1
+
+  def __setupWorker(geant4, sim):
+    logger.debug("Setting up worker")
+    kernel = geant4.kernel()
+    logger.debug("Setting up actions")
+    sim.__setupActions(kernel)
+    logger.debug("Setting up generator actions")
+    sim.__setupGeneratorActions(kernel, geant4)
+    return 1
+
+  def __setupMaster(geant4):
+    logger.debug("Setting up master")
+    kernel = geant4.master()
+    return 1
+
+  def run(self):
+    """setup the geometry and dd4hep and geant4 and do what was asked to be done"""
+    import ROOT
+    ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+    import DDG4
+    import dd4hep
+
+    self.printLevel = getOutputLevel(self.printLevel)
+
+    kernel = DDG4.Kernel()
+    dd4hep.setPrintLevel(self.printLevel)
+
+    for compactFile in self.compactFile:
+      kernel.loadGeometry(str("file:" + os.path.abspath(compactFile)))
+    detectorDescription = kernel.detectorDescription()
+
+    DDG4.importConstants(detectorDescription)
+
+    # ----------------------------------------------------------------------------------
+
+    geant4 = DDG4.Geant4(kernel, tracker=self.action.tracker, calo=self.action.calo)
+    if not self.disableSignalHandler:
+      geant4.registerInterruptHandler()
+
+    geant4.printDetectors()
+
+    if self.runType == "vis":
+      uiaction = geant4.setupUI(typ="tcsh", vis=True, macro=self.macroFile)
+    elif self.runType == "qt":
+      uiaction = geant4.setupUI(typ="qt", vis=True, macro=self.macroFile)
+    elif self.runType == "run":
+      uiaction = geant4.setupUI(typ="tcsh", vis=False, macro=self.macroFile, ui=False)
+    elif self.runType == "shell":
+      uiaction = geant4.setupUI(typ="tcsh", vis=False, macro=None, ui=True)
+    elif self.runType == "batch":
+      uiaction = geant4.setupUI(typ="tcsh", vis=False, macro=None, ui=False)
+    else:
+      logger.error("unknown runType")
+      return 1
+
+    # User Configuration for the Geant4Phases
+    uiaction.ConfigureCommands = self.ui._commandsConfigure
+    uiaction.InitializeCommands = self.ui._commandsInitialize
+    uiaction.PostRunCommands = self.ui._commandsPostRun
+    uiaction.PreRunCommands = self.ui._commandsPreRun
+    uiaction.TerminateCommands = self.ui._commandsTerminate
+
+    kernel.NumEvents = self.numberOfEvents
+
+    if self.numberOfThreads > 1:
+      logger.info("Multi-threaded with %d threads", self.numberOfThreads)
+      kernel.RunManagerType = "G4MTRunManager"
+      kernel.NumberOfThreads = self.numberOfThreads
+      geant4.addUserInitialization(
+        worker=DD4hepSimulation.__setupWorker, worker_args=(geant4, self),
+        master=DD4hepSimulation.__setupMaster, master_args=(geant4,))
+    else:
+      kernel.RunManagerType = "G4RunManager"
+      kernel.NumberOfThreads = 1
+      geant4.addUserInitialization(
+        worker=DD4hepSimulation.__setupWorker, worker_args=(geant4, self))
+
+    # -----------------------------------------------------------------------------------
+
+    logger.info("#  Configure G4 geometry setup")
+    seq, act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
+
+    logger.info("# Configure G4 sensitive detectors: python setup callback")
+    seq, act = geant4.addDetectorConstruction(
+      "Geant4PythonDetectorConstruction/SetupSD",
+      sensitives=DD4hepSimulation.__setupSensitives,
+      sensitives_args=(geant4, detectorDescription, self))
+    logger.info("# Configure G4 sensitive detectors: atach'em to the sensitive volumes")
+    seq, act = geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
+
+    # setup the magnetic field:
+    logger.info("Setting magnetic field")
+    self.__setMagneticFieldOptions(geant4)
+
+    # Configure the random seed, do it before the I/O because we might change the seed!
+    logger.info("Initializing random")
+    self.random.initialize(DDG4, kernel, self.output.random)
+
+    # Configure the output file format and plugin
+    logger.info("Initializing output")
+    self.outputConfig.initialize(dd4hepsimulation=self, geant4=geant4)
+
+    # =================================================================================
     # Now build the physics list:
     _phys = self.physics.setupPhysics(kernel, name=self.physicsList)
     _phys.verbosity = self.output.physics
@@ -543,22 +585,13 @@ class DD4hepSimulation(object):
 
     dd4hep.setPrintLevel(self.printLevel)
 
-    kernel.configure()
-    kernel.initialize()
-
-    # GPS
-    if self._g4gun is not None:
-      self._g4gun.generator()
-    if self._g4gps is not None:
-      self._g4gps.generator()
-
     startUpTime, _sysTime, _cuTime, _csTime, _elapsedTime = os.times()
 
     exitCode = 0
-    if not kernel.run():
+    if not geant4.run():
       logger.error("Simulation failed!")
       exitCode += 1
-    if not kernel.terminate():
+    if not geant4.terminate():
       exitCode += 1
       logger.error("Termination failed!")
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -582,7 +582,10 @@ class DD4hepSimulation(object):
 
   def __setMagneticFieldOptions(self, geant4):
     """ create and configure the magnetic tracking setup """
-    field = geant4.addConfig('Geant4FieldTrackingSetupAction/MagFieldTrackingSetup')
+    if self.numberOfThreads > 1:
+      seq, field = geant4.addDetectorConstruction("Geant4FieldTrackingConstruction/MagFieldTrackingSetup")
+    else:
+      field = geant4.addConfig('Geant4FieldTrackingSetupAction/MagFieldTrackingSetup')
     field.stepper = self.field.stepper
     field.equation = self.field.equation
     field.eps_min = self.field.eps_min

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -576,8 +576,8 @@ class DD4hepSimulation(object):
       if processedEvents != 0:
         eventTime = totalTimeUser - startUpTime
         perEventTime = eventTime / processedEvents
-        logger.info("StartUp Time: %3.2f s, Processing and Init: %3.2f s (~%3.2f s/Event) "
-                    % (startUpTime, eventTime, perEventTime))
+        logger.info("StartUp Time: %3.2f s, Processing and Init: %3.2f s (~%3.2f s/Event @ %d threads) "
+                    % (startUpTime, eventTime, perEventTime, self.numberOfThreads))
     return exitCode
 
   def __setMagneticFieldOptions(self, geant4):

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -446,41 +446,41 @@ class DD4hepSimulation(object):
 
     return 1
 
-  def __setupSensitives(geant4, detectorDescription, sim):
+  def __setupSensitives(self, geant4, detectorDescription):
     kernel = geant4.kernel()
 
     # Setup global filters for use in sensitive detectors
     try:
-      sim.filter.setupFilters(kernel)
+      self.filter.setupFilters(kernel)
     except RuntimeError as e:
       logger.error("%s", e)
       return 1
 
     # get lists of trackers and calorimeters in detectorDescription
-    trk, cal, unk = sim.getDetectorLists(detectorDescription)
+    trk, cal, unk = self.getDetectorLists(detectorDescription)
     for detectors, function, defFilter, defAction, abort in \
-        [(trk, geant4.setupTracker, sim.filter.tracker, sim.action.tracker, False),
-         (cal, geant4.setupCalorimeter, sim.filter.calo, sim.action.calo, False),
+        [(trk, geant4.setupTracker, self.filter.tracker, self.action.tracker, False),
+         (cal, geant4.setupCalorimeter, self.filter.calo, self.action.calo, False),
          (unk, geant4.setupDetector, None, "No Default", True),
          ]:
       try:
-        sim.__setupSensitiveDetectors(detectors, function, defFilter, defAction, abort)
+        self.__setupSensitiveDetectors(detectors, function, defFilter, defAction, abort)
       except Exception as e:
         logger.error("Failed setting up sensitive detector %s", e)
         raise
 
     return 1
 
-  def __setupWorker(geant4, sim):
+  def __setupWorker(self, geant4):
     logger.debug("Setting up worker")
     kernel = geant4.kernel()
     logger.debug("Setting up actions")
-    sim.__setupActions(kernel)
+    self.__setupActions(kernel)
     logger.debug("Setting up generator actions")
-    sim.__setupGeneratorActions(kernel, geant4)
+    self.__setupGeneratorActions(kernel, geant4)
     return 1
 
-  def __setupMaster(geant4):
+  def __setupMaster(self, geant4):
     logger.debug("Setting up master")
     kernel = geant4.master()
     return 1
@@ -540,13 +540,13 @@ class DD4hepSimulation(object):
       kernel.RunManagerType = "G4MTRunManager"
       kernel.NumberOfThreads = self.numberOfThreads
       geant4.addUserInitialization(
-        worker=DD4hepSimulation.__setupWorker, worker_args=(geant4, self),
-        master=DD4hepSimulation.__setupMaster, master_args=(geant4,))
+        worker=self.__setupWorker, worker_args=(geant4,),
+        master=self.__setupMaster, master_args=(geant4,))
     else:
       kernel.RunManagerType = "G4RunManager"
       kernel.NumberOfThreads = 1
       geant4.addUserInitialization(
-        worker=DD4hepSimulation.__setupWorker, worker_args=(geant4, self))
+        worker=self.__setupWorker, worker_args=(geant4,self))
 
     # -----------------------------------------------------------------------------------
 
@@ -556,8 +556,8 @@ class DD4hepSimulation(object):
     logger.info("# Configure G4 sensitive detectors: python setup callback")
     seq, act = geant4.addDetectorConstruction(
       "Geant4PythonDetectorConstruction/SetupSD",
-      sensitives=DD4hepSimulation.__setupSensitives,
-      sensitives_args=(geant4, detectorDescription, self))
+      sensitives=self.__setupSensitives,
+      sensitives_args=(geant4, detectorDescription,))
     logger.info("# Configure G4 sensitive detectors: atach'em to the sensitive volumes")
     seq, act = geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -512,6 +512,11 @@ class DD4hepSimulation(object):
     """setup the geometry and dd4hep and geant4 and do what was asked to be done"""
     import ROOT
     ROOT.PyConfig.IgnoreCommandLineOptions = True
+    
+    # Enable ROOT's thread safety for MT mode
+    if self.numberOfThreads > 1:
+      ROOT.EnableThreadSafety()
+      logger.info("Enabled ROOT thread safety for MT mode")
 
     import DDG4
     import dd4hep

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -583,7 +583,7 @@ class DD4hepSimulation(object):
     # -----------------------------------------------------------------------------------
 
     logger.info("#  Configure G4 geometry setup")
-    seq, act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
+    self.geometry.constructGeometry(kernel, geant4, self.output.geometry)
 
     logger.info("# Configure G4 sensitive detectors: python setup callback")
     seq, act = geant4.addDetectorConstruction(

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -589,9 +589,6 @@ class DD4hepSimulation(object):
     if not geant4.run():
       logger.error("Simulation failed!")
       exitCode += 1
-    if not geant4.terminate():
-      exitCode += 1
-      logger.error("Termination failed!")
 
     totalTimeUser, totalTimeSys, _cuTime, _csTime, _elapsedTime = os.times()
     processedEvents = self.numberOfEvents

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -478,6 +478,8 @@ class DD4hepSimulation(object):
     self.__setupActions(kernel)
     logger.debug("Setting up generator actions")
     self.__setupGeneratorActions(kernel, geant4)
+    logger.debug("Setting up output")
+    self.outputConfig.initialize(dd4hepsimulation=self, geant4=geant4)
     return 1
 
   def __setupMaster(self, geant4):
@@ -568,10 +570,6 @@ class DD4hepSimulation(object):
     # Configure the random seed, do it before the I/O because we might change the seed!
     logger.info("Initializing random")
     self.random.initialize(DDG4, kernel, self.output.random)
-
-    # Configure the output file format and plugin
-    logger.info("Initializing output")
-    self.outputConfig.initialize(dd4hepsimulation=self, geant4=geant4)
 
     # =================================================================================
     # Now build the physics list:

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -616,10 +616,7 @@ class DD4hepSimulation(object):
 
   def __setMagneticFieldOptions(self, geant4):
     """ create and configure the magnetic tracking setup """
-    if self.numberOfThreads > 1:
-      seq, field = geant4.addDetectorConstruction("Geant4FieldTrackingConstruction/MagFieldTrackingSetup")
-    else:
-      field = geant4.addConfig('Geant4FieldTrackingSetupAction/MagFieldTrackingSetup')
+    field = geant4.addConfig('Geant4FieldTrackingSetupAction/MagFieldTrackingSetup')
     field.stepper = self.field.stepper
     field.equation = self.field.equation
     field.eps_min = self.field.eps_min

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -549,13 +549,13 @@ class DD4hepSimulation(object):
       kernel.RunManagerType = "G4MTRunManager"
       kernel.NumberOfThreads = self.numberOfThreads
       geant4.addUserInitialization(
-        worker=self.__setupWorker, worker_args=(geant4,),
-        master=self.__setupMaster, master_args=(geant4,))
+          worker=self.__setupWorker, worker_args=(geant4,),
+          master=self.__setupMaster, master_args=(geant4,))
     else:
       kernel.RunManagerType = "G4RunManager"
       kernel.NumberOfThreads = 1
       geant4.addUserInitialization(
-        worker=self.__setupWorker, worker_args=(geant4,))
+          worker=self.__setupWorker, worker_args=(geant4,))
 
     # -----------------------------------------------------------------------------------
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -624,14 +624,12 @@ class DD4hepSimulation(object):
     # In multi-threaded mode with shared=False, the actual generators are created
     # per-worker and initialized automatically by Geant4, so we skip this step
     if self.numberOfThreads == 1:
-      if self._g4gun is not []:
-        for g4gun in self._g4gun:
-          g4gun.generator()  # Initialize G4ParticleGun and register UI commands
-          logger.debug("Initialized G4Gun generator")
-      if self._g4gps is not []:
-        for g4gps in self._g4gps:
-          g4gps.generator()  # Initialize GPS and register UI commands
-          logger.debug("Initialized GPS generator")
+      for g4gun in self._g4gun:
+        g4gun.generator()  # Initialize G4ParticleGun and register UI commands
+        logger.debug("Initialized G4Gun generator")
+      for g4gps in self._g4gps:
+        g4gps.generator()  # Initialize GPS and register UI commands
+        logger.debug("Initialized GPS generator")
 
     startUpTime, _sysTime, _cuTime, _csTime, _elapsedTime = os.times()
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -548,7 +548,7 @@ class DD4hepSimulation(object):
       kernel.RunManagerType = "G4RunManager"
       kernel.NumberOfThreads = 1
       geant4.addUserInitialization(
-        worker=self.__setupWorker, worker_args=(geant4,self))
+        worker=self.__setupWorker, worker_args=(geant4,))
 
     # -----------------------------------------------------------------------------------
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -589,12 +589,20 @@ class DD4hepSimulation(object):
 
     dd4hep.setPrintLevel(self.printLevel)
 
+    from ROOT import PyDDG4
+    master = geant4.master().get()
+
+    PyDDG4.configure(master)
+    PyDDG4.initialize(master)
+
     startUpTime, _sysTime, _cuTime, _csTime, _elapsedTime = os.times()
 
-    exitCode = 0
-    if not geant4.run():
+    if not PyDDG4.run(master):
       logger.error("Simulation failed!")
       exitCode += 1
+    if not PyDDG4.terminate(master):
+      exitCode += 1
+      logger.error("Termination failed!")
 
     totalTimeUser, totalTimeSys, _cuTime, _csTime, _elapsedTime = os.times()
     processedEvents = self.numberOfEvents

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -389,17 +389,17 @@ class DD4hepSimulation(object):
 
     for index, inputFile in enumerate(self.inputFiles, start=start):
       if inputFile.endswith(".slcio"):
-        gen = DDG4.GeneratorAction(kernel, "LCIOInputAction/LCIO%d" % index)
+        gen = DDG4.GeneratorAction(kernel, "LCIOInputAction/LCIO%d" % index, shared=shared)
         gen.Parameters = self.lcio.getParameters()
         gen.Input = "LCIOFileReader|" + inputFile
       elif inputFile.endswith(".stdhep"):
-        gen = DDG4.GeneratorAction(kernel, "LCIOInputAction/STDHEP%d" % index)
+        gen = DDG4.GeneratorAction(kernel, "LCIOInputAction/STDHEP%d" % index, shared=shared)
         gen.Input = "LCIOStdHepReader|" + inputFile
       elif inputFile.endswith(".HEPEvt"):
-        gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/HEPEvt%d" % index)
+        gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/HEPEvt%d" % index, shared=shared)
         gen.Input = "Geant4EventReaderHepEvtShort|" + inputFile
       elif inputFile.endswith(".hepevt"):
-        gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepevt%d" % index)
+        gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepevt%d" % index, shared=shared)
         gen.Input = "Geant4EventReaderHepEvtLong|" + inputFile
       elif inputFile.endswith(tuple([".hepmc"] + HEPMC3_SUPPORTED_EXTENSIONS)):
         if self.hepmc3.useHepMC3:
@@ -410,12 +410,12 @@ class DD4hepSimulation(object):
           gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=shared)
           gen.Input = "Geant4EventReaderHepMC|" + inputFile
       elif inputFile.endswith(".pairs"):
-        gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/GuineaPig%d" % index)
+        gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/GuineaPig%d" % index, shared=shared)
         gen.Input = "Geant4EventReaderGuineaPig|" + inputFile
         gen.Parameters = self.guineapig.getParameters()
       elif inputFile.endswith(tuple(EDM4HEP_INPUT_EXTENSIONS)):
         # EDM4HEP must come after HEPMC3 because of .root also part of hepmc3 extensions
-        gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/EDM4hep%d" % index)
+        gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/EDM4hep%d" % index, shared=shared)
         gen.Parameters = self.edm4hep.getParameters()
         gen.Input = "EDM4hepFileReader|" + inputFile
       else:

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -616,12 +616,6 @@ class DD4hepSimulation(object):
     from ROOT import PyDDG4
     master = geant4.master().get()
 
-    # Preload reader libraries on the master thread before workers start.
-    if self.inputFiles and self.numberOfThreads > 1:
-      from ROOT import gSystem
-      if any(f.endswith(tuple(EDM4HEP_INPUT_EXTENSIONS)) for f in self.inputFiles):
-        gSystem.Load("libDDG4EDM4HEPReader")
-
     PyDDG4.configure(master)
     PyDDG4.initialize(master)
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -363,20 +363,22 @@ class DD4hepSimulation(object):
       logger.info("++++ Adding DD4hep Particle Gun ++++")
 
     if self.enableG4Gun:
-      # GPS Create something
-      g4gun = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/Gun", shared=shared)
+      # G4Gun: Always use shared=False to allow macro configuration
+      # In MT mode, Geant4 will handle making the gun available to workers
+      g4gun = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/Gun", shared=False)
       g4gun.Uses = 'G4ParticleGun'
       g4gun.Mask = 2
-      logger.info("++++ Adding Geant4 Particle Gun ++++")
+      logger.info("++++ Adding Geant4 Particle Gun (non-shared for macro support) ++++")
       actionList.append(g4gun)
       self._g4gun.append(g4gun)
 
     if self.enableG4GPS:
-      # GPS Create something
-      g4gps = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/GPS", shared=shared)
+      # GPS: Always use shared=False to allow macro configuration
+      # In MT mode, Geant4 will handle making GPS available to workers
+      g4gps = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/GPS", shared=False)
       g4gps.Uses = 'G4GeneralParticleSource'
       g4gps.Mask = 3
-      logger.info("++++ Adding Geant4 General Particle Source ++++")
+      logger.info("++++ Adding Geant4 General Particle Source (non-shared for macro support) ++++")
       actionList.append(g4gps)
       self._g4gps.append(g4gps)
 
@@ -491,6 +493,11 @@ class DD4hepSimulation(object):
     kernel = geant4.kernel()
     logger.debug("Setting up actions")
     self.__setupActions(kernel)
+    logger.debug("Setting up EventSeeder for worker")
+    # Setup EventSeeder for this worker
+    # Uses the shared Geant4Random instance from master
+    import DDG4
+    self.random.setupEventSeeder(DDG4, kernel)
     logger.debug("Setting up generator actions")
     self.__setupGeneratorActions(kernel, geant4)
     logger.debug("Setting up output")
@@ -603,14 +610,19 @@ class DD4hepSimulation(object):
     PyDDG4.configure(master)
     PyDDG4.initialize(master)
 
-    # GPS
-    # FIXME this applies to only 1 thread, and Geant4GeneratorWrapper doesn't work as shared=True
-    if self._g4gun is not []:
-      for g4gun in self._g4gun:
-        g4gun.generator()
-    if self._g4gps is not []:
-      for g4gps in self._g4gps:
-        g4gps.generator()
+    # Initialize G4Gun and GPS generators for macro execution
+    # In single-threaded mode, we can access .generator() on the action objects
+    # In multi-threaded mode with shared=False, the actual generators are created
+    # per-worker and initialized automatically by Geant4, so we skip this step
+    if self.numberOfThreads == 1:
+      if self._g4gun is not []:
+        for g4gun in self._g4gun:
+          g4gun.generator()  # Initialize G4ParticleGun and register UI commands
+          logger.debug("Initialized G4Gun generator")
+      if self._g4gps is not []:
+        for g4gps in self._g4gps:
+          g4gps.generator()  # Initialize GPS and register UI commands
+          logger.debug("Initialized GPS generator")
 
     startUpTime, _sysTime, _cuTime, _csTime, _elapsedTime = os.times()
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -514,7 +514,7 @@ class DD4hepSimulation(object):
     """setup the geometry and dd4hep and geant4 and do what was asked to be done"""
     import ROOT
     ROOT.PyConfig.IgnoreCommandLineOptions = True
-    
+
     # Enable ROOT's thread safety for MT mode
     if self.numberOfThreads > 1:
       ROOT.EnableThreadSafety()
@@ -885,7 +885,7 @@ class DD4hepSimulation(object):
     # Register Generation initialization action
     shared = (self.numberOfThreads > 1)
     logger.debug(f"Determined shared={shared} based on self.numberOfThreads={self.numberOfThreads}")
-    gen = GeneratorAction(geant4.kernel(), "Geant4GeneratorActionInit/GenerationInit", shared = shared)
+    gen = GeneratorAction(geant4.kernel(), "Geant4GeneratorActionInit/GenerationInit", shared=shared)
     generationInit = gen
     if output_level is not None:
       gen.OutputLevel = output_level

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -599,6 +599,13 @@ class DD4hepSimulation(object):
     logger.info("# Configure G4 sensitive detectors: atach'em to the sensitive volumes")
     seq, act = geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
 
+    # Configure regex-based sensitive detectors
+    for index, (detName, regexDetectors) in enumerate(sorted(self.geometry._regexSDDict.items())):
+      seq, act = geant4.addDetectorConstruction(f'Geant4RegexSensitivesConstruction/ConstrSDRegEx_{index}_{detName}')
+      act.Detector = detName
+      for key, value in regexDetectors.items():
+        setattr(act, key, value)
+
     # setup the magnetic field:
     logger.info("Setting magnetic field")
     self.__setMagneticFieldOptions(geant4)

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -509,6 +509,12 @@ class DD4hepSimulation(object):
     return 1
 
   def __setupMaster(self, geant4):
+    """Setup master thread in multi-threaded mode.
+
+    This is a placeholder callback for master-thread initialization.
+    Currently minimal as master setup is handled by the framework.
+    Future extensions may add master-specific configuration here.
+    """
     logger.debug("Setting up master")
     return 1
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -368,7 +368,7 @@ class DD4hepSimulation(object):
       g4gun = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/Gun", shared=False)
       g4gun.Uses = 'G4ParticleGun'
       g4gun.Mask = 2
-      logger.info("++++ Adding Geant4 Particle Gun (non-shared for macro support) ++++")
+      logger.info("++++ Adding Geant4 Particle Gun ++++")
       actionList.append(g4gun)
       self._g4gun.append(g4gun)
 
@@ -378,7 +378,7 @@ class DD4hepSimulation(object):
       g4gps = DDG4.GeneratorAction(kernel, "Geant4GeneratorWrapper/GPS", shared=False)
       g4gps.Uses = 'G4GeneralParticleSource'
       g4gps.Mask = 3
-      logger.info("++++ Adding Geant4 General Particle Source (non-shared for macro support) ++++")
+      logger.info("++++ Adding Geant4 General Particle Source ++++")
       actionList.append(g4gps)
       self._g4gps.append(g4gps)
 

--- a/DDG4/python/DDSim/Helper/Geometry.py
+++ b/DDG4/python/DDSim/Helper/Geometry.py
@@ -60,10 +60,14 @@ class Geometry(ConfigHelper):
       return
     raise RuntimeError(f"Unsupported type for regexSensitiveDetector: {val!r}")
 
-  def constructGeometry(self, kernel, geant4, geoPrintLevel=2, numberOfThreads=1):
-    """Construct Geant4 geometry."""
-    from DDG4 import DetectorConstruction
+  def constructGeometry(self, kernel, geant4, geoPrintLevel=2):
+    """Construct Geant4 geometry.
 
+    Adds Geant4DetectorGeometryConstruction with all debug/print flags and any
+    regex-based sensitive detector constructions.  The caller is responsible for
+    inserting Geant4DetectorSensitivesConstruction (and any intermediate steps
+    such as a Python sensitive-detector setup callback) into the sequence.
+    """
     seq, act = geant4.addDetectorConstruction('Geant4DetectorGeometryConstruction/ConstructGeo')
     act.DebugMaterials = self.enableDebugMaterials
     act.DebugElements = self.enableDebugElements
@@ -79,14 +83,8 @@ class Geometry(ConfigHelper):
     act.DumpHierarchy = self.dumpHierarchy
     act.DumpGDML = self.dumpGDML
 
-    # Apply sensitive detectors
-    sensitives = DetectorConstruction(kernel, str('Geant4DetectorSensitivesConstruction/ConstructSD'))
-    sensitives.enableUI()
-    seq.adopt(sensitives)
-
     for index, (detName, regexDetectors) in enumerate(sorted(self._regexSDDict.items())):
       seq, act = geant4.addDetectorConstruction(f'Geant4RegexSensitivesConstruction/ConstrSDRegEx_{index}_{detName}')
       act.Detector = detName
-      # this will set Match, and other properties if possible
       for key, value in regexDetectors.items():
         setattr(act, key, value)

--- a/DDG4/python/DDSim/Helper/Geometry.py
+++ b/DDG4/python/DDSim/Helper/Geometry.py
@@ -63,10 +63,9 @@ class Geometry(ConfigHelper):
   def constructGeometry(self, kernel, geant4, geoPrintLevel=2):
     """Construct Geant4 geometry.
 
-    Adds Geant4DetectorGeometryConstruction with all debug/print flags and any
-    regex-based sensitive detector constructions.  The caller is responsible for
-    inserting Geant4DetectorSensitivesConstruction (and any intermediate steps
-    such as a Python sensitive-detector setup callback) into the sequence.
+    Adds Geant4DetectorGeometryConstruction with all debug/print flags.
+    The caller is responsible for inserting regex-based sensitive detector
+    constructions and Geant4DetectorSensitivesConstruction.
     """
     seq, act = geant4.addDetectorConstruction('Geant4DetectorGeometryConstruction/ConstructGeo')
     act.DebugMaterials = self.enableDebugMaterials
@@ -82,9 +81,3 @@ class Geometry(ConfigHelper):
     act.GeoInfoPrintLevel = geoPrintLevel
     act.DumpHierarchy = self.dumpHierarchy
     act.DumpGDML = self.dumpGDML
-
-    for index, (detName, regexDetectors) in enumerate(sorted(self._regexSDDict.items())):
-      seq, act = geant4.addDetectorConstruction(f'Geant4RegexSensitivesConstruction/ConstrSDRegEx_{index}_{detName}')
-      act.Detector = detName
-      for key, value in regexDetectors.items():
-        setattr(act, key, value)

--- a/DDG4/python/DDSim/Helper/Random.py
+++ b/DDG4/python/DDSim/Helper/Random.py
@@ -42,7 +42,8 @@ class Random (ConfigHelper):
     self.replace_gRandom = True
     self.file = None
     self._random = None
-    self._eventseed = None
+    self._eventseeds = []
+    self._worker_randoms = []
 
     self._enableEventSeed_EXTRA = {'help': "If True, calculate random seed for each event based"
                                            "on eventID and runID\nAllows reproducibility even when"
@@ -95,22 +96,16 @@ class Random (ConfigHelper):
     worker thread, creating an independent EventSeeder for each worker.
 
     :param DDG4: DDG4 module
-    :param kernel: Geant4 kernel (master kernel in ST mode, worker kernel in MT mode)
+    :param kernel: worker kernel (or the only kernel in ST mode)
     """
     if self.seed is not None and self.enableEventSeed:
-      # Only create EventSeeder once (check if already created)
-      if self._eventseed is not None:
-        logger.debug("EventSeeder already created, skipping")
-        return self._eventseed
-      
       # Create EventSeeder - use shared=True for MT mode to avoid multiple instances
       seeder_name = 'Geant4EventSeed/EventSeeder'
       eventseed = DDG4.RunAction(kernel, seeder_name, shared=True)
       # Explicitly add to run action sequence
       kernel.runAction().add(eventseed)
-      logger.info("EventSeeder created and added to run action")
-      # Store reference
-      self._eventseed = eventseed
+      self._eventseeds.append(eventseed)  # keep reference alive
+      logger.info("EventSeeder added to run action of kernel %s", kernel)
       return eventseed
     return None
 
@@ -147,4 +142,5 @@ class Random (ConfigHelper):
 
     logger.info("Initialized Geant4Random for worker (thread-local ID %d) with seed %d",
                 random_id, self.seed)
+    self._worker_randoms.append(worker_random)  # keep reference alive
     return worker_random

--- a/DDG4/python/DDSim/Helper/Random.py
+++ b/DDG4/python/DDSim/Helper/Random.py
@@ -3,8 +3,30 @@
 from DDSim.Helper.ConfigHelper import ConfigHelper
 import random
 import logging
+import threading
 
 logger = logging.getLogger(__name__)
+
+# Thread-local counter for EventSeeder naming
+_eventseed_counter = threading.local()
+# Thread-local counter for Geant4Random naming in workers
+_random_counter = threading.local()
+
+def _get_eventseed_id():
+  """Get a unique ID for EventSeeder in this thread"""
+  if not hasattr(_eventseed_counter, 'value'):
+    _eventseed_counter.value = 0
+  else:
+    _eventseed_counter.value += 1
+  return _eventseed_counter.value
+
+def _get_random_id():
+  """Get a unique ID for Geant4Random in this thread"""
+  if not hasattr(_random_counter, 'value'):
+    _random_counter.value = 0
+  else:
+    _random_counter.value += 1
+  return _random_counter.value
 
 
 class Random (ConfigHelper):
@@ -18,6 +40,7 @@ class Random (ConfigHelper):
     self.replace_gRandom = True
     self.file = None
     self._random = None
+    self._eventseed = None
 
     self._enableEventSeed_EXTRA = {'help': "If True, calculate random seed for each event based"
                                            "on eventID and runID\nAllows reproducibility even when"
@@ -41,6 +64,9 @@ class Random (ConfigHelper):
       # System provided random source, truely random according to documentation
       self.seed = random.SystemRandom().randint(0, 2**31 - 1)
       logger.info("Choosing random seed for you: %s", self.seed)
+    else:
+      # Ensure seed is an integer (may be string from command line)
+      self.seed = int(self.seed)
 
     self._random.Seed = self.seed
     self._random.Luxury = self.luxury
@@ -50,10 +76,73 @@ class Random (ConfigHelper):
 
     self._random.initialize()
 
-    if self.seed is not None and self.enableEventSeed:
-      self._eventseed = DDG4.RunAction(kernel, 'Geant4EventSeed/EventSeeder1')
+    # EventSeeder initialization is deferred to setupEventSeeder()
+    # which is called during worker initialization in MT mode
+    # or can be called immediately in ST mode
 
     # Needs to be called after initilisation
     if output <= 3:
       self._random.showStatus()
     return self._random
+
+  def setupEventSeeder(self, DDG4, kernel):
+    """Setup EventSeeder action for per-event random seeding.
+    
+    This method should be called during worker initialization in MT mode,
+    or after initialize() in ST mode. In MT mode, this is called once per
+    worker thread, creating an independent EventSeeder for each worker.
+    
+    :param DDG4: DDG4 module
+    :param kernel: Geant4 kernel (master kernel in ST mode, worker kernel in MT mode)
+    """
+    if self.seed is not None and self.enableEventSeed:
+      # Only create EventSeeder once (check if already created)
+      if self._eventseed is not None:
+        logger.debug("EventSeeder already created, skipping")
+        return self._eventseed
+      
+      # Create EventSeeder - use shared=True for MT mode to avoid multiple instances
+      seeder_name = 'Geant4EventSeed/EventSeeder'
+      eventseed = DDG4.RunAction(kernel, seeder_name, shared=True)
+      # Explicitly add to run action sequence
+      kernel.runAction().add(eventseed)
+      logger.info("EventSeeder created and added to run action")
+      # Store reference
+      self._eventseed = eventseed
+      return eventseed
+    return None
+
+  def initializeWorker(self, DDG4, kernel, output):
+    """Initialize Geant4Random for a worker thread in MT mode.
+    
+    In MT mode, each worker thread needs its own Geant4Random instance.
+    We use the same initial seed as the master so that EventSeeder computes
+    the same per-event seeds across all workers.
+    
+    :param DDG4: DDG4 module
+    :param kernel: Worker kernel
+    :param int output: output level
+    :returns: Geant4Random instance for this worker
+    """
+    # Create a Geant4Random wrapper for this worker
+    random_id = _get_random_id()
+    random_name = 'Geant4Random/R_worker_%d' % random_id
+    worker_random = DDG4.Action(kernel, random_name)
+    
+    # Use the same seed as master so EventSeeder computes identical event seeds
+    worker_random.Seed = self.seed
+    worker_random.Luxury = self.luxury
+    worker_random.Replace_gRandom = self.replace_gRandom
+    
+    if self.type is not None:
+      worker_random.Type = self.type
+    
+    # Initialize the worker's random engine
+    worker_random.initialize()
+    
+    if output <= 3:
+      worker_random.showStatus()
+    
+    logger.info("Initialized Geant4Random for worker (thread-local ID %d) with seed %d", 
+                random_id, self.seed)
+    return worker_random

--- a/DDG4/python/DDSim/Helper/Random.py
+++ b/DDG4/python/DDSim/Helper/Random.py
@@ -12,6 +12,7 @@ _eventseed_counter = threading.local()
 # Thread-local counter for Geant4Random naming in workers
 _random_counter = threading.local()
 
+
 def _get_eventseed_id():
   """Get a unique ID for EventSeeder in this thread"""
   if not hasattr(_eventseed_counter, 'value'):
@@ -19,6 +20,7 @@ def _get_eventseed_id():
   else:
     _eventseed_counter.value += 1
   return _eventseed_counter.value
+
 
 def _get_random_id():
   """Get a unique ID for Geant4Random in this thread"""
@@ -87,11 +89,11 @@ class Random (ConfigHelper):
 
   def setupEventSeeder(self, DDG4, kernel):
     """Setup EventSeeder action for per-event random seeding.
-    
+
     This method should be called during worker initialization in MT mode,
     or after initialize() in ST mode. In MT mode, this is called once per
     worker thread, creating an independent EventSeeder for each worker.
-    
+
     :param DDG4: DDG4 module
     :param kernel: Geant4 kernel (master kernel in ST mode, worker kernel in MT mode)
     """
@@ -114,11 +116,11 @@ class Random (ConfigHelper):
 
   def initializeWorker(self, DDG4, kernel, output):
     """Initialize Geant4Random for a worker thread in MT mode.
-    
+
     In MT mode, each worker thread needs its own Geant4Random instance.
     We use the same initial seed as the master so that EventSeeder computes
     the same per-event seeds across all workers.
-    
+
     :param DDG4: DDG4 module
     :param kernel: Worker kernel
     :param int output: output level
@@ -128,21 +130,21 @@ class Random (ConfigHelper):
     random_id = _get_random_id()
     random_name = 'Geant4Random/R_worker_%d' % random_id
     worker_random = DDG4.Action(kernel, random_name)
-    
+
     # Use the same seed as master so EventSeeder computes identical event seeds
     worker_random.Seed = self.seed
     worker_random.Luxury = self.luxury
     worker_random.Replace_gRandom = self.replace_gRandom
-    
+
     if self.type is not None:
       worker_random.Type = self.type
-    
+
     # Initialize the worker's random engine
     worker_random.initialize()
-    
+
     if output <= 3:
       worker_random.showStatus()
-    
-    logger.info("Initialized Geant4Random for worker (thread-local ID %d) with seed %d", 
+
+    logger.info("Initialized Geant4Random for worker (thread-local ID %d) with seed %d",
                 random_id, self.seed)
     return worker_random

--- a/DDG4/python/DDSim/Helper/Random.py
+++ b/DDG4/python/DDSim/Helper/Random.py
@@ -99,9 +99,9 @@ class Random (ConfigHelper):
     :param kernel: worker kernel (or the only kernel in ST mode)
     """
     if self.seed is not None and self.enableEventSeed:
-      # Create EventSeeder - use shared=True for MT mode to avoid multiple instances
+      # Use shared=False so the seeder registers on the worker's event/stacking action sequences.
       seeder_name = 'Geant4EventSeed/EventSeeder'
-      eventseed = DDG4.RunAction(kernel, seeder_name, shared=True)
+      eventseed = DDG4.RunAction(kernel, seeder_name, shared=False)
       # Explicitly add to run action sequence
       kernel.runAction().add(eventseed)
       self._eventseeds.append(eventseed)  # keep reference alive

--- a/DDG4/python/DDSim/Helper/Random.py
+++ b/DDG4/python/DDSim/Helper/Random.py
@@ -7,19 +7,8 @@ import threading
 
 logger = logging.getLogger(__name__)
 
-# Thread-local counter for EventSeeder naming
-_eventseed_counter = threading.local()
 # Thread-local counter for Geant4Random naming in workers
 _random_counter = threading.local()
-
-
-def _get_eventseed_id():
-  """Get a unique ID for EventSeeder in this thread"""
-  if not hasattr(_eventseed_counter, 'value'):
-    _eventseed_counter.value = 0
-  else:
-    _eventseed_counter.value += 1
-  return _eventseed_counter.value
 
 
 def _get_random_id():

--- a/DDG4/python/DDSim/Helper/Random.py
+++ b/DDG4/python/DDSim/Helper/Random.py
@@ -7,17 +7,18 @@ import threading
 
 logger = logging.getLogger(__name__)
 
-# Thread-local counter for Geant4Random naming in workers
-_random_counter = threading.local()
+# Global counter with lock for thread-safe unique ID generation for Geant4Random
+_random_counter = 0
+_random_counter_lock = threading.Lock()
 
 
 def _get_random_id():
-  """Get a unique ID for Geant4Random in this thread"""
-  if not hasattr(_random_counter, 'value'):
-    _random_counter.value = 0
-  else:
-    _random_counter.value += 1
-  return _random_counter.value
+  """Get a globally unique ID for Geant4Random across all threads"""
+  global _random_counter
+  with _random_counter_lock:
+    current_id = _random_counter
+    _random_counter += 1
+    return current_id
 
 
 class Random (ConfigHelper):

--- a/DDG4/src/Geant4Kernel.cpp
+++ b/DDG4/src/Geant4Kernel.cpp
@@ -119,7 +119,7 @@ Geant4Kernel::Geant4Kernel(Geant4Kernel* krnl, unsigned long ident)
   m_world          = m_master->m_world;
   m_ident          = m_master->m_workers.size();
   m_numEvent       = m_master->m_numEvent;
-  m_runManagerType = m_master->m_runManagerType;
+  declareProperty("RunManagerType", m_runManagerType = m_master->m_runManagerType);
   m_sensitiveDetectorTypes      = m_master->m_sensitiveDetectorTypes;
   m_dfltSensitiveDetectorType   = m_master->m_dfltSensitiveDetectorType;
   declareProperty("UI",m_uiName = m_master->m_uiName);

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -68,9 +68,8 @@ void Geant4Output2ROOT::endRun(const G4Run* run) {
   Geant4OutputAction::endRun(run);
 }
 
-/// Close current output file
-void Geant4Output2ROOT::closeOutput()   {
-  std::lock_guard<std::mutex> lock(s_rootMutex);
+/// Close current output file. Must be called with s_rootMutex held.
+void Geant4Output2ROOT::closeOutputLocked()   {
   if (!m_file) return;
   TDirectory::TContext ctxt(m_file.get());
   info("+++ Closing ROOT output file %s", m_file->GetName());
@@ -83,6 +82,12 @@ void Geant4Output2ROOT::closeOutput()   {
   m_file->Close();
   m_tree = nullptr;
   m_file.reset();
+}
+
+/// Close current output file
+void Geant4Output2ROOT::closeOutput()   {
+  std::lock_guard<std::mutex> lock(s_rootMutex);
+  closeOutputLocked();
 }
 
 /// Create/access tree by name
@@ -104,11 +109,7 @@ void Geant4Output2ROOT::beginRun(const G4Run* run) {
   if ( m_filesByRun )    {
     size_t idx = m_output.rfind(".");
     if ( m_file ) {
-      // closeOutput() takes the same mutex; temporarily release it to avoid
-      // recursive locking while retaining serialized ROOT I/O.
-      lock.unlock();
-      closeOutput();
-      lock.lock();
+      closeOutputLocked();
     }
     fname  = m_output.substr(0, idx);
     fname += _toString(run->GetRunID(), ".run%08d");

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -16,10 +16,12 @@
 #include <DD4hep/InstanceCount.h>
 #include <DDG4/Geant4HitCollection.h>
 #include <DDG4/Geant4Output2ROOT.h>
+#include <DDG4/Geant4Kernel.h>
 #include <DDG4/Geant4Particle.h>
 #include <DDG4/Geant4Data.h>
 
 // Geant4 include files
+#include <G4Event.hh>
 #include <G4HCofThisEvent.hh>
 #include <G4ParticleTable.hh>
 #include <G4Run.hh>
@@ -50,6 +52,20 @@ Geant4Output2ROOT::Geant4Output2ROOT(Geant4Context* ctxt, const std::string& nam
 Geant4Output2ROOT::~Geant4Output2ROOT() {
   closeOutput();
   InstanceCount::decrement(this);
+}
+
+/// Callback at end of run: write and close the output file while DDG4 is still alive.
+/// In MT mode this fires once per worker; only the last worker closes the file
+void Geant4Output2ROOT::endRun(const G4Run* run) {
+  const int nThreads = context()->kernel().master().numThreads();
+  // ST: nThreads==0, close immediately
+  // MT: wait until every worker has called endRun before closing
+  int done = ++m_endRunCount;
+  if (nThreads == 0 || done >= nThreads) {
+    closeOutput();
+    m_endRunCount = 0;
+  }
+  Geant4OutputAction::endRun(run);
 }
 
 /// Close current output file

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -32,6 +32,9 @@
 
 using namespace dd4hep::sim;
 
+/// Define the static mutex for ROOT I/O protection
+std::mutex Geant4Output2ROOT::s_rootMutex;
+
 /// Standard constructor
 Geant4Output2ROOT::Geant4Output2ROOT(Geant4Context* ctxt, const std::string& nam)
   : Geant4OutputAction(ctxt, nam) {
@@ -51,6 +54,7 @@ Geant4Output2ROOT::~Geant4Output2ROOT() {
 
 /// Close current output file
 void Geant4Output2ROOT::closeOutput()   {
+  std::lock_guard<std::mutex> lock(s_rootMutex);
   if (!m_file) return;
   TDirectory::TContext ctxt(m_file.get());
   info("+++ Closing ROOT output file %s", m_file->GetName());
@@ -76,11 +80,17 @@ TTree* Geant4Output2ROOT::section(const std::string& nam) {
 
 /// Callback to store the Geant4 run information
 void Geant4Output2ROOT::beginRun(const G4Run* run) {
+  std::unique_lock<std::mutex> lock(s_rootMutex);
   std::string fname = m_output;
   if ( m_filesByRun )    {
     size_t idx = m_output.rfind(".");
-    if ( m_file )
+    if ( m_file ) {
+      // closeOutput() takes the same mutex; temporarily release it to avoid
+      // recursive locking while retaining serialized ROOT I/O.
+      lock.unlock();
       closeOutput();
+      lock.lock();
+    }
     fname  = m_output.substr(0, idx);
     fname += _toString(run->GetRunID(), ".run%08d");
     if ( idx != std::string::npos )
@@ -109,6 +119,7 @@ void Geant4Output2ROOT::beginRun(const G4Run* run) {
 
 /// Fill single EVENT branch entry (Geant4 collection data)
 int Geant4Output2ROOT::fill(const std::string& nam, const ComponentCast& type, void* ptr) {
+  std::lock_guard<std::mutex> lock(s_rootMutex);
   if (!m_file) return 0;
   TBranch* b = nullptr;
   auto i = m_branches.find(nam);
@@ -143,6 +154,7 @@ int Geant4Output2ROOT::fill(const std::string& nam, const ComponentCast& type, v
 
 /// Commit data at end of filling procedure
 void Geant4Output2ROOT::commit(OutputContext<G4Event>& ctxt) {
+  std::lock_guard<std::mutex> lock(s_rootMutex);
   if (m_file) {
     auto* a = m_tree->GetListOfBranches();
     const Long64_t evt = m_tree->GetEntries() + 1;

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -63,7 +63,6 @@ void Geant4Output2ROOT::endRun(const G4Run* run) {
   int done = ++m_endRunCount;
   if (nThreads == 0 || done >= nThreads) {
     closeOutput();
-    m_endRunCount = 0;
   }
   Geant4OutputAction::endRun(run);
 }
@@ -105,6 +104,9 @@ TTree* Geant4Output2ROOT::section(const std::string& nam) {
 /// Callback to store the Geant4 run information
 void Geant4Output2ROOT::beginRun(const G4Run* run) {
   std::unique_lock<std::mutex> lock(s_rootMutex);
+  // Reset per-run counter here, before any events, so a new run never sees
+  // stale counts from the previous run.
+  m_endRunCount = 0;
   std::string fname = m_output;
   if ( m_filesByRun )    {
     size_t idx = m_output.rfind(".");

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -172,15 +172,16 @@ int Geant4Output2ROOT::fill(const std::string& nam, const ComponentCast& type, v
 void Geant4Output2ROOT::commit(OutputContext<G4Event>& ctxt) {
   std::lock_guard<std::mutex> lock(s_rootMutex);
   if (m_file) {
-    static const char* evtIDBranchName = "G4EventID";
-    TBranch* evtIDBr = m_tree->GetBranch(evtIDBranchName);
-    if (!evtIDBr) {
-      evtIDBr = m_tree->Branch(evtIDBranchName, &m_currentEventID, "G4EventID/I");
+    Int_t evtid = ctxt.context->GetEventID();
+    TTree* id_tree = section("G4EventIDs");
+    TBranch* br = id_tree->GetBranch("G4EventID");
+    if (!br) {
+      br = id_tree->Branch("G4EventID", &evtid, "G4EventID/I");
     }
     else {
-      evtIDBr->SetAddress(&m_currentEventID);
+      br->SetAddress(&evtid);
     }
-    evtIDBr->Fill();
+    id_tree->Fill();
 
     auto* a = m_tree->GetListOfBranches();
     const Long64_t evt = m_tree->GetEntries() + 1;
@@ -201,8 +202,7 @@ void Geant4Output2ROOT::commit(OutputContext<G4Event>& ctxt) {
 }
 
 /// Callback to store the Geant4 event
-void Geant4Output2ROOT::saveEvent(OutputContext<G4Event>& ctxt) {
-  m_currentEventID = ctxt.context->GetEventID();
+void Geant4Output2ROOT::saveEvent(OutputContext<G4Event>& /* ctxt */) {
   if (m_disableParticles) return;
   auto* parts = context()->event().extension<Geant4ParticleMap>();
   if (!parts) return;

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -172,6 +172,16 @@ int Geant4Output2ROOT::fill(const std::string& nam, const ComponentCast& type, v
 void Geant4Output2ROOT::commit(OutputContext<G4Event>& ctxt) {
   std::lock_guard<std::mutex> lock(s_rootMutex);
   if (m_file) {
+    static const char* evtIDBranchName = "G4EventID";
+    TBranch* evtIDBr = m_tree->GetBranch(evtIDBranchName);
+    if (!evtIDBr) {
+      evtIDBr = m_tree->Branch(evtIDBranchName, &m_currentEventID, "G4EventID/I");
+    }
+    else {
+      evtIDBr->SetAddress(&m_currentEventID);
+    }
+    evtIDBr->Fill();
+
     auto* a = m_tree->GetListOfBranches();
     const Long64_t evt = m_tree->GetEntries() + 1;
     const Int_t nb = a->GetEntriesFast();
@@ -191,7 +201,8 @@ void Geant4Output2ROOT::commit(OutputContext<G4Event>& ctxt) {
 }
 
 /// Callback to store the Geant4 event
-void Geant4Output2ROOT::saveEvent(OutputContext<G4Event>& /* ctxt */) {
+void Geant4Output2ROOT::saveEvent(OutputContext<G4Event>& ctxt) {
+  m_currentEventID = ctxt.context->GetEventID();
   if (m_disableParticles) return;
   auto* parts = context()->event().extension<Geant4ParticleMap>();
   if (!parts) return;

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -74,8 +74,11 @@ void Geant4Output2ROOT::closeOutput()   {
   if (!m_file) return;
   TDirectory::TContext ctxt(m_file.get());
   info("+++ Closing ROOT output file %s", m_file->GetName());
-  m_sections.clear();
   m_branches.clear();
+  for (const auto& [name, tree] : m_sections) {
+    if (tree != m_tree) tree->Write();
+  }
+  m_sections.clear();
   m_tree->Write();
   m_file->Close();
   m_tree = nullptr;

--- a/DDG4/src/Geant4Random.cpp
+++ b/DDG4/src/Geant4Random.cpp
@@ -75,7 +75,8 @@ namespace    {
       m_engine->flatArray(size,array);
     }
   };
-  static Geant4Random* s_instance = 0;
+  // Thread-local so each worker thread has its own Geant4Random instance.
+  static thread_local Geant4Random* s_instance = nullptr;
 }
 
 /// Default constructor
@@ -267,73 +268,73 @@ double Geant4Random::rndm_clhep()  {
 /// Create flat distributed random numbers in the interval ]0,1]
 double Geant4Random::rndm(int i)  {
   if ( !m_inited ) initialize();
-  return gRandom->Rndm(i);
+  return m_rootRandom->Rndm(i);
 }
 
 /// Create a float array of flat distributed random numbers in the interval ]0,1]
 void   Geant4Random::rndmArray(int n, float *array)  {
   if ( !m_inited ) initialize();
-  gRandom->RndmArray(n,array);
+  m_rootRandom->RndmArray(n,array);
 }
 
 /// Create a double array of flat distributed random numbers in the interval ]0,1]
 void   Geant4Random::rndmArray(int n, double *array)  {
   if ( !m_inited ) initialize();
-  gRandom->RndmArray(n,array);
+  m_rootRandom->RndmArray(n,array);
 }
 
 /// Create uniformly disributed random numbers in the interval ]0,x1]
 double Geant4Random::uniform(double x1)  {
   if ( !m_inited ) initialize();
-  return gRandom->Uniform(x1);
+  return m_rootRandom->Uniform(x1);
 }
 
 /// Create uniformly disributed random numbers in the interval ]x1,x2]
 double Geant4Random::uniform(double x1, double x2)  {
   if ( !m_inited ) initialize();
-  return gRandom->Uniform(x1,x2);
+  return m_rootRandom->Uniform(x1,x2);
 }
 
 /// Create exponentially distributed random numbers
 double Geant4Random::exp(double tau)  {
   if ( !m_inited ) initialize();
-  return gRandom->Exp(tau);
+  return m_rootRandom->Exp(tau);
 }
 
 /// Generates random vectors, uniformly distributed over a circle of given radius.
 double Geant4Random::gauss(double mean, double sigma)  {
   if ( !m_inited ) initialize();
-  return gRandom->Gaus(mean,sigma);
+  return m_rootRandom->Gaus(mean,sigma);
 }
 
 /// Create landau distributed random numbers
 double Geant4Random::landau(double mean, double sigma)  {
   if ( !m_inited ) initialize();
-  return gRandom->Landau(mean,sigma);
+  return m_rootRandom->Landau(mean,sigma);
 }
 
 /// Create tuple of randum number around a circle with radius r
 void   Geant4Random::circle(double &x, double &y, double r)  {
-  if ( !m_inited ) initialize();  
-  gRandom->Circle(x,y,r);
+  if ( !m_inited ) initialize();
+  m_rootRandom->Circle(x,y,r);
 }
 
 /// Create tuple of randum number on a sphere with radius r
 void   Geant4Random::sphere(double &x, double &y, double &z, double r)  {
   if ( !m_inited ) initialize();
-  gRandom->Sphere(x,y,z,r);
+  m_rootRandom->Sphere(x,y,z,r);
 }
 
 /// Create poisson distributed random numbers
 double Geant4Random::poisson(double mean)   {
   if ( !m_inited ) initialize();
-  return gRandom->PoissonD(mean);
+  return m_rootRandom->PoissonD(mean);
 }
 
 /// Create breit wigner distributed random numbers
 double Geant4Random::breit_wigner(double mean, double gamma)   {
   if ( !m_inited ) initialize();
-  return gRandom->BreitWigner(mean, gamma);
+  return m_rootRandom->BreitWigner(mean, gamma);
 }
 
 /// Create gamma distributed random numbers

--- a/DDG4/src/python/PyDDG4.cpp
+++ b/DDG4/src/python/PyDDG4.cpp
@@ -18,7 +18,7 @@
 #include <DDG4/Python/DDPython.h>
 #include <DDG4/Geant4Kernel.h>
 
-int PyDDG4::run(Kernel& kernel)  {
+int PyDDG4::runAll(Kernel& kernel)  {
   int ret;
   dd4hep::DDPython::AllowThreads allow(0);
   if ( 1 != (ret=kernel.configure()) )
@@ -30,6 +30,38 @@ int PyDDG4::run(Kernel& kernel)  {
   else if ( 1 != (ret=kernel.terminate()) )
     return ret;
     //dd4hep::DDPython::shutdown();
+  return ret;
+}
+
+int PyDDG4::configure(Kernel& kernel)  {
+  int ret;
+  dd4hep::DDPython::AllowThreads allow(0);
+  if ( 1 != (ret=kernel.configure()) )
+    return ret;
+  return ret;
+}
+
+int PyDDG4::initialize(Kernel& kernel)  {
+  int ret;
+  dd4hep::DDPython::AllowThreads allow(0);
+  if ( 1 != (ret=kernel.initialize()) )
+    return ret;
+  return ret;
+}
+
+int PyDDG4::run(Kernel& kernel)  {
+  int ret;
+  dd4hep::DDPython::AllowThreads allow(0);
+  if ( 1 != (ret=kernel.run()) )
+    return ret;
+  return ret;
+}
+
+int PyDDG4::terminate(Kernel& kernel)  {
+  int ret;
+  dd4hep::DDPython::AllowThreads allow(0);
+  if ( 1 != (ret=kernel.terminate()) )
+    return ret;
   return ret;
 }
 

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -180,6 +180,395 @@ if (DD4HEP_USE_GEANT4)
     )
   endif()
 
+  #---Multi-threading tests---------------------------------------------------------
+  # Test basic MT functionality
+  add_test(NAME t_ddsim_mt_basic_2threads
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 2 -G
+            --outputFile=test_mt_2threads.root
+            --random.seed=123456
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.energy=10*GeV
+            --gun.particle=mu-
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt_basic_2threads PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
+    PASS_REGULAR_EXPRESSION "@ 2 threads")
+
+  # Test MT with different thread counts
+  add_test(NAME t_ddsim_mt_basic_4threads
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=8 -j 4 -G
+            --outputFile=test_mt_4threads.root
+            --random.seed=654321
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.energy=20*GeV
+            --gun.particle=pi+
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt_basic_4threads PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
+    PASS_REGULAR_EXPRESSION "@ 4 threads")
+
+  # Test backward compatibility: -j 1 should work like ST
+  add_test(NAME t_ddsim_mt_single_thread
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=5 -j 1 -G
+            --outputFile=test_mt_1thread.root
+            --random.seed=111111
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.energy=15*GeV
+            --gun.particle=gamma
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt_single_thread PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
+    PASS_REGULAR_EXPRESSION "@ 1 threads")
+
+  # MT vs MT output comparison tests
+  # These tests verify reproducibility within multi-threaded mode by comparing
+  # runs with different thread counts (2 vs 4 threads).
+  #
+  # With proper per-event seeding (--random.enableEventSeed), different
+  # thread counts should produce identical physics results. This validates:
+  # 1. EventSeeder works correctly in MT mode
+  # 2. Thread-local RNG state is properly managed
+  # 3. Physics is independent of thread count
+  # 4. No race conditions or thread-unsafe operations
+  #
+  # The comparison validates:
+  # - No crashes or exceptions in either configuration
+  # - Output files are readable and well-formed
+  # - Event counts match
+  # - Branch structure is identical
+  # - Event-by-event physics results are identical (within tolerance)
+  
+  # Test 2-thread vs 4-thread MT with particle gun
+  add_test(NAME t_ddsim_mt2_vs_mt4_gun_generate_2t
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=20 -j 2 -G
+            --outputFile=mt2_gun.root
+            --random.seed=987654321
+            --random.enableEventSeed
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.energy=10*GeV
+            --gun.particle=mu-
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_gun_generate_2t PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  add_test(NAME t_ddsim_mt2_vs_mt4_gun_generate_4t
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=20 -j 4 -G
+            --outputFile=mt4_gun.root
+            --random.seed=987654321
+            --random.enableEventSeed
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.energy=10*GeV
+            --gun.particle=mu-
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_gun_generate_4t PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  # Comparison test expects exact equivalence with proper event seeding
+  add_test(NAME t_ddsim_mt2_vs_mt4_gun_compare
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+            mt2_gun.root mt4_gun.root --tolerance=1e-9)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_gun_compare PROPERTIES
+    DEPENDS "t_ddsim_mt2_vs_mt4_gun_generate_2t;t_ddsim_mt2_vs_mt4_gun_generate_4t"
+    LABELS "comparison;mt")
+
+  # Test 2-thread vs 4-thread MT with HepMC input (file-based generators)
+  if(DD4HEP_USE_HEPMC3)
+    add_test(NAME t_ddsim_mt2_vs_mt4_hepmc_2t
+      COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+        ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+              --runType=batch -N=5 -j 2
+              --outputFile=mt2_hepmc.root
+              --random.seed=111111
+              --random.enableEventSeed
+              --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
+              --part.userParticleHandler=)
+    set_tests_properties(t_ddsim_mt2_vs_mt4_hepmc_2t PROPERTIES
+      FAIL_REGULAR_EXPRESSION "ERROR;Error")
+
+    add_test(NAME t_ddsim_mt2_vs_mt4_hepmc_4t
+      COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+        ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+              --runType=batch -N=5 -j 4
+              --outputFile=mt4_hepmc.root
+              --random.seed=111111
+              --random.enableEventSeed
+              --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
+              --part.userParticleHandler=)
+    set_tests_properties(t_ddsim_mt2_vs_mt4_hepmc_4t PROPERTIES
+      FAIL_REGULAR_EXPRESSION "ERROR;Error")
+
+    add_test(NAME t_ddsim_mt2_vs_mt4_hepmc_compare
+      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+              mt2_hepmc.root mt4_hepmc.root --tolerance=1e-9)
+    set_tests_properties(t_ddsim_mt2_vs_mt4_hepmc_compare PROPERTIES
+      DEPENDS "t_ddsim_mt2_vs_mt4_hepmc_2t;t_ddsim_mt2_vs_mt4_hepmc_4t"
+      LABELS "comparison;mt")
+  endif()
+
+  # Test 2-thread vs 4-thread MT with EDM4hep input (file-based generators)
+  if(DD4HEP_USE_EDM4HEP)
+    add_test(NAME t_ddsim_mt2_vs_mt4_edm4hep_2t
+      COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+        ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+              --runType=batch -N=3 -j 2
+              --outputFile=mt2_edm4hep.root
+              --random.seed=222222
+              --random.enableEventSeed
+              --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/ZH250_ISR.edm4hep.root
+              --part.userParticleHandler=)
+    set_tests_properties(t_ddsim_mt2_vs_mt4_edm4hep_2t PROPERTIES
+      FAIL_REGULAR_EXPRESSION "ERROR;Error")
+
+    add_test(NAME t_ddsim_mt2_vs_mt4_edm4hep_4t
+      COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+        ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+              --runType=batch -N=3 -j 4
+              --outputFile=mt4_edm4hep.root
+              --random.seed=222222
+              --random.enableEventSeed
+              --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/ZH250_ISR.edm4hep.root
+              --part.userParticleHandler=)
+    set_tests_properties(t_ddsim_mt2_vs_mt4_edm4hep_4t PROPERTIES
+      FAIL_REGULAR_EXPRESSION "ERROR;Error")
+
+    add_test(NAME t_ddsim_mt2_vs_mt4_edm4hep_compare
+      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+              mt2_edm4hep.root mt4_edm4hep.root --tolerance=1e-9)
+    set_tests_properties(t_ddsim_mt2_vs_mt4_edm4hep_compare PROPERTIES
+      DEPENDS "t_ddsim_mt2_vs_mt4_edm4hep_2t;t_ddsim_mt2_vs_mt4_edm4hep_4t"
+      LABELS "comparison;mt")
+  endif()
+
+  #---Advanced Gun Features Tests (G4Gun and GPS with macroFile)------------
+  # These tests document known failures in MT mode
+  # See: DDG4/python/DDSim/DD4hepSimulation.py:596 FIXME comment
+  # Test G4Gun with macroFile - Single Threaded (smoke test)
+  add_test(NAME t_ddsim_g4gun_macro_st
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=run -j 1
+            --outputFile=g4gun_st.root
+            --random.seed=333333
+            --random.enableEventSeed
+            --enableG4Gun
+            --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gun_test.mac
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_g4gun_macro_st PROPERTIES
+    FAIL_REGULAR_EXPRESSION "ERROR;Error;Exception"
+    LABELS "gun;g4gun;singlethread")
+
+  # Test G4Gun: 2-thread vs 4-thread MT comparison
+  # Note: Using regular DD4hep gun (-G) for comparison, not G4Gun
+  # G4Gun is tested separately with macroFile in smoke tests
+  add_test(NAME t_ddsim_mt2_vs_mt4_g4gun_generate_2t
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 2
+            --outputFile=mt2_g4gun.root
+            --random.seed=333333
+            --random.enableEventSeed
+            --enableG4Gun
+            --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gun_test.mac
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_g4gun_generate_2t PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  add_test(NAME t_ddsim_mt2_vs_mt4_g4gun_generate_4t
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 4
+            --outputFile=mt4_g4gun.root
+            --random.seed=333333
+            --random.enableEventSeed
+            --enableG4Gun
+            --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gun_test.mac
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_g4gun_generate_4t PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  add_test(NAME t_ddsim_mt2_vs_mt4_g4gun_compare
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+            mt2_g4gun.root mt4_g4gun.root --tolerance=1e-9)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_g4gun_compare PROPERTIES
+    DEPENDS "t_ddsim_mt2_vs_mt4_g4gun_generate_2t;t_ddsim_mt2_vs_mt4_g4gun_generate_4t"
+    LABELS "comparison;mt;g4gun")
+
+  # Test GPS with macroFile - Single Threaded (smoke test)
+  add_test(NAME t_ddsim_g4gps_macro_st
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=run -j 1
+            --outputFile=g4gps_st.root
+            --random.seed=444444
+            --random.enableEventSeed
+            --enableG4GPS
+            --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gps_test.mac
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_g4gps_macro_st PROPERTIES
+    FAIL_REGULAR_EXPRESSION "ERROR;Error;Exception"
+    LABELS "gun;gps;singlethread")
+
+  # Test GPS: 2-thread vs 4-thread MT comparison
+  # Note: Using regular DD4hep gun (-G) for comparison tests
+  # GPS with macroFile is tested in smoke tests
+  add_test(NAME t_ddsim_mt2_vs_mt4_gps_generate_2t
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 2 -G
+            --outputFile=mt2_gps.root
+            --random.seed=444444
+            --random.enableEventSeed
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_gps_generate_2t PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  add_test(NAME t_ddsim_mt2_vs_mt4_gps_generate_4t
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 4 -G
+            --outputFile=mt4_gps.root
+            --random.seed=444444
+            --random.enableEventSeed
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_gps_generate_4t PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  add_test(NAME t_ddsim_mt2_vs_mt4_gps_compare
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+            mt2_gps.root mt4_gps.root --tolerance=1e-9)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_gps_compare PROPERTIES
+    DEPENDS "t_ddsim_mt2_vs_mt4_gps_generate_2t;t_ddsim_mt2_vs_mt4_gps_generate_4t"
+    LABELS "comparison;mt;gps")
+
+  #---ST vs MT Comparison Tests (Gun)-------------------------------
+  # With proper per-event seeding and event ID matching in the comparison script,
+  # ST and MT modes should produce identical physics results event-by-event.
+  # The comparison script handles out-of-order events by matching on event ID.
+  # Note: Using regular DD4hep gun (-G) since G4Gun/GPS require macroFile
+
+  # Test regular gun: Single-threaded vs Multi-threaded comparison
+  add_test(NAME t_ddsim_st_vs_mt_gun_generate_st
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 1 -G
+            --outputFile=st_gun.root
+            --random.seed=333333
+            --random.enableEventSeed
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.particle=mu-
+            --gun.energy=10*GeV
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_st_vs_mt_gun_generate_st PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  add_test(NAME t_ddsim_st_vs_mt_gun_generate_mt
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 2 -G
+            --outputFile=mt_gun.root
+            --random.seed=333333
+            --random.enableEventSeed
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.particle=mu-
+            --gun.energy=10*GeV
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_st_vs_mt_gun_generate_mt PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  add_test(NAME t_ddsim_st_vs_mt_gun_compare
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+            st_gun.root mt_gun.root --tolerance=1e-9)
+  set_tests_properties(t_ddsim_st_vs_mt_gun_compare PROPERTIES
+    DEPENDS "t_ddsim_st_vs_mt_gun_generate_st;t_ddsim_st_vs_mt_gun_generate_mt"
+    LABELS "comparison;gun")
+
+  #---Magnetic Field Tests (2-thread vs 4-thread MT)-------------------------
+  # These tests verify that magnetic fields are properly propagated to all
+  # worker threads in MT mode by comparing particle trajectories with different
+  # thread counts.
+  #
+  # IMPORTANT: This tests SHARED field access in MT mode.
+  # The SiD solenoid field is defined in the detector description (XML),
+  # which is loaded once and shared across all threads. This is analogous
+  # to how field maps from files would be shared - the field object itself
+  # is shared, not copied per thread. The field evaluation at different
+  # positions happens thread-safely via Geant4's field manager.
+  #
+  # This test validates that:
+  # 1. Field setup from detector description is shared correctly
+  # 2. Field evaluation is thread-safe in MT mode
+  # 3. Particle trajectories are identical regardless of thread count
+  # 4. Field parameters (eps_min, eps_max, etc.) are applied uniformly
+  #
+  # The solenoid field serves as a proxy for field maps since both:
+  # - Are defined once in detector description
+  # - Must be shared across worker threads (not copied)
+  # - Require thread-safe field evaluation
+  # - Would fail identically if sharing mechanism is broken
+  
+  # Test with magnetic field - 2 threads
+  add_test(NAME t_ddsim_mt2_vs_mt4_field_2t
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 2 -G
+            --outputFile=mt2_field.root
+            --random.seed=111111
+            --random.enableEventSeed
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.energy=5*GeV
+            --gun.particle=mu+
+            --field.eps_min=1e-3*mm
+            --field.eps_max=1e-2*mm
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_field_2t PROPERTIES
+    FAIL_REGULAR_EXPRESSION "ERROR;Error;Exception"
+    LABELS "field;multithread")
+
+  # Test with magnetic field - 4 threads
+  add_test(NAME t_ddsim_mt2_vs_mt4_field_4t
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 4 -G
+            --outputFile=mt4_field.root
+            --random.seed=111111
+            --random.enableEventSeed
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.energy=5*GeV
+            --gun.particle=mu+
+            --field.eps_min=1e-3*mm
+            --field.eps_max=1e-2*mm
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_field_4t PROPERTIES
+    FAIL_REGULAR_EXPRESSION "ERROR;Error;Exception"
+    LABELS "field;multithread")
+
+  # Compare field test outputs
+  add_test(NAME t_ddsim_mt2_vs_mt4_field_compare
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+            mt2_field.root mt4_field.root --tolerance=1e-9)
+  set_tests_properties(t_ddsim_mt2_vs_mt4_field_compare PROPERTIES
+    DEPENDS "t_ddsim_mt2_vs_mt4_field_2t;t_ddsim_mt2_vs_mt4_field_4t"
+    LABELS "field;comparison;mt")
+
 endif()
 install(DIRECTORY include/DD4hep DESTINATION include)
 

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -181,393 +181,198 @@ if (DD4HEP_USE_GEANT4)
   endif()
 
   #---Multi-threading tests---------------------------------------------------------
-  # Test basic MT functionality
-  add_test(NAME t_ddsim_mt_basic_2threads
+
+  add_test(NAME t_ddsim_gun_mt1
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 1 -G
+            --outputFile=gun_mt1.root
+            --random.seed=333333
+            --random.enableEventSeed
+            --gun.position \"0.0 0.0 1.0*cm\"
+            --gun.direction \"1.0 0.0 1.0\"
+            --gun.particle=mu-
+            --gun.energy=10*GeV
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_gun_mt1 PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
+    PASS_REGULAR_EXPRESSION "@ 1 threads"
+    LABELS "gun;singlethread")
+
+  add_test(NAME t_ddsim_gun_mt2
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
       ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
             --runType=batch -N=10 -j 2 -G
-            --outputFile=test_mt_2threads.root
-            --random.seed=123456
-            --gun.position \"0.0 0.0 1.0*cm\"
-            --gun.direction \"1.0 0.0 1.0\"
-            --gun.energy=10*GeV
-            --gun.particle=mu-
-            --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt_basic_2threads PROPERTIES
-    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
-    PASS_REGULAR_EXPRESSION "@ 2 threads")
-
-  # Test MT with different thread counts
-  add_test(NAME t_ddsim_mt_basic_4threads
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=8 -j 4 -G
-            --outputFile=test_mt_4threads.root
-            --random.seed=654321
-            --gun.position \"0.0 0.0 1.0*cm\"
-            --gun.direction \"1.0 0.0 1.0\"
-            --gun.energy=20*GeV
-            --gun.particle=pi+
-            --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt_basic_4threads PROPERTIES
-    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
-    PASS_REGULAR_EXPRESSION "@ 4 threads")
-
-  # Test backward compatibility: -j 1 should work like ST
-  add_test(NAME t_ddsim_mt_single_thread
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=5 -j 1 -G
-            --outputFile=test_mt_1thread.root
-            --random.seed=111111
-            --gun.position \"0.0 0.0 1.0*cm\"
-            --gun.direction \"1.0 0.0 1.0\"
-            --gun.energy=15*GeV
-            --gun.particle=gamma
-            --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt_single_thread PROPERTIES
-    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
-    PASS_REGULAR_EXPRESSION "@ 1 threads")
-
-  # MT vs MT output comparison tests
-  # These tests verify reproducibility within multi-threaded mode by comparing
-  # runs with different thread counts (2 vs 4 threads).
-  #
-  # With proper per-event seeding (--random.enableEventSeed), different
-  # thread counts should produce identical physics results. This validates:
-  # 1. EventSeeder works correctly in MT mode
-  # 2. Thread-local RNG state is properly managed
-  # 3. Physics is independent of thread count
-  # 4. No race conditions or thread-unsafe operations
-  #
-  # The comparison validates:
-  # - No crashes or exceptions in either configuration
-  # - Output files are readable and well-formed
-  # - Event counts match
-  # - Branch structure is identical
-  # - Event-by-event physics results are identical (within tolerance)
-  
-  # Test 2-thread vs 4-thread MT with particle gun
-  add_test(NAME t_ddsim_mt2_vs_mt4_gun_generate_2t
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=20 -j 2 -G
-            --outputFile=mt2_gun.root
-            --random.seed=987654321
+            --outputFile=gun_mt2.root
+            --random.seed=333333
             --random.enableEventSeed
             --gun.position \"0.0 0.0 1.0*cm\"
             --gun.direction \"1.0 0.0 1.0\"
-            --gun.energy=10*GeV
             --gun.particle=mu-
+            --gun.energy=10*GeV
             --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_gun_generate_2t PROPERTIES
-    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+  set_tests_properties(t_ddsim_gun_mt2 PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
+    PASS_REGULAR_EXPRESSION "@ 2 threads"
+    LABELS "gun;multithread")
 
-  add_test(NAME t_ddsim_mt2_vs_mt4_gun_generate_4t
+  add_test(NAME t_ddsim_gun_mt4
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
       ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=20 -j 4 -G
-            --outputFile=mt4_gun.root
-            --random.seed=987654321
+            --runType=batch -N=10 -j 4 -G
+            --outputFile=gun_mt4.root
+            --random.seed=333333
             --random.enableEventSeed
             --gun.position \"0.0 0.0 1.0*cm\"
             --gun.direction \"1.0 0.0 1.0\"
-            --gun.energy=10*GeV
             --gun.particle=mu-
+            --gun.energy=10*GeV
             --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_gun_generate_4t PROPERTIES
-    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+  set_tests_properties(t_ddsim_gun_mt4 PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
+    PASS_REGULAR_EXPRESSION "@ 4 threads"
+    LABELS "gun;multithread")
 
-  # Comparison test expects exact equivalence with proper event seeding
-  add_test(NAME t_ddsim_mt2_vs_mt4_gun_compare
+  add_test(NAME t_ddsim_gun_mt1_mt2_compare
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
-            mt2_gun.root mt4_gun.root --tolerance=1e-9)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_gun_compare PROPERTIES
-    DEPENDS "t_ddsim_mt2_vs_mt4_gun_generate_2t;t_ddsim_mt2_vs_mt4_gun_generate_4t"
-    LABELS "comparison;mt")
+            gun_mt1.root gun_mt2.root --tolerance=1e-9)
+  set_tests_properties(t_ddsim_gun_mt1_mt2_compare PROPERTIES
+    DEPENDS "t_ddsim_gun_mt1;t_ddsim_gun_mt2"
+    LABELS "comparison;gun")
 
-  # Test 2-thread vs 4-thread MT with HepMC input (file-based generators)
+  add_test(NAME t_ddsim_gun_mt2_mt4_compare
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+            gun_mt2.root gun_mt4.root --tolerance=1e-9)
+  set_tests_properties(t_ddsim_gun_mt2_mt4_compare PROPERTIES
+    DEPENDS "t_ddsim_gun_mt2;t_ddsim_gun_mt4"
+    LABELS "comparison;gun;mt")
+
   if(DD4HEP_USE_HEPMC3)
-    add_test(NAME t_ddsim_mt2_vs_mt4_hepmc_2t
+    add_test(NAME t_ddsim_hepmc_mt2
       COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
         ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
               --runType=batch -N=5 -j 2
-              --outputFile=mt2_hepmc.root
+              --outputFile=hepmc_mt2.root
               --random.seed=111111
               --random.enableEventSeed
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
               --part.userParticleHandler=)
-    set_tests_properties(t_ddsim_mt2_vs_mt4_hepmc_2t PROPERTIES
+    set_tests_properties(t_ddsim_hepmc_mt2 PROPERTIES
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
-    add_test(NAME t_ddsim_mt2_vs_mt4_hepmc_4t
+    add_test(NAME t_ddsim_hepmc_mt4
       COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
         ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
               --runType=batch -N=5 -j 4
-              --outputFile=mt4_hepmc.root
+              --outputFile=hepmc_mt4.root
               --random.seed=111111
               --random.enableEventSeed
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
               --part.userParticleHandler=)
-    set_tests_properties(t_ddsim_mt2_vs_mt4_hepmc_4t PROPERTIES
+    set_tests_properties(t_ddsim_hepmc_mt4 PROPERTIES
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
-    add_test(NAME t_ddsim_mt2_vs_mt4_hepmc_compare
+    add_test(NAME t_ddsim_hepmc_mt2_mt4_compare
       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
-              mt2_hepmc.root mt4_hepmc.root --tolerance=1e-9)
-    set_tests_properties(t_ddsim_mt2_vs_mt4_hepmc_compare PROPERTIES
-      DEPENDS "t_ddsim_mt2_vs_mt4_hepmc_2t;t_ddsim_mt2_vs_mt4_hepmc_4t"
+              hepmc_mt2.root hepmc_mt4.root --tolerance=1e-9)
+    set_tests_properties(t_ddsim_hepmc_mt2_mt4_compare PROPERTIES
+      DEPENDS "t_ddsim_hepmc_mt2;t_ddsim_hepmc_mt4"
       LABELS "comparison;mt")
   endif()
 
-  # Test 2-thread vs 4-thread MT with EDM4hep input (file-based generators)
   if(DD4HEP_USE_EDM4HEP)
-    add_test(NAME t_ddsim_mt2_vs_mt4_edm4hep_2t
+    add_test(NAME t_ddsim_edm4hep_mt2
       COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
         ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
               --runType=batch -N=3 -j 2
-              --outputFile=mt2_edm4hep.root
+              --outputFile=edm4hep_mt2.root
               --random.seed=222222
               --random.enableEventSeed
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/ZH250_ISR.edm4hep.root
               --part.userParticleHandler=)
-    set_tests_properties(t_ddsim_mt2_vs_mt4_edm4hep_2t PROPERTIES
+    set_tests_properties(t_ddsim_edm4hep_mt2 PROPERTIES
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
-    add_test(NAME t_ddsim_mt2_vs_mt4_edm4hep_4t
+    add_test(NAME t_ddsim_edm4hep_mt4
       COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
         ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
               --runType=batch -N=3 -j 4
-              --outputFile=mt4_edm4hep.root
+              --outputFile=edm4hep_mt4.root
               --random.seed=222222
               --random.enableEventSeed
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/ZH250_ISR.edm4hep.root
               --part.userParticleHandler=)
-    set_tests_properties(t_ddsim_mt2_vs_mt4_edm4hep_4t PROPERTIES
+    set_tests_properties(t_ddsim_edm4hep_mt4 PROPERTIES
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
-    add_test(NAME t_ddsim_mt2_vs_mt4_edm4hep_compare
+    add_test(NAME t_ddsim_edm4hep_mt2_mt4_compare
       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
-              mt2_edm4hep.root mt4_edm4hep.root --tolerance=1e-9)
-    set_tests_properties(t_ddsim_mt2_vs_mt4_edm4hep_compare PROPERTIES
-      DEPENDS "t_ddsim_mt2_vs_mt4_edm4hep_2t;t_ddsim_mt2_vs_mt4_edm4hep_4t"
+              edm4hep_mt2.root edm4hep_mt4.root --tolerance=1e-9)
+    set_tests_properties(t_ddsim_edm4hep_mt2_mt4_compare PROPERTIES
+      DEPENDS "t_ddsim_edm4hep_mt2;t_ddsim_edm4hep_mt4"
       LABELS "comparison;mt")
   endif()
 
-  #---Advanced Gun Features Tests (G4Gun and GPS with macroFile)------------
-  # These tests document known failures in MT mode
-  # See: DDG4/python/DDSim/DD4hepSimulation.py:596 FIXME comment
-  # Test G4Gun with macroFile - Single Threaded (smoke test)
-  add_test(NAME t_ddsim_g4gun_macro_st
+  add_test(NAME t_ddsim_g4gun_mt1
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
       ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
             --runType=run -j 1
-            --outputFile=g4gun_st.root
+            --outputFile=g4gun_mt1.root
             --random.seed=333333
             --random.enableEventSeed
             --enableG4Gun
             --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gun_test.mac
             --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_g4gun_macro_st PROPERTIES
+  set_tests_properties(t_ddsim_g4gun_mt1 PROPERTIES
     FAIL_REGULAR_EXPRESSION "ERROR;Error;Exception"
     LABELS "gun;g4gun;singlethread")
 
-  # Test G4Gun: 2-thread vs 4-thread MT comparison
-  # Note: Using regular DD4hep gun (-G) for comparison, not G4Gun
-  # G4Gun is tested separately with macroFile in smoke tests
-  add_test(NAME t_ddsim_mt2_vs_mt4_g4gun_generate_2t
+  add_test(NAME t_ddsim_g4gun_mt2
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
       ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
             --runType=batch -N=10 -j 2
-            --outputFile=mt2_g4gun.root
+            --outputFile=g4gun_mt2.root
             --random.seed=333333
             --random.enableEventSeed
             --enableG4Gun
             --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gun_test.mac
             --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_g4gun_generate_2t PROPERTIES
+  set_tests_properties(t_ddsim_g4gun_mt2 PROPERTIES
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
 
-  add_test(NAME t_ddsim_mt2_vs_mt4_g4gun_generate_4t
+  add_test(NAME t_ddsim_g4gun_mt4
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
       ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
             --runType=batch -N=10 -j 4
-            --outputFile=mt4_g4gun.root
+            --outputFile=g4gun_mt4.root
             --random.seed=333333
             --random.enableEventSeed
             --enableG4Gun
             --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gun_test.mac
             --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_g4gun_generate_4t PROPERTIES
+  set_tests_properties(t_ddsim_g4gun_mt4 PROPERTIES
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
 
-  add_test(NAME t_ddsim_mt2_vs_mt4_g4gun_compare
+  add_test(NAME t_ddsim_g4gun_mt2_mt4_compare
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
-            mt2_g4gun.root mt4_g4gun.root --tolerance=1e-9)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_g4gun_compare PROPERTIES
-    DEPENDS "t_ddsim_mt2_vs_mt4_g4gun_generate_2t;t_ddsim_mt2_vs_mt4_g4gun_generate_4t"
+            g4gun_mt2.root g4gun_mt4.root --tolerance=1e-9)
+  set_tests_properties(t_ddsim_g4gun_mt2_mt4_compare PROPERTIES
+    DEPENDS "t_ddsim_g4gun_mt2;t_ddsim_g4gun_mt4"
     LABELS "comparison;mt;g4gun")
 
-  # Test GPS with macroFile - Single Threaded (smoke test)
-  add_test(NAME t_ddsim_g4gps_macro_st
+  add_test(NAME t_ddsim_gps_mt1
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
       ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
             --runType=run -j 1
-            --outputFile=g4gps_st.root
+            --outputFile=gps_mt1.root
             --random.seed=444444
             --random.enableEventSeed
             --enableG4GPS
             --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gps_test.mac
             --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_g4gps_macro_st PROPERTIES
+  set_tests_properties(t_ddsim_gps_mt1 PROPERTIES
     FAIL_REGULAR_EXPRESSION "ERROR;Error;Exception"
     LABELS "gun;gps;singlethread")
-
-  # Test GPS: 2-thread vs 4-thread MT comparison
-  # Note: Using regular DD4hep gun (-G) for comparison tests
-  # GPS with macroFile is tested in smoke tests
-  add_test(NAME t_ddsim_mt2_vs_mt4_gps_generate_2t
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=10 -j 2 -G
-            --outputFile=mt2_gps.root
-            --random.seed=444444
-            --random.enableEventSeed
-            --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_gps_generate_2t PROPERTIES
-    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
-
-  add_test(NAME t_ddsim_mt2_vs_mt4_gps_generate_4t
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=10 -j 4 -G
-            --outputFile=mt4_gps.root
-            --random.seed=444444
-            --random.enableEventSeed
-            --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_gps_generate_4t PROPERTIES
-    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
-
-  add_test(NAME t_ddsim_mt2_vs_mt4_gps_compare
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
-            mt2_gps.root mt4_gps.root --tolerance=1e-9)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_gps_compare PROPERTIES
-    DEPENDS "t_ddsim_mt2_vs_mt4_gps_generate_2t;t_ddsim_mt2_vs_mt4_gps_generate_4t"
-    LABELS "comparison;mt;gps")
-
-  #---ST vs MT Comparison Tests (Gun)-------------------------------
-  # With proper per-event seeding and event ID matching in the comparison script,
-  # ST and MT modes should produce identical physics results event-by-event.
-  # The comparison script handles out-of-order events by matching on event ID.
-  # Note: Using regular DD4hep gun (-G) since G4Gun/GPS require macroFile
-
-  # Test regular gun: Single-threaded vs Multi-threaded comparison
-  add_test(NAME t_ddsim_st_vs_mt_gun_generate_st
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=10 -j 1 -G
-            --outputFile=st_gun.root
-            --random.seed=333333
-            --random.enableEventSeed
-            --gun.position \"0.0 0.0 1.0*cm\"
-            --gun.direction \"1.0 0.0 1.0\"
-            --gun.particle=mu-
-            --gun.energy=10*GeV
-            --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_st_vs_mt_gun_generate_st PROPERTIES
-    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
-
-  add_test(NAME t_ddsim_st_vs_mt_gun_generate_mt
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=10 -j 2 -G
-            --outputFile=mt_gun.root
-            --random.seed=333333
-            --random.enableEventSeed
-            --gun.position \"0.0 0.0 1.0*cm\"
-            --gun.direction \"1.0 0.0 1.0\"
-            --gun.particle=mu-
-            --gun.energy=10*GeV
-            --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_st_vs_mt_gun_generate_mt PROPERTIES
-    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
-
-  add_test(NAME t_ddsim_st_vs_mt_gun_compare
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
-            st_gun.root mt_gun.root --tolerance=1e-9)
-  set_tests_properties(t_ddsim_st_vs_mt_gun_compare PROPERTIES
-    DEPENDS "t_ddsim_st_vs_mt_gun_generate_st;t_ddsim_st_vs_mt_gun_generate_mt"
-    LABELS "comparison;gun")
-
-  #---Magnetic Field Tests (2-thread vs 4-thread MT)-------------------------
-  # These tests verify that magnetic fields are properly propagated to all
-  # worker threads in MT mode by comparing particle trajectories with different
-  # thread counts.
-  #
-  # IMPORTANT: This tests SHARED field access in MT mode.
-  # The SiD solenoid field is defined in the detector description (XML),
-  # which is loaded once and shared across all threads. This is analogous
-  # to how field maps from files would be shared - the field object itself
-  # is shared, not copied per thread. The field evaluation at different
-  # positions happens thread-safely via Geant4's field manager.
-  #
-  # This test validates that:
-  # 1. Field setup from detector description is shared correctly
-  # 2. Field evaluation is thread-safe in MT mode
-  # 3. Particle trajectories are identical regardless of thread count
-  # 4. Field parameters (eps_min, eps_max, etc.) are applied uniformly
-  #
-  # The solenoid field serves as a proxy for field maps since both:
-  # - Are defined once in detector description
-  # - Must be shared across worker threads (not copied)
-  # - Require thread-safe field evaluation
-  # - Would fail identically if sharing mechanism is broken
-  
-  # Test with magnetic field - 2 threads
-  add_test(NAME t_ddsim_mt2_vs_mt4_field_2t
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=10 -j 2 -G
-            --outputFile=mt2_field.root
-            --random.seed=111111
-            --random.enableEventSeed
-            --gun.position \"0.0 0.0 1.0*cm\"
-            --gun.direction \"1.0 0.0 1.0\"
-            --gun.energy=5*GeV
-            --gun.particle=mu+
-            --field.eps_min=1e-3*mm
-            --field.eps_max=1e-2*mm
-            --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_field_2t PROPERTIES
-    FAIL_REGULAR_EXPRESSION "ERROR;Error;Exception"
-    LABELS "field;multithread")
-
-  # Test with magnetic field - 4 threads
-  add_test(NAME t_ddsim_mt2_vs_mt4_field_4t
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
-            --runType=batch -N=10 -j 4 -G
-            --outputFile=mt4_field.root
-            --random.seed=111111
-            --random.enableEventSeed
-            --gun.position \"0.0 0.0 1.0*cm\"
-            --gun.direction \"1.0 0.0 1.0\"
-            --gun.energy=5*GeV
-            --gun.particle=mu+
-            --field.eps_min=1e-3*mm
-            --field.eps_max=1e-2*mm
-            --part.userParticleHandler=)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_field_4t PROPERTIES
-    FAIL_REGULAR_EXPRESSION "ERROR;Error;Exception"
-    LABELS "field;multithread")
-
-  # Compare field test outputs
-  add_test(NAME t_ddsim_mt2_vs_mt4_field_compare
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
-            mt2_field.root mt4_field.root --tolerance=1e-9)
-  set_tests_properties(t_ddsim_mt2_vs_mt4_field_compare PROPERTIES
-    DEPENDS "t_ddsim_mt2_vs_mt4_field_2t;t_ddsim_mt2_vs_mt4_field_4t"
-    LABELS "field;comparison;mt")
 
 endif()
 install(DIRECTORY include/DD4hep DESTINATION include)

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -374,6 +374,39 @@ if (DD4HEP_USE_GEANT4)
     FAIL_REGULAR_EXPRESSION "ERROR;Error;Exception"
     LABELS "gun;gps;singlethread")
 
+  add_test(NAME t_ddsim_gps_mt2
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 2
+            --outputFile=gps_mt2.root
+            --random.seed=444444
+            --random.enableEventSeed
+            --enableG4GPS
+            --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gps_test.mac
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_gps_mt2 PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  add_test(NAME t_ddsim_gps_mt4
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+            --runType=batch -N=10 -j 4
+            --outputFile=gps_mt4.root
+            --random.seed=444444
+            --random.enableEventSeed
+            --enableG4GPS
+            --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gps_test.mac
+            --part.userParticleHandler=)
+  set_tests_properties(t_ddsim_gps_mt4 PROPERTIES
+    FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
+
+  add_test(NAME t_ddsim_gps_mt2_mt4_compare
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+            gps_mt2.root gps_mt4.root --tolerance=1e-9)
+  set_tests_properties(t_ddsim_gps_mt2_mt4_compare PROPERTIES
+    DEPENDS "t_ddsim_gps_mt2;t_ddsim_gps_mt4"
+    LABELS "comparison;mt;gps")
+
 endif()
 install(DIRECTORY include/DD4hep DESTINATION include)
 

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -258,6 +258,7 @@ if (DD4HEP_USE_GEANT4)
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
               --part.userParticleHandler=)
     set_tests_properties(t_ddsim_hepmc_mt1 PROPERTIES
+      TIMEOUT 3000 # 50 minutes (default is 25 minutes)
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
     add_test(NAME t_ddsim_hepmc_mt2

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -212,6 +212,7 @@ if (DD4HEP_USE_GEANT4)
             --gun.energy=10*GeV
             --part.userParticleHandler=)
   set_tests_properties(t_ddsim_gun_mt2 PROPERTIES
+    PROCESSORS 2
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 2 threads"
     LABELS "gun;multithread")
@@ -229,6 +230,7 @@ if (DD4HEP_USE_GEANT4)
             --gun.energy=10*GeV
             --part.userParticleHandler=)
   set_tests_properties(t_ddsim_gun_mt4 PROPERTIES
+    PROCESSORS 4
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 4 threads"
     LABELS "gun;multithread")
@@ -271,6 +273,7 @@ if (DD4HEP_USE_GEANT4)
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
               --part.userParticleHandler=)
     set_tests_properties(t_ddsim_hepmc_mt2 PROPERTIES
+      PROCESSORS 2
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
     add_test(NAME t_ddsim_hepmc_mt4
@@ -283,6 +286,7 @@ if (DD4HEP_USE_GEANT4)
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
               --part.userParticleHandler=)
     set_tests_properties(t_ddsim_hepmc_mt4 PROPERTIES
+      PROCESSORS 4
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
     add_test(NAME t_ddsim_hepmc_mt1_mt2_compare
@@ -323,6 +327,7 @@ if (DD4HEP_USE_GEANT4)
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/ZH250_ISR.edm4hep.root
               --part.userParticleHandler=)
     set_tests_properties(t_ddsim_edm4hep_mt2 PROPERTIES
+      PROCESSORS 2
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
     add_test(NAME t_ddsim_edm4hep_mt4
@@ -335,6 +340,7 @@ if (DD4HEP_USE_GEANT4)
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/ZH250_ISR.edm4hep.root
               --part.userParticleHandler=)
     set_tests_properties(t_ddsim_edm4hep_mt4 PROPERTIES
+      PROCESSORS 4
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
     add_test(NAME t_ddsim_edm4hep_mt1_mt2_compare
@@ -377,6 +383,7 @@ if (DD4HEP_USE_GEANT4)
             --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gun_test.mac
             --part.userParticleHandler=)
   set_tests_properties(t_ddsim_g4gun_mt2 PROPERTIES
+    PROCESSORS 2
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
 
   add_test(NAME t_ddsim_g4gun_mt4
@@ -390,6 +397,7 @@ if (DD4HEP_USE_GEANT4)
             --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gun_test.mac
             --part.userParticleHandler=)
   set_tests_properties(t_ddsim_g4gun_mt4 PROPERTIES
+    PROCESSORS 4
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
 
   add_test(NAME t_ddsim_g4gun_mt2_mt4_compare
@@ -424,6 +432,7 @@ if (DD4HEP_USE_GEANT4)
             --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gps_test.mac
             --part.userParticleHandler=)
   set_tests_properties(t_ddsim_gps_mt2 PROPERTIES
+    PROCESSORS 2
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
 
   add_test(NAME t_ddsim_gps_mt4
@@ -437,6 +446,7 @@ if (DD4HEP_USE_GEANT4)
             --macroFile=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/g4gps_test.mac
             --part.userParticleHandler=)
   set_tests_properties(t_ddsim_gps_mt4 PROPERTIES
+    PROCESSORS 4
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error")
 
   add_test(NAME t_ddsim_gps_mt2_mt4_compare

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -299,7 +299,7 @@ if (DD4HEP_USE_GEANT4)
       LABELS "comparison;mt")
   endif()
 
-  if(DD4HEP_USE_EDM4HEP)
+  if(DD4HEP_USE_EDM4HEP AND TARGET podio::podioIO)
     add_test(NAME t_ddsim_edm4hep_mt1
       COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
         ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -248,6 +248,18 @@ if (DD4HEP_USE_GEANT4)
     LABELS "comparison;gun;mt")
 
   if(DD4HEP_USE_HEPMC3)
+    add_test(NAME t_ddsim_hepmc_mt1
+      COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+        ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+              --runType=batch -N=5 -j 1
+              --outputFile=hepmc_mt1.root
+              --random.seed=111111
+              --random.enableEventSeed
+              --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
+              --part.userParticleHandler=)
+    set_tests_properties(t_ddsim_hepmc_mt1 PROPERTIES
+      FAIL_REGULAR_EXPRESSION "ERROR;Error")
+
     add_test(NAME t_ddsim_hepmc_mt2
       COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
         ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
@@ -272,6 +284,13 @@ if (DD4HEP_USE_GEANT4)
     set_tests_properties(t_ddsim_hepmc_mt4 PROPERTIES
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
+    add_test(NAME t_ddsim_hepmc_mt1_mt2_compare
+      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+              hepmc_mt1.root hepmc_mt2.root --tolerance=1e-9)
+    set_tests_properties(t_ddsim_hepmc_mt1_mt2_compare PROPERTIES
+      DEPENDS "t_ddsim_hepmc_mt1;t_ddsim_hepmc_mt2"
+      LABELS "comparison;mt")
+
     add_test(NAME t_ddsim_hepmc_mt2_mt4_compare
       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
               hepmc_mt2.root hepmc_mt4.root --tolerance=1e-9)
@@ -281,6 +300,18 @@ if (DD4HEP_USE_GEANT4)
   endif()
 
   if(DD4HEP_USE_EDM4HEP)
+    add_test(NAME t_ddsim_edm4hep_mt1
+      COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+        ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
+              --runType=batch -N=3 -j 1
+              --outputFile=edm4hep_mt1.root
+              --random.seed=222222
+              --random.enableEventSeed
+              --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/ZH250_ISR.edm4hep.root
+              --part.userParticleHandler=)
+    set_tests_properties(t_ddsim_edm4hep_mt1 PROPERTIES
+      FAIL_REGULAR_EXPRESSION "ERROR;Error")
+
     add_test(NAME t_ddsim_edm4hep_mt2
       COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
         ddsim --compactFile=${CMAKE_INSTALL_PREFIX}/DDDetectors/compact/SiD.xml
@@ -304,6 +335,13 @@ if (DD4HEP_USE_GEANT4)
               --part.userParticleHandler=)
     set_tests_properties(t_ddsim_edm4hep_mt4 PROPERTIES
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
+
+    add_test(NAME t_ddsim_edm4hep_mt1_mt2_compare
+      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
+              edm4hep_mt1.root edm4hep_mt2.root --tolerance=1e-9)
+    set_tests_properties(t_ddsim_edm4hep_mt1_mt2_compare PROPERTIES
+      DEPENDS "t_ddsim_edm4hep_mt1;t_ddsim_edm4hep_mt2"
+      LABELS "comparison;mt")
 
     add_test(NAME t_ddsim_edm4hep_mt2_mt4_compare
       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -202,7 +202,7 @@ if (DD4HEP_USE_GEANT4)
   set_tests_properties(t_ddsim_gun_mt1 PROPERTIES
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 1 threads"
-    DISABLE ${disable_mt_tests}
+    DISABLED ${disable_mt_tests}
     LABELS "gun;singlethread")
 
   add_test(NAME t_ddsim_gun_mt2
@@ -221,7 +221,7 @@ if (DD4HEP_USE_GEANT4)
     PROCESSORS 2
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 2 threads"
-    DISABLE ${disable_mt_tests}
+    DISABLED ${disable_mt_tests}
     LABELS "gun;multithread")
 
   add_test(NAME t_ddsim_gun_mt4
@@ -240,7 +240,7 @@ if (DD4HEP_USE_GEANT4)
     PROCESSORS 4
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 4 threads"
-    DISABLE ${disable_mt_tests}
+    DISABLED ${disable_mt_tests}
     LABELS "gun;multithread")
 
   add_test(NAME t_ddsim_gun_mt1_mt2_compare
@@ -248,6 +248,7 @@ if (DD4HEP_USE_GEANT4)
             gun_mt1.root gun_mt2.root --tolerance=1e-9)
   set_tests_properties(t_ddsim_gun_mt1_mt2_compare PROPERTIES
     DEPENDS "t_ddsim_gun_mt1;t_ddsim_gun_mt2"
+    DISABLED ${disable_mt_tests}
     LABELS "comparison;gun")
 
   add_test(NAME t_ddsim_gun_mt2_mt4_compare
@@ -255,6 +256,7 @@ if (DD4HEP_USE_GEANT4)
             gun_mt2.root gun_mt4.root --tolerance=1e-9)
   set_tests_properties(t_ddsim_gun_mt2_mt4_compare PROPERTIES
     DEPENDS "t_ddsim_gun_mt2;t_ddsim_gun_mt4"
+    DISABLED ${disable_mt_tests}
     LABELS "comparison;gun;mt")
 
   if(DD4HEP_USE_HEPMC3)
@@ -269,6 +271,7 @@ if (DD4HEP_USE_GEANT4)
               --part.userParticleHandler=)
     set_tests_properties(t_ddsim_hepmc_mt1 PROPERTIES
       TIMEOUT 3000 # 50 minutes (default is 25 minutes)
+      DISABLED ${disable_mt_tests}
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
     add_test(NAME t_ddsim_hepmc_mt2
@@ -281,6 +284,7 @@ if (DD4HEP_USE_GEANT4)
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
               --part.userParticleHandler=)
     set_tests_properties(t_ddsim_hepmc_mt2 PROPERTIES
+      DISABLED ${disable_mt_tests}
       PROCESSORS 2
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
@@ -294,6 +298,7 @@ if (DD4HEP_USE_GEANT4)
               --inputFiles=${CMAKE_CURRENT_SOURCE_DIR}/inputFiles/Pythia_output.hepmc
               --part.userParticleHandler=)
     set_tests_properties(t_ddsim_hepmc_mt4 PROPERTIES
+      DISABLED ${disable_mt_tests}
       PROCESSORS 4
       FAIL_REGULAR_EXPRESSION "ERROR;Error")
 
@@ -301,6 +306,7 @@ if (DD4HEP_USE_GEANT4)
       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
               hepmc_mt1.root hepmc_mt2.root --tolerance=1e-9)
     set_tests_properties(t_ddsim_hepmc_mt1_mt2_compare PROPERTIES
+      DISABLED ${disable_mt_tests}
       DEPENDS "t_ddsim_hepmc_mt1;t_ddsim_hepmc_mt2"
       LABELS "comparison;mt")
 
@@ -308,6 +314,7 @@ if (DD4HEP_USE_GEANT4)
       COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/python/compare_simulation_output.py
               hepmc_mt2.root hepmc_mt4.root --tolerance=1e-9)
     set_tests_properties(t_ddsim_hepmc_mt2_mt4_compare PROPERTIES
+      DISABLED ${disable_mt_tests}
       DEPENDS "t_ddsim_hepmc_mt2;t_ddsim_hepmc_mt4"
       LABELS "comparison;mt")
   endif()

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -202,7 +202,7 @@ if (DD4HEP_USE_GEANT4)
   set_tests_properties(t_ddsim_gun_mt1 PROPERTIES
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 1 threads"
-    DISBALE ${disable_mt_tests}
+    DISABLE ${disable_mt_tests}
     LABELS "gun;singlethread")
 
   add_test(NAME t_ddsim_gun_mt2
@@ -221,7 +221,7 @@ if (DD4HEP_USE_GEANT4)
     PROCESSORS 2
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 2 threads"
-    DISBALE ${disable_mt_tests}
+    DISABLE ${disable_mt_tests}
     LABELS "gun;multithread")
 
   add_test(NAME t_ddsim_gun_mt4
@@ -240,7 +240,7 @@ if (DD4HEP_USE_GEANT4)
     PROCESSORS 4
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 4 threads"
-    DISBALE ${disable_mt_tests}
+    DISABLE ${disable_mt_tests}
     LABELS "gun;multithread")
 
   add_test(NAME t_ddsim_gun_mt1_mt2_compare

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -181,6 +181,11 @@ if (DD4HEP_USE_GEANT4)
   endif()
 
   #---Multi-threading tests---------------------------------------------------------
+  # disable tests for geant4 version 10.7
+  set(disable_mt_tests FALSE)
+  if(Geant4_VERSION VERSION_LESS 11.0)
+    set(disable_mt_tests TRUE)
+  endif()
 
   add_test(NAME t_ddsim_gun_mt1
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
@@ -197,6 +202,7 @@ if (DD4HEP_USE_GEANT4)
   set_tests_properties(t_ddsim_gun_mt1 PROPERTIES
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 1 threads"
+    DISBALE ${disable_mt_tests}
     LABELS "gun;singlethread")
 
   add_test(NAME t_ddsim_gun_mt2
@@ -215,6 +221,7 @@ if (DD4HEP_USE_GEANT4)
     PROCESSORS 2
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 2 threads"
+    DISBALE ${disable_mt_tests}
     LABELS "gun;multithread")
 
   add_test(NAME t_ddsim_gun_mt4
@@ -233,6 +240,7 @@ if (DD4HEP_USE_GEANT4)
     PROCESSORS 4
     FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
     PASS_REGULAR_EXPRESSION "@ 4 threads"
+    DISBALE ${disable_mt_tests}
     LABELS "gun;multithread")
 
   add_test(NAME t_ddsim_gun_mt1_mt2_compare

--- a/DDTest/inputFiles/g4gps_test.mac
+++ b/DDTest/inputFiles/g4gps_test.mac
@@ -3,8 +3,8 @@
 
 /gps/particle e-
 /gps/energy 5 GeV
-/gps/position 0 0 0 mm
-/gps/direction 0 0 1
+/gps/position 0 0 1 cm
+/gps/direction 1 0 1
 
 # Run events
 /run/beamOn 3

--- a/DDTest/inputFiles/g4gps_test.mac
+++ b/DDTest/inputFiles/g4gps_test.mac
@@ -1,0 +1,10 @@
+# Geant4 macro file for testing GPS (General Particle Source)
+# This tests if macroFile works with --enableG4GPS
+
+/gps/particle e-
+/gps/energy 5 GeV
+/gps/position 0 0 0 mm
+/gps/direction 0 0 1
+
+# Run events
+/run/beamOn 3

--- a/DDTest/inputFiles/g4gps_test.mac
+++ b/DDTest/inputFiles/g4gps_test.mac
@@ -7,4 +7,4 @@
 /gps/direction 1 0 1
 
 # Run events
-/run/beamOn 3
+/run/beamOn 10

--- a/DDTest/inputFiles/g4gun_test.mac
+++ b/DDTest/inputFiles/g4gun_test.mac
@@ -3,8 +3,8 @@
 
 /gun/particle mu-
 /gun/energy 10 GeV
-/gun/position 0 0 0 mm
-/gun/direction 0 0 1
+/gun/position 0 0 1 cm
+/gun/direction 1 0 1
 
 # Run events
 /run/beamOn 3

--- a/DDTest/inputFiles/g4gun_test.mac
+++ b/DDTest/inputFiles/g4gun_test.mac
@@ -1,0 +1,10 @@
+# Geant4 macro file for testing G4Gun
+# This tests if macroFile works with --enableG4Gun
+
+/gun/particle mu-
+/gun/energy 10 GeV
+/gun/position 0 0 0 mm
+/gun/direction 0 0 1
+
+# Run events
+/run/beamOn 3

--- a/DDTest/inputFiles/g4gun_test.mac
+++ b/DDTest/inputFiles/g4gun_test.mac
@@ -7,4 +7,4 @@
 /gun/direction 1 0 1
 
 # Run events
-/run/beamOn 3
+/run/beamOn 10

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -12,17 +12,27 @@ produce identical physics results by comparing:
 
 import argparse
 import sys
+def _coord(v, attr):
+    """Get a coordinate from a vector, handling both attributes and callables."""
+    val = getattr(v, attr)
+    return val() if callable(val) else val
 
 
 def compare_vectors(v1, v2, tolerance, description=""):
     """Compare two 3-vectors component by component."""
-    if hasattr(v1, 'x') and hasattr(v2, 'x'):
-        dx = abs(v1.x - v2.x)
-        dy = abs(v1.y - v2.y)
-        dz = abs(v1.z - v2.z)
-        if dx > tolerance or dy > tolerance or dz > tolerance:
-            print(f"  {description} mismatch: ({v1.x}, {v1.y}, {v1.z}) vs ({v2.x}, {v2.y}, {v2.z})")
-            return False
+    # Try lowercase attributes first (plain structs), then uppercase methods (ROOT math types)
+    for x_attr, y_attr, z_attr in (('x', 'y', 'z'), ('X', 'Y', 'Z')):
+        if hasattr(v1, x_attr) and hasattr(v2, x_attr):
+            try:
+                x1, x2 = _coord(v1, x_attr), _coord(v2, x_attr)
+                y1, y2 = _coord(v1, y_attr), _coord(v2, y_attr)
+                z1, z2 = _coord(v1, z_attr), _coord(v2, z_attr)
+                if abs(x1 - x2) > tolerance or abs(y1 - y2) > tolerance or abs(z1 - z2) > tolerance:
+                    print(f"  {description} mismatch: ({x1}, {y1}, {z1}) vs ({x2}, {y2}, {z2})")
+                    return False
+                return True
+            except Exception:
+                continue
     return True
 
 

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -34,6 +34,9 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
         print("ERROR: ROOT/PyROOT not available")
         return False
 
+    if ROOT.gSystem.Load("libDDG4IO") < 0:
+        raise RuntimeError("Failed to load libDDG4IO. Ensure DD4hep is installed and LD_LIBRARY_PATH is set.")
+
     # Open files
     f1 = ROOT.TFile.Open(file1)
     f2 = ROOT.TFile.Open(file2)

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+Compare two DD4hep simulation output files for equivalence.
+
+This script validates that single-threaded and multi-threaded simulations
+produce identical physics results by comparing:
+- Event counts
+- Hit collection sizes
+- Hit positions and energies
+- MCParticle properties
+"""
+
+import argparse
+import sys
+import math
+
+def compare_vectors(v1, v2, tolerance, description=""):
+    """Compare two 3-vectors component by component."""
+    if hasattr(v1, 'x') and hasattr(v2, 'x'):
+        dx = abs(v1.x - v2.x)
+        dy = abs(v1.y - v2.y)
+        dz = abs(v1.z - v2.z)
+        if dx > tolerance or dy > tolerance or dz > tolerance:
+            print(f"  {description} mismatch: ({v1.x}, {v1.y}, {v1.z}) vs ({v2.x}, {v2.y}, {v2.z})")
+            return False
+    return True
+
+def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
+    """Compare hit collections between two ROOT files."""
+    try:
+        import ROOT
+    except ImportError:
+        print("ERROR: ROOT/PyROOT not available")
+        return False
+    
+    # Open files
+    f1 = ROOT.TFile.Open(file1)
+    f2 = ROOT.TFile.Open(file2)
+    
+    if not f1 or f1.IsZombie():
+        print(f"ERROR: Cannot open {file1}")
+        return False
+    if not f2 or f2.IsZombie():
+        print(f"ERROR: Cannot open {file2}")
+        return False
+    
+    # Get trees - try common tree names
+    t1 = f1.Get(tree_name)
+    if not t1:
+        # Try common alternative names
+        for name in ['events', 'EVENT', 'Events']:
+            t1 = f1.Get(name)
+            if t1:
+                tree_name = name
+                break
+        if not t1:
+            # Try to find any TTree
+            for key in f1.GetListOfKeys():
+                obj = key.ReadObj()
+                if obj.InheritsFrom("TTree") and 'event' in key.GetName().lower():
+                    t1 = obj
+                    tree_name = key.GetName()
+                    break
+    
+    t2 = f2.Get(tree_name)
+    
+    if not t1:
+        print(f"ERROR: Cannot find tree in {file1}")
+        return False
+    if not t2:
+        print(f"ERROR: Cannot find tree {tree_name} in {file2}")
+        return False
+    
+    n_entries = t1.GetEntries()
+    if n_entries != t2.GetEntries():
+        print(f"ERROR: Different number of entries: {n_entries} vs {t2.GetEntries()}")
+        return False
+    
+    print(f"Comparing {file1} vs {file2}")
+    print(f"Tree: {tree_name}, Entries: {n_entries}")
+    
+    # Get list of branches (collections)
+    branches1 = set(b.GetName() for b in t1.GetListOfBranches())
+    branches2 = set(b.GetName() for b in t2.GetListOfBranches())
+    
+    if branches1 != branches2:
+        print(f"WARNING: Different branches")
+        print(f"  Only in file1: {branches1 - branches2}")
+        print(f"  Only in file2: {branches2 - branches1}")
+        # Continue with common branches
+        branches = branches1 & branches2
+    else:
+        branches = branches1
+    
+    # Build event ID index for file2 to handle out-of-order events
+    # This is critical for MT comparison where events may be written in different orders
+    print("Building event ID index for file2...")
+    event_id_map = {}
+    for i in range(n_entries):
+        t2.GetEntry(i)
+        # Try to get EventHeader collection
+        try:
+            if hasattr(t2, 'EventHeader') and hasattr(t2.EventHeader, 'size'):
+                if t2.EventHeader.size() > 0:
+                    evt_hdr = t2.EventHeader[0]
+                    # Try different methods to get event number
+                    event_id = None
+                    if hasattr(evt_hdr, 'getEventNumber'):
+                        event_id = evt_hdr.getEventNumber()
+                    elif hasattr(evt_hdr, 'eventNumber'):
+                        event_id = evt_hdr.eventNumber
+                    if event_id is not None:
+                        event_id_map[event_id] = i
+        except Exception as e:
+            print(f"WARNING: Failed to get event ID from entry {i}: {e}")
+            pass
+    
+    # If we couldn't build event ID map, fall back to sequential comparison
+    use_event_id_matching = len(event_id_map) == n_entries
+    if use_event_id_matching:
+        print(f"Using event ID matching ({len(event_id_map)} events indexed)")
+    else:
+        print("WARNING: Could not build event ID index, using sequential comparison")
+        print("This may fail if events are in different orders!")
+    
+    mismatches = 0
+    total_comparisons = 0
+    total_elements = 0
+    
+    # Track which collections we've seen to report
+    collection_types = set()
+    
+    # Event-by-event comparison
+    for i in range(n_entries):
+        t1.GetEntry(i)
+        
+        # Find corresponding event in file2
+        if use_event_id_matching:
+            # Get event ID from file1
+            try:
+                if hasattr(t1, 'EventHeader') and hasattr(t1.EventHeader, 'size'):
+                    if t1.EventHeader.size() > 0:
+                        evt_hdr = t1.EventHeader[0]
+                        # Try different methods to get event number
+                        event_id = None
+                        if hasattr(evt_hdr, 'getEventNumber'):
+                            event_id = evt_hdr.getEventNumber()
+                        elif hasattr(evt_hdr, 'eventNumber'):
+                            event_id = evt_hdr.eventNumber
+                        
+                        if event_id is None:
+                            print(f"ERROR: Could not get event ID from entry {i} in file1")
+                            mismatches += 1
+                            continue
+                        if event_id not in event_id_map:
+                            print(f"ERROR: Event ID {event_id} from file1 not found in file2")
+                            mismatches += 1
+                            continue
+                        j = event_id_map[event_id]
+                        t2.GetEntry(j)
+                    else:
+                        print(f"ERROR: EventHeader is empty at entry {i} in file1")
+                        mismatches += 1
+                        continue
+                else:
+                    print(f"ERROR: No EventHeader found at entry {i} in file1")
+                    mismatches += 1
+                    continue
+            except Exception as e:
+                print(f"ERROR: Could not get event ID from entry {i} in file1: {e}")
+                mismatches += 1
+                continue
+        else:
+            # Sequential comparison
+            t2.GetEntry(i)
+            event_id = i  # Use entry number as pseudo-event ID for reporting
+        
+        for branch_name in sorted(branches):
+            # Skip metadata branches and EventHeader (already used for matching)
+            if branch_name.startswith('_') or 'objIdx' in branch_name or branch_name == 'EventHeader':
+                continue
+            
+            try:
+                # Get the collection objects from the tree
+                coll1 = getattr(t1, branch_name, None)
+                coll2 = getattr(t2, branch_name, None)
+                
+                if coll1 is None or coll2 is None:
+                    continue
+                
+                # Check if it's a collection (has size())
+                if not hasattr(coll1, 'size'):
+                    # Scalar branch - compare directly
+                    if hasattr(coll1, 'value') and hasattr(coll2, 'value'):
+                        if abs(coll1.value - coll2.value) > tolerance:
+                            print(f"Event {event_id}, {branch_name}: {coll1.value} != {coll2.value}")
+                            mismatches += 1
+                        total_comparisons += 1
+                    continue
+                
+                # Compare collection sizes
+                size1 = coll1.size()
+                size2 = coll2.size()
+                
+                if size1 != size2:
+                    print(f"Event {event_id}, {branch_name}: size mismatch {size1} != {size2}")
+                    mismatches += 1
+                    continue
+                
+                total_comparisons += 1
+                collection_types.add(branch_name)
+                
+                # Compare collection elements
+                for j in range(size1):
+                    elem1 = coll1[j]
+                    elem2 = coll2[j]
+                    total_elements += 1
+                    elem_mismatch = False
+                    
+                    # Compare common EDM4hep properties
+                    # Check for position (SimTrackerHit, CalorimeterHit, etc.)
+                    if hasattr(elem1, 'getPosition'):
+                        pos1 = elem1.getPosition()
+                        pos2 = elem2.getPosition()
+                        if not compare_vectors(pos1, pos2, tolerance, f"Event {event_id}, {branch_name}[{j}] position"):
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'position'):
+                        pos1 = elem1.position
+                        pos2 = elem2.position
+                        if not compare_vectors(pos1, pos2, tolerance, f"Event {event_id}, {branch_name}[{j}] position"):
+                            elem_mismatch = True
+                    
+                    # Check for energy/EDep
+                    if hasattr(elem1, 'getEDep'):
+                        e1 = elem1.getEDep()
+                        e2 = elem2.getEDep()
+                        if abs(e1 - e2) > tolerance:
+                            print(f"Event {event_id}, {branch_name}[{j}] EDep: {e1} != {e2}")
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'EDep'):
+                        if abs(elem1.EDep - elem2.EDep) > tolerance:
+                            print(f"Event {event_id}, {branch_name}[{j}] EDep: {elem1.EDep} != {elem2.EDep}")
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'getEnergy'):
+                        e1 = elem1.getEnergy()
+                        e2 = elem2.getEnergy()
+                        if abs(e1 - e2) > tolerance:
+                            print(f"Event {event_id}, {branch_name}[{j}] Energy: {e1} != {e2}")
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'energy'):
+                        if abs(elem1.energy - elem2.energy) > tolerance:
+                            print(f"Event {event_id}, {branch_name}[{j}] energy: {elem1.energy} != {elem2.energy}")
+                            elem_mismatch = True
+                    
+                    # Check for momentum (MCParticle)
+                    if hasattr(elem1, 'getMomentum'):
+                        mom1 = elem1.getMomentum()
+                        mom2 = elem2.getMomentum()
+                        if not compare_vectors(mom1, mom2, tolerance, f"Event {event_id}, {branch_name}[{j}] momentum"):
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'momentum'):
+                        if not compare_vectors(elem1.momentum, elem2.momentum, tolerance, f"Event {event_id}, {branch_name}[{j}] momentum"):
+                            elem_mismatch = True
+                    
+                    # Check for vertex (MCParticle)
+                    if hasattr(elem1, 'getVertex'):
+                        vtx1 = elem1.getVertex()
+                        vtx2 = elem2.getVertex()
+                        if not compare_vectors(vtx1, vtx2, tolerance, f"Event {event_id}, {branch_name}[{j}] vertex"):
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'vertex'):
+                        if not compare_vectors(elem1.vertex, elem2.vertex, tolerance, f"Event {event_id}, {branch_name}[{j}] vertex"):
+                            elem_mismatch = True
+                    
+                    # Check for time
+                    if hasattr(elem1, 'getTime'):
+                        t1_val = elem1.getTime()
+                        t2_val = elem2.getTime()
+                        if abs(t1_val - t2_val) > tolerance:
+                            print(f"Event {event_id}, {branch_name}[{j}] time: {t1_val} != {t2_val}")
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'time'):
+                        if abs(elem1.time - elem2.time) > tolerance:
+                            print(f"Event {event_id}, {branch_name}[{j}] time: {elem1.time} != {elem2.time}")
+                            elem_mismatch = True
+                    
+                    # Check for PDG (MCParticle)
+                    if hasattr(elem1, 'getPDG'):
+                        pdg1 = elem1.getPDG()
+                        pdg2 = elem2.getPDG()
+                        if pdg1 != pdg2:
+                            print(f"Event {event_id}, {branch_name}[{j}] PDG: {pdg1} != {pdg2}")
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'PDG'):
+                        if elem1.PDG != elem2.PDG:
+                            print(f"Event {event_id}, {branch_name}[{j}] PDG: {elem1.PDG} != {elem2.PDG}")
+                            elem_mismatch = True
+                    
+                    # Check for cellID (tracker/calo hits)
+                    if hasattr(elem1, 'getCellID'):
+                        cell1 = elem1.getCellID()
+                        cell2 = elem2.getCellID()
+                        if cell1 != cell2:
+                            print(f"Event {event_id}, {branch_name}[{j}] cellID: {cell1} != {cell2}")
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'cellID'):
+                        if elem1.cellID != elem2.cellID:
+                            print(f"Event {event_id}, {branch_name}[{j}] cellID: {elem1.cellID} != {elem2.cellID}")
+                            elem_mismatch = True
+                    
+                    if elem_mismatch:
+                        mismatches += 1
+                
+            except Exception as e:
+                print(f"Event {event_id}, branch {branch_name}: comparison error: {e}")
+                import traceback
+                traceback.print_exc()
+                mismatches += 1
+    
+    print(f"Performed {total_comparisons} comparisons on {total_elements} elements")
+    print(f"Collections compared: {', '.join(sorted(collection_types))}")
+    
+    if mismatches > 0:
+        print(f"FAILURE: {mismatches} mismatches found")
+        return False
+    
+    print("SUCCESS: Files are equivalent within tolerance")
+    return True
+
+def main():
+    parser = argparse.ArgumentParser(description='Compare DD4hep simulation outputs')
+    parser.add_argument('file1', help='First ROOT file (reference, typically ST)')
+    parser.add_argument('file2', help='Second ROOT file (test, typically MT)')
+    parser.add_argument('--tolerance', type=float, default=1e-9,
+                       help='Numerical comparison tolerance')
+    parser.add_argument('--tree', default='EVENT',
+                       help='Tree name to compare')
+    
+    args = parser.parse_args()
+    
+    success = compare_hit_collections(args.file1, args.file2, args.tolerance, args.tree)
+    return 0 if success else 1
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -36,6 +36,27 @@ def compare_vectors(v1, v2, tolerance, description=""):
     return True
 
 
+def _get_event_id(tree, entry_idx):
+    """Get event ID from a tree entry. Returns None if not available."""
+    tree.GetEntry(entry_idx)
+    # DD4hep ROOT output
+    g4_br = tree.GetBranch('G4EventID')
+    if g4_br:
+        return int(tree.G4EventID)
+    # EDM4hep output
+    try:
+        if hasattr(tree, 'EventHeader') and hasattr(tree.EventHeader, 'size'):
+            if tree.EventHeader.size() > 0:
+                hdr = tree.EventHeader[0]
+                if hasattr(hdr, 'getEventNumber'):
+                    return hdr.getEventNumber()
+                if hasattr(hdr, 'eventNumber'):
+                    return hdr.eventNumber
+    except Exception:
+        pass
+    return None
+
+
 def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
     """Compare hit collections between two ROOT files."""
     try:
@@ -111,25 +132,10 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
     print("Building event ID index for file2...")
     event_id_map = {}
     for i in range(n_entries):
-        t2.GetEntry(i)
-        # Try to get EventHeader collection
-        try:
-            if hasattr(t2, 'EventHeader') and hasattr(t2.EventHeader, 'size'):
-                if t2.EventHeader.size() > 0:
-                    evt_hdr = t2.EventHeader[0]
-                    # Try different methods to get event number
-                    event_id = None
-                    if hasattr(evt_hdr, 'getEventNumber'):
-                        event_id = evt_hdr.getEventNumber()
-                    elif hasattr(evt_hdr, 'eventNumber'):
-                        event_id = evt_hdr.eventNumber
-                    if event_id is not None:
-                        event_id_map[event_id] = i
-        except Exception as e:
-            print(f"WARNING: Failed to get event ID from entry {i}: {e}")
-            pass
+        eid = _get_event_id(t2, i)
+        if eid is not None:
+            event_id_map[eid] = i
 
-    # If we couldn't build event ID map, fall back to sequential comparison
     use_event_id_matching = len(event_id_map) == n_entries
     if use_event_id_matching:
         print(f"Using event ID matching ({len(event_id_map)} events indexed)")
@@ -144,54 +150,32 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
     # Track which collections we've seen to report
     collection_types = set()
 
-    # Event-by-event comparison
+    # Branches to skip
+    skip_branches = {'G4EventID', 'EventHeader'}
+
     for i in range(n_entries):
         t1.GetEntry(i)
+        event_id = i  # default for reporting
 
-        # Find corresponding event in file2
         if use_event_id_matching:
-            # Get event ID from file1
-            try:
-                if hasattr(t1, 'EventHeader') and hasattr(t1.EventHeader, 'size'):
-                    if t1.EventHeader.size() > 0:
-                        evt_hdr = t1.EventHeader[0]
-                        # Try different methods to get event number
-                        event_id = None
-                        if hasattr(evt_hdr, 'getEventNumber'):
-                            event_id = evt_hdr.getEventNumber()
-                        elif hasattr(evt_hdr, 'eventNumber'):
-                            event_id = evt_hdr.eventNumber
-
-                        if event_id is None:
-                            print(f"ERROR: Could not get event ID from entry {i} in file1")
-                            mismatches += 1
-                            continue
-                        if event_id not in event_id_map:
-                            print(f"ERROR: Event ID {event_id} from file1 not found in file2")
-                            mismatches += 1
-                            continue
-                        j = event_id_map[event_id]
-                        t2.GetEntry(j)
-                    else:
-                        print(f"ERROR: EventHeader is empty at entry {i} in file1")
-                        mismatches += 1
-                        continue
-                else:
-                    print(f"ERROR: No EventHeader found at entry {i} in file1")
-                    mismatches += 1
-                    continue
-            except Exception as e:
-                print(f"ERROR: Could not get event ID from entry {i} in file1: {e}")
+            eid1 = _get_event_id(t1, i)
+            if eid1 is None:
+                print(f"ERROR: Could not get event ID from entry {i} in file1")
                 mismatches += 1
                 continue
+            if eid1 not in event_id_map:
+                print(f"ERROR: Event ID {eid1} from file1 not found in file2")
+                mismatches += 1
+                continue
+            event_id = eid1
+            t1.GetEntry(i)  # re-load (GetEntry in _get_event_id may have changed state)
+            t2.GetEntry(event_id_map[eid1])
         else:
             # Sequential comparison
             t2.GetEntry(i)
-            event_id = i  # Use entry number as pseudo-event ID for reporting
 
         for branch_name in sorted(branches):
-            # Skip metadata branches and EventHeader (already used for matching)
-            if branch_name.startswith('_') or 'objIdx' in branch_name or branch_name == 'EventHeader':
+            if branch_name.startswith('_') or 'objIdx' in branch_name or branch_name in skip_branches:
                 continue
 
             try:

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -12,7 +12,7 @@ produce identical physics results by comparing:
 
 import argparse
 import sys
-import math
+
 
 def compare_vectors(v1, v2, tolerance, description=""):
     """Compare two 3-vectors component by component."""
@@ -25,6 +25,7 @@ def compare_vectors(v1, v2, tolerance, description=""):
             return False
     return True
 
+
 def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
     """Compare hit collections between two ROOT files."""
     try:
@@ -32,18 +33,18 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
     except ImportError:
         print("ERROR: ROOT/PyROOT not available")
         return False
-    
+
     # Open files
     f1 = ROOT.TFile.Open(file1)
     f2 = ROOT.TFile.Open(file2)
-    
+
     if not f1 or f1.IsZombie():
         print(f"ERROR: Cannot open {file1}")
         return False
     if not f2 or f2.IsZombie():
         print(f"ERROR: Cannot open {file2}")
         return False
-    
+
     # Get trees - try common tree names
     t1 = f1.Get(tree_name)
     if not t1:
@@ -61,37 +62,37 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                     t1 = obj
                     tree_name = key.GetName()
                     break
-    
+
     t2 = f2.Get(tree_name)
-    
+
     if not t1:
         print(f"ERROR: Cannot find tree in {file1}")
         return False
     if not t2:
         print(f"ERROR: Cannot find tree {tree_name} in {file2}")
         return False
-    
+
     n_entries = t1.GetEntries()
     if n_entries != t2.GetEntries():
         print(f"ERROR: Different number of entries: {n_entries} vs {t2.GetEntries()}")
         return False
-    
+
     print(f"Comparing {file1} vs {file2}")
     print(f"Tree: {tree_name}, Entries: {n_entries}")
-    
+
     # Get list of branches (collections)
     branches1 = set(b.GetName() for b in t1.GetListOfBranches())
     branches2 = set(b.GetName() for b in t2.GetListOfBranches())
-    
+
     if branches1 != branches2:
-        print(f"WARNING: Different branches")
+        print("WARNING: Different branches")
         print(f"  Only in file1: {branches1 - branches2}")
         print(f"  Only in file2: {branches2 - branches1}")
         # Continue with common branches
         branches = branches1 & branches2
     else:
         branches = branches1
-    
+
     # Build event ID index for file2 to handle out-of-order events
     # This is critical for MT comparison where events may be written in different orders
     print("Building event ID index for file2...")
@@ -114,7 +115,7 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
         except Exception as e:
             print(f"WARNING: Failed to get event ID from entry {i}: {e}")
             pass
-    
+
     # If we couldn't build event ID map, fall back to sequential comparison
     use_event_id_matching = len(event_id_map) == n_entries
     if use_event_id_matching:
@@ -122,18 +123,18 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
     else:
         print("WARNING: Could not build event ID index, using sequential comparison")
         print("This may fail if events are in different orders!")
-    
+
     mismatches = 0
     total_comparisons = 0
     total_elements = 0
-    
+
     # Track which collections we've seen to report
     collection_types = set()
-    
+
     # Event-by-event comparison
     for i in range(n_entries):
         t1.GetEntry(i)
-        
+
         # Find corresponding event in file2
         if use_event_id_matching:
             # Get event ID from file1
@@ -147,7 +148,7 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                             event_id = evt_hdr.getEventNumber()
                         elif hasattr(evt_hdr, 'eventNumber'):
                             event_id = evt_hdr.eventNumber
-                        
+
                         if event_id is None:
                             print(f"ERROR: Could not get event ID from entry {i} in file1")
                             mismatches += 1
@@ -174,20 +175,20 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
             # Sequential comparison
             t2.GetEntry(i)
             event_id = i  # Use entry number as pseudo-event ID for reporting
-        
+
         for branch_name in sorted(branches):
             # Skip metadata branches and EventHeader (already used for matching)
             if branch_name.startswith('_') or 'objIdx' in branch_name or branch_name == 'EventHeader':
                 continue
-            
+
             try:
                 # Get the collection objects from the tree
                 coll1 = getattr(t1, branch_name, None)
                 coll2 = getattr(t2, branch_name, None)
-                
+
                 if coll1 is None or coll2 is None:
                     continue
-                
+
                 # Check if it's a collection (has size())
                 if not hasattr(coll1, 'size'):
                     # Scalar branch - compare directly
@@ -197,26 +198,26 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                             mismatches += 1
                         total_comparisons += 1
                     continue
-                
+
                 # Compare collection sizes
                 size1 = coll1.size()
                 size2 = coll2.size()
-                
+
                 if size1 != size2:
                     print(f"Event {event_id}, {branch_name}: size mismatch {size1} != {size2}")
                     mismatches += 1
                     continue
-                
+
                 total_comparisons += 1
                 collection_types.add(branch_name)
-                
+
                 # Compare collection elements
                 for j in range(size1):
                     elem1 = coll1[j]
                     elem2 = coll2[j]
                     total_elements += 1
                     elem_mismatch = False
-                    
+
                     # Compare common EDM4hep properties
                     # Check for position (SimTrackerHit, CalorimeterHit, etc.)
                     if hasattr(elem1, 'getPosition'):
@@ -229,7 +230,7 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                         pos2 = elem2.position
                         if not compare_vectors(pos1, pos2, tolerance, f"Event {event_id}, {branch_name}[{j}] position"):
                             elem_mismatch = True
-                    
+
                     # Check for energy/EDep
                     if hasattr(elem1, 'getEDep'):
                         e1 = elem1.getEDep()
@@ -251,7 +252,7 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                         if abs(elem1.energy - elem2.energy) > tolerance:
                             print(f"Event {event_id}, {branch_name}[{j}] energy: {elem1.energy} != {elem2.energy}")
                             elem_mismatch = True
-                    
+
                     # Check for momentum (MCParticle)
                     if hasattr(elem1, 'getMomentum'):
                         mom1 = elem1.getMomentum()
@@ -259,9 +260,10 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                         if not compare_vectors(mom1, mom2, tolerance, f"Event {event_id}, {branch_name}[{j}] momentum"):
                             elem_mismatch = True
                     elif hasattr(elem1, 'momentum'):
-                        if not compare_vectors(elem1.momentum, elem2.momentum, tolerance, f"Event {event_id}, {branch_name}[{j}] momentum"):
+                        desc = f"Event {event_id}, {branch_name}[{j}] momentum"
+                        if not compare_vectors(elem1.momentum, elem2.momentum, tolerance, desc):
                             elem_mismatch = True
-                    
+
                     # Check for vertex (MCParticle)
                     if hasattr(elem1, 'getVertex'):
                         vtx1 = elem1.getVertex()
@@ -269,9 +271,10 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                         if not compare_vectors(vtx1, vtx2, tolerance, f"Event {event_id}, {branch_name}[{j}] vertex"):
                             elem_mismatch = True
                     elif hasattr(elem1, 'vertex'):
-                        if not compare_vectors(elem1.vertex, elem2.vertex, tolerance, f"Event {event_id}, {branch_name}[{j}] vertex"):
+                        desc = f"Event {event_id}, {branch_name}[{j}] vertex"
+                        if not compare_vectors(elem1.vertex, elem2.vertex, tolerance, desc):
                             elem_mismatch = True
-                    
+
                     # Check for time
                     if hasattr(elem1, 'getTime'):
                         t1_val = elem1.getTime()
@@ -283,7 +286,7 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                         if abs(elem1.time - elem2.time) > tolerance:
                             print(f"Event {event_id}, {branch_name}[{j}] time: {elem1.time} != {elem2.time}")
                             elem_mismatch = True
-                    
+
                     # Check for PDG (MCParticle)
                     if hasattr(elem1, 'getPDG'):
                         pdg1 = elem1.getPDG()
@@ -295,7 +298,7 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                         if elem1.PDG != elem2.PDG:
                             print(f"Event {event_id}, {branch_name}[{j}] PDG: {elem1.PDG} != {elem2.PDG}")
                             elem_mismatch = True
-                    
+
                     # Check for cellID (tracker/calo hits)
                     if hasattr(elem1, 'getCellID'):
                         cell1 = elem1.getCellID()
@@ -307,39 +310,41 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                         if elem1.cellID != elem2.cellID:
                             print(f"Event {event_id}, {branch_name}[{j}] cellID: {elem1.cellID} != {elem2.cellID}")
                             elem_mismatch = True
-                    
+
                     if elem_mismatch:
                         mismatches += 1
-                
+
             except Exception as e:
                 print(f"Event {event_id}, branch {branch_name}: comparison error: {e}")
                 import traceback
                 traceback.print_exc()
                 mismatches += 1
-    
+
     print(f"Performed {total_comparisons} comparisons on {total_elements} elements")
     print(f"Collections compared: {', '.join(sorted(collection_types))}")
-    
+
     if mismatches > 0:
         print(f"FAILURE: {mismatches} mismatches found")
         return False
-    
+
     print("SUCCESS: Files are equivalent within tolerance")
     return True
+
 
 def main():
     parser = argparse.ArgumentParser(description='Compare DD4hep simulation outputs')
     parser.add_argument('file1', help='First ROOT file (reference, typically ST)')
     parser.add_argument('file2', help='Second ROOT file (test, typically MT)')
     parser.add_argument('--tolerance', type=float, default=1e-9,
-                       help='Numerical comparison tolerance')
+                        help='Numerical comparison tolerance')
     parser.add_argument('--tree', default='EVENT',
-                       help='Tree name to compare')
-    
+                        help='Tree name to compare')
+
     args = parser.parse_args()
-    
+
     success = compare_hit_collections(args.file1, args.file2, args.tolerance, args.tree)
     return 0 if success else 1
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -37,23 +37,28 @@ def compare_vectors(v1, v2, tolerance, description=""):
                 continue
     return True
 
+def _read_g4event_ids(tree):
+    """Return list of G4EventIDs indexed by entry number, or None if not available."""
+    id_tree = tree.GetDirectory().Get("G4EventIDs")
+    if not id_tree:
+        return None
+    ids = []
+    for i in range(id_tree.GetEntries()):
+        id_tree.GetEntry(i)
+        ids.append(int(id_tree.G4EventID))
+    return ids
+
 
 def _get_event_id(tree, entry_idx):
-    """Get event ID from a tree entry. Returns None if not available."""
+    """Get event ID from a tree entry (EDM4hep EventHeader). Returns None if not available."""
     tree.GetEntry(entry_idx)
-    # DD4hep ROOT output
-    g4_br = tree.GetBranch('G4EventID')
-    if g4_br:
-        return int(tree.G4EventID)
-    # EDM4hep output
     try:
-        if hasattr(tree, 'EventHeader') and hasattr(tree.EventHeader, 'size'):
-            if tree.EventHeader.size() > 0:
-                hdr = tree.EventHeader[0]
-                if hasattr(hdr, 'getEventNumber'):
-                    return hdr.getEventNumber()
-                if hasattr(hdr, 'eventNumber'):
-                    return hdr.eventNumber
+        if hasattr(tree, 'EventHeader') and tree.EventHeader.size() > 0:
+            hdr = tree.EventHeader[0]
+            if hasattr(hdr, 'getEventNumber'):
+                return hdr.getEventNumber()
+            if hasattr(hdr, 'eventNumber'):
+                return hdr.eventNumber
     except Exception:
         pass
     return None
@@ -131,14 +136,18 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
     else:
         branches = branches1
 
-    # Build event ID index for file2 to handle out-of-order events
-    # This is critical for MT comparison where events may be written in different orders
+    # Build event ID index for file2 to handle out-of-order events in MT mode.
+    # Try G4EventIDs companion tree (DD4hep native), then EDM4hep EventHeader.
     print("Building event ID index for file2...")
-    event_id_map = {}
-    for i in range(n_entries):
-        eid = _get_event_id(t2, i)
-        if eid is not None:
-            event_id_map[eid] = i
+    ids2 = _read_g4event_ids(t2)
+    if ids2:
+        event_id_map = {eid: i for i, eid in enumerate(ids2)}
+    else:
+        event_id_map = {}
+        for i in range(n_entries):
+            eid = _get_event_id(t2, i)
+            if eid is not None:
+                event_id_map[eid] = i
 
     use_event_id_matching = len(event_id_map) == n_entries
     if use_event_id_matching:
@@ -155,14 +164,16 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
     collection_types = set()
 
     # Branches to skip
-    skip_branches = {'G4EventID', 'EventHeader'}
+    skip_branches = {'EventHeader'}
+
+    ids1 = _read_g4event_ids(t1)
 
     for i in range(n_entries):
         t1.GetEntry(i)
         event_id = i  # default for reporting
 
         if use_event_id_matching:
-            eid1 = _get_event_id(t1, i)
+            eid1 = ids1[i] if ids1 else _get_event_id(t1, i)
             if eid1 is None:
                 print(f"ERROR: Could not get event ID from entry {i} in file1")
                 mismatches += 1
@@ -172,10 +183,9 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                 mismatches += 1
                 continue
             event_id = eid1
-            t1.GetEntry(i)  # re-load (GetEntry in _get_event_id may have changed state)
+            t1.GetEntry(i)
             t2.GetEntry(event_id_map[eid1])
         else:
-            # Sequential comparison
             t2.GetEntry(i)
 
         for branch_name in sorted(branches):

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -37,6 +37,7 @@ def compare_vectors(v1, v2, tolerance, description=""):
                 continue
     return True
 
+
 def _read_g4event_ids(tree):
     """Return list of G4EventIDs indexed by entry number, or None if not available."""
     id_tree = tree.GetDirectory().Get("G4EventIDs")

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -65,9 +65,6 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
         print("ERROR: ROOT/PyROOT not available")
         return False
 
-    if ROOT.gSystem.Load("libDDG4IO") < 0:
-        raise RuntimeError("Failed to load libDDG4IO. Ensure DD4hep is installed and LD_LIBRARY_PATH is set.")
-
     # Open files
     f1 = ROOT.TFile.Open(file1)
     f2 = ROOT.TFile.Open(file2)

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -245,7 +245,8 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                             elem_mismatch = True
                     elif hasattr(elem1, 'energyDeposit'):
                         if abs(elem1.energyDeposit - elem2.energyDeposit) > tolerance:
-                            print(f"Event {event_id}, {branch_name}[{j}] energyDeposit: {elem1.energyDeposit} != {elem2.energyDeposit}")
+                            print(f"Event {event_id}, {branch_name}[{j}] energyDeposit: "
+                                  f"{elem1.energyDeposit} != {elem2.energyDeposit}")
                             elem_mismatch = True
                     elif hasattr(elem1, 'getEnergy'):
                         e1 = elem1.getEnergy()

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -12,6 +12,8 @@ produce identical physics results by comparing:
 
 import argparse
 import sys
+
+
 def _coord(v, attr):
     """Get a coordinate from a vector, handling both attributes and callables."""
     val = getattr(v, attr)

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -67,6 +67,11 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
         print("ERROR: ROOT/PyROOT not available")
         return False
 
+    # Load the DDG4 dictionary so ROOT can read DD4hep-native output files.
+    # This is a no-op when only EDM4hep output is used.
+    ROOT.gSystem.Load("libDDG4")
+    ROOT.gSystem.Load("libDDG4Plugins")
+
     # Open files
     f1 = ROOT.TFile.Open(file1)
     f2 = ROOT.TFile.Open(file2)
@@ -237,6 +242,10 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
                     elif hasattr(elem1, 'EDep'):
                         if abs(elem1.EDep - elem2.EDep) > tolerance:
                             print(f"Event {event_id}, {branch_name}[{j}] EDep: {elem1.EDep} != {elem2.EDep}")
+                            elem_mismatch = True
+                    elif hasattr(elem1, 'energyDeposit'):
+                        if abs(elem1.energyDeposit - elem2.energyDeposit) > tolerance:
+                            print(f"Event {event_id}, {branch_name}[{j}] energyDeposit: {elem1.energyDeposit} != {elem2.energyDeposit}")
                             elem_mismatch = True
                     elif hasattr(elem1, 'getEnergy'):
                         e1 = elem1.getEnergy()

--- a/DDTest/python/compare_simulation_output.py
+++ b/DDTest/python/compare_simulation_output.py
@@ -35,6 +35,7 @@ def compare_vectors(v1, v2, tolerance, description=""):
                 return True
             except Exception:
                 continue
+    print(f"WARNING: {description} skipped: vector type has no recognised coordinate attributes")
     return True
 
 
@@ -75,8 +76,9 @@ def compare_hit_collections(file1, file2, tolerance=1e-9, tree_name='EVENT'):
 
     # Load the DDG4 dictionary so ROOT can read DD4hep-native output files.
     # This is a no-op when only EDM4hep output is used.
-    ROOT.gSystem.Load("libDDG4")
-    ROOT.gSystem.Load("libDDG4Plugins")
+    for lib in ("libDDG4", "libDDG4Plugins"):
+        if ROOT.gSystem.Load(lib) < 0:
+            print(f"WARNING: Failed to load {lib} - DD4hep-native branches may not be readable")
 
     # Open files
     f1 = ROOT.TFile.Open(file1)


### PR DESCRIPTION
This PR adds multithreading support to ddsim, through the `-j` flag.

Backwards-incompatible effects (as the corner cases that they are):
- Because some of the actions have to be place into `__setupWorker`, this means they may not be available in the same context as global actions. This means that during user physics list initialization one cannot query particle handlers which have not been created yet.

BEGINRELEASENOTES
- Multithreading support in ddsim

ENDRELEASENOTES