### PR TITLE
CI: update which releases to test against

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -34,7 +34,7 @@ jobs:
             -DDD4HEP_USE_XERCESC=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always"  \
-            -DCMAKE_CXX_STANDARD=17 ..
+            -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::Tidy"
           cd ..
           HEADER_FILES=$(find */include/* -name "*.h" | grep -v "/detail/\|/src/\|DDGear.h")

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -16,6 +16,8 @@ jobs:
       with:
         release-platform: ${{ matrix.LCG }}
         run: |
+          # clang-tidy does not work with the clang-wrapper, we setup the direct clang here
+          source /cvmfs/sft.cern.ch/lcg/contrib/clang/16/x86_64-el9/setup.sh
           mkdir build
           cd build
           unset CPATH

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,13 +9,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["LCG_100/x86_64-centos7-gcc10-opt",    # g4 10.7
-              "LCG_101/x86_64-centos7-gcc11-opt",    # g4 10.7
+        LCG: ["LCG_101/x86_64-centos7-gcc11-opt",    # g4 10.7
               "LCG_102/x86_64-centos9-gcc11-opt",    # g4 11
-              "LCG_102/x86_64-centos7-clang12-opt",  # g4 11
-              "LCG_102/x86_64-ubuntu2004-gcc9-opt",  # g4 11
-              "dev3/x86_64-centos7-gcc11-opt",
-              "dev4/x86_64-centos7-gcc11-opt"]
+              "LCG_104/x86_64-el9-clang16-opt",      # g4 11
+              "LCG_105/x86_64-ubuntu2204-gcc11-opt",  # g4 11
+              "dev3/x86_64-el9-gcc13-opt",
+              "dev4/x86_64-el9-gcc13-opt"]
     steps:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
@@ -27,6 +26,10 @@ jobs:
           cd build
           unset CPATH
           echo "::group::CMakeConfig"
+          CMAKE_CXX_STANDARD=17
+          if [[ "${{ matrix.LCG }}" =~ "gcc13|clang16" ]]; then
+            CMAKE_CXX_STANDARD=20
+          fi
           cmake -GNinja \
             -DDD4HEP_USE_GEANT4=ON \
             -DBoost_NO_BOOST_CMAKE=ON \
@@ -40,8 +43,8 @@ jobs:
             -DDD4HEP_USE_XERCESC=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always"  \
-            -DCMAKE_CXX_STANDARD=17 ..
-          if [ "${{ matrix.LCG }}" = "dev3/x86_64-centos7-gcc11-opt" ]; then
+            -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} ..
+          if [ "${{ matrix.LCG }}" =~ "dev3" ]; then
             cmake -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON ..
           fi
           echo "::group::Compile"
@@ -56,7 +59,7 @@ jobs:
           cmake -GNinja \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DDD4HEP_USE_XERCESC=ON \
-            -DCMAKE_CXX_STANDARD=17 ..
+            -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} ..
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"
@@ -146,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["LCG_102/x86_64-centos7-gcc11-opt"]
+        LCG: ["LCG_105/x86_64-centos7-gcc11-opt"]
     steps:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
@@ -181,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["dev3/x86_64-centos7-gcc11-opt"]
+        LCG: ["dev3/x86_64-el9-gcc13-opt"]
     steps:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
@@ -207,7 +210,7 @@ jobs:
             -DDD4HEP_USE_XERCESC=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always"  \
-            -DCMAKE_CXX_STANDARD=17 ..
+            -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::Compile"
           ninja install
           . ../bin/thisdd4hep.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,6 +23,9 @@ jobs:
       with:
         release-platform: ${{ matrix.LCG }}
         run: |
+          if [[ ${{ matrix.LCG }} =~ clang16 ]]; then
+            source /cvmfs/sft.cern.ch/lcg/contrib/clang/16/x86_64-el9/setup-wrapper.sh
+          fi
           mkdir build
           cd build
           unset CPATH

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,25 +26,41 @@ jobs:
           cd build
           unset CPATH
           echo "::group::CMakeConfig"
-          CMAKE_CXX_STANDARD=17
-          if [[ "${{ matrix.LCG }}" =~ "gcc13|clang16" ]]; then
-            CMAKE_CXX_STANDARD=20
+          if [[ ${{ matrix.LCG }} =~ gcc13|clang16 ]]; then
+            echo "::group::CMakeConfig C++20"
+            cmake -GNinja \
+              -DDD4HEP_USE_GEANT4=ON \
+              -DBoost_NO_BOOST_CMAKE=ON \
+              -DDD4HEP_USE_LCIO=ON \
+              -DDD4HEP_USE_EDM4HEP=OFF \
+              -DDD4HEP_USE_TBB=ON \
+              -DDD4HEP_USE_HEPMC3=ON \
+              -DDD4HEP_BUILD_DEBUG=OFF \
+              -DBUILD_TESTING=ON \
+              -DDD4HEP_DEBUG_CMAKE=ON \
+              -DDD4HEP_USE_XERCESC=ON \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
+              -DCMAKE_CXX_STANDARD=20 ..
+            else
+              echo "::group::CMakeConfig C++17"
+              cmake -GNinja \
+                -DDD4HEP_USE_GEANT4=ON \
+                -DBoost_NO_BOOST_CMAKE=ON \
+                -DDD4HEP_USE_LCIO=ON \
+                -DDD4HEP_USE_EDM4HEP=OFF \
+                -DDD4HEP_USE_TBB=ON \
+                -DDD4HEP_USE_HEPMC3=ON \
+                -DDD4HEP_BUILD_DEBUG=OFF \
+                -DBUILD_TESTING=ON \
+                -DDD4HEP_DEBUG_CMAKE=ON \
+                -DDD4HEP_USE_XERCESC=ON \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
+                -DCMAKE_CXX_STANDARD=17 ..
           fi
-          cmake -GNinja \
-            -DDD4HEP_USE_GEANT4=ON \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DDD4HEP_USE_LCIO=ON \
-            -DDD4HEP_USE_EDM4HEP=OFF \
-            -DDD4HEP_USE_TBB=ON \
-            -DDD4HEP_USE_HEPMC3=ON \
-            -DDD4HEP_BUILD_DEBUG=OFF \
-            -DBUILD_TESTING=ON \
-            -DDD4HEP_DEBUG_CMAKE=ON \
-            -DDD4HEP_USE_XERCESC=ON \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always"  \
-            -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} ..
-          if [ "${{ matrix.LCG }}" =~ "dev3" ]; then
+          if [[ ${{ matrix.LCG }} =~ dev3 ]]; then
+            echo "::group::CMakeConfig 2"
             cmake -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON ..
           fi
           echo "::group::Compile"
@@ -56,10 +72,17 @@ jobs:
           cd ../examples/
           mkdir build
           cd build
+          if [[ ${{ matrix.LCG }} =~ gcc13|clang16 ]]; then
           cmake -GNinja \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DDD4HEP_USE_XERCESC=ON \
-            -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} ..
+            -DCMAKE_CXX_STANDARD=20 ..
+          else
+            cmake -GNinja \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DDD4HEP_USE_XERCESC=ON \
+            -DCMAKE_CXX_STANDARD=17 ..
+          fi
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"
@@ -223,7 +246,7 @@ jobs:
           cmake -GNinja \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DDD4HEP_USE_XERCESC=ON \
-            -DCMAKE_CXX_STANDARD=17 ..
+            -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,9 +11,10 @@ jobs:
       matrix:
         LCG: ["LCG_101/x86_64-centos7-gcc11-opt",    # g4 10.7
               "LCG_102/x86_64-centos9-gcc11-opt",    # g4 11
-              "LCG_104/x86_64-el9-clang16-opt",      # g4 11
+              "LCG_104/x86_64-el9-gcc13-opt",         # g4 11
               "LCG_105/x86_64-ubuntu2204-gcc11-opt",  # g4 11
               "dev3/x86_64-el9-gcc13-opt",
+              "dev3/x86_64-el9-clang16-opt",          # g4 11
               "dev4/x86_64-el9-gcc13-opt"]
     steps:
     - uses: actions/checkout@v4

--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -118,6 +118,8 @@ def unicode_2_string(value):
     value = value
   elif isinstance(value, six.string_types):
     value = str(value)
+  elif isinstance(value, bytes):
+    value = value.decode()
   elif isinstance(value, (list, set, tuple)):
     value = [unicode_2_string(x) for x in value]
   elif isinstance(value, dict):

--- a/DDDigi/include/DDDigi/DigiAction.h
+++ b/DDDigi/include/DDDigi/DigiAction.h
@@ -53,18 +53,20 @@ namespace dd4hep {
      *  \version 1.0
      *  \ingroup DD4HEP_DIGITIZATION
      */
-    class TypeName : public std::pair<std::string, std::string> {
+    class TypeName {
     public:
+      std::string first;
+      std::string second;
       /// Default constructor
       TypeName() = default;
       /// Copy constructor
       TypeName(const TypeName& copy) = default;
       /// Copy constructor from pair
       TypeName(const std::pair<std::string, std::string>& c)
-        : std::pair<std::string, std::string>(c) {      }
+        : first(c.first), second(c.second) { }
       /// Initializing constructor
       TypeName(const std::string& typ, const std::string& nam)
-        : std::pair<std::string, std::string>(typ, nam) {      }
+        : first(typ), second(nam) { }
       /// Assignment operator
       TypeName& operator=(const TypeName& copy) = default;
       /// Split string pair according to default delimiter ('/')

--- a/DDDigi/python/dddigi.py
+++ b/DDDigi/python/dddigi.py
@@ -105,9 +105,9 @@ def importConstants(description, namespace=None, debug=False):
   strings = {}
   for c in description.constants():
     if c.second.dataType == 'string':
-      strings[c.first] = c.second.GetTitle()
+      strings[str(c.first)] = c.second.GetTitle()
     else:
-      todo[c.first] = c.second.GetTitle().replace('(int)', '')
+      todo[str(c.first)] = c.second.GetTitle().replace('(int)', '')
   while len(todo) and cnt < 100:
     cnt = cnt + 1
     if cnt == 100:

--- a/DDDigi/python/dddigi.py
+++ b/DDDigi/python/dddigi.py
@@ -9,6 +9,7 @@
 #
 # ==========================================================================
 from __future__ import absolute_import, unicode_literals
+import cppyy
 from dd4hep_base import *  # noqa: F401, F403
 
 logger = None
@@ -276,6 +277,8 @@ def _set(self, name, value):
   import dd4hep as dd4hep
   act = _get_action(self)
   nam = dd4hep.unicode_2_string(name)
+  if isinstance(value, (list,)):  # cppyy.gbl.string showing up for some reason
+    value = [x.decode('utf-8') if isinstance(x, cppyy.gbl.std.string) else x for x in value]
   if isinstance(value, str):
     val = dd4hep.unicode_2_string(value)
   else:

--- a/DDDigi/python/dddigi.py
+++ b/DDDigi/python/dddigi.py
@@ -121,7 +121,7 @@ def importConstants(description, namespace=None, debug=False):
           logger.info('+++ FAILED to import: "' + k + '" = "' + str(v) + '"')
       logger.info('+++ %s' % (100 * '=',))
 
-    for k, v in todo.items():
+    for k, v in list(todo.items()):
       if not hasattr(ns, k):
         val = evaluator.evaluate(v)
         status = evaluator.status()

--- a/DDG4/include/DDG4/Geant4Action.h
+++ b/DDG4/include/DDG4/Geant4Action.h
@@ -79,18 +79,20 @@ namespace dd4hep {
      *  \version 1.0
      *  \ingroup DD4HEP_SIMULATION
      */
-    class TypeName : public std::pair<std::string, std::string> {
+    class TypeName {
     public:
+      std::string first;
+      std::string second;
       /// Default constructor
       TypeName() = default;
       /// Copy constructor
       TypeName(const TypeName& copy) = default;
       /// Copy constructor from pair
       TypeName(const std::pair<std::string, std::string>& c)
-        : std::pair<std::string, std::string>(c) {      }
+        : first(c.first), second(c.second) { }
       /// Initializing constructor
       TypeName(const std::string& typ, const std::string& nam)
-        : std::pair<std::string, std::string>(typ, nam) {      }
+        : first(typ), second(nam) { }
       /// Assignment operator
       TypeName& operator=(const TypeName& copy) = default;
       /// Split string pair according to default delimiter ('/')

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -10,6 +10,7 @@
 # ==========================================================================
 from __future__ import absolute_import, unicode_literals
 import logging
+import cppyy
 from dd4hep_base import *  # noqa: F403
 import ddsix as six
 
@@ -134,9 +135,11 @@ def _registerGlobalFilter(self, filter):  # noqa: A002
 def _evalProperty(data):
   """
     Function necessary to extract real strings from the property value.
-    Strings may be embraced by quotes: '<value>'
+    Strings may be embraced by quotes: '<value>', or could be cppyy.gbl.std.string with extra "b''"
   """
   try:
+    if isinstance(data, (cppyy.gbl.std.string, )):
+      return _evalProperty(data.decode('utf-8'))
     if isinstance(data, str):
       import ast
       return ast.literal_eval(data)

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -93,9 +93,9 @@ def importConstants(description, namespace=None, debug=False):
   strings = {}
   for c in description.constants():
     if c.second.dataType == 'string':
-      strings[c.first] = c.second.GetTitle()
+      strings[str(c.first)] = c.second.GetTitle()
     else:
-      todo[c.first] = c.second.GetTitle().replace('(int)', '')
+      todo[str(c.first)] = c.second.GetTitle().replace('(int)', '')
   while len(todo) and cnt < 100:
     cnt = cnt + 1
     if cnt == 100:

--- a/DDG4/python/DDSim/Helper/ParticleHandler.py
+++ b/DDG4/python/DDSim/Helper/ParticleHandler.py
@@ -143,7 +143,7 @@ class ParticleHandler(ConfigHelper):
       except AttributeError as e:
         logger.debug("Attribute tracker_region_zmin for asymmetric tracker region missing %s", e)
         logger.debug("  will use symmetric region defined by tracker_region_zmax")
-        user.TrackingVolume_Zmin = str(-float(user.TrackingVolume_Zmax))
+        user.TrackingVolume_Zmin = str(-float(DDG4.tracker_region_zmax))
 
       logger.info(" *** definition of tracker region *** ")
       logger.info("    tracker_region_zmin = %s", user.TrackingVolume_Zmin)


### PR DESCRIPTION
BEGINRELEASENOTES
- CI: change which LCG_releases/ROOT versions DD4hep is tested.
- Fix various issues with latest version of ROOT (6-32-patches, master) and cppyy in ROOT.
   - :warning: : You may encounter issues with python setup complaining about mismatched types, strings, conversions 

ENDRELEASENOTES

Different errors encountered for better searching and finding in the future:
Mostly related to the change discussed here https://github.com/root-project/root/issues/15153

### 1
```
350: Traceback (most recent call last):
350:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/bin/ddsim", line 25, in <module>
350:     sys.exit(RUNNER.run())
350:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/lib/python3.9/site-packages/DDSim/DD4hepSimulation.py", line 470, in run
350:     self.part.setupUserParticleHandler(part, kernel, DDG4)
350:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/lib/python3.9/site-packages/DDSim/Helper/ParticleHandler.py", line 146, in setupUserParticleHandler
350:     user.TrackingVolume_Zmin = str(-float(user.TrackingVolume_Zmax))
350: TypeError: float() argument must be a string or a number, not 'string'
350: corrupted size vs. prev_size in fastbins
```
Solution: In this case don't use properties obtained from the userHandler object, other cases might mean `decoding` the cppyy.gbl.std.string` or similar

### 2 
```
294: Geant4Kernel     ERROR DDG4: The action ''UI'' is not globally registered. [Action-Missing]
294: Traceback (most recent call last):
294:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/examples/DDG4/scripts/TestUserCommands.py", line 107, in <module>
294:     run()
294:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/examples/DDG4/scripts/TestUserCommands.py", line 89, in run
294:     geant4.ui().applyCommand('/ddg4/Print/param interactive-2')
294:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/lib/python3.9/site-packages/DDG4.py", line 445, in ui
294:     return self.master().globalAction(ui_name)
294: cppyy.gbl.std.runtime_error: dd4hep::sim::Geant4Action* dd4hep::sim::Geant4Kernel::globalAction(const string& action_name, bool throw_if_not_present = true) =>
294:     runtime_error: Geant4Kernel: DDG4: The action ''UI'' is not globally registered. [Action-Missing]
294: corrupted size vs. prev_size in fastbins
294:  *** Break *** abort
```

Note the too many quotes `''UI''`, solution again decoding the string returned from the cppyy object

### 3
```
279: Traceback (most recent call last):
279:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/examples/DDDigi/scripts/TestMultiInteractions.py", line 61, in <module>
279:     run()
279:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/examples/DDDigi/scripts/TestMultiInteractions.py", line 28, in run
279:     hist_drop = overlay.adopt_action('DigiHitHistoryDrop/Drop-1', masks=[evtreader.mask])
279:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/lib/python3.9/site-packages/dddigi.py", line 239, in _adopt_sequence_action
279:     setattr(action, option[0], option[1])
279:   File "/build/sailer/testDD4hep/dd4hep/dd4hepinstall/lib/python3.9/site-packages/dddigi.py", line 283, in _set
279:     if Interface.setProperty(act, nam, val):
279: cppyy.gbl.dd4hep.unrelated_value_error: static int dd4hep::digi::DigiActionCreation::setProperty(dd4hep::digi::DigiAction* action, const string& name, const string& value) =>
279:     unrelated_value_error: The type std::vector<int, std::allocator<int> > cannot be converted: Data conversion of [b'1'] to type 'std::vector<int, std::allocator<int> >' is not defined.
```

`cppyy.gbl.std.string` shows up in a list. Decoded all content inside lists.