### PR TITLE
Fixed TwistedTube when only half-length is provided

### DIFF
--- a/DDG4/src/Geant4ShapeConverter.cpp
+++ b/DDG4/src/Geant4ShapeConverter.cpp
@@ -109,7 +109,7 @@ namespace dd4hep {
       if ( std::fabs(std::fabs(sh->GetNegativeEndZ()) - std::fabs(sh->GetPositiveEndZ())) < 1e-10 )   {
         return new G4TwistedTubs(sh->GetName(),sh->GetPhiTwist() * DEGREE_2_RAD,
                                  sh->GetRmin() * CM_2_MM, sh->GetRmax() * CM_2_MM,
-                                 sh->GetNegativeEndZ() * CM_2_MM,
+                                 sh->GetPositiveEndZ() * CM_2_MM,
                                  sh->GetNsegments(),
                                  (sh->GetPhi2()-sh->GetPhi1()) * DEGREE_2_RAD);
       }


### PR DESCRIPTION
It turns out that `GetNegativeEndZ` may be <0, leading to undefined behavior when the value is used as 'half-length'
Replacing `GetNegativeEndZ` by `GetPositiveEndZ` in the Geant4 converting function fixes the problem because `GetPositiveEndZ` corresponds to the user value (that is expected to be the half-length of the twisted tube, as the half-length parameter of a regular tube)

The change is tested in my local installation of DD4hep. 

BEGINRELEASENOTES
- Fixed TwistedTube when only half-length is provided, making the tube is symmetric along Z axis 

ENDRELEASENOTES

