### PR TITLE
Fix: propagate build type to included plugins and add corresponding example

### DIFF
--- a/DDCore/include/DD4hep/BuildType.h
+++ b/DDCore/include/DD4hep/BuildType.h
@@ -22,6 +22,9 @@
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
 
+  /// Forward declarations
+  class Detector;
+  
   /// Detector description build types.
   /** enum DetectorBuildType Detector.h  dd4hep/Detector.h
    * The corresponding flag is ONLY valid while parsing the
@@ -42,6 +45,12 @@ namespace dd4hep {
 
   /// Translate string representation of the geometry build type to value
   DetectorBuildType buildType(const std::string& value);
+
+  /// Translate the geometry build type to value to the string representation
+  std::string buildTypeName(DetectorBuildType type);
+
+  /// Translate the geometry build type to value to the string representation
+  std::string buildTypeName(Detector& detector);
 
   /// Check if a build type matches the current 
   bool buildMatch(const std::string& value, DetectorBuildType match);

--- a/DDCore/include/DD4hep/Detector.h
+++ b/DDCore/include/DD4hep/Detector.h
@@ -302,13 +302,15 @@ namespace dd4hep {
     virtual Detector& addField(const Handle<NamedObject>& field) = 0;
     
     /// Deprecated call (use fromXML): Read compact geometry description or alignment file
-    virtual void fromCompact(const std::string& fname, DetectorBuildType type = BUILD_DEFAULT) = 0;
+    virtual void fromCompact(const std::string& fname,
+                             DetectorBuildType type = BUILD_DEFAULT) = 0;
     /// Read any geometry description or alignment file
-    virtual void fromXML(const std::string& fname, DetectorBuildType type = BUILD_DEFAULT) = 0;
+    virtual void fromXML    (const std::string& fname,
+                             DetectorBuildType type = BUILD_DEFAULT) = 0;
     /// Read any geometry description or alignment file with external XML entity resolution
-    virtual void fromXML(const std::string& fname,
-                         xml::UriReader* entity_resolver,
-                         DetectorBuildType type = BUILD_DEFAULT) = 0;
+    virtual void fromXML    (const std::string& fname,
+                             xml::UriReader* entity_resolver,
+                             DetectorBuildType type = BUILD_DEFAULT) = 0;
 
     /// Stupid legacy method
     virtual void dump() const = 0;

--- a/DDCore/src/BuildType.cpp
+++ b/DDCore/src/BuildType.cpp
@@ -13,6 +13,7 @@
 
 // Framework includes
 #include <DD4hep/BuildType.h>
+#include <DD4hep/Detector.h>
 
 // C/C++ include files
 #include <stdexcept>
@@ -47,6 +48,31 @@ dd4hep::DetectorBuildType dd4hep::buildType(const char* value)   {
 /// Translate string representation of the geometry build type to value
 dd4hep::DetectorBuildType dd4hep::buildType(const std::string& value)   {
   return buildType(value.c_str());
+}
+
+/// Translate the geometry build type to value to the string representation
+std::string dd4hep::buildTypeName(dd4hep::DetectorBuildType type)   {
+  switch(type)   {
+  case BUILD_NONE:
+    return "BUILD_NONE";
+  case BUILD_DEFAULT:
+    return "BUILD_DEFAULT";
+    //case BUILD_SIMU:
+    //return "BUILD_SIMU";
+  case BUILD_RECO:
+    return "BUILD_RECO";
+  case BUILD_DISPLAY:
+    return "BUILD_DISPLAY";
+  case BUILD_ENVELOPE:
+    return "BUILD_ENVELOPE";
+  default:
+    throw std::runtime_error("Invalid build type value: "+std::to_string(int(type)));
+  }
+}
+
+/// Translate the geometry build type to value to the string representation
+std::string dd4hep::buildTypeName(dd4hep::Detector& detector)   {
+  return buildTypeName(detector.buildType());
 }
 
 /// Check if a build type matches the current 

--- a/DDCore/src/DD4hepUI.cpp
+++ b/DDCore/src/DD4hepUI.cpp
@@ -74,7 +74,7 @@ Handle<NamedObject> detail::DD4hepUI::conditionsMgr()  const  {
 long detail::DD4hepUI::loadConditions(const std::string& fname)  const  {
   Handle<NamedObject> h = conditionsMgr();
   if ( h.isValid() )  {
-    m_detDesc.fromXML(fname, BUILD_DEFAULT);
+    m_detDesc.fromXML(fname, m_detDesc.buildType());
     return 1;
   }
   return 0;

--- a/DDCore/src/DetectorImp.cpp
+++ b/DDCore/src/DetectorImp.cpp
@@ -810,16 +810,16 @@ void DetectorImp::init() {
 
 /// Read any geometry description or alignment file
 void DetectorImp::fromXML(const std::string& xmlfile, DetectorBuildType build_type) {
-  TypePreserve build_type_preserve(m_buildType = build_type);
   std::lock_guard<std::recursive_mutex> lock(s_detector_apply_lock);
-  processXML(xmlfile,0);
+  m_buildType = build_type;
+  processXML(xmlfile, 0);
 }
 
 /// Read any geometry description or alignment file with external XML entity resolution
 void DetectorImp::fromXML(const std::string& fname, xml::UriReader* entity_resolver, DetectorBuildType build_type)  {
-  TypePreserve build_type_preserve(m_buildType = build_type);
   std::lock_guard<std::recursive_mutex> lock(s_detector_apply_lock);
-  processXML(fname,entity_resolver);
+  m_buildType = build_type;
+  processXML(fname, entity_resolver);
 }
 
 void DetectorImp::dump() const {

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -1469,7 +1469,7 @@ template <> void Converter<IncludeFile>::operator()(xml_h element) const   {
     xml_coll_t(root, _U(material)).for_each(Converter<Material>(this->description));
     return;
   }
-  this->description.fromXML(doc.uri());
+  this->description.fromXML(doc.uri(), this->description.buildType());
 }
 
 /// Read material entries from a seperate file in one of the include sections of the geometry
@@ -1490,23 +1490,23 @@ template <> void Converter<XMLFile>::operator()(xml_h element) const {
   if ( idx == std::string::npos && std::filesystem::exists(fname, ec) )  {
     // Regular file without protocol specification
     printout(level, "Compact","++ Processing xml document %s.", fname.c_str());
-    this->description.fromXML(fname);
+    this->description.fromXML(fname, this->description.buildType());
   }
   else if ( idx == std::string::npos )  {
     // File relative to location of xml tag (protocol specification not possible)
     std::string location = xml::DocumentHandler::system_path(element, fname);
     printout(level, "Compact","++ Processing xml document %s.", location.c_str());
-    this->description.fromXML(location);
+    this->description.fromXML(location, this->description.buildType());
   }
   else if ( idx > 0 )   {
     // File with protocol specification: must trust the location and the parser capabilities
     printout(level, "Compact","++ Processing xml document %s.", fname.c_str());
-    this->description.fromXML(fname);
+    this->description.fromXML(fname, this->description.buildType());
   }
   else  {
     // Are there any other possibilities ?
     printout(level, "Compact","++ Processing xml document %s.", fname.c_str());
-    this->description.fromXML(fname);
+    this->description.fromXML(fname, this->description.buildType());
   }
 }
 

--- a/DDCore/src/plugins/ShapePlugins.cpp
+++ b/DDCore/src/plugins/ShapePlugins.cpp
@@ -948,6 +948,8 @@ static Ref_t create_shape(Detector& description, xml_h e, SensitiveDetector sens
   PlacedVolume pv;
   int count = 0;
   
+  printout(DEBUG,"TestShape","+++ Create shape: %s build type is: %s",
+           name.c_str(), buildTypeName(description.buildType()).c_str());
   if ( x_det.hasChild(_U(material)) )  {
     mat = description.material(x_det.child(_U(material)).attr<std::string>(_U(name)));
     printout(INFO,"TestShape","+++ Volume material is %s", mat.name());      

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -744,11 +744,11 @@ static long load_xml(Detector& description, int argc, char** argv) {
       type = buildType(argv[1]);
       printout(INFO,"XMLLoader","+++ Processing XML file: %s with flag %s",
                input.c_str(), argv[1]);
-      description.fromXML(input,type);
+      description.fromXML(input, type);
       return 1;
     }
     printout(INFO,"XMLLoader","+++ Processing XML file: %s",input.c_str());
-    description.fromXML(input);
+    description.fromXML(input, description.buildType());
     return 1;
   }
   return 0;

--- a/DDDigi/plugins/DigiResegment.cpp
+++ b/DDDigi/plugins/DigiResegment.cpp
@@ -57,100 +57,100 @@ namespace dd4hep {
     public:
       /// Standard constructor
       DigiResegment(const DigiKernel& krnl, const std::string& nam)
-	: DigiContainerProcessor(krnl, nam)
+        : DigiContainerProcessor(krnl, nam)
       {
-	declareProperty("debug",      m_debug);
-	declareProperty("detector",   m_detector_name);
-	declareProperty("readout",    m_readout_name);
-	declareProperty("descriptor", m_readout_descriptor);
-	m_kernel.register_initialize(std::bind(&DigiResegment::initialize, this));
+        declareProperty("debug",      m_debug);
+        declareProperty("detector",   m_detector_name);
+        declareProperty("readout",    m_readout_name);
+        declareProperty("descriptor", m_readout_descriptor);
+        m_kernel.register_initialize(std::bind(&DigiResegment::initialize, this));
       }
 
       void initialize()   {
-	auto& detector = m_kernel.detectorDescription();
-	if ( m_readout_descriptor.empty() )   {
-	  except("+++ Invalid ID descriptor %s", m_readout_descriptor.c_str());
-	}
-	DetectorLoad loader(detector);
-	loader.processXMLString(m_readout_descriptor.c_str());
-	m_new_readout = detector.readout(m_readout_name);
-	if ( !m_new_readout.isValid() )  {
-	  except("+++ Invalid resegmentation readout for %s", m_readout_name.c_str());
-	}
-	m_new_id_desc = m_new_readout.idSpec();
-	m_new_segment = m_new_readout.segmentation();
+        auto& detector = m_kernel.detectorDescription();
+        if ( m_readout_descriptor.empty() )   {
+          except("+++ Invalid ID descriptor %s", m_readout_descriptor.c_str());
+        }
+        DetectorLoad loader(detector);
+        loader.processXMLString(m_readout_descriptor.c_str());
+        m_new_readout = detector.readout(m_readout_name);
+        if ( !m_new_readout.isValid() )  {
+          except("+++ Invalid resegmentation readout for %s", m_readout_name.c_str());
+        }
+        m_new_id_desc = m_new_readout.idSpec();
+        m_new_segment = m_new_readout.segmentation();
 
 
-	m_detector = detector.detector(m_detector_name);
-	if ( !m_detector.isValid() )   {
-	  except("+++ Cannot locate subdetector: %s", m_detector_name.c_str());
-	}
-	m_org_readout = detector.sensitiveDetector(m_detector_name).readout();
-	if ( !m_org_readout.isValid() )  {
-	  except("+++ Invalid resegmentation readout for %s", m_readout_name.c_str());
-	}
-	m_org_id_desc = m_org_readout.idSpec();
-	m_org_segment = m_org_readout.segmentation();
+        m_detector = detector.detector(m_detector_name);
+        if ( !m_detector.isValid() )   {
+          except("+++ Cannot locate subdetector: %s", m_detector_name.c_str());
+        }
+        m_org_readout = detector.sensitiveDetector(m_detector_name).readout();
+        if ( !m_org_readout.isValid() )  {
+          except("+++ Invalid resegmentation readout for %s", m_readout_name.c_str());
+        }
+        m_org_id_desc = m_org_readout.idSpec();
+        m_org_segment = m_org_readout.segmentation();
 
-	m_volmgr = detector.volumeManager();
-	if ( !m_volmgr.isValid() )   {
-	  detector.apply("DD4hepVolumeManager",0,nullptr);
-	}
-	m_volmgr = detector.volumeManager();
-	if ( !m_volmgr.isValid() )   {
-	  except("+++ Cannot locate volume manager!");
-	}
-	info("+++ Successfully initialized resegmentation action.");
+        m_volmgr = detector.volumeManager();
+        if ( !m_volmgr.isValid() )   {
+          detector.apply("DD4hepVolumeManager",0,nullptr);
+        }
+        m_volmgr = detector.volumeManager();
+        if ( !m_volmgr.isValid() )   {
+          except("+++ Cannot locate volume manager!");
+        }
+        info("+++ Successfully initialized resegmentation action.");
       }
 
       template <typename T> void
       resegment_deposits(const T& cont, work_t& work, const predicate_t& predicate)  const  {
-	Key key(cont.name, work.environ.output.mask);
-	DepositVector m(cont.name, key.mask(), cont.data_type);
-	std::size_t start = m.size();
-	for( const auto& dep : cont )   {
-	  if( predicate(dep) )   {
-	    CellID cell = dep.first;
-	    auto*  ctxt = m_volmgr.lookupContext(cell);
-	    if ( !ctxt )   {
-	      error("+++ Cannot locate volume context for cell %016lX", cell);
-	    }
-	    else   {
-	      VolumeID volID     = m_org_segment.volumeID(cell);
-	      Position org_local = m_org_segment.position(cell);
-	      Position global    = ctxt->localToWorld(org_local);
-	      CellID   new_cell  = m_new_segment.cellID(org_local, global, volID);
-	      Position new_local = m_new_segment.position(new_cell);
-	      if ( m_debug )   {
-		info("+++ Cell: %016lX -> %016lX DE: %-20s "
-		     "Pos global: %8.2f %8.2f %8.2f  local: %8.2f %8.2f %8.2f -> %8.2f %8.2f %8.2f",
-		     cell, new_cell, ctxt->element.name(), 
-		     global.X(), global.Y(), global.Z(),
-		     org_local.X(), org_local.Y(), org_local.Z(),
-		     new_local.X(), new_local.Y(), new_local.Z()
-		     );
-	      }
-	      EnergyDeposit d(dep.second);
-	      d.position = global;
-	      d.momentum = dep.second.momentum;
-	      m.emplace(new_cell, std::move(d));
-	    }
-	  }
-	}
-	std::size_t end   = m.size();
-	work.environ.output.data.put(m.key, std::move(m));
-	info("+++ %-32s added %6ld entries (now: %6ld) from mask: %04X to mask: %04X",
-	     cont.name.c_str(), end-start, end, cont.key.mask(), m.key.mask());
+        Key key(cont.name, work.environ.output.mask);
+        DepositVector m(cont.name, key.mask(), cont.data_type);
+        std::size_t start = m.size();
+        for( const auto& dep : cont )   {
+          if( predicate(dep) )   {
+            CellID cell = dep.first;
+            auto*  ctxt = m_volmgr.lookupContext(cell);
+            if ( !ctxt )   {
+              error("+++ Cannot locate volume context for cell %016lX", cell);
+            }
+            else   {
+              VolumeID volID     = m_org_segment.volumeID(cell);
+              Position org_local = m_org_segment.position(cell);
+              Position global    = ctxt->localToWorld(org_local);
+              CellID   new_cell  = m_new_segment.cellID(org_local, global, volID);
+              Position new_local = m_new_segment.position(new_cell);
+              if ( m_debug )   {
+                info("+++ Cell: %016lX -> %016lX DE: %-20s "
+                     "Pos global: %8.2f %8.2f %8.2f  local: %8.2f %8.2f %8.2f -> %8.2f %8.2f %8.2f",
+                     cell, new_cell, ctxt->element.name(), 
+                     global.X(), global.Y(), global.Z(),
+                     org_local.X(), org_local.Y(), org_local.Z(),
+                     new_local.X(), new_local.Y(), new_local.Z()
+                     );
+              }
+              EnergyDeposit d(dep.second);
+              d.position = global;
+              d.momentum = dep.second.momentum;
+              m.emplace(new_cell, std::move(d));
+            }
+          }
+        }
+        std::size_t end   = m.size();
+        work.environ.output.data.put(m.key, std::move(m));
+        info("+++ %-32s added %6ld entries (now: %6ld) from mask: %04X to mask: %04X",
+             cont.name.c_str(), end-start, end, cont.key.mask(), m.key.mask());
       }
 
       /// Main functional callback
       virtual void execute(DigiContext&, work_t& work, const predicate_t& predicate)  const override final  {
-	if ( const auto* m = work.get_input<DepositMapping>() )
-	  resegment_deposits(*m, work, predicate);
-	else if ( const auto* v = work.get_input<DepositVector>() )
-	  resegment_deposits(*v, work, predicate);
-	else
-	  except("Request to handle unknown data type: %s", work.input_type_name().c_str());
+        if ( const auto* m = work.get_input<DepositMapping>() )
+          resegment_deposits(*m, work, predicate);
+        else if ( const auto* v = work.get_input<DepositVector>() )
+          resegment_deposits(*v, work, predicate);
+        else
+          except("Request to handle unknown data type: %s", work.input_type_name().c_str());
       }
     };
   }    // End namespace digi

--- a/DDEve/src/DisplayConfigurationParser.cpp
+++ b/DDEve/src/DisplayConfigurationParser.cpp
@@ -247,7 +247,7 @@ template <> void Converter<include>::operator()(xml_h e)  const  {
   if ( e )  {
     DetectorLoad* load = dynamic_cast<DetectorLoad*>(&this->description);
     if ( load )   {
-      load->processXML(e,e.attr<std::string>(_U(ref)));
+      load->processXML(e, e.attr<std::string>(_U(ref)));
       return;
     }
     except("DisplayConfiguration","++ Invalid DetectorLoad instance in XML converter <include>");

--- a/DDG4/src/Geant4SensDetAction.cpp
+++ b/DDG4/src/Geant4SensDetAction.cpp
@@ -279,9 +279,9 @@ long long int Geant4Sensitive::cellID(const G4Step* step) {
       error("....... TGeo-local: (%f, %f, %f) TGeo-global: (%f, %f, %f)",
 	    loc.x(), loc.y(), loc.z(), glob.x(), glob.y(), glob.z());
       if ( h.pre )
-	error("....... Pre-step:  %s  SD: %s", h.volName(h.pre), h.sdName(h.pre));
+        error("....... Pre-step:  %s  SD: %s", h.volName(h.pre), h.sdName(h.pre).c_str());
       if ( h.post )
-	error("....... Post-step: %s  SD: %s", h.volName(h.post), h.sdName(h.post));
+	error("....... Post-step: %s  SD: %s", h.volName(h.post), h.sdName(h.post).c_str());
       std::rethrow_exception(eptr);
     }
   }

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -460,6 +460,15 @@ dd4hep_add_test_reg( minitel_config_world
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
+# Test setting build type to BUILD_DISPLAY rather than the default BUILD_DEFAULT/BUILD_SIMU
+dd4hep_add_test_reg( box_shape_build_type
+  COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+  EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/Check_Shape_Box.xml -build_type BUILD_DISPLAY
+             -print DEBUG -destroy -load 
+  REGEX_PASS "\\+\\+\\+ Create shape: Shape_Box build type is: BUILD_DISPLAY"
+  REGEX_FAIL "Exception;EXCEPTION;ERROR"
+)
+#
 #      EXEC_ARGS  test_with_root.sh ${script}
 #
 if (DD4HEP_USE_GEANT4)

--- a/examples/ClientTests/compact/Check_Shape_Box_Det.xml
+++ b/examples/ClientTests/compact/Check_Shape_Box_Det.xml
@@ -11,10 +11,14 @@
      #
      #==========================================================================
 -->
-
-  <includes>
-    <gdmlFile ref="CheckShape.xml"/>
-  </includes>
-
-  <include ref="Check_Shape_Box_Detectors.xml"/>
+  <detectors>
+    <detector id="1" name="Shape_Box" type="DD4hep_TestShape_Creator">
+      <check vis="Shape1_vis">
+        <shape type="Box" dx="30*cm" dy="20*cm" dz="10*cm"/>
+        <position x="30*cm"  y="30*cm"   z="30*cm"/>
+        <rotation x="0*rad"  y="0*rad"   z="0*rad"/>
+      </check>
+      <test  type="DD4hep_Mesh_Verifier" ref="${DD4hepExamplesINSTALL}/examples/ClientTests/ref/Ref_Box.txt" create="CheckShape_create"/>
+    </detector>
+  </detectors>
 </lccdd>

--- a/examples/ClientTests/compact/Check_Shape_Box_Detectors.xml
+++ b/examples/ClientTests/compact/Check_Shape_Box_Detectors.xml
@@ -12,9 +12,7 @@
      #==========================================================================
 -->
 
-  <includes>
-    <gdmlFile ref="CheckShape.xml"/>
-  </includes>
-
-  <include ref="Check_Shape_Box_Detectors.xml"/>
+  <detectors>
+    <include ref="Check_Shape_Box_Det.xml"/>
+  </detectors>
 </lccdd>


### PR DESCRIPTION
BEGINRELEASENOTES

* The build type flag was lost when including files from compact. This PR fixes this deficiency and ensures the flag propagation. Example:  'box_shape_build_type'

ENDRELEASENOTES