### PR TITLE
fix: Polycone::addZPlanes when already 2 planes defined

### DIFF
--- a/DDCore/src/Shapes.cpp
+++ b/DDCore/src/Shapes.cpp
@@ -268,7 +268,7 @@ void Polycone::addZPlanes(const std::vector<double>& rmin, const std::vector<dou
   TGeoPcon* sh = *this;
   std::vector<double> params;
   std::size_t num = sh->GetNz();
-  if (rmin.size() < 2)   {
+  if (num + rmin.size() < 2)   {
     except("PolyCone","++ addZPlanes: Not enough Z planes. minimum is 2!");
   }
   params.emplace_back(sh->GetPhi1());

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -25,6 +25,7 @@ foreach(TEST_NAME
     test_cellDimensionsRPhi2
     test_segmentationHandles
     test_Evaluator
+    test_shapes
     )
   add_executable(${TEST_NAME} src/${TEST_NAME}.cc)
   target_link_libraries(${TEST_NAME} DD4hep::DDCore DD4hep::DDRec DD4hep::DDTest)

--- a/DDTest/src/test_shapes.cc
+++ b/DDTest/src/test_shapes.cc
@@ -1,0 +1,33 @@
+#include "DD4hep/DDTest.h"
+
+#include "DD4hep/Shapes.h"
+
+#include <exception>
+#include <iostream>
+#include <assert.h>
+#include <cmath>
+
+//=============================================================================
+int main(int /* argc */, char** /* argv */ ){
+
+  // this should be the first line in your test
+  dd4hep::DDTest test( "shapes" );
+    
+  try{
+    
+    // --------------------------------------------------------------------
+    // Polycone
+
+    // add single plane with addZPlanes
+    Polycone polycone(0, 2*M_PI, {0, 0}, {1, 1}, {0, 1});
+    polycone.addZPlanes({0}, {1}, {0.5});
+
+    // --------------------------------------------------------------------
+  }
+  catch( std::exception &e ){
+    test.log( e.what() );
+    test.error( "exception occurred" );
+  }
+  return 0;
+}
+//=============================================================================

--- a/DDTest/src/test_shapes.cc
+++ b/DDTest/src/test_shapes.cc
@@ -19,7 +19,7 @@ int main(int /* argc */, char** /* argv */ ){
     // Polycone
 
     // add single plane with addZPlanes
-    Polycone polycone(0, 2*M_PI, {0, 0}, {1, 1}, {0, 1});
+    dd4hep::Polycone polycone(0, 2*M_PI, {0, 0}, {1, 1}, {0, 1});
     polycone.addZPlanes({0}, {1}, {0.5});
 
     // --------------------------------------------------------------------

--- a/DDTest/src/test_shapes.cc
+++ b/DDTest/src/test_shapes.cc
@@ -20,7 +20,7 @@ int main(int /* argc */, char** /* argv */ ){
 
     // add single plane with addZPlanes
     dd4hep::Polycone polycone(0, 2*M_PI, {0, 0}, {1, 1}, {0, 1});
-    polycone.addZPlanes({0}, {1}, {0.5});
+    polycone.addZPlanes({0}, {1}, {2});
 
     // --------------------------------------------------------------------
   }


### PR DESCRIPTION
When a valid Polycone exists with 2 (or more) z-planes, calling addZPlanes with a single z-plane is well-defined.

BEGINRELEASENOTES
- fix adding individual planes to existing Polycone 

ENDRELEASENOTES