### PR TITLE
DDSim: add checking that files exists to input argument parsing

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -561,7 +561,7 @@ class DD4hepSimulation(object):
     if isinstance(fileNames, str):
       fileNames = [fileNames]
     if not all(fileName.endswith(tuple(extensions)) for fileName in fileNames):
-      self._errorMessages.append("ERROR: Unknown fileformat for file: %s" % fileNames)
+      self._errorMessages.append(f"ERROR: Unknown fileformat for file(s): {','.join(fileNames)}")
     is_hepmc3_extension = any(fileName.endswith(tuple(HEPMC3_SUPPORTED_EXTENSIONS)) for fileName in fileNames)
     if not self.hepmc3.useHepMC3 and is_hepmc3_extension:
       self._errorMessages.append("ERROR: HepMC3 files or compressed HepMC2 require the use of HepMC3 library")

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -223,8 +223,10 @@ class DD4hepSimulation(object):
     self._dumpSteeringFile = parsed.dumpSteeringFile
 
     self.compactFile = ConfigHelper.makeList(parsed.compactFile)
+    self.__checkFilesExist(self.compactFile, fileType='compact')
     self.inputFiles = parsed.inputFiles
     self.inputFiles = self.__checkFileFormat(self.inputFiles, POSSIBLEINPUTFILES)
+    self.__checkFilesExist(self.inputFiles, fileType='input')
     self.outputFile = parsed.outputFile
     self.__checkFileFormat(self.outputFile, ('.root', '.slcio'))
     self.runType = parsed.runType
@@ -538,6 +540,19 @@ class DD4hepSimulation(object):
     field.delta_intersection = self.field.delta_intersection
     field.delta_one_step = self.field.delta_one_step
     field.largest_step = self.field.largest_step
+
+  def __checkFilesExist(self, fileNames, fileType=''):
+    """Make sure all files in the given list exist, add to errorMessage otherwise.
+
+
+    :param list fileNames: list of files to check for existence
+    :param str fileType: type if file, for nicer error message
+    """
+    if isinstance(fileNames, str):
+      fileNames = [fileNames]
+    for fileName in fileNames:
+      if not os.path.exists(fileName):
+        self._errorMessages.append(f"ERROR: The {fileType}file '{fileName}' does not exist")
 
   def __checkFileFormat(self, fileNames, extensions):
     """check if the fileName is allowed, note that the filenames are case


### PR DESCRIPTION

BEGINRELEASENOTES
- DDSim: add checks that input files and compact files exist before doing anything extensive and provide proper error message. Fixes #1246 

ENDRELEASENOTES

e.g.:
```
ddsim --inputFile foobar.tar.gz --compactFile baz.xml | tail -n 5

ERROR: Unknown fileformat for file: ['foobar.tar.gz']
ERROR: the inputfile 'foobar.tar.gz' does not exist
ERROR: the compactfile 'baz.xml' does not exist
ERROR: Batch mode requested, but did not set number of events
```