### PR TITLE
Fix usage of podio pre-processor version checks

### DIFF
--- a/DDDigi/io/DigiEdm4hepInput.cpp
+++ b/DDDigi/io/DigiEdm4hepInput.cpp
@@ -16,12 +16,16 @@
 #include "DigiIO.h"
 
 // podio/edm4hep include files
-#include <podio/Frame.h>
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include <podio/podioVersion.h>
+#if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
 #include <podio/ROOTReader.h>
 #else
 #include <podio/ROOTFrameReader.h>
+namespace podio {
+  using ROOTReader = podio::ROOTFrameReader;
+}
 #endif
+#include <podio/Frame.h>
 
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/SimCalorimeterHit.h>
@@ -51,11 +55,7 @@ namespace dd4hep {
       const podio::CollectionBase* get(const std::string& nam) const { return frame.get(nam); }
     };
     
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
     using reader_t = podio::ROOTReader;
-#else
-    using reader_t = podio::ROOTFrameReader;
-#endif
     using frame_t  = edm4hep_read_frame_t;
 
     /// EDM4HEP Digi input reader: Collection descriptor definition

--- a/DDDigi/io/DigiEdm4hepOutput.cpp
+++ b/DDDigi/io/DigiEdm4hepOutput.cpp
@@ -20,11 +20,14 @@
 #include "DigiIO.h"
 
 /// edm4hep include files
-#include <podio/CollectionBase.h>
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include <podio/podioVersion.h>
+#if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
 #include <podio/ROOTWriter.h>
 #else
 #include <podio/ROOTFrameWriter.h>
+namespace podio {
+  using ROOTWriter = podio::ROOTFrameWriter;
+}
 #endif
 #include <podio/Frame.h>
 #include <edm4hep/SimTrackerHit.h>
@@ -53,11 +56,7 @@ namespace dd4hep {
       using headercollection_t   = std::pair<std::string,std::unique_ptr<edm4hep::EventHeaderCollection> >;
       DigiEdm4hepOutput*                      m_parent    { nullptr };
       /// Reference to podio writer
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
       std::unique_ptr<podio::ROOTWriter>      m_writer    { };
-#else
-      std::unique_ptr<podio::ROOTFrameWriter> m_writer    { };
-#endif
       /// edm4hep event header collection
       headercollection_t                      m_header    { };
       /// MC particle collection
@@ -197,11 +196,7 @@ namespace dd4hep {
       clear();
       m_writer.reset();
       std::string fname = m_parent->next_stream_name();
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
       m_writer = std::make_unique<podio::ROOTWriter>(fname);
-#else
-      m_writer = std::make_unique<podio::ROOTFrameWriter>(fname);
-#endif
       m_parent->info("+++ Opened EDM4HEP output file %s", fname.c_str());
     }
 

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -525,7 +525,11 @@ void Geant4Output2EDM4hep::saveCollection(OutputContext<G4Event>& /*ctxt*/, G4VH
       sth.setEDep(hit->energyDeposit/CLHEP::GeV);
       sth.setPathLength(hit->length/CLHEP::mm);
       sth.setTime(hit->truth.time/CLHEP::ns);
+#if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 10, 99)
+      sth.setParticle(mcp);
+#else
       sth.setMCParticle(mcp);
+#endif
       sth.setPosition( {pos.x()/CLHEP::mm, pos.y()/CLHEP::mm, pos.z()/CLHEP::mm} );
       sth.setMomentum( {float(mom.x()/CLHEP::GeV),float(mom.y()/CLHEP::GeV),float(mom.z()/CLHEP::GeV)} );
       auto particleIt = pm->particles().find(trackID);

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -26,13 +26,16 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/EDM4hepVersion.h>
 /// podio include files
+#include <podio/podioVersion.h>
 #include <podio/Frame.h>
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
 #include <podio/ROOTWriter.h>
 #else
 #include <podio/ROOTFrameWriter.h>
+namespace podio {
+  using ROOTWriter = podio::ROOTFrameWriter;
+}
 #endif
-#include <podio/podioVersion.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -52,11 +55,7 @@ namespace dd4hep {
      */
     class Geant4Output2EDM4hep : public Geant4OutputAction  {
     protected:
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
       using writer_t = podio::ROOTWriter;
-#else
-      using writer_t = podio::ROOTFrameWriter;
-#endif
       using stringmap_t = std::map< std::string, std::string >;
       using trackermap_t = std::map< std::string, edm4hep::SimTrackerHitCollection >;
       using calorimeterpair_t = std::pair< edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionCollection >;
@@ -246,11 +245,7 @@ void Geant4Output2EDM4hep::beginRun(const G4Run* run)  {
     }
   }
   if ( !fname.empty() )   {
-#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
     m_file = std::make_unique<podio::ROOTWriter>(fname);
-#else
-    m_file = std::make_unique<podio::ROOTFrameWriter>(fname);
-#endif
     if ( !m_file )   {
       fatal("+++ Failed to open output file: %s", fname.c_str());
     }

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -26,6 +26,7 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/EDM4hepVersion.h>
 /// podio include files
+#include <podio/CollectionBase.h>
 #include <podio/podioVersion.h>
 #include <podio/Frame.h>
 #if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)


### PR DESCRIPTION
BEGINRELEASENOTES
- DDDigiEDM4hep: Switch to the correct podio pre-processor version checks for switching to the non-deprecated readers / writers. Also simplify this such that choosing which type(name) to use is handled in one place rather than several.
- Geant4Output2EDM4hep: Switch to a non-deprecated setter for setting the MCParticle for a SimTrackerHit once EDM4hep ships with it.

ENDRELEASENOTES