### PR TITLE
Geant4GFlashShowerModel: remove wrong unit conversions from particleBound properties

### DIFF
--- a/DDG4/plugins/Geant4GFlashShowerModel.cpp
+++ b/DDG4/plugins/Geant4GFlashShowerModel.cpp
@@ -231,19 +231,19 @@ void Geant4GFlashShowerModel::constructSensitives(Geant4DetectorConstructionCont
 
   for(const auto& prop : this->m_eMin)    {
     G4ParticleDefinition* def = this->getParticleDefinition(prop.first);
-    double val = dd4hep::_toDouble(prop.second) * dd4hep::GeV/CLHEP::GeV;
+    double val = dd4hep::_toDouble(prop.second) / CLHEP::GeV;
     this->m_particleBounds->SetMinEneToParametrise(*def, val);
     this->info("SetMinEneToParametrise [%-16s] = %8.4f GeV", prop.first.c_str(), val);
   }
   for(const auto& prop : this->m_eMax)    {
     G4ParticleDefinition* def = this->getParticleDefinition(prop.first);
-    double val = dd4hep::_toDouble(prop.second) * dd4hep::GeV/CLHEP::GeV;
+    double val = dd4hep::_toDouble(prop.second) / CLHEP::GeV;
     this->m_particleBounds->SetMaxEneToParametrise(*def, val);
     this->info("SetMaxEneToParametrise [%-16s] = %8.4f GeV", prop.first.c_str(), val);
   }
   for(const auto& prop : this->m_eKill)    {
     G4ParticleDefinition* def = this->getParticleDefinition(prop.first);
-    double val = dd4hep::_toDouble(prop.second) * dd4hep::GeV/CLHEP::GeV;
+    double val = dd4hep::_toDouble(prop.second) / CLHEP::GeV;
     this->m_particleBounds->SetEneToKill(*def, val);
     this->info("SetEneToKill           [%-16s] = %8.4f GeV", prop.first.c_str(), val);
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Geant4GFlashShowerModel: remove wrong unit conversions from particleBound properties. Caused particle bounds to be off by 1e3 when GEANT_UNITS were enabled.

ENDRELEASENOTES

The reason why the test failed was that `nan` showed up in the position of the hit.
This nan comes originally from here

https://github.com/Geant4/geant4/blob/dda54bbdcfe0cc76177eaa03a657592aac0b1eb8/source/parameterisations/gflash/src/GFlashHomoShowerParameterisation.cc#L177

_Why_ we only saw this sometimes is not clear. If this is related to the particle bounds, or if we were just lucky before, or something systematic in the functions.