### PR TITLE
DDSim: correct the number of events when running over all events (-1)

### DIFF
--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -304,11 +304,11 @@ def _get(self, name):
   a = Interface.toAction(self)
   ret = Interface.getProperty(a, name)
   if ret.status > 0:
-    return ret.data
+    return _evalProperty(ret.data)
   elif hasattr(self.action, name):
-    return getattr(self.action, name)
+    return _evalProperty(getattr(self.action, name))
   elif hasattr(a, name):
-    return getattr(a, name)
+    return _evalProperty(getattr(a, name))
   msg = 'Geant4Action::GetProperty [Unhandled]: Cannot access property ' + a.name() + '.' + name
   raise KeyError(msg)
 

--- a/DDG4/src/Geant4GeneratorActionInit.cpp
+++ b/DDG4/src/Geant4GeneratorActionInit.cpp
@@ -30,6 +30,8 @@ Geant4GeneratorActionInit::Geant4GeneratorActionInit(Geant4Context* ctxt, const 
   InstanceCount::increment(this);
   context()->kernel().runAction().callAtEnd(this,&Geant4GeneratorActionInit::end);
   context()->kernel().runAction().callAtBegin(this,&Geant4GeneratorActionInit::begin);
+  declareProperty("numberOfEvents", m_evtTotal);
+  declareProperty("numberOfRuns",  m_evtRun);
 }
 
 /// Default destructor


### PR DESCRIPTION




BEGINRELEASENOTES
- DDSim: correct the number of events when running over all events (-1), fixes #1257 
- GenerationActionInit: declare properties to access number of processed runs (numberOfRuns) and events (numberOfEVents)
- DDG4: decode or eval all properties out of str or cppyy.gbl.string types

ENDRELEASENOTES