### PR TITLE
Protect Geant4 Primary creation against negative masses.

### DIFF
--- a/DDCore/include/Parsers/detail/Dimension.h
+++ b/DDCore/include/Parsers/detail/Dimension.h
@@ -746,11 +746,11 @@ namespace dd4hep {
       std::string refStr() const;
       /// Access "module" attribute as STL string
       std::string moduleStr() const;
-      /// Access "module" attribute as STL string
+      /// Access "module" attribute as STL string. Return default value if not present
       std::string moduleStr(const std::string& default_value) const;
       /// Access "readout" attribute as STL string
       std::string readoutStr() const;
-      /// Access "readout" attribute as STL string
+      /// Access "readout" attribute as STL string. Return default value if not present
       std::string readoutStr(const std::string& default_value) const;
       /// Access vis attribute as STL string. If not present empty return empty string
       std::string visStr() const;

--- a/DDCore/include/Parsers/detail/Dimension.h
+++ b/DDCore/include/Parsers/detail/Dimension.h
@@ -746,14 +746,24 @@ namespace dd4hep {
       std::string refStr() const;
       /// Access "module" attribute as STL string
       std::string moduleStr() const;
+      /// Access "module" attribute as STL string
+      std::string moduleStr(const std::string& default_value) const;
       /// Access "readout" attribute as STL string
       std::string readoutStr() const;
+      /// Access "readout" attribute as STL string
+      std::string readoutStr(const std::string& default_value) const;
       /// Access vis attribute as STL string. If not present empty return empty string
       std::string visStr() const;
+      /// Access vis attribute as STL string. If not present empty return empty string
+      std::string visStr(const std::string& default_value) const;
       /// Access region attribute as STL string. If not present empty return empty string
       std::string regionStr() const;
+      /// Access region attribute as STL string. If not present empty return empty string
+      std::string regionStr(const std::string& default_value) const;
       /// Access limits attribute as STL string. If not present empty return empty string
       std::string limitsStr() const;
+      /// Access limits attribute as STL string. If not present empty return empty string
+      std::string limitsStr(const std::string& default_value) const;
     };
 
   }       /* End namespace DD4HEP_DIMENSION_NS        */

--- a/DDCore/include/Parsers/detail/Dimension.imp
+++ b/DDCore/include/Parsers/detail/Dimension.imp
@@ -310,9 +310,19 @@ std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::regionStr() const {
   return m_element.hasAttr(_U(region)) ? m_element.attr < std::string > (_U(region)) : std::string();
 }
 
+/// Access "region" attribute as STL std::string. If not present returns empty string.
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::regionStr(const std::string& default_value) const {
+  return m_element.hasAttr(_U(region)) ? m_element.attr < std::string > (_U(region)) : default_value;
+}
+
 /// Access "limits" attribute as STL std::string. If not present returns empty string.
 std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::limitsStr() const {
   return m_element.hasAttr(_U(limits)) ? m_element.attr < std::string > (_U(limits)) : std::string();
+}
+
+/// Access "limits" attribute as STL std::string. If not present returns empty string.
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::limitsStr(const std::string& default_value) const {
+  return m_element.hasAttr(_U(limits)) ? m_element.attr < std::string > (_U(limits)) : default_value;
 }
 
 /// Access "vis" attribute as STL std::string. If not present returns empty string.
@@ -320,12 +330,27 @@ std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::visStr() const {
   return m_element.hasAttr(_U(vis)) ? m_element.attr < std::string > (_U(vis)) : std::string();
 }
 
+/// Access "vis" attribute as STL std::string. If not present returns empty string.
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::visStr(const std::string& default_value) const {
+  return m_element.hasAttr(_U(vis)) ? m_element.attr < std::string > (_U(vis)) : default_value;
+}
+
 /// Access "readout" attribute as STL std::string. If not present returns empty string.
 std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::readoutStr() const {
   return m_element.hasAttr(_U(readout)) ? m_element.attr < std::string > (_U(readout)) : std::string();
 }
 
+/// Access "readout" attribute as STL std::string. If not present returns empty string.
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::readoutStr(const std::string& default_value) const {
+  return m_element.hasAttr(_U(readout)) ? m_element.attr < std::string > (_U(readout)) : default_value;
+}
+
 /// Access "module" attribute as STL std::string. If not present returns empty string.
 std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::moduleStr() const {
   return m_element.hasAttr(_U(module)) ? m_element.attr < std::string > (_U(module)) : std::string();
+}
+
+/// Access "module" attribute as STL std::string. If not present returns empty string.
+std::string dd4hep::DD4HEP_DIMENSION_NS::Dimension::moduleStr(const std::string& default_value) const {
+  return m_element.hasAttr(_U(module)) ? m_element.attr < std::string > (_U(module)) : default_value;
 }

--- a/DDCore/src/plugins/ShapePlugins.cpp
+++ b/DDCore/src/plugins/ShapePlugins.cpp
@@ -954,7 +954,7 @@ static Ref_t create_shape(Detector& description, xml_h e, SensitiveDetector sens
     mat = description.material(x_det.child(_U(material)).attr<std::string>(_U(name)));
     printout(INFO,"TestShape","+++ Volume material is %s", mat.name());      
   }
-  for ( xml_coll_t itm(e, _U(check)); itm; ++itm, ++count )   {
+  for ( xml_coll_t itm(e, _U(check)); itm; ++itm, ++count )  {
     xml_dim_t   x_check  = itm;
     xml_comp_t  shape      (x_check.child(_U(shape)));
     xml_dim_t   pos        (x_check.child(_U(position), false));
@@ -964,11 +964,19 @@ static Ref_t create_shape(Detector& description, xml_h e, SensitiveDetector sens
     bool        reflectY = x_check.hasChild(_U(reflect_y));
     bool        reflectX = x_check.hasChild(_U(reflect_x));
     std::string shape_type = shape.typeStr();
-    Solid       solid;
     Volume      volume;
+    Solid       solid;
 
-    if ( shape_type == "CAD_Assembly" || shape_type == "CAD_MultiVolume" )   {
+    if ( shape_type == "CAD_Assembly" || shape_type == "CAD_MultiVolume" )  {
       volume = xml::createVolume(description, shape_type, shape);
+      solid  = volume->GetShape();
+    }
+    else if ( shape_type == "StdVolume" )  {
+      volume = xml::createStdVolume(description, shape.child(_U(volume)));
+      solid  = volume->GetShape();
+    }
+    else if ( shape_type == "GenVolume" )  {
+      volume = xml::createVolume(description, shape_type, shape.child(_U(volume)));
       solid  = volume->GetShape();
     }
     else   {

--- a/examples/DDCAD/compact/DD4hep_Issue_1134_resolved.xml
+++ b/examples/DDCAD/compact/DD4hep_Issue_1134_resolved.xml
@@ -1,0 +1,93 @@
+<lccdd>
+<!-- #==========================================================================
+     #  AIDA Detector description implementation 
+     #==========================================================================
+     # Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+     # All rights reserved.
+     #
+     # For the licensing terms see $DD4hepINSTALL/LICENSE.
+     # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+     #
+     #==========================================================================
+
+-->
+
+  <info name=   "DDCAD_test"
+	title=  "Checking issue 1134"
+	author= "Markus Frank"
+	url=    "http://www.cern.ch/lhcb"
+	status= "development"
+	version="1.0">
+    <comment>CAD Shape tester</comment>        
+  </info>
+
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/materials.xml"/>
+  </includes>
+  
+  <materials>
+    <material name="DefaultMaterial">
+      <D value="7.85" unit="g/cm3"/>
+      <fraction n="0.998" ref="Fe"/>
+      <fraction n=".002"  ref="C"/>
+    </material>
+    <material name="Material01">
+      <D value="7.85" unit="g/cm3"/>
+      <fraction n="1.0" ref="Fe"/>
+    </material>
+  </materials>
+
+
+  <define>
+    <constant name="world_side"  value="15*m"/>
+    <constant name="world_x"     value="world_side"/>
+    <constant name="world_y"     value="world_side"/>
+    <constant name="world_z"     value="world_side"/>
+    <constant name="unit_length" value="1*10"/>
+    <constant name="unit_pos"    value="unit_length/10"/>
+    <constant name="CheckShape_create"   value="0"/>
+    <constant name="tracker_region_zmax" value="15*m"/>
+    <constant name="tracker_region_rmax" value="5*m"/>
+  </define>
+
+  <display>
+    <vis name="InvisibleNoDaughters"      showDaughters="false" visible="false"/>
+    <vis name="InvisibleWithDaughters"    showDaughters="true"  visible="false"/>
+    <vis name="Shape1_vis_20"    alpha="0.2" r="0.9" g="0.8" b="0.8" showDaughters="true" visible="true"/>
+    <vis name="ShapeGray_vis_50" alpha="0.5" r="0.9" g="0.8" b="0.8" showDaughters="true" visible="true"/>
+    <vis name="Shape0_vis"       alpha="1.0" r="0"   g="1"   b="1"   showDaughters="true" visible="true"/>
+    <vis name="Shape1_vis"       alpha="1.0" r="1"   g="0"   b="0"   showDaughters="true" visible="true"/>
+    <vis name="Shape2_vis"       alpha="1.0" r="0"   g="1"   b="0"   showDaughters="true" visible="true"/>
+    <vis name="Shape3_vis"       alpha="1.0" r="0"   g="0"   b="1"   showDaughters="true" visible="true"/>
+    <vis name="Shape_grey"       alpha="0.5" r="0.0" g="0.4" b="0.4" showDaughters="true" visible="true"/>
+  </display>
+
+  <detectors>
+    <detector id="1" name="Shape_STL" type="DD4hep_TestShape_Creator">
+      <check>
+        <shape type="StdVolume">
+          <volume name="Assembly" type="Assembly" vis="ShapeGray_vis_50">
+            <volume material="Air" vis="ShapeGray_vis_50">
+              <!-- create a box to place the CAD inside. The box can then be placed into the assembly's origin
+                   and rotated/positioned as desired.  -->
+              <shape name="box" type="Box" dx="8*cm" dy="8*cm" dz="30*cm">
+                <volume type="CAD_MultiVolume"
+    	          ref="${DD4hepExamplesINSTALL}/examples/DDCAD/models/STL/DD4hep_Issue_1134.stl"
+	          unit="cm">
+                  <!-- select shape # 0 from the multi-shape CAD and place it in the origin of the box -->
+      	          <volume id="0" name="s1" vis="Shape3_vis" material="Gold"/>
+                  <position x="454*mm" y="-9*mm" z="-385*mm"/>
+                  <rotation x="0*pi/8*rad" y="-2*pi/8*rad" z="0*rad"/>
+                </volume>
+              </shape>
+            </volume>
+          </volume>
+        </shape>
+
+        <rotation x="2*pi/8*rad" y="0*pi/8*rad" z="0*rad"/>  
+
+      </check>
+    </detector>
+  </detectors>
+</lccdd>


### PR DESCRIPTION
BEGINRELEASENOTES
- Protect Geant4 Primary creation against negative masses.
- See issue https://github.com/AIDASoft/DD4hep/issues/1233 for a detailed discussion of the problem.
- Allow shapes to be defined recursively using shape creation plugin.
- Show how to properly use CAD shapes with a non-zero origin (Issue : https://github.com/AIDASoft/DD4hep/issues/1200)
   examples/DDCAD/compact/DD4hep_Issue_1134_resolved.xml
   Once the CAD shape (aka volume) is placed correctly into the origin of a mother mother, the mother can then be placed 
   rotated and shifted according to the the boxed mother's origin like any other volume.
ENDRELEASENOTES