### PR TITLE
Enhance handling of transformations in VolumeBuilder

### DIFF
--- a/DDCore/include/XML/VolumeBuilder.h
+++ b/DDCore/include/XML/VolumeBuilder.h
@@ -187,6 +187,8 @@ namespace dd4hep {
         /// Collect a set of materials from the leafs of an xml tag
         size_t collectMaterials(Handle_t element);
         
+        /// Access element from transformation cache by name
+        Transform3D getTransform(const std::string& nam)  const;
         /// Access element from shape cache by name. Invalid returns means 'veto'. Otherwise exception
         Solid getShape(const std::string& nam)  const;
         /// Create a new shape from the information given in the xml handle

--- a/DDCore/src/XML/VolumeBuilder.cpp
+++ b/DDCore/src/XML/VolumeBuilder.cpp
@@ -94,6 +94,15 @@ dd4hep::Volume VolumeBuilder::volume(const std::string& nam)  const    {
   return vol;
 }
 
+/// Access element from transformation cache by name
+dd4hep::Transform3D VolumeBuilder::getTransform(const std::string& nam)  const   {
+  auto it = transformations.find(nam);
+  if ( it == transformations.end() )  {
+    except("VolumeBuilder","+++ Tranformation %s is not known to this builder unit. ",nam.c_str());
+  }
+  return (*it).second.second;
+}
+
 /// Access element from shape cache by name. Invalid returns means 'veto'. Otherwise exception
 dd4hep::Solid VolumeBuilder::getShape(const std::string& nam)  const   {
   auto is = shapes.find(nam);
@@ -434,6 +443,7 @@ std::size_t VolumeBuilder::load(xml_h element, const std::string& tag)  {
              "++ Processing xml document %s.", doc->uri().c_str());
     included_docs[ref] = std::unique_ptr<xml::DocumentHolder>(doc.release());
     buildShapes(vols);
+    buildTransformations(vols);
     buildVolumes(vols);
     ++count;
   }


### PR DESCRIPTION
The `VolumeBuilder` helper class has a store for transformations and a function to populate it from the XML but that function is never called.  In addition there is no access function (analogous to `getShape` or `volume`) to retrieve the transformations from the store.  This PR adds a call to `buildTransformations` in the `load` function to populate the store and adds a new `getTransform` function to retrieve objects from the store.

BEGINRELEASENOTES
- Enhance handling of transformations in VolumeBuilder

ENDRELEASENOTES