### PR TITLE
Transparently introduce switch to optional parameter values

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -444,7 +444,11 @@ void Geant4Output2EDM4hep::saveEvent(OutputContext<G4Event>& ctxt)  {
     parameters->extractParameters(m_frame);
 #if PODIO_BUILD_VERSION > PODIO_VERSION(0, 16, 2)
     // This functionality is only present in podio > 0.16.2
+#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 99, 0)
+    eventWeight = m_frame.getParameter<double>("EventWeights").value_or(0.0);
+#else
     eventWeight = m_frame.getParameter<double>("EventWeights");
+#endif
 #endif
   } else { // ... or from DD4hep framework
     runNumber = m_runNo + runNumberOffset;

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -127,7 +127,7 @@ namespace dd4hep {
         printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
         frame.putParameter(p.first, p.second);
       }
-#if podio_VERSION_MAJOR > 0 || podio_VERSION_MINOR > 16 || podio_VERSION_PATCH > 2
+#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 16, 2)
       // This functionality is only present in podio > 0.16.2
       for (auto const& p: this->dblParameters()) {
         printout(DEBUG, "Geant4OutputEDM4hep", "Saving event parameter: %s", p.first.c_str());
@@ -149,7 +149,7 @@ namespace dd4hep {
         printout(DEBUG, "Geant4OutputEDM4hep", "Saving run parameter: %s", p.first.c_str());
         frame.putParameter(p.first, p.second);
       }
-#if podio_VERSION_MAJOR > 0 || podio_VERSION_MINOR > 16 || podio_VERSION_PATCH > 2
+#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 16, 2)
       // This functionality is only present in podio > 0.16.2
       for (auto const& p: this->dblParameters()) {
         printout(DEBUG, "Geant4OutputEDM4hep", "Saving run parameter: %s", p.first.c_str());
@@ -442,7 +442,7 @@ void Geant4Output2EDM4hep::saveEvent(OutputContext<G4Event>& ctxt)  {
     runNumber = parameters->runNumber() + runNumberOffset;
     eventNumber = parameters->eventNumber() + eventNumberOffset;
     parameters->extractParameters(m_frame);
-#if podio_VERSION_MAJOR > 0 || podio_VERSION_MINOR > 16 || podio_VERSION_PATCH > 2
+#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 16, 2)
     // This functionality is only present in podio > 0.16.2
     eventWeight = m_frame.getParameter<double>("EventWeights");
 #endif


### PR DESCRIPTION
BEGINRELEASENOTES
- EDM4hepOUTPUT: Introduce pre-processor checks to transparently switch to the new `std::optional` return values of `podio::Frame::getParameter` (introduced with [AIDASoft/podio#580](https://github.com/AIDASoft/podio/pull/580))

ENDRELEASENOTES