### PR TITLE
XMLElements: fix tinyxml include

### DIFF
--- a/DDCore/src/XML/XMLElements.cpp
+++ b/DDCore/src/XML/XMLElements.cpp
@@ -1266,7 +1266,8 @@ Handle_t Document::clone(Handle_t source) const {
 }
 
 #ifdef DD4HEP_USE_TINYXML
-#include <tinyxml_inl.h>
-#include <tinyxmlerror_inl.h>
-#include <tinyxmlparser_inl.h>
+//These files are located parallel to this one, we cannot use angle brackets for include
+#include "tinyxml_inl.h"
+#include "tinyxmlerror_inl.h"
+#include "tinyxmlparser_inl.h"
 #endif


### PR DESCRIPTION

BEGINRELEASENOTES
- XMLElements: fix build when not using XercesC, failing to include header files

ENDRELEASENOTES