### PR TITLE
Allow finding newer versions of podio (for EDM4hep IO)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ endif()
 
 if(DD4HEP_USE_EDM4HEP)
   find_package(EDM4HEP REQUIRED)
-  find_package(podio 0.16.3 REQUIRED)
+  find_package(podio REQUIRED)
 #  DD4HEP_SETUP_EDM4HEP_TARGETS()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,13 @@ endif()
 
 if(DD4HEP_USE_EDM4HEP)
   find_package(EDM4HEP REQUIRED)
-  find_package(podio REQUIRED)
+  # we need podio with Frame support (>=0.16.3)
+  # podio is "SameMajorVersion" compatible
+  find_package(podio 0.16.3)  # this will not find 1.0 and newer
+  if(NOT podio_FOUND)
+    # we try to find a newer version now
+    find_package(podio 1.0 REQUIRED)
+  endif()
 #  DD4HEP_SETUP_EDM4HEP_TARGETS()
 endif()
 


### PR DESCRIPTION
After podio changed to 1.0.0 (see https://github.com/AIDASoft/podio/commit/072c7dce699a2dc90f225cb0a75a4f2ce9677cf8), cmake won't run when asking for version 0.16.3. I think we can remove the requirement and let the build systems figure which versions are compatible with which.

The error when configuring is:

```
  >> 61    CMake Error at CMakeLists.txt:158 (find_package):
     62      Could not find a configuration file for package "podio" that is co
           mpatible
     63      with requested version "0.16.3".
     64    
     65      The following configuration files were considered but not accepted
           :
     66    
     67        /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2024-06-21/x86_64-a
           lmalinux9-gcc11.4.1-opt/podio/072c7dce699a2dc90f225cb0a75a4f2ce9677c
           f8_develop-52hwbt/lib64/cmake/podio/podioConfig.cmake, version: 1.0.
           0
```

BEGINRELEASENOTES
- CMake: Allow finding version 1.0 (and newer) for podio

ENDRELEASENOTES