### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/DDCore/src/plugins/CodeGenerator.cpp
+++ b/DDCore/src/plugins/CodeGenerator.cpp
@@ -667,9 +667,8 @@ static long generate_cxx(Detector& description, int argc, char** argv) {
 
   for(int i=0; i<argc; ++i)  {
     char c = ::tolower(argv[i][0]);
-    char* p = argv[i];
-    if ( c == '-' ) { ++p; c = ::tolower(argv[i][1]); }
-    if ( c == '-' ) { ++p; c = ::tolower(argv[i][1]); }
+    if ( c == '-' ) { c = ::tolower(argv[i][1]); }
+    if ( c == '-' ) { c = ::tolower(argv[i][1]); }
     if ( c == 'o' && i+1<argc )
       output = argv[++i];
     else if ( c == 'f' && i+1<argc )

--- a/DDCore/src/plugins/TGeoCodeGenerator.cpp
+++ b/DDCore/src/plugins/TGeoCodeGenerator.cpp
@@ -536,9 +536,8 @@ static long generate_cxx(Detector& description, int argc, char** argv) {
 
   for(int i=0; i<argc; ++i)  {
     char c = ::tolower(argv[i][0]);
-    char* p = argv[i];
-    if ( c == '-' ) { ++p; c = ::tolower(argv[i][1]); }
-    if ( c == '-' ) { ++p; c = ::tolower(argv[i][1]); }
+    if ( c == '-' ) { c = ::tolower(argv[i][1]); }
+    if ( c == '-' ) { c = ::tolower(argv[i][1]); }
     if ( c == 'o' && i+1<argc )
       output = argv[++i];
     else if ( c == 'f' && i+1<argc )

--- a/DDDigi/src/DigiSegmentSplitter.cpp
+++ b/DDDigi/src/DigiSegmentSplitter.cpp
@@ -87,7 +87,6 @@ std::vector<std::string> DigiSegmentSplitter::collection_names()  const   {
 /// Initialization function
 void DigiSegmentSplitter::initialize()   {
   char text[256];
-  std::size_t count = 0;
 
   m_split_tool.set_detector(m_detector_name);
   m_keys          = m_split_tool.collection_keys();
@@ -135,7 +134,6 @@ void DigiSegmentSplitter::initialize()   {
     auto* w = new worker_t(proc, m_split_context);
     w->options.enable(id);
     m_workers.insert(w);
-    ++count;
   }
   info("+++ Detector splitter is now fully initialized!");
 }

--- a/DDEve/src/ElementList.cpp
+++ b/DDEve/src/ElementList.cpp
@@ -55,8 +55,8 @@ TEveElementList* ElementList::CloneElement() const  {
 
 /// Instantiator
 ElementListContextMenu& ElementListContextMenu::install(Display* disp)   {
-  static ElementListContextMenu s(disp);
-  return s;
+  static ElementListContextMenu menu(disp);
+  return menu;
 }
 
 /// Initializing constructor

--- a/DDEve/src/ParticleActors.cpp
+++ b/DDEve/src/ParticleActors.cpp
@@ -89,13 +89,11 @@ void MCParticleCreator::addCompound(const std::string& name, TEveLine* e)   {
 void MCParticleCreator::addCompoundLight(const std::string& name, TEveLine* e)   {
   Compounds::const_iterator i = types.find(name);
   if ( i == types.end() )  {
-    static int icol = 0;
     TEveCompound* o = new TEveCompound(name.c_str(),name.c_str());
     particles->AddElement(o);
     i = types.emplace(name,o).first;
     o->SetMainColor(kBlack);
     o->CSCApplyMainColorToAllChildren();
-    ++icol;
   }
   TEveCompound* c = (*i).second;
   e->SetLineWidth(1);

--- a/DDG4/plugins/Geant4EventReaderHepMC.cpp
+++ b/DDG4/plugins/Geant4EventReaderHepMC.cpp
@@ -728,17 +728,13 @@ void HepMC::EventStream::clear()   {
 bool HepMC::EventStream::read()   {
   EventStream& info = *this;
   bool event_read = false;
-  static int num_evt = 0;
-  int num_line = 0, num_line_accepted = 0;
 
   detail::releaseObjects(vertices());
   detail::releaseObjects(particles());
 
-  ++num_evt;
   while( instream.good() ) {
     char value = instream.peek();
     std::istringstream input_line;
-    ++num_line;
     if      ( value == 'E' && event_read )
       break;
     else if ( instream.eof() && event_read )
@@ -755,7 +751,6 @@ bool HepMC::EventStream::read()   {
     if( !input_line || value < 0 )
       goto Skip;
 
-    ++num_line_accepted;
     switch( value )   {
     case 'H':  {
       int iotype = 0;

--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -37,7 +37,6 @@
 
 // C/C++ include files
 #include <set>
-#include <stdexcept>
 #include <algorithm>
 
 using namespace dd4hep::sim;
@@ -508,11 +507,11 @@ void Geant4ParticleHandler::rebaseSimulatedTracks(int )   {
       Geant4ParticleHandle p = (*ipar).second;
       equivalents[(*ie).first] = p->id;  // requires (1) to be filled properly!
       const G4ParticleDefinition* def = p.definition();
-      int pdg = int(fabs(def->GetPDGEncoding())+0.1);
+      int pdg = int(std::abs(def->GetPDGEncoding())+0.1);
       if ( pdg != 0 && pdg<36 && !(pdg > 10 && pdg < 17) && pdg != 22 )  {
         error("+++ ERROR: Geant4 particle for track:%d last known is:%d -- is gluon or quark!",equiv,g4_equiv);
       }
-      pdg = int(fabs(p->pdgID)+0.1);
+      pdg = int(std::abs(p->pdgID)+0.1);
       if ( pdg != 0 && pdg<36 && !(pdg > 10 && pdg < 17) && pdg != 22 )  {
         error("+++ ERROR(2): Geant4 particle for track:%d last known is:%d -- is gluon or quark!",equiv,g4_equiv);
       }

--- a/UtilityApps/src/materialBudget.cpp
+++ b/UtilityApps/src/materialBudget.cpp
@@ -217,14 +217,15 @@ int main_wrapper(int argc, char** argv)   {
 
   for(int i=0 ; i< nbins ;++i){
     double theta = ( etaMax > 0. ?  2. * atan ( exp ( - ( etaMin + (0.5+i)*dEta) ) ) : ( thetaMin + (0.5+i)*dTheta ) ) ;
-    std::stringstream line;
+    std::stringstream paramLine;
 
-    line << std::scientific << theta << " " ;
+    paramLine << std::scientific << theta << " " ;
     for( auto& det : subdets )  {
       Vector3D p0 = pointOnCylinder( theta, det.r0 , det.z0 , phi0  ) ;// double theta, double r, double z, double phi)
       Vector3D p1 = pointOnCylinder( theta, det.r1 , det.z1 , phi0  ) ;// double theta, double r, double z, double phi)
       const MaterialVec& materials = matMgr.materialsBetween(p0, p1);
-      double sum_x0(0.), sum_lambda(0.),path_length(0.);
+      double sum_x0(0.), sum_lambda(0.);
+      // double path_length(0.);
 
       for( auto amat : materials )  {
         TGeoMaterial* mat =  amat.first->GetMaterial();
@@ -233,15 +234,15 @@ int main_wrapper(int argc, char** argv)   {
         sum_x0 += nx0;
         double nLambda = length / mat->GetIntLen();
         sum_lambda += nLambda;
-        path_length += length;
+        // path_length += length;
       }
 
       double binX = ( etaMax > 0. ? (etaMin + (0.5+i)*dEta) : -theta/M_PI*180. ) ;
       det.hx->Fill( binX , sum_x0 ) ;
       det.hl->Fill( binX , sum_lambda ) ;
-      line  << std::scientific  << sum_x0 << "  " << sum_lambda << "  " ; // << path_length ;
+      paramLine  << std::scientific  << sum_x0 << "  " << sum_lambda << "  " ; // << path_length ;
     }
-    std::cout << line.str() << std::endl;
+    std::cout << paramLine.str() << std::endl;
   }  
   std::cout  << "====================================================================================================" << std::endl ;
   rootFile->Write();


### PR DESCRIPTION
`PySys_SetArgv` is deprecated since Python 3.11 (see https://docs.python.org/3/c-api/init.html#c.PySys_SetArgv). The recommended way can be found [here](https://docs.python.org/3/c-api/init_config.html#init-config). I also removed a couple of checks for Python 3.

BEGINRELEASENOTES
- Fix warnings related to unused variables and shadowing of already existing variables
- Don't use the deprecated `PySys_SetArgv`

ENDRELEASENOTES