### PR TITLE
Update to global alignment

### DIFF
--- a/DDAlign/include/DDAlign/AlignmentTags.h
+++ b/DDAlign/include/DDAlign/AlignmentTags.h
@@ -13,8 +13,8 @@
 #ifndef DDALIGN_ALIGNMENTTAGS_H
 #define DDALIGN_ALIGNMENTTAGS_H
 
-// Framework include files
-#include "XML/XMLElements.h"
+/// Framework include files
+#include <XML/XMLElements.h>
 #ifndef UNICODE
 #define UNICODE(x)  extern const ::dd4hep::xml::Tag_t Unicode_##x 
 #endif
@@ -45,7 +45,7 @@ namespace dd4hep {
 }
 
 #undef UNICODE // Do not miss this one!
-#include "XML/XMLTags.h"
+#include <XML/XMLTags.h>
 
 #define _ALU(a) ::dd4hep::DDAlign::Unicode_##a
 

--- a/DDAlign/include/DDAlign/AlignmentsCalib.h
+++ b/DDAlign/include/DDAlign/AlignmentsCalib.h
@@ -14,11 +14,11 @@
 #define DDALIGN_ALIGNMENTSCALIB_H
 
 // Framework includes
-#include "DD4hep/DetElement.h"
-#include "DD4hep/Alignments.h"
-#include "DD4hep/AlignmentData.h"
-#include "DD4hep/ConditionsMap.h"
-#include "DD4hep/AlignmentsCalculator.h"
+#include <DD4hep/DetElement.h>
+#include <DD4hep/Alignments.h>
+#include <DD4hep/AlignmentData.h>
+#include <DD4hep/ConditionsMap.h>
+#include <DD4hep/AlignmentsCalculator.h>
 
 // C/C++ include files
 #include <set>

--- a/DDAlign/include/DDAlign/GlobalAlignmentCache.h
+++ b/DDAlign/include/DDAlign/GlobalAlignmentCache.h
@@ -14,9 +14,9 @@
 #define DDALIGN_GLOBALALIGNMENTCACHE_H
 
 // Framework include files
-#include "DD4hep/ExtensionEntry.h"
-#include "DD4hep/GlobalAlignment.h"
-#include "DDAlign/GlobalAlignmentStack.h"
+#include <DD4hep/ExtensionEntry.h>
+#include <DD4hep/GlobalAlignment.h>
+#include <DDAlign/GlobalAlignmentStack.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDAlign/include/DDAlign/GlobalAlignmentOperators.h
+++ b/DDAlign/include/DDAlign/GlobalAlignmentOperators.h
@@ -14,9 +14,9 @@
 #define DDALIGN_GLOBALALIGNMENTOPERATORS_H
 
 // Framework include files
-#include "DD4hep/Alignments.h"
-#include "DD4hep/GlobalAlignment.h"
-#include "DDAlign/GlobalAlignmentCache.h"
+#include <DD4hep/Alignments.h>
+#include <DD4hep/GlobalAlignment.h>
+#include <DDAlign/GlobalAlignmentCache.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDAlign/include/DDAlign/GlobalAlignmentStack.h
+++ b/DDAlign/include/DDAlign/GlobalAlignmentStack.h
@@ -14,10 +14,9 @@
 #define DDALIGN_GLOBALALIGNMENTSTACK_H
 
 // Framework include files
-#include "DD4hep/Alignments.h"
-#include "DD4hep/AlignmentData.h"
-//#include "DD4hep/Objects.h"
-#include "DD4hep/Memory.h"
+#include <DD4hep/Alignments.h>
+#include <DD4hep/AlignmentData.h>
+#include <DD4hep/Memory.h>
 
 
 /// Namespace for the AIDA detector description toolkit

--- a/DDAlign/include/DDAlign/GlobalAlignmentWriter.h
+++ b/DDAlign/include/DDAlign/GlobalAlignmentWriter.h
@@ -14,9 +14,9 @@
 #define DDALIGN_GLOBALALIGNMENTWRITER_H
 
 // Framework include files
-#include "XML/XMLElements.h"
-#include "DD4hep/DetElement.h"
-#include "DD4hep/GlobalAlignment.h"
+#include <XML/XMLElements.h>
+#include <DD4hep/DetElement.h>
+#include <DD4hep/GlobalAlignment.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDAlign/include/DDAlign/GlobalDetectorAlignment.h
+++ b/DDAlign/include/DDAlign/GlobalDetectorAlignment.h
@@ -14,8 +14,8 @@
 #define DDALIGN_GLOBALDETECTORALIGNMENT_H
 
 // Framework include files
-#include "DD4hep/DetElement.h"
-#include "DD4hep/GlobalAlignment.h"
+#include <DD4hep/DetElement.h>
+#include <DD4hep/GlobalAlignment.h>
 
 // Forward declarations
 class TGeoHMatrix;

--- a/DDAlign/src/GlobalDetectorAlignment.cpp
+++ b/DDAlign/src/GlobalDetectorAlignment.cpp
@@ -24,10 +24,14 @@
 #include <TGeoMatrix.h>
 #include <TGeoManager.h>
 
-
 #ifdef __GNUC__    // Disable some diagnostics.
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif
+
+using LevelElements = std::vector<std::pair<int,dd4hep::DetElement> >;
+using namespace dd4hep::align;
+using dd4hep::printout;
+using dd4hep::INFO;
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -43,63 +47,95 @@ namespace dd4hep {
      */
     class GlobalAlignmentData : public NamedObject  {
     public:
-      GlobalAlignment global;
+      GlobalAlignment              global;
       std::vector<GlobalAlignment> volume_alignments;
+      
     public:
-      GlobalAlignmentData(const std::string& path) : NamedObject(path,"global-alignment") {
-        global = GlobalAlignment(path);
+      GlobalAlignmentData(const std::string& path)
+        : NamedObject(path, "global-alignment")
+      {
+        this->global = GlobalAlignment( path );
       }
-      virtual ~GlobalAlignmentData() {
-        detail::destroyHandle (global);
+      virtual ~GlobalAlignmentData()  {
+        detail::destroyHandle( this->global );
       }
     };
-  } /* End namespace Aligments               */
-} /* End namespace dd4hep                    */
-
-using namespace dd4hep::align;
-typedef std::vector<std::pair<int,dd4hep::DetElement> > LevelElements;
+  }   /* End namespace Aligments               */
+}     /* End namespace dd4hep                  */
 
 DD4HEP_INSTANTIATE_HANDLE_NAMED(GlobalAlignmentData);
 
 namespace {
 
-  static bool s_GlobalDetectorAlignment_debug = false;
-  
+  static bool s_GlobalDetectorAlignment_debug = true;
+
   GlobalAlignment _align(const GlobalAlignment& a, TGeoHMatrix* transform, bool check, double overlap) {
-    TGeoPhysicalNode* n = a.ptr();
-    if ( n )  {
-      TGeoMatrix* mm = n->GetNode()->GetMatrix();
+    TGeoPhysicalNode* node = a.ptr();
+    if ( node )  {
+      TGeoMatrix* mm = node->GetNode()->GetMatrix();
       bool dbg = GlobalDetectorAlignment::debug();
       if ( dbg )  {
-        printout(dd4hep::INFO,"Alignment","DELTA matrix of %s", n->GetName());
+        printout(INFO, "Alignment", "DELTA matrix of %s", node->GetName());
         transform->Print();
-        dd4hep::printout(dd4hep::INFO,"Alignment","OLD matrix of %s", n->GetName());
+        printout(INFO, "Alignment", "OLD matrix of %s", node->GetName());
         mm->Print();
       }
+      std::vector<dd4hep::PlacedVolume> places;
+      for( int i = 0; i < node->GetLevel(); ++i )
+        places.emplace_back(node->GetNode(i+1));
+
       transform->MultiplyLeft(mm); // orig * delta
-      n->Align(transform, 0, check, overlap);
-      if ( dbg )   {
-        dd4hep::printout(dd4hep::INFO,"Alignment","NEW matrix of %s", n->GetName());
-        n->GetNode()->GetMatrix()->Print();
+      node->Align(transform, 0, check, overlap);
+      if ( dbg )  {
+        printout(INFO, "Alignment", "NEW matrix of %s", node->GetName());
+        node->GetNode()->GetMatrix()->Print();
       }
+
+      for( int i = 0; i < node->GetLevel(); ++i )  {
+        //const char *tag = "    ";
+        dd4hep::PlacedVolume p = node->GetNode(i+1);
+        if ( nullptr == p->GetUserExtension() )  {
+          //tag = "SET ";
+          p->SetUserExtension(places[i]->GetUserExtension());
+        }
+#if 0
+        printout(INFO, "Alignment", "_align(places):  %s Path[%d]: %-24s %p <-> %p %s",
+                 tag, i, p.name(), p.ptr(), places[i].ptr(), places[i].name());
+        tag = "    ";
+#endif
+        dd4hep::Volume v = p->GetVolume();
+        if ( nullptr == v->GetUserExtension() )  {
+          //tag = "SET ";
+          v->SetUserExtension(places[i].volume()->GetUserExtension());
+        }
+#if 0
+        printout(INFO, "Alignment", "_align(volumes): %s Path[%d]: %-24s %p <-> %p %s",
+                 tag, i, v.name(), v.ptr(), places[i].volume().ptr(), places[i].volume().name());
+        p.access();
+        v.access();
+        places[i].access();
+        places[i].volume().access();
+#endif
+      }
+
       /*
-        printout(dd4hep::INFO,"Alignment","Apply new relative matrix  mother to daughter:");
+        printout(INFO, "Alignment", "Apply new relative matrix  mother to daughter:");
         transform->Print();
         transform->MultiplyLeft(mm); // orig * delta
-        printout(dd4hep::INFO,"Alignment","With deltas %s ....", n->GetName());
+        printout(INFO, "Alignment", "With deltas %s ....", n->GetName());
         transform->Print();
         n->Align(transform, 0, check, overlap);
-
+        
         Position local, global = a.toGlobal(local);
         cout << "Local:" << local << " Global: " << global
         << " and back:" << a.globalToLocal(global) << endl;
       */
-      return GlobalAlignment(n);
+      return GlobalAlignment(node);
     }
     dd4hep::except("GlobalDetectorAlignment", "Cannot align non existing physical node. [Invalid Handle]");
     return { };
   }
-
+  
   GlobalAlignment _alignment(const GlobalDetectorAlignment& det)  {
     dd4hep::DetElement::Object& e = det._data();
     if ( !e.global_alignment.isValid() )  {
@@ -118,17 +154,17 @@ namespace {
     int level = 0;
     dd4hep::detail::tools::PlacementPath nodes;
     dd4hep::detail::tools::ElementPath   det_nodes;
-    dd4hep::detail::tools::placementPath(det,nodes);
-    dd4hep::detail::tools::elementPath(det,det_nodes);
+    dd4hep::detail::tools::placementPath(det, nodes);
+    dd4hep::detail::tools::elementPath(det, det_nodes);
     ///    std::cout << "Placement path:";
     dd4hep::detail::tools::PlacementPath::const_reverse_iterator j=nodes.rbegin();
     dd4hep::detail::tools::ElementPath::const_reverse_iterator   k=det_nodes.rbegin();
     for(; j!=nodes.rend(); ++j, ++level)  {
       //cout << "(" << level << ") " << (void*)((*j).ptr())
       //           << " " << string((*j)->GetName()) << " ";
-      if ( ::strcmp((*j).ptr()->GetName(),(*k).placement().ptr()->GetName()) )  {
+      if ( ::strcmp((*j).ptr()->GetName(), (*k).placement().ptr()->GetName()) )  {
         //cout << "[DE]";
-        elements.emplace_back(level,*k);
+        elements.emplace_back(level, *k);
         ++k;
       }
       else  {
@@ -166,7 +202,7 @@ bool GlobalDetectorAlignment::debug(bool value)   {
 
 /// Collect all placements from the detector element up to the world volume
 void GlobalDetectorAlignment::collectNodes(std::vector<PlacedVolume>& nodes)   {
-  detail::tools::placementPath(*this,nodes);
+  detail::tools::placementPath(*this, nodes);
 }
 
 /// Access to the alignment block
@@ -188,62 +224,62 @@ const std::vector<GlobalAlignment>& GlobalDetectorAlignment::volumeAlignments() 
 
 /// Align the PhysicalNode of the placement of the detector element (translation only)
 GlobalAlignment GlobalDetectorAlignment::align(const Position& pos, bool chk, double overlap) {
-  return align(detail::matrix::_transform(pos),chk,overlap);
+  return align(detail::matrix::_transform(pos), chk, overlap);
 }
 
 /// Align the PhysicalNode of the placement of the detector element (rotation only)
 GlobalAlignment GlobalDetectorAlignment::align(const RotationZYX& rot, bool chk, double overlap) {
-  return align(detail::matrix::_transform(rot),chk,overlap);
+  return align(detail::matrix::_transform(rot), chk, overlap);
 }
 
 /// Align the PhysicalNode of the placement of the detector element (translation + rotation)
 GlobalAlignment GlobalDetectorAlignment::align(const Position& pos, const RotationZYX& rot, bool chk, double overlap) {
-  return align(detail::matrix::_transform(pos,rot),chk,overlap);
+  return align(detail::matrix::_transform(pos, rot), chk, overlap);
 }
 
 /// Align the physical node according to a generic Transform3D
 GlobalAlignment GlobalDetectorAlignment::align(const Transform3D& transform, bool chk, double overlap)  {
-  return align(detail::matrix::_transform(transform),chk,overlap);
+  return align(detail::matrix::_transform(transform), chk, overlap);
 }
 
 /// Align the physical node according to a generic TGeo matrix
 GlobalAlignment GlobalDetectorAlignment::align(TGeoHMatrix* matrix, bool chk, double overlap)  {
-  return _align(_alignment(*this),matrix,chk,overlap);
+  return _align(_alignment(*this), matrix, chk, overlap);
 }
 
 /// Align the PhysicalNode of the placement of the detector element (translation only)
 GlobalAlignment GlobalDetectorAlignment::align(const std::string& elt_path, const Position& pos, bool chk, double overlap) {
-  return align(elt_path,detail::matrix::_transform(pos),chk,overlap);
+  return align(elt_path,detail::matrix::_transform(pos), chk, overlap);
 }
 
 /// Align the PhysicalNode of the placement of the detector element (rotation only)
 GlobalAlignment GlobalDetectorAlignment::align(const std::string& elt_path, const RotationZYX& rot, bool chk, double overlap) {
-  return align(elt_path,detail::matrix::_transform(rot),chk,overlap);
+  return align(elt_path,detail::matrix::_transform(rot), chk, overlap);
 }
 
 /// Align the PhysicalNode of the placement of the detector element (translation + rotation)
 GlobalAlignment 
 GlobalDetectorAlignment::align(const std::string& elt_path, const Position& pos, const RotationZYX& rot, bool chk, double overlap) {
-  return align(elt_path,detail::matrix::_transform(pos,rot),chk,overlap);
+  return align(elt_path,detail::matrix::_transform(pos, rot), chk, overlap);
 }
 
 /// Align the physical node according to a generic Transform3D
 GlobalAlignment GlobalDetectorAlignment::align(const std::string& elt_path, const Transform3D& transform, bool chk, double overlap)  {
-  return align(elt_path,detail::matrix::_transform(transform),chk,overlap);
+  return align(elt_path,detail::matrix::_transform(transform), chk, overlap);
 }
 
 /// Align the physical node according to a generic TGeo matrix
 GlobalAlignment GlobalDetectorAlignment::align(const std::string& elt_path, TGeoHMatrix* matrix, bool chk, double overlap)  {
   if ( elt_path.empty() )
-    return _align(_alignment(*this),matrix,chk,overlap);
+    return _align(_alignment(*this), matrix, chk, overlap);
   else if ( elt_path == placementPath() )
-    return _align(_alignment(*this),matrix,chk,overlap);
+    return _align(_alignment(*this), matrix, chk, overlap);
   else if ( elt_path[0] == '/' )   {
     GlobalAlignment a(elt_path);
     volumeAlignments().emplace_back(a);
-    return _align(a,matrix,chk,overlap);
+    return _align(a, matrix, chk, overlap);
   }
-  GlobalAlignment a(placementPath()+'/'+elt_path);
+  GlobalAlignment a(placementPath() + '/' + elt_path);
   volumeAlignments().emplace_back(a);
-  return _align(a,matrix,chk,overlap);
+  return _align(a, matrix, chk, overlap);
 }

--- a/DDCore/src/GlobalAlignment.cpp
+++ b/DDCore/src/GlobalAlignment.cpp
@@ -13,47 +13,42 @@
 
 // Framework include files
 #include <DD4hep/GlobalAlignment.h>
-#include <DD4hep/InstanceCount.h>
 #include <DD4hep/MatrixHelpers.h>
 #include <DD4hep/Printout.h>
 
 // ROOT include files
-#include <TGeoMatrix.h>
 #include <TGeoManager.h>
-
-using namespace dd4hep;
-using namespace dd4hep::align;
 
 namespace  {
   struct CheckHandle  {
-    CheckHandle(const GlobalAlignment& a)  {
+    CheckHandle(const dd4hep::align::GlobalAlignment& a)  {
       if ( a.isValid() ) return;
-      except("dd4hep:GlobalAlignment", "Attempt to access invalid alignment object. [Invalid Handle]");
+      dd4hep::except("dd4hep:GlobalAlignment", "Attempt to access invalid alignment object. [Invalid Handle]");
     }
     ~CheckHandle() {}
   };
 }
 
 /// Initializing constructor to create a new object
-GlobalAlignment::GlobalAlignment(const std::string& path) {
+dd4hep::align::GlobalAlignment::GlobalAlignment(const std::string& path) {
   //cout << "GlobalAlignment: path=" << path << endl;
   m_element = new TGeoPhysicalNode(path.c_str());
 }
 
 /// Number of nodes in this branch
-int GlobalAlignment::numNodes() const  {
+int dd4hep::align::GlobalAlignment::numNodes() const  {
   CheckHandle verify_handle(*this);
   return ptr()->GetLevel();
 }
 
 /// Access the placement of this node
-PlacedVolume GlobalAlignment::placement()   const   {
+dd4hep::PlacedVolume dd4hep::align::GlobalAlignment::placement()   const   {
   CheckHandle verify_handle(*this);
   return ptr()->GetNode(0);
 }
 
 /// Access the placement of a node in the chain of placements for this branch
-PlacedVolume GlobalAlignment::nodePlacement(int level)   const   {
+dd4hep::PlacedVolume dd4hep::align::GlobalAlignment::nodePlacement(int level)   const   {
   CheckHandle verify_handle(*this);
   TGeoNode* n = ptr()->GetNode(level);
   if ( n ) return n;
@@ -63,7 +58,7 @@ PlacedVolume GlobalAlignment::nodePlacement(int level)   const   {
 }
 
 /// Access the placement of the mother of this node
-PlacedVolume GlobalAlignment::motherPlacement(int level_up)   const    {
+dd4hep::PlacedVolume dd4hep::align::GlobalAlignment::motherPlacement(int level_up)   const    {
   CheckHandle verify_handle(*this);
   Int_t ind = ptr()->GetLevel()-level_up;
   if ( ind >= 0 )  {
@@ -75,13 +70,13 @@ PlacedVolume GlobalAlignment::motherPlacement(int level_up)   const    {
 }
 
 /// Access the currently applied alignment/placement matrix
-Transform3D GlobalAlignment::toGlobal(int level) const   {
+dd4hep::Transform3D dd4hep::align::GlobalAlignment::toGlobal(int level) const   {
   CheckHandle verify_handle(*this);
   return detail::matrix::_transform(ptr()->GetMatrix(level));
 }
 
 /// Transform a point from local coordinates of a given level to global coordinates
-Position GlobalAlignment::toGlobal(const Position& localPoint, int level) const   {
+dd4hep::Position dd4hep::align::GlobalAlignment::toGlobal(const Position& localPoint, int level) const   {
   CheckHandle verify_handle(*this);
   Position result;
   TGeoHMatrix* matrix = ptr()->GetMatrix(level);
@@ -90,7 +85,7 @@ Position GlobalAlignment::toGlobal(const Position& localPoint, int level) const 
 }
 
 /// Transform a point from local coordinates of a given level to global coordinates
-Position GlobalAlignment::globalToLocal(const Position& globalPoint, int level) const   {
+dd4hep::Position dd4hep::align::GlobalAlignment::globalToLocal(const Position& globalPoint, int level) const   {
   CheckHandle verify_handle(*this);
   Position result;
   TGeoHMatrix* matrix = ptr()->GetMatrix(level);
@@ -99,19 +94,19 @@ Position GlobalAlignment::globalToLocal(const Position& globalPoint, int level) 
 }
 
 /// Access the currently applied alignment/placement matrix
-Transform3D GlobalAlignment::toMother(int level) const   {
+dd4hep::Transform3D dd4hep::align::GlobalAlignment::toMother(int level) const   {
   CheckHandle verify_handle(*this);
   return detail::matrix::_transform(ptr()->GetNode(level)->GetMatrix());
 }
 
 /// Access the currently applied alignment/placement matrix
-Transform3D GlobalAlignment::nominal() const   {
+dd4hep::Transform3D dd4hep::align::GlobalAlignment::nominal() const   {
   CheckHandle verify_handle(*this);
   return detail::matrix::_transform(ptr()->GetOriginalMatrix());
 }
 
 /// Access the currently applied correction matrix (delta)
-Transform3D GlobalAlignment::delta() const   {
+dd4hep::Transform3D dd4hep::align::GlobalAlignment::delta() const   {
   // It may be useful at some point to cache some of these matrices....
   CheckHandle verify_handle(*this);
   TGeoPhysicalNode* n = ptr();
@@ -122,7 +117,7 @@ Transform3D GlobalAlignment::delta() const   {
 }
 
 /// Access the inverse of the currently applied correction matrix (delta) (mother to daughter)
-Transform3D GlobalAlignment::invDelta() const   {
+dd4hep::Transform3D dd4hep::align::GlobalAlignment::invDelta() const   {
   // It may be useful at some point to cache some of these matrices....
   CheckHandle verify_handle(*this);
   TGeoPhysicalNode* n = ptr();

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -1157,12 +1157,15 @@ static long dump_volume_tree(Detector& description, int argc, char** argv) {
         pref += aligned->GetName();
       }
       /// 
+      TGeoVolume* mother = ideal ? ideal->GetMotherVolume() : nullptr;
       if ( m_printPositions || m_printVolIDs )  {
         if ( m_printPointers )    {
           if ( ideal != aligned )
-            std::snprintf(fmt,sizeof(fmt),"Ideal:%p Aligned:%p ",(void*)ideal,(void*)aligned);
+            std::snprintf(fmt,sizeof(fmt),"Ideal:%p Aligned:%p ",
+                          (void*)ideal,(void*)aligned);
           else
-            std::snprintf(fmt,sizeof(fmt),"Ideal:%p ",(void*)ideal);
+            std::snprintf(fmt,sizeof(fmt),"Ideal:%p MotherVol:%p",
+                          (void*)ideal, (void*)mother);
           log << fmt;
         }
         // Top level volume! have no volume ids
@@ -1204,8 +1207,8 @@ static long dump_volume_tree(Detector& description, int argc, char** argv) {
         char  sens = vol.isSensitive() ? 'S' : ' ';
         if ( m_printPointers )    {
           if ( ideal == aligned )  {
-            std::snprintf(fmt,sizeof(fmt),"%03d %%s [Ideal:%p] %%-%ds %%-16s Vol:%%s shape:%%s \t %c %%s",
-                          level+1,(void*)ideal,2*level+1,sens);
+            std::snprintf(fmt,sizeof(fmt),"%03d %%s [Ideal:%p Vol:%p MotherVol:%p] %%-%ds %%-16s Vol:%%s shape:%%s \t %c %%s",
+                          level+1,(void*)ideal,(void*)vol, (void*)mother, 2*level+1, sens);
           }
           else  {
             std::snprintf(fmt,sizeof(fmt),"%03d %%s Ideal:%p Aligned:%p %%-%ds %%-16s Vol:%%s shape:%%s %c %%s",

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -908,9 +908,9 @@ void* Geant4Converter::handleAssembly(const std::string& name, const TGeoNode* n
           return nullptr;
         }
         g4->placeAssembly(dau, (*ia).second, transform);
-        printout(lvl, "Geant4Converter", "+++ Assembly: AddPlacedAssembly : dau:%s "
+        printout(lvl, "Geant4Converter", "+++ Assembly: AddPlacedAssembly %p: dau:%s "
                  "to mother %s Tr:x=%8.3f y=%8.3f z=%8.3f",
-                 dau_vol->GetName(), mot_vol->GetName(),
+                 (void*)dau_vol, dau_vol->GetName(), mot_vol->GetName(),
                  transform.dx(), transform.dy(), transform.dz());
       }
       else   {
@@ -922,9 +922,9 @@ void* Geant4Converter::handleAssembly(const std::string& name, const TGeoNode* n
                  __FILE__, __LINE__, name.c_str(), dau->GetName());
         }
         g4->placeVolume(dau,(*iv).second, transform);
-        printout(lvl, "Geant4Converter", "+++ Assembly: AddPlacedVolume : dau:%s "
+        printout(lvl, "Geant4Converter", "+++ Assembly: AddPlacedVolume %p: dau:%s "
                  "to mother %s Tr:x=%8.3f y=%8.3f z=%8.3f",
-                 dau_vol->GetName(), mot_vol->GetName(),
+                 (void*)dau_vol, dau_vol->GetName(), mot_vol->GetName(),
                  transform.dx(), transform.dy(), transform.dz());
       }
     }
@@ -1003,7 +1003,7 @@ void* Geant4Converter::handlePlacement(const std::string& name, const TGeoNode* 
         return nullptr;
       }
       else if ( node != info.manager->GetTopNode() && volIt == info.g4Volumes.end() )  {
-        throw std::logic_error("Geant4Converter: Invalid mother volume found!");
+        //throw std::logic_error("Geant4Converter: Invalid mother volume found!");
       }
       PlacedVolume pv(node);
       const auto*  pv_data = pv.data();
@@ -1692,51 +1692,7 @@ Geant4Converter& Geant4Converter::create(DetElement top) {
   std::map<int, std::vector<const TGeoNode*> >::const_reverse_iterator i = m_data->rbegin();
   for ( ; i != m_data->rend(); ++i )  {
     for ( const TGeoNode* node : i->second )  {
-#if 0
-      TGeoVolume* vm = node->GetMotherVolume();
-      if ( vm )   {
-        for(int iv=0; iv < vm->GetNdaughters(); ++iv)  {
-          TGeoNode* n = vm->GetNode(iv);
-          this->handlePlacement(n->GetName(), n);
-        }
-      }
-#endif
       this->handlePlacement(node->GetName(), node);
-#if 0
-#if 0
-      auto idau = m_daughters->find(Volume(node->GetVolume()));
-      std::vector<std::pair<TGeoNode*, G4VPhysicalVolume*> > vol_daughters;
-      if ( idau != m_daughters->end() )  {
-        for( auto* d : idau->second )  {
-          void* dau = handlePlacement(d->GetName(), d);
-          vol_daughters.push_back({ d, (G4VPhysicalVolume*)dau });
-        }
-      }
-      G4VPhysicalVolume* pl = (G4VPhysicalVolume*)handlePlacement(node->GetName(), node);
-      if ( pl )  {
-        // Now run check:
-        G4LogicalVolume* lv = pl->GetLogicalVolume();
-        for(int ik=0; ik<node->GetNdaughters(); ++ik)   {
-          const auto& p = vol_daughters[ik];
-          printout(INFO, "Geant4Converter", "+++ %i TGEO Parent: %s daughter: %s",
-                   ik, node->GetName(), node->GetDaughter(ik)->GetName());
-          printout(INFO, "Geant4Converter", "+++ %i G4   Parent: %s daughter: %s",
-                   ik, pl->GetName().c_str(),   lv->GetDaughter(ik)->GetName().c_str());
-          if ( p.first != node->GetDaughter(ik) || p.second != lv->GetDaughter(ik) )  {
-            printout(INFO, "Geant4Converter", "+++  BAD Volume order: %s", p.first->GetName());          
-          }
-        }
-      }
-#else
-      auto id = m_daughters->find(node);
-      if ( id != m_daughters->end() )  {
-        for( auto* dau : id->second )  {
-          handlePlacement(dau->GetName(), dau);
-        }
-      }
-      handlePlacement(node->GetName(), node);
-#endif
-#endif
     }
   }
   /// Handle concrete surfaces

--- a/examples/AlignDet/CMakeLists.txt
+++ b/examples/AlignDet/CMakeLists.txt
@@ -152,7 +152,7 @@ dd4hep_add_test_reg( AlignDet_AlephTPC_load
   EXEC_ARGS  geoPluginRun
              -input file:${AlignDet_INSTALL}/compact/AlephTPC.xml
              -destroy -no-interpreter -plugin DD4hep_GlobalAlignmentInstall
-  REGEX_PASS "189 nodes/ 24 volume UID's in Detector Geometry"
+  REGEX_PASS "190 nodes/ 25 volume UID's in Detector Geometry"
   REGEX_FAIL " ERROR ;EXCEPTION;Exception"
   )
 #

--- a/examples/AlignDet/compact/AlephTPC_alignment.xml
+++ b/examples/AlignDet/compact/AlephTPC_alignment.xml
@@ -34,50 +34,50 @@
 
     <detelement path="TPC" reset="true" reset_children="true">
       <comment ref="Move the entire TPC in the world volume."/>
-      <position x="0"       y="0"  z="0*mm"/>
-      <rotation x="0"       y="0" z="0"/>     
+      <position x="0"   y="0"   z="0*mm"/>
+      <rotation x="0"   y="0"   z="0"/>     
 
       <comment ref="Twist a bit the entire endcap A"/>
       <detelement path="/world/TPC/TPC_SideA" check_overlaps="false">
-	<position x="0"     y="0"  z="-500*mm"/>
+	<position x="0"     y="0"     z="-5*mm"/>
 	<rotation x="-0.2"  y="-0.2"  z="0"/>
 
 	<comment ref="A detector element relative to the parent"/>
 	<detelement path="TPC_SideA_sector02" check_overlaps="true">
-	  <position x="0"   y="0"   z="0"/>
-	  <rotation x="0.5" y="0.1" z="0.2"/>     
+	  <position x="0"    y="0"    z="0"/>
+	  <rotation x="0.005"  y="0.001"  z="0.002"/>     
 	</detelement>
       </detelement>
 
       <detelement path="TPC_SideA/TPC_SideA_sector03" check_overlaps="true">
-	<position x="0"     y="0"    z="290.0*mm"/>
-	<rotation x="0"     y="pi/2" z="0"/>     
-	<pivot    x="0"     y="0"    z="100"/>     
+	<position x="0"     y="0"     z="0.029*mm"/>
+	<rotation x="0"     y="pi/200"  z="0"/>     
+	<pivot    x="0"     y="0"     z="1"/>     
 	<volume path="TPC_sector_K_layer2_2">
-	  <position x="0"   y="0"  z="0.0001*mm"/>
-	  <rotation x="0"   y="0.5"  z="0"/>     
+	  <position x="0"   y="0"     z="0.0001*mm"/>
+	  <rotation x="0"   y="0.005"   z="0"/>     
 	</volume>
       </detelement>
 
       <detelement path="TPC_SideA/TPC_SideA_sector05" check_overlaps="false">
-	<position x="0"    y="0" z="150.0*mm"/>
-	<rotation x="0" y="0" z="0"/>     
+	<position x="0"    y="0"   z="1.50*mm"/>
+	<rotation x="0"    y="0"   z="0"/>     
       </detelement>
 
       <detelement path="TPC_SideA/TPC_SideA_sector10" check_overlaps="false">
-	<position x="0"  y="0" z="450.0*mm"/>
-	<rotation x="0"  y="0" z="pi/4"/>     
+	<position x="0"    y="0"   z="0.045*mm"/>
+	<rotation x="0"    y="0"   z="pi/400"/>     
       </detelement>
 
       <comment ref="Twist a bit the entire endcap B"/>
       <detelement path="TPC_SideB" check_overlaps="false">
-	<position x="0"   y="0"  z="0"/>
-	<rotation x="0" y="0"  z="0"/>
+	<position x="0"    y="0"   z="0"/>
+	<rotation x="0"    y="0"   z="0"/>
 
 	<comment ref="A detector element relative to the parent"/>
 	<detelement path="TPC_SideB_sector02" check_overlaps="true">
-	  <position x="0"   y="0"   z="0"/>
-	  <rotation x="0.5" y="0.1" z="0.2"/>     
+	  <position x="0"     y="0"      z="0"/>
+	  <rotation x="0.005"   y="0.001"    z="0.002"/>     
 	</detelement>
       </detelement>  <comment ref="end: TPC side B"/>
 <!--

--- a/examples/AlignDet/scripts/AlephTPC.py
+++ b/examples/AlignDet/scripts/AlephTPC.py
@@ -13,7 +13,6 @@
 #
 from __future__ import absolute_import, unicode_literals
 import os
-import time
 import DDG4
 from DDG4 import OutputLevel as Output
 from g4units import GeV, MeV, m, cm

--- a/examples/AlignDet/scripts/AlephTPC.py
+++ b/examples/AlignDet/scripts/AlephTPC.py
@@ -1,0 +1,97 @@
+
+# ==========================================================================
+#  AIDA Detector description implementation
+# --------------------------------------------------------------------------
+# Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+# All rights reserved.
+#
+# For the licensing terms see $DD4hepINSTALL/LICENSE.
+# For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+#
+# ==========================================================================
+#
+#
+from __future__ import absolute_import, unicode_literals
+import os
+import time
+import DDG4
+from DDG4 import OutputLevel as Output
+from g4units import GeV, MeV, m, cm
+#
+#
+"""
+
+   dd4hep simulation example setup using the python configuration
+
+   @author  M.Frank
+   @version 1.0
+
+"""
+
+
+def run():
+  args = DDG4.CommandLine()
+  kernel = DDG4.Kernel()
+  install_dir = os.environ['DD4hepExamplesINSTALL']
+  kernel.loadGeometry(str("file:" + install_dir + "/examples/AlignDet/compact/AlephTPC.xml"))
+
+  if args.alignments:
+    kernel.loadXML(str("file:") + str(args.alignments))
+
+  DDG4.importConstants(kernel.detectorDescription(), debug=False)
+  geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')
+  geant4.printDetectors()
+  # Configure UI
+  if args.macro:
+    ui = geant4.setupCshUI(macro=args.macro)
+  else:
+    ui = geant4.setupCshUI()
+  if args.batch:
+    ui.Commands = ['/run/beamOn ' + str(args.events), '/ddg4/UI/terminate']
+
+  # Configure field
+  geant4.setupTrackingField(prt=True)
+  # Configure Event actions
+  prt = DDG4.EventAction(kernel, 'Geant4ParticlePrint/ParticlePrint')
+  prt.OutputLevel = Output.DEBUG
+  prt.OutputType = 3  # Print both: table and tree
+  kernel.eventAction().adopt(prt)
+
+  generator_output_level = Output.INFO
+
+  # Configure G4 geometry setup
+  seq, act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
+  act.DebugMaterials = True
+  act.DebugElements = False
+  act.DebugVolumes = True
+  act.DebugShapes = True
+  seq, act = geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
+
+  # Setup particle gun
+  pos = (0.0, 0.0, -364.0 * cm)
+  gun = geant4.setupGun("Gun", particle='e+', energy=50 * GeV, multiplicity=1, position=pos)
+  gun.OutputLevel = generator_output_level
+
+  # And handle the simulation particles.
+  part = DDG4.GeneratorAction(kernel, "Geant4ParticleHandler/ParticleHandler")
+  kernel.generatorAction().adopt(part)
+  part.SaveProcesses = ['Decay']
+  part.MinimalKineticEnergy = 100 * MeV
+  part.OutputLevel = Output.INFO  # generator_output_level
+  part.enableUI()
+  user = DDG4.Action(kernel, "Geant4TCUserParticleHandler/UserParticleHandler")
+  user.TrackingVolume_Zmax = 3.0 * m
+  user.TrackingVolume_Rmax = 3.0 * m
+  user.enableUI()
+  part.adopt(user)
+
+  geant4.setupTracker('TPC')
+
+  # Now build the physics list:
+  phys = geant4.setupPhysics('QGSP_BERT')
+  phys.dump()
+  geant4.execute()
+
+
+if __name__ == "__main__":
+  run()

--- a/examples/AlignDet/src/AlephTPC_geo.cpp
+++ b/examples/AlignDet/src/AlephTPC_geo.cpp
@@ -12,8 +12,11 @@
 //==========================================================================
 
 // Framework include files
-#include "DD4hep/DetFactoryHelper.h"
-#include "TGeoArb8.h"
+#include <DD4hep/DetFactoryHelper.h>
+#include <DD4hep/DD4hepUnits.h>
+#include <TGeoArb8.h>
+
+// C/C++ include files
 #include <iomanip>
 
 using namespace std;
@@ -50,7 +53,7 @@ static Ref_t create_element(Detector& description, xml_h e, SensitiveDetector se
   cylinder_t env        = { x_envelope.inner_r(), x_envelope.outer_r(), x_envelope.zhalf() };
   cylinder_t inner_wall = { x_inner.inner_r(), x_inner.inner_r()+x_inner.thickness(), env.zhalf };
   cylinder_t outer_wall = { x_outer.outer_r()-x_outer.thickness(), x_outer.outer_r(), env.zhalf };
-  cylinder_t gas        = { inner_wall.outer, outer_wall.inner, x_gas.zhalf() };
+  cylinder_t gas        = { inner_wall.outer+5*dd4hep::cm, outer_wall.inner-5*dd4hep::cm, x_gas.zhalf()-5*dd4hep::cm };
 
   // TPC sensitive detector
   sens_det.setType("tracker");
@@ -80,15 +83,13 @@ static Ref_t create_element(Detector& description, xml_h e, SensitiveDetector se
   outerVol.setVisAttributes(description.visAttributes(x_outer.visStr()));
   envVol.placeVolume(outerVol);
 
-#if 0
   // TPC gas chamber envelope
   Material gasMat = description.material(x_gas.materialStr());
   Tube     gasTub(gas.inner,gas.outer,gas.zhalf);
   Volume   gasVol(name+"_chamber",gasTub,gasMat);
   gasVol.setVisAttributes(description.visAttributes(x_gas.visStr()));
-  //gasVol.setVisAttributes(description.invisible());
+  gasVol.setSensitiveDetector(sens_det);
   envVol.placeVolume(gasVol);
-#endif
   
   // TPC HV plane
   Tube    hvTub(gas.inner,gas.outer,x_cathode.thickness()/2);


### PR DESCRIPTION

BEGINRELEASENOTES
- As noted by Ben, the global alignment does not work in the presence of assemblies.
  This PR together with https://github.com/root-project/root/pull/15905 fixes this deficiency.
- An example was added to convert a globally misaligned geometry to Geant4:
  ` $ python examples/AlignDet/scripts/AlephTPC.py -batch -events 5 -alignments examples/AlignDet/compact/AlephTPC_alignment.xml`

ENDRELEASENOTES