### PR TITLE
Geant4 sensitive assignment action depending on regex rather than brute force Geant4VolumeManager

### DIFF
--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -336,6 +336,21 @@ class Logger:
 
   def setPrintLevel(self, level):
     "Adjust printout level of dd4hep"
+    if isinstance(level, str):
+      if level == 'VERBOSE':
+        level = OutputLevel.VERBOSE
+      elif level == 'DEBUG':
+        level = OutputLevel.DEBUG
+      elif level == 'INFO':
+        level = OutputLevel.INFO
+      elif level == 'WARNING':
+        level = OutputLevel.WARNING
+      elif level == 'ERROR':
+        level = OutputLevel.ERROR
+      elif level == 'FATAL':
+        level = OutputLevel.FATAL
+      else:
+        level = int(level)
     dd4hep.setPrintLevel(level)
 
   def always(self, msg):
@@ -407,6 +422,9 @@ class CommandLine:
          have_help = True
     if have_help and help_call:
       help_call()
+    if self.data.get('print_level'):
+      log = Logger('CommandLine')
+      log.setPrintLevel(self.data.get('print_level'))
 
   def __getattr__(self, attr):
     if self.data.get(attr):

--- a/DDG4/include/DDG4/Geant4DetectorConstruction.h
+++ b/DDG4/include/DDG4/Geant4DetectorConstruction.h
@@ -73,7 +73,7 @@ namespace dd4hep {
       /// G4 User detector initializer
       G4VUserDetectorConstruction* detector  { nullptr };
       /// Initializing Constructor
-      Geant4DetectorConstructionContext(Detector& l,G4VUserDetectorConstruction* d)
+      Geant4DetectorConstructionContext(Detector& l, G4VUserDetectorConstruction* d)
         : description(l), world(0), geometry(0), detector(d)  { }
       /// Default destructor
       ~Geant4DetectorConstructionContext()             { }
@@ -111,6 +111,9 @@ namespace dd4hep {
       virtual void constructField(Geant4DetectorConstructionContext* ctxt);
       /// Sensitive detector construction callback. Called at "ConstructSDandField()"
       virtual void constructSensitives(Geant4DetectorConstructionContext* ctxt);
+      /// Create Geant4 sensitive detector object using the factory mechanism
+      virtual G4VSensitiveDetector* createSensitiveDetector(const std::string& type,
+                                                            const std::string& name);
     };
 
     /// Concrete basic implementation of the Geant4 detector construction sequencer.

--- a/DDG4/include/DDG4/Geant4Kernel.h
+++ b/DDG4/include/DDG4/Geant4Kernel.h
@@ -88,20 +88,20 @@ namespace dd4hep {
       /// Property: Name of the UI action. Must be member of the global actions
       std::string   m_uiName                   { };
       /// Property: Name of the G4 run manager factory to be used. Default: Geant4RunManager
-      std::string m_runManagerType;
+      std::string   m_runManagerType;
       /// Property: Name of the default factory to create G4VSensitiveDetector instances
-      std::string m_dfltSensitiveDetectorType;
+      std::string   m_dfltSensitiveDetectorType;
       /// Property: Names with specialized factories to create G4VSensitiveDetector instances
       std::map<std::string, std::string> m_sensitiveDetectorTypes;
       /// Property: Number of events to be executed in batch mode
-      long        m_numEvent = 10;
+      long          m_numEvent = 10;
       /// Property: Output level
-      int         m_outputLevel = 0;
+      int           m_outputLevel = 0;
 
       /// Master property: Number of execution threads in multi threaded mode.
-      int         m_numThreads = 0;
+      int           m_numThreads = 0;
       /// Master property: Instantiate the Geant4 scoring manager object
-      int         m_haveScoringMgr = false;
+      int           m_haveScoringMgr = false;
       
       /// Registered action callbacks on configure
       UserCallbacks m_actionConfigure  { };
@@ -205,6 +205,13 @@ namespace dd4hep {
       const std::map<std::string, std::string>& sensitiveDetectorTypes()  const   {
         return m_sensitiveDetectorTypes;
       }
+      /// Add new sensitive type to factory list
+      /** This is present mainly for debugging purposes and tests.
+       * Never necessary in real life!
+       * For all practical purpose the default type Geant4SensDet is sufficient.
+       *
+       */
+      void defineSensitiveDetectorType(const std::string& type, const std::string& factory);
       /// Access to geometry world
       G4VPhysicalVolume* world()  const;
       /// Set the geometry world

--- a/DDG4/plugins/Geant4DetectorGeometryConstruction.cpp
+++ b/DDG4/plugins/Geant4DetectorGeometryConstruction.cpp
@@ -194,7 +194,7 @@ void Geant4DetectorGeometryConstruction::constructGeo(Geant4DetectorConstruction
 
 std::pair<std::string, dd4hep::PlacedVolume>
 Geant4DetectorGeometryConstruction::resolve_path(const char* vol_path)  const {
-  std::string       p   = vol_path;
+  std::string  p   = vol_path;
   Detector&    det = context()->kernel().detectorDescription();
   PlacedVolume top = det.world().placement();
   PlacedVolume pv  = detail::tools::findNode(top, p);
@@ -437,7 +437,7 @@ int Geant4DetectorGeometryConstruction::writeGDML(const char* output)  {
 
 void Geant4DetectorGeometryConstruction::printG4(const std::string& prefix, const G4VPhysicalVolume* g4pv)    const   {
   std::string path = prefix + "/";
-  printP2(  "+++  GEANT4 volume: %s", prefix.c_str());
+  printP2("+++  GEANT4 volume: %s", prefix.c_str());
   auto* g4v = g4pv->GetLogicalVolume();
   for(size_t i=0, n=g4v->GetNoDaughters(); i<n; ++i)    {
     auto* dau = g4v->GetDaughter(i);
@@ -480,5 +480,3 @@ void Geant4DetectorGeometryConstruction::installCommandMessenger()   {
   m_control->addCall("printMaterial", "Print Geant4 material properties [uses argument]",
                      Callback(this).make(&Geant4DetectorGeometryConstruction::printMaterial),1);
 }
-
-

--- a/DDG4/plugins/Geant4DetectorSensitivesConstruction.cpp
+++ b/DDG4/plugins/Geant4DetectorSensitivesConstruction.cpp
@@ -86,36 +86,18 @@ void Geant4DetectorSensitivesConstruction::constructSensitives(Geant4DetectorCon
   const std::string&  dflt   = kernel.defaultSensitiveDetectorType();
   for( const auto& iv : p->sensitives )  {
     SensitiveDetector sd = iv.first;
-    std::string nam = sd.name();
-    auto iter = types.find(nam);
-    std::string typ = (iter != types.end()) ? (*iter).second : dflt;
-    G4VSensitiveDetector* g4sd = 
-      PluginService::Create<G4VSensitiveDetector*>(typ, nam, &ctxt->description);
-    if (g4sd) {
-      print("Geant4SDConstruction", "+++ Subdetector: %-32s  type: %-16s factory: %s.",
-            nam.c_str(), sd.type().c_str(), typ.c_str());
-    }
-    else  {
-      PluginDebug dbg;
-      g4sd = PluginService::Create<G4VSensitiveDetector*>(typ, nam, &ctxt->description);
-      if ( !g4sd )  {
-        throw std::runtime_error("ConstructSDandField: FATAL Failed to "
-                                 "create Geant4 sensitive detector " + nam + 
-                                 " (" + sd.type() + ") of type " + typ + ".");
-      }
-      print("Geant4SDConstruction", "+++ Subdetector: %-32s  type: %-16s factory: %s.",
-            nam.c_str(), sd.type().c_str(), typ.c_str());
-    }
-    g4sd->Activate(true);
-    G4SDManager::GetSDMpointer()->AddNewDetector(g4sd);
-    for(const TGeoVolume* vol : iv.second )  {
+    std::string nam  = sd.name();
+    auto        iter = types.find(nam);
+    std::string typ  = (iter != types.end()) ? (*iter).second : dflt;
+    G4VSensitiveDetector* g4sd = this->createSensitiveDetector(typ, nam);
+    for( const TGeoVolume* vol : iv.second )  {
       G4LogicalVolume* g4v = p->g4Volumes[vol];
-      if ( !g4v )  {
-        throw std::runtime_error("ConstructSDandField: Failed to access G4LogicalVolume for SD "+
-                                 nam + " of type " + typ + ".");
+      if( !g4v )  {
+        except("ConstructSDandField: Failed to access G4LogicalVolume for SD %s of type %s.",
+               nam.c_str(), typ.c_str());
       }
-      ctxt->setSensitiveDetector(g4v,g4sd);
+      ctxt->setSensitiveDetector(g4v, g4sd);
     }
   }
-  print("Geant4SDConstruction", "+++ Handled %ld sensitive detectors.",p->sensitives.size());
+  print("+++ Handled %ld sensitive detectors.",p->sensitives.size());
 }

--- a/DDG4/plugins/Geant4RegexSensitivesConstruction.cpp
+++ b/DDG4/plugins/Geant4RegexSensitivesConstruction.cpp
@@ -1,0 +1,163 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//  \author Markus Frank
+//  \date   2015-11-09
+//
+//==========================================================================
+
+// Framework include files
+#include <DDG4/Geant4DetectorConstruction.h>
+
+// C/C++ include files
+#include <set>
+#include <regex>
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    /// Class to create Geant4 detector geometry from TGeo representation in memory
+    /**
+     *  On demand the sensitive detectors are created and attached to all sensitive
+     *  volumes. The relevant  callback is executed when the call to 
+     *  ConstructSDandField() of the corresponding G4VUserDetectorConstruction
+     *  instance is called. The call is thread-local!
+     *
+     *  \author  M.Frank
+     *  \version 1.0
+     *  \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4RegexSensitivesConstruction : public Geant4DetectorConstruction   {
+    public:
+      std::string detector_name;
+      std::string regex_value;
+      std::size_t collect_volumes(std::set<Volume>&  volumes,
+                                  PlacedVolume       pv,
+                                  const std::string& path,
+                                  std::regex&        match);
+    public:
+      /// Initializing constructor for DDG4
+      Geant4RegexSensitivesConstruction(Geant4Context* ctxt, const std::string& nam);
+      /// Default destructor
+      virtual ~Geant4RegexSensitivesConstruction();
+      /// Sensitives construction callback. Called at "ConstructSDandField()"
+      void constructSensitives(Geant4DetectorConstructionContext* ctxt);
+    };
+  }    // End namespace sim
+}      // End namespace dd4hep
+
+
+// Framework include files
+#include <DD4hep/InstanceCount.h>
+#include <DD4hep/Printout.h>
+#include <DD4hep/Plugins.h>
+#include <DD4hep/Detector.h>
+#include <DD4hep/DetectorTools.h>
+
+#include <DDG4/Geant4Mapping.h>
+#include <DDG4/Geant4Kernel.h>
+#include <DDG4/Factories.h>
+
+// ROOT include files
+#include <TTimeStamp.h>
+#include <TGeoManager.h>
+// Geant4 include files
+#include <G4PVPlacement.hh>
+#include <G4VSensitiveDetector.hh>
+
+using namespace dd4hep::sim;
+
+DECLARE_GEANT4ACTION(Geant4RegexSensitivesConstruction)
+
+/// Initializing constructor for other clients
+Geant4RegexSensitivesConstruction::Geant4RegexSensitivesConstruction(Geant4Context* ctxt, const std::string& nam)
+: Geant4DetectorConstruction(ctxt,nam)
+{
+  declareProperty("Detector",      detector_name);
+  declareProperty("Regex",         regex_value);
+  InstanceCount::increment(this);
+}
+
+/// Default destructor
+Geant4RegexSensitivesConstruction::~Geant4RegexSensitivesConstruction() {
+  InstanceCount::decrement(this);
+}
+
+std::size_t
+Geant4RegexSensitivesConstruction::collect_volumes(std::set<Volume>&  volumes,
+                                                   PlacedVolume       pv,
+                                                   const std::string& path,
+                                                   std::regex&        match)
+{
+  std::size_t count = 0;
+  // Try to minimize a bit the number of regex matches.
+  if ( volumes.find(pv.volume()) == volumes.end() )  {
+    if( !path.empty() )  {
+      std::smatch sm;
+      bool stat = std::regex_match(path, sm, match);
+      if( stat )  {
+        volumes.insert(pv.volume());
+      }
+      ++count;
+    }
+    // Now recurse down the daughters
+    for( int i=0, num = pv->GetNdaughters(); i < num; ++i )  {
+      PlacedVolume daughter = pv->GetDaughter(i);
+      std::string  daughter_path = path + "/" + daughter.name();
+      count += this->collect_volumes(volumes, daughter, daughter_path, match);
+    }
+  }
+  return count;
+}
+
+/// Sensitive detector construction callback. Called at "ConstructSDandField()"
+void Geant4RegexSensitivesConstruction::constructSensitives(Geant4DetectorConstructionContext* ctxt)   {
+  Geant4GeometryInfo* g4info = Geant4Mapping::instance().ptr();
+  const Geant4Kernel& kernel = context()->kernel();
+  const auto&         types  = kernel.sensitiveDetectorTypes();
+  const std::string&  dflt   = kernel.defaultSensitiveDetectorType();
+  const char*         det    = detector_name.c_str();
+  
+  DetElement de = detail::tools::findElement(ctxt->description, detector_name);
+  if( !de.isValid() )  {
+    except("Failed to locate subdetector DetElement %s to manage Geant4 energy deposits.", det);
+  }
+  SensitiveDetector sd = ctxt->description.sensitiveDetector(detector_name);
+  if( !sd.isValid() )  {
+    except("Failed to locate sensitive detector %s to manage Geant4 energy deposits.", det);
+  }
+  std::string nam  = sd.name();
+  auto        iter = types.find(nam);
+  std::string typ  = (iter != types.end()) ? (*iter).second : dflt;
+  G4VSensitiveDetector* g4sd = this->createSensitiveDetector(typ, nam);
+
+  std::set<Volume> volumes;
+  int flags = std::regex_constants::icase | std::regex_constants::ECMAScript;
+  std::regex expression(regex_value, (std::regex_constants::syntax_option_type)flags);
+
+  TTimeStamp start;
+  print("+++ Detector: %s Starting to scan volume....", det);
+  std::size_t num_nodes = this->collect_volumes(volumes, de.placement(), de.placementPath(), expression);
+  for( const auto& vol : volumes )  {
+    G4LogicalVolume* g4vol = g4info->g4Volumes[vol];
+    if( !g4vol )  {
+      except("+++ Failed to access G4LogicalVolume for SD %s of type %s",
+             nam.c_str(), typ.c_str());
+    }
+    print("+++ Detector: %s Assign sensitive detector [%s] to volume: %s.",
+          nam.c_str(), typ.c_str(), vol.name());
+    ctxt->setSensitiveDetector(g4vol, g4sd);
+  }
+  TTimeStamp stop;
+  print("+++ Detector: %s Handled %ld nodes with %ld sensitive volume type. Total of %7.3f seconds.",
+        det, num_nodes, volumes.size(), stop.AsDouble()-start.AsDouble() );
+}

--- a/DDG4/plugins/Geant4SDActions.cpp
+++ b/DDG4/plugins/Geant4SDActions.cpp
@@ -296,7 +296,7 @@ namespace dd4hep {
       }
       Hit* hit = coll->findByKey<Hit>(cell);
       if ( !hit ) {
-	Geant4TouchableHandler   handler(h.touchable());
+        Geant4TouchableHandler   handler(h.touchable());
         DDSegmentation::Vector3D pos = m_segmentation.position(cell);
         Position global = h.localToGlobal(pos);
         hit = new Hit(global);
@@ -507,7 +507,7 @@ namespace dd4hep {
       }
       Hit* hit = coll->findByKey<Hit>(cell);
       if ( !hit ) {
-	Geant4TouchableHandler   handler(h.touchable());
+        Geant4TouchableHandler   handler(h.touchable());
         DDSegmentation::Vector3D pos = m_segmentation.position(cell);
         Position global = h.localToGlobal(pos);
         hit = new Hit(global);
@@ -577,13 +577,13 @@ namespace dd4hep {
       }
       void start(const G4Step* step, const G4StepPoint* point)   {
         pre.storePoint(step,point);
-	start_collecting(step->GetTrack());
-	firstSpotVolume = step->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
+        start_collecting(step->GetTrack());
+        firstSpotVolume = step->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
       }
       void start(const Geant4FastSimSpot* spot)   {
         pre.storePoint(spot);
-	start_collecting(spot->primary);
-	firstSpotVolume = spot->volume();
+        start_collecting(spot->primary);
+        firstSpotVolume = spot->volume();
       }
 
       /// Update energy and track information during hit info accumulation
@@ -604,11 +604,11 @@ namespace dd4hep {
       }
       void update(const Geant4StepHandler& h) {
         post.storePoint(h.step, h.post);
-	update_collected_hit(h.preTouchable(), h.avgPositionG4()); // Compute cellID
+        update_collected_hit(h.preTouchable(), h.avgPositionG4()); // Compute cellID
       }
       void update(const Geant4FastSimHandler& h)   {
         post.storePoint(h.spot);
-	update_collected_hit(h.touchable(), h.avgPositionG4());       // Compute cellID
+        update_collected_hit(h.touchable(), h.avgPositionG4());       // Compute cellID
       }
 
       /// Clear collected information and restart for new hit
@@ -620,7 +620,7 @@ namespace dd4hep {
         current = -1;
         combined = 0;
         cell = 0;
-	firstSpotVolume = nullptr;
+        firstSpotVolume = nullptr;
       }
 
       /// Helper function to decide if the hit has to be extracted and saved in the collection
@@ -653,10 +653,8 @@ namespace dd4hep {
       /// Method for generating hit(s) using the information of G4Step object.
       G4bool process(const G4Step* step, G4TouchableHistory* ) {
         Geant4StepHandler h(step);
-
-	// std::cout << " process called - pre pos: " << h.prePos() << " post pos " << h.postPos() 
-	// 	  << " edep: " << h.deposit() << std::endl ;
-
+        // std::cout << " process called - pre pos: " << h.prePos() << " post pos " << h.postPos() 
+        // 	  << " edep: " << h.deposit() << std::endl ;
         void *prePV = h.volume(h.pre), *postPV = h.volume(h.post);
 
         Geant4HitCollection* coll = sensitive->collection(0);
@@ -689,7 +687,7 @@ namespace dd4hep {
 
       /// Method for generating hit(s) using the information of fast simulation spot object.
       G4bool process(const Geant4FastSimSpot* spot, G4TouchableHistory* ) {
-	Geant4FastSimHandler h(spot);
+        Geant4FastSimHandler h(spot);
         G4VPhysicalVolume*   prePV = firstSpotVolume, *postPV = h.volume();
         Geant4HitCollection* coll  = sensitive->collection(0);
         /// If we are handling a new track, then store the content of the previous one.
@@ -716,7 +714,7 @@ namespace dd4hep {
         else if ( h.track->GetTrackStatus() == fStopAndKill ) {
           extractHit(coll);
         }
-	return true;
+        return true;
       }
 
       /// Post-event action callback

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -670,7 +670,7 @@ class Geant4:
       return (seq, acts)
     return (seq, acts[0])
 
-  def setupCalorimeter(self, name, type=None, collections=None):  # noqa: A001,A002
+  def setupCalorimeter(self, name, type=None, collections=None):  # noqa: A001
     """
     Setup subdetector of type 'calorimeter' and assign the proper sensitive action
 
@@ -686,7 +686,7 @@ class Geant4:
       typ = self.sensitive_types[typ]
     return self.setupDetector(name, typ, collections)
 
-  def setupTracker(self, name, type=None, collections=None):  # noqa: A001,A002
+  def setupTracker(self, name, type=None, collections=None):  # noqa: A001
     """
     Setup subdetector of type 'tracker' and assign the proper sensitive action
 

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -680,7 +680,10 @@ class Geant4:
     self.description.sensitiveDetector(str(name))
     # sd.setType('calorimeter')
     if typ is None:
+      type = 'calorimeter'
       typ = self.sensitive_types['calorimeter']
+    elif typ is not None and self.sensitive_types.get(typ):
+      typ = self.sensitive_types[typ]
     return self.setupDetector(name, typ, collections)
 
   def setupTracker(self, name, type=None, collections=None):  # noqa: A002
@@ -693,7 +696,10 @@ class Geant4:
     self.description.sensitiveDetector(str(name))
     # sd.setType('tracker')
     if typ is None:
+      type = 'tracker'
       typ = self.sensitive_types['tracker']
+    elif typ is not None and self.sensitive_types.get(typ):
+      typ = self.sensitive_types[typ]
     return self.setupDetector(name, typ, collections)
 
   def _private_setupField(self, field, stepper, equation, prt):

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -670,7 +670,7 @@ class Geant4:
       return (seq, acts)
     return (seq, acts[0])
 
-  def setupCalorimeter(self, name, type=None, collections=None):  # noqa: A002
+  def setupCalorimeter(self, name, type=None, collections=None):  # noqa: A001,A002
     """
     Setup subdetector of type 'calorimeter' and assign the proper sensitive action
 
@@ -686,7 +686,7 @@ class Geant4:
       typ = self.sensitive_types[typ]
     return self.setupDetector(name, typ, collections)
 
-  def setupTracker(self, name, type=None, collections=None):  # noqa: A002
+  def setupTracker(self, name, type=None, collections=None):  # noqa: A001,A002
     """
     Setup subdetector of type 'tracker' and assign the proper sensitive action
 

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -670,7 +670,7 @@ class Geant4:
       return (seq, acts)
     return (seq, acts[0])
 
-  def setupCalorimeter(self, name, type=None, collections=None):  # noqa: A001
+  def setupCalorimeter(self, name, type=None, collections=None):  # noqa: A002
     """
     Setup subdetector of type 'calorimeter' and assign the proper sensitive action
 
@@ -680,13 +680,12 @@ class Geant4:
     self.description.sensitiveDetector(str(name))
     # sd.setType('calorimeter')
     if typ is None:
-      type = 'calorimeter'
       typ = self.sensitive_types['calorimeter']
     elif typ is not None and self.sensitive_types.get(typ):
       typ = self.sensitive_types[typ]
     return self.setupDetector(name, typ, collections)
 
-  def setupTracker(self, name, type=None, collections=None):  # noqa: A001
+  def setupTracker(self, name, type=None, collections=None):  # noqa: A002
     """
     Setup subdetector of type 'tracker' and assign the proper sensitive action
 
@@ -696,7 +695,6 @@ class Geant4:
     self.description.sensitiveDetector(str(name))
     # sd.setType('tracker')
     if typ is None:
-      type = 'tracker'
       typ = self.sensitive_types['tracker']
     elif typ is not None and self.sensitive_types.get(typ):
       typ = self.sensitive_types[typ]

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -34,6 +34,7 @@
 
 // ROOT includes
 #include <TClass.h>
+#include <TTimeStamp.h>
 #include <TGeoBoolNode.h>
 
 // Geant4 include files
@@ -1648,7 +1649,8 @@ void* Geant4Converter::printPlacement(const std::string& name, const TGeoNode* n
   printout(outputLevel, "G4Placement", str.str().c_str());
   printout(outputLevel, "G4Placement", printSolid(sol).c_str());
   str.str("");
-  str << "                  |" << " Ndau:" << vol->GetNoDaughters() << " physvols." << " Mat:" << vol->GetMaterial()->GetName()
+  str << "                  |" << " Ndau:" << vol->GetNoDaughters()
+      << " physvols." << " Mat:" << vol->GetMaterial()->GetName()
       << " Mother:" << (char*) (mot ? mot->GetName().c_str() : "---");
   printout(outputLevel, "G4Placement", str.str().c_str());
   str.str("");
@@ -1660,6 +1662,7 @@ void* Geant4Converter::printPlacement(const std::string& name, const TGeoNode* n
 /// Create geometry conversion
 Geant4Converter& Geant4Converter::create(DetElement top) {
   typedef std::map<const TGeoNode*, std::vector<TGeoNode*> > _DAU;
+  TTimeStamp start;
   _DAU daughters;
   Geant4GeometryInfo& geo = this->init();
   World wrld = top.world();
@@ -1710,6 +1713,9 @@ Geant4Converter& Geant4Converter::create(DetElement top) {
   m_daughters = nullptr;
   geo.setWorld(top.placement().ptr());
   geo.valid = true;
-  printout(INFO, "Geant4Converter", "+++  Successfully converted geometry to Geant4.");
+  TTimeStamp stop;
+  printout(INFO, "Geant4Converter",
+           "+++  Successfully converted geometry to Geant4. [%7.3f seconds]",
+           stop.AsDouble()-start.AsDouble() );
   return *this;
 }

--- a/DDG4/src/Geant4DetectorConstruction.cpp
+++ b/DDG4/src/Geant4DetectorConstruction.cpp
@@ -12,6 +12,7 @@
 //==========================================================================
 
 // Framework include files
+#include <DD4hep/Plugins.h>
 #include <DD4hep/InstanceCount.h>
 #include <DDG4/Geant4Mapping.h>
 #include <DDG4/Geant4GeometryInfo.h>
@@ -23,7 +24,7 @@
 using namespace dd4hep::sim;
 
 /// Helper: Assign sensitive detector to logical volume
-void Geant4DetectorConstructionContext::setSensitiveDetector(G4LogicalVolume* vol, G4VSensitiveDetector* sd)   {
+void Geant4DetectorConstructionContext::setSensitiveDetector(G4LogicalVolume* vol, G4VSensitiveDetector* sd)  {
   //detector->SetSensitiveDetector(vol,sd);
   G4SDManager::GetSDMpointer()->AddNewDetector(sd);
   vol->SetSensitiveDetector(sd);
@@ -39,18 +40,43 @@ Geant4DetectorConstruction::Geant4DetectorConstruction(Geant4Context* ctxt, cons
 Geant4DetectorConstruction::~Geant4DetectorConstruction()  {
 }
 
+/// Create Geant4 sensitive detector object using the factory mechanism
+G4VSensitiveDetector*
+Geant4DetectorConstruction::createSensitiveDetector(const std::string& typ,
+                                                    const std::string& nam)  {
+  Detector& dsc = context()->detectorDescription();
+  G4VSensitiveDetector* g4sd = PluginService::Create<G4VSensitiveDetector*>(typ, nam, &dsc);
+  if( g4sd )  {
+    print("+++ Subdetector: %-32s  type: %s.", nam.c_str(), typ.c_str());
+  }
+  else  {
+    PluginDebug dbg;
+    g4sd = PluginService::Create<G4VSensitiveDetector*>(typ, nam, &dsc);
+    if ( !g4sd )  {
+      except("createSensitiveDetector: FATAL Failed to "
+             "create Geant4 sensitive detector %s of type %s.",
+             nam.c_str(), typ.c_str());
+    }
+    print("+++ Subdetector: %-32s  type: %s.", nam.c_str(), typ.c_str());
+  }
+  if ( g4sd )  {
+    g4sd->Activate(true);
+    G4SDManager::GetSDMpointer()->AddNewDetector(g4sd);
+  }
+  return g4sd;
+}
+
 /// Geometry construction callback. Called at "Construct()"
-void Geant4DetectorConstruction::constructGeo(Geant4DetectorConstructionContext* )   {
+void Geant4DetectorConstruction::constructGeo(Geant4DetectorConstructionContext* )  {
 }
 
 /// Electromagnetic field construction callback. Called at "ConstructSDandField()"
-void Geant4DetectorConstruction::constructField(Geant4DetectorConstructionContext* )   {
+void Geant4DetectorConstruction::constructField(Geant4DetectorConstructionContext* )  {
 }
 
 /// Sensitive detector construction callback. Called at "ConstructSDandField()"
-void Geant4DetectorConstruction::constructSensitives(Geant4DetectorConstructionContext* )   {
+void Geant4DetectorConstruction::constructSensitives(Geant4DetectorConstructionContext* )  {
 }
-
 
 /// Standard Constructor
 Geant4DetectorConstructionSequence::Geant4DetectorConstructionSequence(Geant4Context* ctxt, const std::string& nam)
@@ -61,19 +87,19 @@ Geant4DetectorConstructionSequence::Geant4DetectorConstructionSequence(Geant4Con
 }
 
 /// Default destructor
-Geant4DetectorConstructionSequence::~Geant4DetectorConstructionSequence()   {
+Geant4DetectorConstructionSequence::~Geant4DetectorConstructionSequence()  {
   m_actors(&Geant4DetectorConstruction::release);  
   InstanceCount::decrement(this);
 }
 
 /// Set or update client context
-void Geant4DetectorConstructionSequence::updateContext(Geant4Context* ctxt)   {
+void Geant4DetectorConstructionSequence::updateContext(Geant4Context* ctxt)  {
   m_context = ctxt;
   m_actors(&Geant4DetectorConstruction::updateContext,ctxt);  
 }
 
 /// Add an actor responding to all callbacks. Sequence takes ownership.
-void Geant4DetectorConstructionSequence::adopt(Geant4DetectorConstruction* action)   {
+void Geant4DetectorConstructionSequence::adopt(Geant4DetectorConstruction* action)  {
   if (action) {
     action->addRef();
     m_actors.add(action);
@@ -83,7 +109,7 @@ void Geant4DetectorConstructionSequence::adopt(Geant4DetectorConstruction* actio
 }
 
 /// Access an actor by name
-Geant4DetectorConstruction* Geant4DetectorConstructionSequence::get(const std::string& nam)  const   {
+Geant4DetectorConstruction* Geant4DetectorConstructionSequence::get(const std::string& nam)  const  {
   for(auto* i : m_actors)  {
     if ( i->name() == nam )  {
       return i;
@@ -94,23 +120,23 @@ Geant4DetectorConstruction* Geant4DetectorConstructionSequence::get(const std::s
 }
 
 /// Geometry construction callback. Called at "Construct()"
-void Geant4DetectorConstructionSequence::constructGeo(Geant4DetectorConstructionContext* ctxt)   {
+void Geant4DetectorConstructionSequence::constructGeo(Geant4DetectorConstructionContext* ctxt)  {
   m_actors(&Geant4DetectorConstruction::constructGeo, ctxt);  
 }
 
 /// Electromagnetic field construction callback. Called at "ConstructSDandField()"
-void Geant4DetectorConstructionSequence::constructField(Geant4DetectorConstructionContext* ctxt)   {
+void Geant4DetectorConstructionSequence::constructField(Geant4DetectorConstructionContext* ctxt)  {
   m_actors(&Geant4DetectorConstruction::constructField, ctxt);  
 }
 
 /// Sensitive detector construction callback. Called at "ConstructSDandField()"
-void Geant4DetectorConstructionSequence::constructSensitives(Geant4DetectorConstructionContext* ctxt)   {
+void Geant4DetectorConstructionSequence::constructSensitives(Geant4DetectorConstructionContext* ctxt)  {
   m_actors(&Geant4DetectorConstruction::constructSensitives, ctxt);  
 }
 
 /// Access to the converted regions
 const std::map<dd4hep::Region, G4Region*>&
-Geant4DetectorConstructionSequence::regions() const   {
+Geant4DetectorConstructionSequence::regions() const  {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Regions;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::regions: Access not possible. Geometry is not yet converted!");
@@ -118,14 +144,14 @@ Geant4DetectorConstructionSequence::regions() const   {
 
 /// Access to the converted volumes
 const std::map<dd4hep::Volume, G4LogicalVolume*>&
-Geant4DetectorConstructionSequence::volumes() const   {
+Geant4DetectorConstructionSequence::volumes() const  {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Volumes;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::volumes: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted shapes
-const std::map<const TGeoShape*, G4VSolid*>& Geant4DetectorConstructionSequence::shapes() const   {
+const std::map<const TGeoShape*, G4VSolid*>& Geant4DetectorConstructionSequence::shapes() const  {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Solids;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::shapes: Access not possible. Geometry is not yet converted!");
@@ -133,7 +159,7 @@ const std::map<const TGeoShape*, G4VSolid*>& Geant4DetectorConstructionSequence:
 
 /// Access to the converted limit sets
 const std::map<dd4hep::LimitSet, G4UserLimits*>&
-Geant4DetectorConstructionSequence::limits() const   {
+Geant4DetectorConstructionSequence::limits() const  {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Limits;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::limits: Access not possible. Geometry is not yet converted!");
@@ -141,7 +167,7 @@ Geant4DetectorConstructionSequence::limits() const   {
 
 /// Access to the converted assemblies
 const std::map<dd4hep::PlacedVolume, Geant4AssemblyVolume*>&
-Geant4DetectorConstructionSequence::assemblies() const   {
+Geant4DetectorConstructionSequence::assemblies() const  {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4AssemblyVolumes;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::assemblies: Access not possible. Geometry is not yet converted!");
@@ -149,21 +175,21 @@ Geant4DetectorConstructionSequence::assemblies() const   {
 
 /// Access to the converted placements
 const std::map<dd4hep::PlacedVolume, G4VPhysicalVolume*>&
-Geant4DetectorConstructionSequence::placements() const   {
+Geant4DetectorConstructionSequence::placements() const  {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Placements;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::placements: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted materials
-const Geant4GeometryMaps::MaterialMap& Geant4DetectorConstructionSequence::materials() const   {
+const Geant4GeometryMaps::MaterialMap& Geant4DetectorConstructionSequence::materials() const  {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Materials;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::materials: Access not possible. Geometry is not yet converted!");
 }
 
 /// Access to the converted elements
-const Geant4GeometryMaps::ElementMap& Geant4DetectorConstructionSequence::elements() const   {
+const Geant4GeometryMaps::ElementMap& Geant4DetectorConstructionSequence::elements() const  {
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   if ( p ) return p->g4Elements;
   throw std::runtime_error("+++ Geant4DetectorConstructionSequence::elements: Access not possible. Geometry is not yet converted!");

--- a/DDG4/src/Geant4Kernel.cpp
+++ b/DDG4/src/Geant4Kernel.cpp
@@ -202,7 +202,7 @@ Geant4Kernel& Geant4Kernel::worker(unsigned long identifier, bool create_if)    
       return *this;
     }
   }
-  else if ( create_if )  {
+  else if( create_if )  {
     return createWorker();
   }
   except("Geant4Kernel", "DDG4: The Kernel object 0x%p does not exists!",(void*)identifier);
@@ -216,14 +216,30 @@ int Geant4Kernel::numWorkers() const   {
 
 /// Access to geometry world
 G4VPhysicalVolume* Geant4Kernel::world()  const   {
-  if ( this != m_master ) return m_master->world();
+  if( this != m_master ) return m_master->world();
   return m_world;
 }
 
 /// Set the geometry world
 void Geant4Kernel::setWorld(G4VPhysicalVolume* volume)  {
-  if ( this == m_master ) m_world = volume;
+  if( this == m_master ) m_world = volume;
   else m_master->setWorld(volume);
+}
+
+/// Add new sensitive type to factory list
+void Geant4Kernel::defineSensitiveDetectorType(const std::string& type, const std::string& factory)  {
+  auto iter = m_sensitiveDetectorTypes.find(type);
+  if( iter == m_sensitiveDetectorTypes.end() )  {
+    printout(INFO,"Geant4Kernel","+++ Define sensitive type: %s -> %s", type.c_str(), factory.c_str());
+    m_sensitiveDetectorTypes.emplace(type, factory);
+    return;
+  }
+  else if( iter->first == type && iter->second == factory )  {
+    return;
+  }
+  except("Geant4Kernel",
+         "+++ The sensitive type %s is already defined and used %s. Cannot overwrite with %s",
+         type.c_str(), iter->second.c_str(), factory.c_str());
 }
 
 void Geant4Kernel::printProperties()  const  {

--- a/examples/ClientTests/compact/BoxOfStraws.xml
+++ b/examples/ClientTests/compact/BoxOfStraws.xml
@@ -68,7 +68,7 @@
   
   <readouts>
     <readout name="BoxOfStrawsHits">
-      <id>system:8,module:16,straw:16,y:-12</id>
+      <id>system:8,layer:16,straw:16,y:-12</id>
     </readout>
   </readouts>
 

--- a/examples/ClientTests/compact/BoxOfStraws.xml
+++ b/examples/ClientTests/compact/BoxOfStraws.xml
@@ -39,17 +39,18 @@
     <vis name="VisibleRed"   alpha="0.4" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="VisibleBlue"  alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
     <vis name="VisibleGreen" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="false" visible="true"/>
+    <vis name="VisibleGray"  alpha="0.5" r="0.5" g="0.5" b="0.5" showDaughters="true" visible="true"/>
   </display>
 
   <limits>
     <limitset name="BoxOfStrawsLimitSet">
-      <limit name="step_length_max"  particles="*" value="1.0" unit="mm" />
+      <limit name="step_length_max"  particles="*" value="5.0" unit="mm" />
       <limit name="track_length_max" particles="*" value="1.0" unit="mm" />
     </limitset>
   </limits>
 
   <regions>
-    <region name="StrawRegion" eunit="MeV" lunit="mm" cut="0.001" threshold="0.001">
+    <region name="StrawRegion" eunit="MeV" lunit="mm" cut="0.01" threshold="0.01">
       <limitsetref name="BoxOfStrawsLimitSet"/>
     </region>
   </regions>

--- a/examples/ClientTests/compact/BoxOfStraws.xml
+++ b/examples/ClientTests/compact/BoxOfStraws.xml
@@ -57,8 +57,8 @@
   <detectors>
     <detector id="1" name="BoxOfStrawsDet" type="DD4hep_BoxOfStraws" readout="BoxOfStrawsHits" vis="VisibleGreen" region="StrawRegion" limits="BoxOfStrawsLimitSet">
       <box      x="1*m"    y="1*m" z="1000*mm"  limits="BoxOfStrawsLimitSet" vis="VisibleRed"/>
-      <straw rmax="1*mm"   y="1*m" vis="VisibleBlue">
-        <material name="Iron"/>
+      <straw rmax="2*mm"   y="1*m" thickness="0.5*mm" vis="VisibleBlue">
+        <material name="Argon"/>
         <non_sensitive/>
       </straw>
       <position x="0*m"   y="0*m"   z="0*m"/>

--- a/examples/ClientTests/compact/BoxOfStraws.xml
+++ b/examples/ClientTests/compact/BoxOfStraws.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+<!-- #==========================================================================
+     #  AIDA Detector description implementation 
+     #==========================================================================
+     # Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+     # All rights reserved.
+     #
+     # For the licensing terms see $DD4hepINSTALL/LICENSE.
+     # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+     #
+     #==========================================================================
+-->
+ 
+  <info name="BoxOfStraws"
+	title="Test with silicon boxes"
+	author="Markus Frank"
+	url="http://www.cern.ch/frankm"
+	status="development"
+	version="1.0">
+    <comment>Alignment test with 2 simple boxes</comment>        
+  </info>
+
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/materials.xml"/>
+  </includes>
+
+  <define>
+    <constant name="world_size" value="3*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+  </define>
+
+  <display>
+    <vis name="Invisible" showDaughters="false" visible="false"/>
+    <vis name="InvisibleWithChildren" showDaughters="true" visible="false"/>
+    <vis name="VisibleRed"   alpha="0.4" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="VisibleBlue"  alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="false" visible="true"/>
+    <vis name="VisibleGreen" alpha="1.0" r="0.0" g="1.0" b="0.0" drawingStyle="solid" lineStyle="solid" showDaughters="true" visible="true"/>
+  </display>
+
+  <limits>
+    <limitset name="BoxOfStrawsLimitSet">
+      <limit name="step_length_max"  particles="*" value="1.0" unit="mm" />
+      <limit name="track_length_max" particles="*" value="1.0" unit="mm" />
+    </limitset>
+  </limits>
+
+  <regions>
+    <region name="StrawRegion" eunit="MeV" lunit="mm" cut="0.001" threshold="0.001">
+      <limitsetref name="BoxOfStrawsLimitSet"/>
+    </region>
+  </regions>
+
+  <detectors>
+    <detector id="1" name="BoxOfStrawsDet" type="DD4hep_BoxOfStraws" readout="BoxOfStrawsHits" vis="VisibleGreen" region="StrawRegion" limits="BoxOfStrawsLimitSet">
+      <box      x="1*m"    y="1*m" z="1000*mm"  limits="BoxOfStrawsLimitSet" vis="VisibleRed"/>
+      <straw rmax="1*mm"   y="1*m" vis="VisibleBlue">
+        <material name="Iron"/>
+        <non_sensitive/>
+      </straw>
+      <position x="0*m"   y="0*m"   z="0*m"/>
+      <rotation x="0"     y="0"     z="0"/>
+    </detector>
+  </detectors>
+  
+  <readouts>
+    <readout name="BoxOfStrawsHits">
+      <id>system:8,module:16,straw:16,y:-12</id>
+    </readout>
+  </readouts>
+
+  <fields>
+    <field name="GlobalSolenoid" type="solenoid" 
+	   inner_field="5.0*tesla"
+	   outer_field="-1.5*tesla" 
+	   zmax="2*m"
+	   outer_radius="2*m">
+    </field>
+  </fields>
+
+</lccdd>

--- a/examples/ClientTests/compact/BoxOfStraws.xml
+++ b/examples/ClientTests/compact/BoxOfStraws.xml
@@ -13,12 +13,12 @@
 -->
  
   <info name="BoxOfStraws"
-	title="Test with silicon boxes"
+	title="Test with a box of straws"
 	author="Markus Frank"
-	url="http://www.cern.ch/frankm"
+	url="http://www.cern.ch"
 	status="development"
 	version="1.0">
-    <comment>Alignment test with 2 simple boxes</comment>        
+    <comment>Detector scalability test with a box of straws</comment>        
   </info>
 
   <includes>
@@ -37,8 +37,8 @@
     <vis name="Invisible" showDaughters="false" visible="false"/>
     <vis name="InvisibleWithChildren" showDaughters="true" visible="false"/>
     <vis name="VisibleRed"   alpha="0.4" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
-    <vis name="VisibleBlue"  alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="false" visible="true"/>
-    <vis name="VisibleGreen" alpha="1.0" r="0.0" g="1.0" b="0.0" drawingStyle="solid" lineStyle="solid" showDaughters="true" visible="true"/>
+    <vis name="VisibleBlue"  alpha="1.0" r="0.0" g="0.0" b="1.0" showDaughters="true" visible="true"/>
+    <vis name="VisibleGreen" alpha="1.0" r="0.0" g="1.0" b="0.0" showDaughters="false" visible="true"/>
   </display>
 
   <limits>
@@ -57,10 +57,13 @@
   <detectors>
     <detector id="1" name="BoxOfStrawsDet" type="DD4hep_BoxOfStraws" readout="BoxOfStrawsHits" vis="VisibleGreen" region="StrawRegion" limits="BoxOfStrawsLimitSet">
       <box      x="1*m"    y="1*m" z="1000*mm"  limits="BoxOfStrawsLimitSet" vis="VisibleRed"/>
-      <straw rmax="2*mm"   y="1*m" thickness="0.5*mm" vis="VisibleBlue">
+      <straw rmax="0.5*mm" y="1*m" thickness="0.1*mm" vis="VisibleBlue">
+        <material name="Iron"/>
+      </straw>
+      <gas vis="VisibleGreen">
         <material name="Argon"/>
         <non_sensitive/>
-      </straw>
+      </gas>
       <position x="0*m"   y="0*m"   z="0*m"/>
       <rotation x="0"     y="0"     z="0"/>
     </detector>
@@ -74,7 +77,7 @@
 
   <fields>
     <field name="GlobalSolenoid" type="solenoid" 
-	   inner_field="5.0*tesla"
+	   inner_field="3.0*tesla"
 	   outer_field="-1.5*tesla" 
 	   zmax="2*m"
 	   outer_radius="2*m">

--- a/examples/ClientTests/scripts/BoxOfStraws.py
+++ b/examples/ClientTests/scripts/BoxOfStraws.py
@@ -69,6 +69,7 @@ def run():
   #
   # Setup particle gun
   gun = geant4.setupGun("Gun", particle='e+', energy=10 * GeV, multiplicity=1)
+  gun.enableUI()
   #
   # And handle the simulation particles.
   part = DDG4.GeneratorAction(kernel, "Geant4ParticleHandler/ParticleHandler")

--- a/examples/ClientTests/scripts/BoxOfStraws.py
+++ b/examples/ClientTests/scripts/BoxOfStraws.py
@@ -89,12 +89,12 @@ def run():
   # Map sensitive detectors of type 'BoxOfStraws' to Geant4CalorimeterAction
   sd = geant4.description.sensitiveDetector(str('BoxOfStrawsDet'))
   logger.info(f'+++ BoxOfStraws: SD type: {str(sd.type())}')
-  filter = DDG4.Filter(kernel, 'EnergyDepositMinimumCut')
-  filter.Cut = 1.0 * MeV
-  filter.enableUI()
-  kernel.registerGlobalFilter(filter)
+  energy_filter = DDG4.Filter(kernel, 'EnergyDepositMinimumCut')
+  energy_filter.Cut = 1.0 * MeV
+  energy_filter.enableUI()
+  kernel.registerGlobalFilter(energy_filter)
   seq, act = geant4.setupDetector(name='BoxOfStrawsDet', action='MyTrackerSDAction')
-  seq.adopt(filter)
+  seq.adopt(energy_filter)
   act.HaveCellID = False
   #
   # Now build the physics list:

--- a/examples/ClientTests/scripts/BoxOfStraws.py
+++ b/examples/ClientTests/scripts/BoxOfStraws.py
@@ -1,0 +1,118 @@
+# ==========================================================================
+#  AIDA Detector description implementation
+# --------------------------------------------------------------------------
+# Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+# All rights reserved.
+#
+# For the licensing terms see $DD4hepINSTALL/LICENSE.
+# For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+#
+# ==========================================================================
+#
+#
+from __future__ import absolute_import, unicode_literals
+import os
+import time
+import cmath
+import DDG4
+from DDG4 import OutputLevel as Output
+from g4units import GeV, MeV, m
+#
+#
+"""
+
+   dd4hep simulation example setup using the python configuration
+
+   @author  M.Frank
+   @version 1.0
+
+"""
+
+
+def run():
+  args = DDG4.CommandLine()
+  kernel = DDG4.Kernel()
+  logger = DDG4.Logger('BoxOfStraws')
+  install_dir = os.environ['DD4hepExamplesINSTALL']
+  kernel.loadGeometry(str("file:" + install_dir + "/examples/ClientTests/compact/BoxOfStraws.xml"))
+
+  DDG4.importConstants(kernel.detectorDescription(), debug=False)
+  geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')
+  geant4.printDetectors()
+  # Configure UI
+  if args.macro:
+    ui = geant4.setupCshUI(macro=args.macro)
+  else:
+    ui = geant4.setupCshUI()
+  if args.batch:
+    ui.Commands = ['/run/beamOn ' + str(args.events), '/ddg4/UI/terminate']
+
+  # Configure field
+  geant4.setupTrackingField(prt=True)
+  # Configure Event actions
+  prt = DDG4.EventAction(kernel, 'Geant4ParticlePrint/ParticlePrint')
+  prt.OutputLevel = Output.DEBUG
+  prt.OutputType = 3
+  kernel.eventAction().adopt(prt)
+
+  generator_output_level = Output.DEBUG
+
+  # Configure G4 geometry setup
+  seq, act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
+  act.DebugVolumes = True
+  #
+  # Assign sensitive detectors according to the declarations 'tracker' or 'calorimeter', etc
+  seq, act = geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
+  # 
+  # Assign sensitive detectors in Geant4 by matching a regular expression in the detector sub-tree
+  seq, act = geant4.addDetectorConstruction("Geant4RegexSensitivesConstruction/ConstructSDRegEx")
+  act.Detector = 'BoxOfStrawsDet'
+  act.Regex = '/world_volume_(.*)/BoxOfStrawsDet_(.*)/row_(.*)/straw_(.*)'
+  act.OutputLevel = Output.ALWAYS
+  act.enableUI()
+
+  # Configure I/O
+  geant4.setupROOTOutput('RootOutput', 'BoxOfStraws_' + time.strftime('%Y-%m-%d_%H-%M'))
+
+  # Setup particle gun
+  gun = geant4.setupGun("Gun", particle='e+', energy=10 * GeV, multiplicity=1)
+  gun.OutputLevel = Output.DEBUG
+
+  # And handle the simulation particles.
+  part = DDG4.GeneratorAction(kernel, "Geant4ParticleHandler/ParticleHandler")
+  kernel.generatorAction().adopt(part)
+  part.SaveProcesses = ['Decay']
+  part.MinimalKineticEnergy = 100 * MeV
+  part.OutputLevel = Output.DEBUG  # generator_output_level
+  part.enableUI()
+  user = DDG4.Action(kernel, "Geant4TCUserParticleHandler/UserParticleHandler")
+  user.TrackingVolume_Zmax = 2.5 * m
+  user.TrackingVolume_Rmax = 2.5 * m
+  user.enableUI()
+  part.adopt(user)
+
+  # Map sensitive detectors of type 'BoxOfStraws' to Geant4CalorimeterAction
+  sd = geant4.description.sensitiveDetector(str('BoxOfStrawsDet'))
+  logger.info(f'+++ BoxOfStraws: SD type: {str(sd.type())}')
+  seq, act = geant4.setupDetector(name='BoxOfStrawsDet', action='MyTrackerSDAction')
+  act.HaveCellID = False
+  
+  # Now build the physics list:
+  phys = geant4.setupPhysics(str('QGSP_BERT'))
+  ph = DDG4.PhysicsList(kernel, str('Geant4PhysicsList/Myphysics'))
+  # Add b osons to the model (redundant if already implemented by the model)
+  ph.addParticleGroup(str('G4BosonConstructor'))
+  ph.addParticleGroup(str('G4BaryonConstructor'))
+  ph.addParticleGroup(str('G4MesonConstructor'))
+  ph.addParticleGroup(str('G4LeptonConstructor'))
+  # Add multiple scattering in the material
+  ph.addParticleProcess(str('e[+-]'), str('G4eMultipleScattering'), -1, 1, 1)
+  # Interactivity
+  ph.enableUI()
+  phys.adopt(ph)
+  phys.dump()
+  geant4.execute()
+
+
+if __name__ == "__main__":
+  run()

--- a/examples/ClientTests/scripts/BoxOfStraws.py
+++ b/examples/ClientTests/scripts/BoxOfStraws.py
@@ -13,7 +13,6 @@
 from __future__ import absolute_import, unicode_literals
 import os
 import time
-import cmath
 import DDG4
 from DDG4 import OutputLevel as Output
 from g4units import GeV, MeV, m
@@ -46,70 +45,49 @@ def run():
     ui = geant4.setupCshUI()
   if args.batch:
     ui.Commands = ['/run/beamOn ' + str(args.events), '/ddg4/UI/terminate']
-
+  if args.print:
+    logger.setPrintLevel(int(args.print))
+  #
   # Configure field
   geant4.setupTrackingField(prt=True)
-  # Configure Event actions
-  prt = DDG4.EventAction(kernel, 'Geant4ParticlePrint/ParticlePrint')
-  prt.OutputLevel = Output.DEBUG
-  prt.OutputType = 3
-  kernel.eventAction().adopt(prt)
-
-  generator_output_level = Output.DEBUG
-
+  #
   # Configure G4 geometry setup
   seq, act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
   act.DebugVolumes = True
   #
   # Assign sensitive detectors according to the declarations 'tracker' or 'calorimeter', etc
   seq, act = geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
-  # 
+  #
   # Assign sensitive detectors in Geant4 by matching a regular expression in the detector sub-tree
   seq, act = geant4.addDetectorConstruction("Geant4RegexSensitivesConstruction/ConstructSDRegEx")
   act.Detector = 'BoxOfStrawsDet'
-  act.Regex = '/world_volume_(.*)/BoxOfStrawsDet_(.*)/row_(.*)/straw_(.*)'
   act.OutputLevel = Output.ALWAYS
-  act.enableUI()
-
+  act.Regex = '/world_volume_(.*)/BoxOfStrawsDet_(.*)/row_(.*)/straw_(.*)'
+  #
   # Configure I/O
   geant4.setupROOTOutput('RootOutput', 'BoxOfStraws_' + time.strftime('%Y-%m-%d_%H-%M'))
-
+  #
   # Setup particle gun
   gun = geant4.setupGun("Gun", particle='e+', energy=10 * GeV, multiplicity=1)
-  gun.OutputLevel = Output.DEBUG
-
+  #
   # And handle the simulation particles.
   part = DDG4.GeneratorAction(kernel, "Geant4ParticleHandler/ParticleHandler")
   kernel.generatorAction().adopt(part)
   part.SaveProcesses = ['Decay']
   part.MinimalKineticEnergy = 100 * MeV
-  part.OutputLevel = Output.DEBUG  # generator_output_level
-  part.enableUI()
   user = DDG4.Action(kernel, "Geant4TCUserParticleHandler/UserParticleHandler")
   user.TrackingVolume_Zmax = 2.5 * m
   user.TrackingVolume_Rmax = 2.5 * m
-  user.enableUI()
   part.adopt(user)
-
+  #
   # Map sensitive detectors of type 'BoxOfStraws' to Geant4CalorimeterAction
   sd = geant4.description.sensitiveDetector(str('BoxOfStrawsDet'))
   logger.info(f'+++ BoxOfStraws: SD type: {str(sd.type())}')
   seq, act = geant4.setupDetector(name='BoxOfStrawsDet', action='MyTrackerSDAction')
   act.HaveCellID = False
-  
+  #
   # Now build the physics list:
   phys = geant4.setupPhysics(str('QGSP_BERT'))
-  ph = DDG4.PhysicsList(kernel, str('Geant4PhysicsList/Myphysics'))
-  # Add b osons to the model (redundant if already implemented by the model)
-  ph.addParticleGroup(str('G4BosonConstructor'))
-  ph.addParticleGroup(str('G4BaryonConstructor'))
-  ph.addParticleGroup(str('G4MesonConstructor'))
-  ph.addParticleGroup(str('G4LeptonConstructor'))
-  # Add multiple scattering in the material
-  ph.addParticleProcess(str('e[+-]'), str('G4eMultipleScattering'), -1, 1, 1)
-  # Interactivity
-  ph.enableUI()
-  phys.adopt(ph)
   phys.dump()
   geant4.execute()
 

--- a/examples/ClientTests/scripts/BoxOfStraws.py
+++ b/examples/ClientTests/scripts/BoxOfStraws.py
@@ -32,7 +32,8 @@ def run():
   args = DDG4.CommandLine()
   kernel = DDG4.Kernel()
   logger = DDG4.Logger('BoxOfStraws')
-  kernel.loadGeometry(str("file:" + os.environ['DD4hepExamplesINSTALL'] + "/examples/ClientTests/compact/BoxOfStraws.xml"))
+  install_dir = os.environ['DD4hepExamplesINSTALL']
+  kernel.loadGeometry(str('file:' + install_dir + '/examples/ClientTests/compact/BoxOfStraws.xml'))
 
   DDG4.importConstants(kernel.detectorDescription(), debug=False)
   geant4 = DDG4.Geant4(kernel)
@@ -49,32 +50,32 @@ def run():
   geant4.setupTrackingField(prt=True)
   #
   # Configure G4 geometry setup
-  seq, act = geant4.addDetectorConstruction("Geant4DetectorGeometryConstruction/ConstructGeo")
+  seq, act = geant4.addDetectorConstruction('Geant4DetectorGeometryConstruction/ConstructGeo')
   act.DebugVolumes = True
   #
   # Assign sensitive detectors according to the declarations 'tracker' or 'calorimeter', etc
-  seq, act = geant4.addDetectorConstruction("Geant4DetectorSensitivesConstruction/ConstructSD")
+  seq, act = geant4.addDetectorConstruction('Geant4DetectorSensitivesConstruction/ConstructSD')
   #
   # Assign sensitive detectors in Geant4 by matching a regular expression in the detector sub-tree
-  seq, act = geant4.addDetectorConstruction("Geant4RegexSensitivesConstruction/ConstructSDRegEx")
+  seq, act = geant4.addDetectorConstruction('Geant4RegexSensitivesConstruction/ConstructSDRegEx')
   act.Detector = 'BoxOfStrawsDet'
   act.OutputLevel = Output.ALWAYS
-  act.Regex = '/world_volume_(.*)/BoxOfStrawsDet_(.*)/layer_(.*)/straw_(.*)/gas_(.*)'
-  act.Regex = '/world_volume_(.*)/BoxOfStrawsDet_(.*)/layer_(.*)/straw_(.*)'
+  act.Match = ['/world_volume_(.*)/BoxOfStrawsDet_(.*)/layer_(.*)/straw_(.*)/gas_(.*)']
+  act.Match = ['/world_volume_(.*)/BoxOfStrawsDet_(.*)/layer_(.*)/straw_(.*)']
   #
   # Configure I/O
   geant4.setupROOTOutput('RootOutput', 'BoxOfStraws_' + time.strftime('%Y-%m-%d_%H-%M'))
   #
   # Setup particle gun
-  gun = geant4.setupGun("Gun", particle='pi+', energy=100 * GeV, multiplicity=1)
+  gun = geant4.setupGun('Gun', particle='pi+', energy=100 * GeV, multiplicity=1)
   gun.enableUI()
   #
   # And handle the simulation particles.
-  part = DDG4.GeneratorAction(kernel, "Geant4ParticleHandler/ParticleHandler")
+  part = DDG4.GeneratorAction(kernel, 'Geant4ParticleHandler/ParticleHandler')
   kernel.generatorAction().adopt(part)
   part.SaveProcesses = ['Decay']
-  part.MinimalKineticEnergy = 100 * MeV
-  user = DDG4.Action(kernel, "Geant4TCUserParticleHandler/UserParticleHandler")
+  part.MinimalKineticEnergy = 50 * MeV
+  user = DDG4.Action(kernel, 'Geant4TCUserParticleHandler/UserParticleHandler')
   user.TrackingVolume_Zmax = 2.5 * m
   user.TrackingVolume_Rmax = 2.5 * m
   part.adopt(user)

--- a/examples/ClientTests/scripts/BoxOfStraws.py
+++ b/examples/ClientTests/scripts/BoxOfStraws.py
@@ -49,6 +49,11 @@ def run():
   # Configure field
   geant4.setupTrackingField(prt=True)
   #
+  prt = DDG4.EventAction(kernel, 'Geant4ParticlePrint/ParticlePrint')
+  prt.OutputLevel = Output.DEBUG
+  prt.OutputType = 3  # Print both: table and tree
+  kernel.eventAction().adopt(prt)
+  #
   # Configure G4 geometry setup
   seq, act = geant4.addDetectorConstruction('Geant4DetectorGeometryConstruction/ConstructGeo')
   act.DebugVolumes = True
@@ -67,7 +72,8 @@ def run():
   geant4.setupROOTOutput('RootOutput', 'BoxOfStraws_' + time.strftime('%Y-%m-%d_%H-%M'))
   #
   # Setup particle gun
-  gun = geant4.setupGun('Gun', particle='pi+', energy=100 * GeV, multiplicity=1)
+  gun = geant4.setupGun('Gun', particle='pi+', energy=10 * GeV, multiplicity=1)
+  gun.OutputLevel = Output.INFO
   gun.enableUI()
   #
   # And handle the simulation particles.
@@ -83,7 +89,12 @@ def run():
   # Map sensitive detectors of type 'BoxOfStraws' to Geant4CalorimeterAction
   sd = geant4.description.sensitiveDetector(str('BoxOfStrawsDet'))
   logger.info(f'+++ BoxOfStraws: SD type: {str(sd.type())}')
+  filter = DDG4.Filter(kernel, 'EnergyDepositMinimumCut')
+  filter.Cut = 1.0 * MeV
+  filter.enableUI()
+  kernel.registerGlobalFilter(filter)
   seq, act = geant4.setupDetector(name='BoxOfStrawsDet', action='MyTrackerSDAction')
+  seq.adopt(filter)
   act.HaveCellID = False
   #
   # Now build the physics list:

--- a/examples/ClientTests/scripts/BoxOfStraws.py
+++ b/examples/ClientTests/scripts/BoxOfStraws.py
@@ -32,11 +32,10 @@ def run():
   args = DDG4.CommandLine()
   kernel = DDG4.Kernel()
   logger = DDG4.Logger('BoxOfStraws')
-  install_dir = os.environ['DD4hepExamplesINSTALL']
-  kernel.loadGeometry(str("file:" + install_dir + "/examples/ClientTests/compact/BoxOfStraws.xml"))
+  kernel.loadGeometry(str("file:" + os.environ['DD4hepExamplesINSTALL'] + "/examples/ClientTests/compact/BoxOfStraws.xml"))
 
   DDG4.importConstants(kernel.detectorDescription(), debug=False)
-  geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')
+  geant4 = DDG4.Geant4(kernel)
   geant4.printDetectors()
   # Configure UI
   if args.macro:
@@ -45,8 +44,6 @@ def run():
     ui = geant4.setupCshUI()
   if args.batch:
     ui.Commands = ['/run/beamOn ' + str(args.events), '/ddg4/UI/terminate']
-  if args.print:
-    logger.setPrintLevel(int(args.print))
   #
   # Configure field
   geant4.setupTrackingField(prt=True)
@@ -62,13 +59,14 @@ def run():
   seq, act = geant4.addDetectorConstruction("Geant4RegexSensitivesConstruction/ConstructSDRegEx")
   act.Detector = 'BoxOfStrawsDet'
   act.OutputLevel = Output.ALWAYS
-  act.Regex = '/world_volume_(.*)/BoxOfStrawsDet_(.*)/row_(.*)/straw_(.*)'
+  act.Regex = '/world_volume_(.*)/BoxOfStrawsDet_(.*)/layer_(.*)/straw_(.*)/gas_(.*)'
+  act.Regex = '/world_volume_(.*)/BoxOfStrawsDet_(.*)/layer_(.*)/straw_(.*)'
   #
   # Configure I/O
   geant4.setupROOTOutput('RootOutput', 'BoxOfStraws_' + time.strftime('%Y-%m-%d_%H-%M'))
   #
   # Setup particle gun
-  gun = geant4.setupGun("Gun", particle='e+', energy=10 * GeV, multiplicity=1)
+  gun = geant4.setupGun("Gun", particle='pi+', energy=100 * GeV, multiplicity=1)
   gun.enableUI()
   #
   # And handle the simulation particles.

--- a/examples/ClientTests/src/BoxOfStraws_geo.cpp
+++ b/examples/ClientTests/src/BoxOfStraws_geo.cpp
@@ -30,22 +30,26 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   xml_dim_t    x_pos   = x_det.child(_U(position));
   xml_det_t    x_straw = x_det.child(_Unicode(straw));
   std::string  nam     = x_det.nameStr();
+  const double thick   = x_straw.thickness();
   const double delta   = 2e0*x_straw.rmax();
   const int    num_x   = int(2e0*x_box.x() / delta);
   const int    num_z   = int(2e0*x_box.z() / delta);
 
-  // Have box like straws: voxelization should be more efficient and for our test it does not matter.
   Tube   straw(0., x_straw.rmax()-tol, x_straw.y()-tol);
-  //Box    straw(x_straw.rmax()-tol, x_straw.rmax()-tol, x_straw.y()-tol);
-  Volume straw_vol("straw", straw, description.material(x_straw.materialStr()));
+  Volume straw_vol("straw", straw, description.material("Iron"));
+  
+  Tube   straw_gas(0., x_straw.rmax()-tol-thick, x_straw.y()-tol-thick);
+  Volume straw_gas_vol("gas", straw_gas, description.material(x_straw.materialStr()));
 
   straw_vol.setAttributes(description, x_straw.regionStr(), x_straw.limitsStr(), x_straw.visStr());
+  straw_vol.placeVolume(straw_gas_vol);
+
   printout(INFO, "BoxOfStraws", "%s: Straw: rmax: %7.3f y: %7.3f mat: %s vis: %s solid: %s",
            nam.c_str(), x_straw.rmax(), x_straw.y(), x_straw.materialStr().c_str(),
            x_straw.visStr().c_str(), straw.type());
   if ( x_straw.hasChild(_U(sensitive)) )  {
     sens.setType("tracker");
-    straw_vol.setSensitiveDetector(sens);
+    straw_gas_vol.setSensitiveDetector(sens);
   }
 
   Box    box(x_box.x(), x_box.y(), x_box.z());

--- a/examples/ClientTests/src/BoxOfStraws_geo.cpp
+++ b/examples/ClientTests/src/BoxOfStraws_geo.cpp
@@ -52,14 +52,14 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   Volume box_vol(nam, box, description.air());
   box_vol.setAttributes(description, x_box.regionStr(), x_box.limitsStr(), x_box.visStr());
 
-  Box    row(x_box.x(), x_box.y(), x_straw.rmax());
-  Volume row_vol("row", row, description.air());
-  row_vol.setVisAttributes(description.visAttributes("InvisibleWithChildren"));
+  Box    layer(x_box.x(), x_box.y(), x_straw.rmax());
+  Volume layer_vol("layer", layer, description.air());
+  layer_vol.setVisAttributes(description.visAttributes("InvisibleWithChildren"));
   
-  printout(INFO, "BoxOfStraws", "%s: Row:   nx: %7d nz: %7d delta: %7.3f", nam.c_str(), num_x, num_z, delta);
+  printout(INFO, "BoxOfStraws", "%s: Layer:   nx: %7d nz: %7d delta: %7.3f", nam.c_str(), num_x, num_z, delta);
   for( int ix=0; ix < num_x; ++ix )  {
     double x = -box.x() + (double(ix)+0.5) * delta;
-    PlacedVolume pv = row_vol.placeVolume(straw_vol, Position(x, 0e0, 0e0));
+    PlacedVolume pv = layer_vol.placeVolume(straw_vol, Position(x, 0e0, 0e0));
     pv.addPhysVolID("straw", ix);
   }
 
@@ -67,10 +67,10 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   Rotation3D rot(RotationZYX(0e0, 0e0, M_PI/2e0));
   for( int iz=0; iz < num_z; ++iz )  {
     double z = -box.z() + (double(iz)+0.5) * delta;
-    PlacedVolume pv = box_vol.placeVolume(row_vol, Transform3D(rot, Position(0e0, 0e0, z)));
-    pv.addPhysVolID("module", iz);
+    PlacedVolume pv = box_vol.placeVolume(layer_vol, Transform3D(rot, Position(0e0, 0e0, z)));
+    pv.addPhysVolID("layer", iz);
   }
-  printout(INFO, "BoxOfStraws", "%s: Created %d rows of %d straws each.", nam.c_str(), num_z, num_x);
+  printout(INFO, "BoxOfStraws", "%s: Created %d layers of %d straws each.", nam.c_str(), num_z, num_x);
   
   DetElement   sdet  (nam, x_det.id());
   Volume       mother(description.pickMotherVolume(sdet));

--- a/examples/ClientTests/src/BoxOfStraws_geo.cpp
+++ b/examples/ClientTests/src/BoxOfStraws_geo.cpp
@@ -17,12 +17,13 @@
 //
 //==========================================================================
 #include <DD4hep/DetFactoryHelper.h>
+#include <DD4hep/DD4hepUnits.h>
 #include <DD4hep/Printout.h>
 
 using namespace dd4hep;
 
 static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector sens)  {
-  double       tol     = 1e-2;
+  double       tol     = 1e-5 * dd4hep::mm;
   xml_det_t    x_det   = e;
   xml_dim_t    x_box   = x_det.child(_U(box));
   xml_dim_t    x_rot   = x_det.child(_U(rotation));

--- a/examples/ClientTests/src/BoxOfStraws_geo.cpp
+++ b/examples/ClientTests/src/BoxOfStraws_geo.cpp
@@ -1,0 +1,85 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+//
+//
+// Display using:
+// $> geoDisplay examples/ClientTests/compact/BoxOfStraws.xml
+//
+//==========================================================================
+#include <DD4hep/DetFactoryHelper.h>
+#include <DD4hep/Printout.h>
+
+using namespace dd4hep;
+
+static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector sens)  {
+  double       tol     = 1e-2;
+  xml_det_t    x_det   = e;
+  xml_dim_t    x_box   = x_det.child(_U(box));
+  xml_dim_t    x_rot   = x_det.child(_U(rotation));
+  xml_dim_t    x_pos   = x_det.child(_U(position));
+  xml_det_t    x_straw = x_det.child(_Unicode(straw));
+  std::string  nam     = x_det.nameStr();
+  const double delta   = 2e0*x_straw.rmax();
+  const int    num_x   = int(2e0*x_box.x() / delta);
+  const int    num_z   = int(2e0*x_box.z() / delta);
+
+  // Have box like straws: voxelization should be more efficient and for our test it does not matter.
+  Tube   straw(0., x_straw.rmax()-tol, x_straw.y()-tol);
+  //Box    straw(x_straw.rmax()-tol, x_straw.rmax()-tol, x_straw.y()-tol);
+  Volume straw_vol("straw", straw, description.material(x_straw.materialStr()));
+
+  straw_vol.setAttributes(description, x_straw.regionStr(), x_straw.limitsStr(), x_straw.visStr());
+  printout(INFO, "BoxOfStraws", "%s: Straw: rmax: %7.3f y: %7.3f mat: %s vis: %s solid: %s",
+           nam.c_str(), x_straw.rmax(), x_straw.y(), x_straw.materialStr().c_str(),
+           x_straw.visStr().c_str(), straw.type());
+  if ( x_straw.hasChild(_U(sensitive)) )  {
+    sens.setType("tracker");
+    straw_vol.setSensitiveDetector(sens);
+  }
+
+  Box    box(x_box.x(), x_box.y(), x_box.z());
+  Volume box_vol(nam, box, description.air());
+  box_vol.setAttributes(description, x_box.regionStr(), x_box.limitsStr(), x_box.visStr());
+
+  Box    row(x_box.x(), x_box.y(), x_straw.rmax());
+  Volume row_vol("row", row, description.air());
+  row_vol.setVisAttributes(description.visAttributes("InvisibleWithChildren"));
+  
+  printout(INFO, "BoxOfStraws", "%s: Row:   nx: %7d nz: %7d delta: %7.3f", nam.c_str(), num_x, num_z, delta);
+  for( int ix=0; ix < num_x; ++ix )  {
+    double x = -box.x() + (double(ix)+0.5) * delta;
+    PlacedVolume pv = row_vol.placeVolume(straw_vol, Position(x, 0e0, 0e0));
+    pv.addPhysVolID("straw", ix);
+  }
+
+  // Not terribly clever: better would be to place layers instead of single straws....
+  Rotation3D rot(RotationZYX(0e0, 0e0, M_PI/2e0));
+  for( int iz=0; iz < num_z; ++iz )  {
+    double z = -box.z() + (double(iz)+0.5) * delta;
+    PlacedVolume pv = box_vol.placeVolume(row_vol, Transform3D(rot, Position(0e0, 0e0, z)));
+    pv.addPhysVolID("module", iz);
+  }
+  printout(INFO, "BoxOfStraws", "%s: Created %d rows of %d straws each.", nam.c_str(), num_z, num_x);
+  
+  DetElement   sdet  (nam, x_det.id());
+  Volume       mother(description.pickMotherVolume(sdet));
+  Rotation3D   rot3D (RotationZYX(x_rot.z(0), x_rot.y(0), x_rot.x(0)));
+  Transform3D  trafo (rot3D, Position(x_pos.x(0), x_pos.y(0), x_pos.z(0)));
+  PlacedVolume pv = mother.placeVolume(box_vol, trafo);
+  pv.addPhysVolID("system", x_det.id());
+  sdet.setPlacement(pv);  // associate the placed volume to the detector element
+  printout(INFO, "BoxOfStraws", "%s: Detector construction finished.", nam.c_str());
+  return sdet;
+}
+
+DECLARE_DETELEMENT(DD4hep_BoxOfStraws,create_detector)

--- a/examples/ClientTests/src/BoxOfStraws_geo.cpp
+++ b/examples/ClientTests/src/BoxOfStraws_geo.cpp
@@ -29,6 +29,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   xml_dim_t    x_rot   = x_det.child(_U(rotation));
   xml_dim_t    x_pos   = x_det.child(_U(position));
   xml_det_t    x_straw = x_det.child(_Unicode(straw));
+  xml_det_t    x_gas   = x_det.child(_Unicode(gas));
   std::string  nam     = x_det.nameStr();
   const double thick   = x_straw.thickness();
   const double delta   = 2e0*x_straw.rmax();
@@ -36,18 +37,19 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   const int    num_z   = int(2e0*x_box.z() / delta);
 
   Tube   straw(0., x_straw.rmax()-tol, x_straw.y()-tol);
-  Volume straw_vol("straw", straw, description.material("Iron"));
-  
-  Tube   straw_gas(0., x_straw.rmax()-tol-thick, x_straw.y()-tol-thick);
-  Volume straw_gas_vol("gas", straw_gas, description.material(x_straw.materialStr()));
-
+  Volume straw_vol("straw", straw, description.material(x_straw.materialStr()));
   straw_vol.setAttributes(description, x_straw.regionStr(), x_straw.limitsStr(), x_straw.visStr());
+  
+  Tube   straw_gas(0., straw.rMax()-thick, straw.dZ()-thick);
+  Volume straw_gas_vol("gas", straw_gas, description.material(x_gas.materialStr()));
+  straw_gas_vol.setAttributes(description, x_gas.regionStr(), x_gas.limitsStr(), x_gas.visStr());
+
   straw_vol.placeVolume(straw_gas_vol);
 
   printout(INFO, "BoxOfStraws", "%s: Straw: rmax: %7.3f y: %7.3f mat: %s vis: %s solid: %s",
            nam.c_str(), x_straw.rmax(), x_straw.y(), x_straw.materialStr().c_str(),
            x_straw.visStr().c_str(), straw.type());
-  if ( x_straw.hasChild(_U(sensitive)) )  {
+  if( x_gas.hasChild(_U(sensitive)) )  {
     sens.setType("tracker");
     straw_gas_vol.setSensitiveDetector(sens);
   }


### PR DESCRIPTION

BEGINRELEASENOTES
- As reported in this issue https://github.com/AIDASoft/DD4hep/issues/1285 under certain circumstances the memory usage of DDG4 goes through the roof. This was traced back to the creation of excessive maps in the `Geant4VolumeManager`, if the number of sensitive pathes is very high like e.g. for straw detectors.
- To solve the problem, geometry constructors may not declare any sensitive volumes. Hence the `Geant4VolumeManager` will not be populated. To still make Geant4 functioning, the sensitive volumes may be declared a posterior after conversion using regular expressions as implemented in the class `Geant4RegexSensitivesConstruction`. This class is only an example how such functionality may be achieved: other solutions are possible as well. This functionality can be switched at the level of each subdetector participating in the experiment setup.
- To illustrate, an example detector `BoxOfStraws` was constructed with a flag in the xml description:
```
    <detector id="1" name="BoxOfStrawsDet" type="DD4hep_BoxOfStraws" readout="BoxOfStrawsHits" vis="VisibleGreen" region="StrawRegion" limits="BoxOfStrawsLimitSet">
      <box      x="1*m"    y="1*m" z="1000*mm"  limits="BoxOfStrawsLimitSet" vis="VisibleRed"/>
      <straw rmax="0.5*mm" y="1*m" thickness="0.1*mm" vis="VisibleBlue">
        <material name="Iron"/>
      </straw>
      <gas vis="VisibleGreen">
        <material name="Argon"/>
        <non_sensitive/>
      </gas>
      <position x="0*m"   y="0*m"   z="0*m"/>
      <rotation x="0"     y="0"     z="0"/>
    </detector>
```
Change `<non_sensitive/>` to `<sensitive/>` and the different behavor of memory allocation when starting Geant4 can be observed.
The corresponding Geant4 python script can be found here:
```
<DD4hep>/examples/ClientTests/scripts/BoxOfStraws.py
```
The memory consumption differs then as follows (depending on the thickness of the straws, which determine the number of sensitive pathes):
```
With explicit sensitive volumes:   
before Geant4VolumeManager:    Virtual: 903.3m   resident: 690.5m
after Geant4VolumeManager:     Virtual: 1848.2m  resident: 1.6g   


With Sensitives matching regex and not sensitive volumes declared:
before Geant4VolumeManager:    Virtual: 903.3m   Resident: 690.6m 
after Geant4VolumeManager:     Virtual: 903.3m   Resident: 690.6m 
Simulating:                    Virtual: 903.5m   Resident: 692.6m 
```
Hence this is a possibility to significantly reduce memory consumption for highly granular subdetectors.
ENDRELEASENOTES