### PR TITLE
Fix compiling with Clang 18 and a few warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ Version.h
 
 # XML files for DDUpgrade that are downloaded with cmake
 /examples/DDUpgrade/data
+
+# clangd files
+.cache
+
+# CMake commands database
+compile_commands.json

--- a/DDCond/src/ConditionsDependencyHandler.cpp
+++ b/DDCond/src/ConditionsDependencyHandler.cpp
@@ -108,7 +108,6 @@ void ConditionsDependencyHandler::compute()   {
 /// 2nd pass:  Handler callback for the second turn to resolve missing dependencies
 void ConditionsDependencyHandler::resolve()    {
   PrintLevel prt_lvl = INFO;
-  size_t num_resolved = 0;
   std::vector<Condition> tmp;
   std::map<IOV::Key,std::vector<Condition> > work_pools;
   Work* w;
@@ -120,7 +119,6 @@ void ConditionsDependencyHandler::resolve()    {
     if ( w->state != RESOLVED )   {
       w->resolve(m_currentWork);
     }
-    ++num_resolved;
     // Fill an empty map of condition vectors for the block inserts
     auto ret = work_pools.emplace(w->iov->keyData,tmp);
     if ( ret.second )   {

--- a/DDG4/plugins/Geant4DetectorConstructionResources.cpp
+++ b/DDG4/plugins/Geant4DetectorConstructionResources.cpp
@@ -14,6 +14,7 @@
 
 // Framework include files
 #include <DDG4/Geant4DetectorConstruction.h>
+#include <unistd.h>
 
 // C/C++ include files
 

--- a/DDG4/plugins/Geant4RegexSensitivesConstruction.cpp
+++ b/DDG4/plugins/Geant4RegexSensitivesConstruction.cpp
@@ -102,9 +102,9 @@ Geant4RegexSensitivesConstruction::collect_volumes(std::set<Volume>&  volumes,
   // Try to minimize a bit the number of regex matches.
   if ( volumes.find(pv.volume()) == volumes.end() )  {
     if( !path.empty() )  {
-      for( const auto& m : matches )  {
+      for( const auto& match : matches )  {
         std::smatch sm;
-        bool stat = std::regex_match(path, sm, m);
+        bool stat = std::regex_match(path, sm, match);
         if( stat )  {
           volumes.insert(pv.volume());
           ++count;

--- a/UtilityApps/src/next_event_dummy.cpp
+++ b/UtilityApps/src/next_event_dummy.cpp
@@ -18,7 +18,7 @@ TEveStraightLineSet* lineset(Int_t nlines = 40, Int_t nmarkers = 4) ;
 
 void next_event(){
 
-  static int count = 1 ;
+  // static int count = 1 ;
 
   std::cout <<  " next_event called - nothing to do ... " << std::endl ;
 
@@ -32,7 +32,7 @@ void next_event(){
   
   gEve->Redraw3D();
   
-  count += 3 ;
+  // count += 3 ;
 }
 
 


### PR DESCRIPTION
The header is needed to be able to find `::open` and `::close`. For the warnings I commented out one case instead of removing it because the place where it's used is also commented out ([here](https://github.com/jmcarcell/DD4hep/blob/e3264a5dff3a5965c8465ba93714f6e4a3916a1d/UtilityApps/src/next_event_dummy.cpp#L31), so it would be easy to reenable in case someone wanted to...). 

BEGINRELEASENOTES
- Add the missing header unistd.h in a file to find `::open` and `::close`
- Fix a few warnings about unused variables or shadowing
- Add .cache and compile_commands.json to .gitignore

ENDRELEASENOTES