### PR TITLE
Fix a crash when an action has dictionaries and is not hashable

### DIFF
--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -678,15 +678,9 @@ class Geant4:
     retType = detType
     if detType is None:
       retType = self.sensitive_types['calorimeter' if isCalo else 'tracker']
-    elif detType is not None:
-      try:
-        retType = self.sensitive_types[detType]
-      # KeyError = not found in the dictionary
-      # TypeError = detType is not a hashable type
-      except (KeyError, TypeError):
-        pass
-      except Exception as X:
-        raise X
+    # detType is a tuple when an action with parameters in a dictionary is passed
+    elif not isinstance(detType, tuple) and detType in self.sensitive_types:
+      retType = self.sensitive_types[detType]
     return self.setupDetector(name, retType, collections)
 
   def setupCalorimeter(self, name, caloType=None, collections=None):  # noqa: A002

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -670,35 +670,40 @@ class Geant4:
       return (seq, acts)
     return (seq, acts[0])
 
-  def setupCalorimeter(self, name, type=None, collections=None):  # noqa: A002
+  def setupCaloOrTracker(self, name, detType=None, collections=None, isCalo=True):  # noqa: A002
+    """
+    Setup subdetector of type 'calorimeter' and assign the proper sensitive action
+    """
+    self.description.sensitiveDetector(str(name))
+    retType = detType
+    if detType is None:
+      retType = self.sensitive_types['calorimeter' if isCalo else 'tracker']
+    elif detType is not None:
+      try:
+        retType = self.sensitive_types[detType]
+      # KeyError = not found in the dictionary
+      # TypeError = detType is not a hashable type
+      except (KeyError, TypeError):
+        pass
+      except Exception as X:
+        raise X
+    return self.setupDetector(name, retType, collections)
+
+  def setupCalorimeter(self, name, caloType=None, collections=None):  # noqa: A002
     """
     Setup subdetector of type 'calorimeter' and assign the proper sensitive action
 
     \author  M.Frank
     """
-    typ = type    # noqa: A002
-    self.description.sensitiveDetector(str(name))
-    # sd.setType('calorimeter')
-    if typ is None:
-      typ = self.sensitive_types['calorimeter']
-    elif typ is not None and self.sensitive_types.get(typ):
-      typ = self.sensitive_types[typ]
-    return self.setupDetector(name, typ, collections)
+    return self.setupCaloOrTracker(name, caloType, collections, True)
 
-  def setupTracker(self, name, type=None, collections=None):  # noqa: A002
+  def setupTracker(self, name, trackerType=None, collections=None):  # noqa: A002
     """
     Setup subdetector of type 'tracker' and assign the proper sensitive action
 
     \author  M.Frank
     """
-    typ = type
-    self.description.sensitiveDetector(str(name))
-    # sd.setType('tracker')
-    if typ is None:
-      typ = self.sensitive_types['tracker']
-    elif typ is not None and self.sensitive_types.get(typ):
-      typ = self.sensitive_types[typ]
-    return self.setupDetector(name, typ, collections)
+    return self.setupCaloOrTracker(name, trackerType, collections, False)
 
   def _private_setupField(self, field, stepper, equation, prt):
     import g4units


### PR DESCRIPTION
Fixes https://github.com/AIDASoft/DD4hep/issues/1292, introduced first in https://github.com/AIDASoft/DD4hep/pull/1288. The issue happens when passing an action that has a dictionary, like in https://github.com/key4hep/k4geo/blob/2e1bba216879562382ea5599b738c14c0938b540/example/steeringFile.py#L22.

BEGINRELEASENOTES
- Fix a crash when passing to ddsim an action has dictionaries and is not hashable.
- Refactor the functions in DDG4.py to setup a calorimeter and a tracker detector into a single one since the logic is the same. In this new function, use a try-except and if the type is not hashable use the default value.

ENDRELEASENOTES