### PR TITLE
Adding CylindricalGridPhiZ files

### DIFF
--- a/DDCore/include/DD4hep/CartesianGridXY.h
+++ b/DDCore/include/DD4hep/CartesianGridXY.h
@@ -41,7 +41,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  M.Frank

--- a/DDCore/include/DD4hep/CartesianGridXYZ.h
+++ b/DDCore/include/DD4hep/CartesianGridXYZ.h
@@ -41,7 +41,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  M.Frank

--- a/DDCore/include/DD4hep/CartesianGridXZ.h
+++ b/DDCore/include/DD4hep/CartesianGridXZ.h
@@ -41,7 +41,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  M.Frank

--- a/DDCore/include/DD4hep/CartesianGridYZ.h
+++ b/DDCore/include/DD4hep/CartesianGridYZ.h
@@ -41,7 +41,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  M.Frank

--- a/DDCore/include/DD4hep/CartesianStripX.h
+++ b/DDCore/include/DD4hep/CartesianStripX.h
@@ -42,7 +42,7 @@ typedef Handle<SegmentationWrapper<DDSegmentation::CartesianStripX> > CartesianS
  *  fiddled with the handled object directly.....
  *
  *  Note:
- *  The handle base corrsponding to this object in for
+ *  The handle base corresponding to this object in for
  *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
  *
  *  \author  M.Frank

--- a/DDCore/include/DD4hep/CartesianStripY.h
+++ b/DDCore/include/DD4hep/CartesianStripY.h
@@ -42,7 +42,7 @@ typedef Handle<SegmentationWrapper<DDSegmentation::CartesianStripY> > CartesianS
  *  fiddled with the handled object directly.....
  *
  *  Note:
- *  The handle base corrsponding to this object in for
+ *  The handle base corresponding to this object in for
  *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
  *
  *  \author  M.Frank
@@ -87,7 +87,7 @@ class CartesianStripY : public CartesianStripYHandle {
         Returns a vector of the cellDimensions of the given cell ID
         \param cellID is ignored as all cells have the same dimension
         \return std::vector<double> size 1:
-        -# size in x
+        -# size in y
     */
     std::vector<double> cellDimensions(const CellID& cellID) const;
 };

--- a/DDCore/include/DD4hep/CartesianStripZ.h
+++ b/DDCore/include/DD4hep/CartesianStripZ.h
@@ -43,7 +43,7 @@ typedef Handle<SegmentationWrapper<DDSegmentation::CartesianStripZ> > CartesianS
  *  fiddled with the handled object directly.....
  *
  *  Note:
- *  The handle base corrsponding to this object in for
+ *  The handle base corresponding to this object in for
  *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
  *
  *  \author  M.Frank
@@ -88,7 +88,7 @@ class CartesianStripZ : public CartesianStripZHandle {
         Returns a vector of the cellDimensions of the given cell ID
         \param cellID is ignored as all cells have the same dimension
         \return std::vector<double> size 1:
-        -# size in x
+        -# size in z
     */
     std::vector<double> cellDimensions(const CellID& cellID) const;
 };

--- a/DDCore/include/DD4hep/CylindricalGridPhiZ.h
+++ b/DDCore/include/DD4hep/CylindricalGridPhiZ.h
@@ -12,8 +12,8 @@
 //  \version  1.0
 //
 //==========================================================================
-#ifndef DD4HEP_CARTESIANGRIDXYZ_H
-#define DD4HEP_CARTESIANGRIDXYZ_H 1
+#ifndef DD4HEP_CYLINDRICALGRIDPHIZ_H
+#define DD4HEP_CYLINDRICALGRIDPHIZ_H 1
 
 // Framework include files
 #include <DD4hep/Segmentations.h>
@@ -22,12 +22,12 @@
 namespace dd4hep {
 
   /// Namespace for base segmentations
-  namespace DDSegmentation  {    class CartesianGridXYZ;  }
-  
+  namespace DDSegmentation  {    class CylindricalGridPhiZ;  }
+    
   /// We need some abbreviation to make the code more readable.
-  typedef Handle<SegmentationWrapper<DDSegmentation::CartesianGridXYZ> > CartesianGridXYZHandle;
-  
-  /// Implementation class for the grid XYZ segmentation.
+  typedef Handle<SegmentationWrapper<DDSegmentation::CylindricalGridPhiZ> > CylindricalGridPhiZHandle;
+ 
+  /// Implementation class for the grid PhiZ segmentation.
   /**
    *  Concrete user handle to serve specific needs of client code
    *  which requires access to the base functionality not served
@@ -48,56 +48,52 @@ namespace dd4hep {
    *  \version 1.0
    *  \ingroup DD4HEP_CORE
    */
-  class CartesianGridXYZ : public CartesianGridXYZHandle {
+  class CylindricalGridPhiZ : public  CylindricalGridPhiZHandle {
   public:
     /// Default constructor
-    CartesianGridXYZ() = default;
+    CylindricalGridPhiZ() = default;
     /// Copy constructor
-    CartesianGridXYZ(const CartesianGridXYZ& e) = default;
+    CylindricalGridPhiZ(const CylindricalGridPhiZ& e) = default;
     /// Copy Constructor from segmentation base object
-    CartesianGridXYZ(const Segmentation& e) : Handle<Object>(e) {}
+    CylindricalGridPhiZ(const Segmentation& e) : Handle<Object>(e) {}
     /// Copy constructor from handle
-    CartesianGridXYZ(const Handle<Object>& e) : Handle<Object>(e) {}
+    CylindricalGridPhiZ(const Handle<Object>& e) : Handle<Object>(e) {}
     /// Copy constructor from other polymorph/equivalent handle
     template <typename Q>
-    CartesianGridXYZ(const Handle<Q>& e) : Handle<Object>(e) {}
+    CylindricalGridPhiZ(const Handle<Q>& e) : Handle<Object>(e) {}
     /// Assignment operator
-    CartesianGridXYZ& operator=(const CartesianGridXYZ& seg) = default;
+    CylindricalGridPhiZ& operator=(const CylindricalGridPhiZ& seg) = default;
     /// Equality operator
-    bool operator==(const CartesianGridXYZ& seg) const
-    {  return m_element == seg.m_element;    }
+    bool operator==(const CylindricalGridPhiZ& seg) const
+    {  return m_element == seg.m_element;           }
+
     /// determine the position based on the cell ID
     Position position(const CellID& cellID) const;
     /// determine the cell ID based on the position
     CellID cellID(const Position& local, const Position& global, const VolumeID& volID) const;
-    /// access the grid size in X
-    double gridSizeX() const;
-    /// access the grid size in Y
-    double gridSizeY() const;
+    /// access the grid size in phi
+    double gridSizePhi() const;
     /// access the grid size in Z
     double gridSizeZ() const;
-    /// set the grid size in X
-    void setGridSizeX(double cellSize) const;
-    /// set the grid size in Y
-    void setGridSizeY(double cellSize) const;
-    /// set the grid size in Z
-    void setGridSizeZ(double cellSize) const;
-    /// access the coordinate offset in X
-    double offsetX() const;
-    /// access the coordinate offset in Y
-    double offsetY() const;
+    /// access the radius
+    double radius() const;
+    /// access the coordinate offset in phi
+    double offsetPhi() const;
     /// access the coordinate offset in Z
     double offsetZ() const;
-    /// set the coordinate offset in X
-    void setOffsetX(double offset) const;
-    /// set the coordinate offset in Y
-    void setOffsetY(double offset) const;
+    
+    /// set the grid size in phi
+    void setGridSizePhi(double cellSize) const;
+    /// set the grid size in Z
+    void setGridSizeZ(double cellSize) const;
+    /// set the coordinate offset in phi
+    void setOffsetPhi(double offset) const;
     /// set the coordinate offset in Z
     void setOffsetZ(double offset) const;
-    /// access the field name used for X
-    const std::string& fieldNameX() const;
-    /// access the field name used for Y
-    const std::string& fieldNameY() const;
+    /// set the radius
+    void setRadius(double radius);
+    /// access the field name used for phi
+    const std::string& fieldNamePhi() const;
     /// access the field name used for Z
     const std::string& fieldNameZ() const;
     /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
@@ -105,12 +101,11 @@ namespace dd4hep {
 
         Returns a vector of the cellDimensions of the given cell ID
         \param cellID is ignored as all cells have the same dimension
-        \return std::vector<double> size 3:
+        \return std::vector<double> size 2:
         -# size in x
-        -# size in y
         -# size in z
     */
     std::vector<double> cellDimensions(const CellID& cellID) const;
   };
 }       /* End namespace dd4hep                */
-#endif // DD4HEP_CARTESIANGRIDXYZ_H
+#endif // DD4HEP_CYLINDRICALGRIDPHIZ_H

--- a/DDCore/include/DD4hep/CylindricalGridPhiZ.h
+++ b/DDCore/include/DD4hep/CylindricalGridPhiZ.h
@@ -41,7 +41,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  M.Frank

--- a/DDCore/include/DD4hep/CylindricalGridPhiZ.h
+++ b/DDCore/include/DD4hep/CylindricalGridPhiZ.h
@@ -97,12 +97,12 @@ namespace dd4hep {
     /// access the field name used for Z
     const std::string& fieldNameZ() const;
     /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-        in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+        in the following order: R*dPhi,dZ
 
         Returns a vector of the cellDimensions of the given cell ID
         \param cellID is ignored as all cells have the same dimension
         \return std::vector<double> size 2:
-        -# size in x
+        -# size in x = R * size in phi
         -# size in z
     */
     std::vector<double> cellDimensions(const CellID& cellID) const;

--- a/DDCore/include/DD4hep/GridPhiEta.h
+++ b/DDCore/include/DD4hep/GridPhiEta.h
@@ -39,7 +39,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  A. Zaborowska

--- a/DDCore/include/DD4hep/GridRPhiEta.h
+++ b/DDCore/include/DD4hep/GridRPhiEta.h
@@ -39,7 +39,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  A. Zaborowska

--- a/DDCore/include/DD4hep/MultiSegmentation.h
+++ b/DDCore/include/DD4hep/MultiSegmentation.h
@@ -42,7 +42,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  M.Frank

--- a/DDCore/include/DD4hep/PolarGridRPhi.h
+++ b/DDCore/include/DD4hep/PolarGridRPhi.h
@@ -41,7 +41,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  M.Frank

--- a/DDCore/include/DD4hep/PolarGridRPhi2.h
+++ b/DDCore/include/DD4hep/PolarGridRPhi2.h
@@ -41,7 +41,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  M.Frank

--- a/DDCore/include/DD4hep/WaferGridXY.h
+++ b/DDCore/include/DD4hep/WaferGridXY.h
@@ -41,7 +41,7 @@ namespace dd4hep {
    *  fiddled with the handled object directly.....
    *
    *  Note:
-   *  The handle base corrsponding to this object in for
+   *  The handle base corresponding to this object in for
    *  conveniance reasons instantiated in dd4hep/src/Segmentations.cpp.
    *
    *  \author  M.Frank

--- a/DDCore/include/DDSegmentation/CartesianGridXZ.h
+++ b/DDCore/include/DDSegmentation/CartesianGridXZ.h
@@ -9,7 +9,7 @@
 //
 //==========================================================================
 /*
- * CartesianGridXY.h
+ * CartesianGridXZ.h
  *
  *  Created on: Jun 28, 2013
  *      Author: Christian Grefe, CERN

--- a/DDCore/include/DDSegmentation/CylindricalGridPhiZ.h
+++ b/DDCore/include/DDSegmentation/CylindricalGridPhiZ.h
@@ -94,12 +94,12 @@ namespace dd4hep {
         _zId = fieldName;
       }
       /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-          in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+          in the following order: R*dPhi,dZ
 
           Returns a vector of the cellDimensions of the given cell ID
           \param cellID is ignored as all cells have the same dimension
           \return std::vector<double> size 2:
-          -# size in x
+          -# size in x = R * size in phi
           -# size in z
       */
       virtual std::vector<double> cellDimensions(const CellID& cellID) const;

--- a/DDCore/include/DDSegmentation/CylindricalGridPhiZ.h
+++ b/DDCore/include/DDSegmentation/CylindricalGridPhiZ.h
@@ -1,0 +1,127 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//==========================================================================
+/*
+ * CylindricalGridPhiZ.h
+ *
+ *  Created on: Jun 28, 2024
+ *      Author: Yann Bedfer, ePIC/Saclay
+ */
+
+#ifndef DDSEGMENTATION_CYLINDRICALGRIDPHIZ_H
+#define DDSEGMENTATION_CYLINDRICALGRIDPHIZ_H
+
+#include <DDSegmentation/CylindricalSegmentation.h>
+
+namespace dd4hep {
+  namespace DDSegmentation {
+
+    /// Segmentation base class describing cylindrical grid segmentation in the Phi-Z cylinder
+    class CylindricalGridPhiZ: public CylindricalSegmentation {
+    public:
+      /// default constructor using an arbitrary type
+      CylindricalGridPhiZ(const std::string& cellEncoding);
+      /// Default constructor used by derived classes passing an existing decoder
+      CylindricalGridPhiZ(const BitFieldCoder* decoder);
+      /// destructor
+      virtual ~CylindricalGridPhiZ();
+
+      /// determine the local based on the cell ID
+      virtual Vector3D position(const CellID& cellID) const;
+      /// determine the cell ID based on the position
+      virtual CellID cellID(const Vector3D& localPosition, const Vector3D& globalPosition, const VolumeID& volumeID) const;
+      /// access the grid size in phi
+      double gridSizePhi() const {
+        return _gridSizePhi;
+      }
+      /// access the grid size in Z
+      double gridSizeZ() const {
+        return _gridSizeZ;
+      }
+      /// access the coordinate offset in phi
+      double offsetPhi() const {
+        return _offsetPhi;
+      }
+      /// access the coordinate offset in Z
+      double offsetZ() const {
+        return _offsetZ;
+      }
+      /// access the radius
+      double radius() const {
+        return _radius;
+      }
+      /// access the field name used for phi
+      const std::string& fieldNamePhi() const {
+        return _phiId;
+      }
+      /// access the field name used for Z
+      const std::string& fieldNameZ() const {
+        return _zId;
+      }
+      /// set the grid size in phi
+      void setGridSizePhi(double cellSize) {
+        _gridSizePhi = cellSize;
+      }
+      /// set the grid size in Z
+      void setGridSizeZ(double cellSize) {
+        _gridSizeZ = cellSize;
+      }
+      /// set the coordinate offset in phi
+      void setOffsetPhi(double offset) {
+        _offsetPhi = offset;
+      }
+      /// set the coordinate offset in Z
+      void setOffsetZ(double offset) {
+        _offsetZ = offset;
+      }
+      /// set the radius
+      void setRadius(double radius) {
+        _radius = radius;
+      }
+      /// set the field name used for phi
+      void setFieldNamePhi(const std::string& fieldName) {
+        _phiId = fieldName;
+      }
+      /// set the field name used for Z
+      void setFieldNameZ(const std::string& fieldName) {
+        _zId = fieldName;
+      }
+      /** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+          in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+          Returns a vector of the cellDimensions of the given cell ID
+          \param cellID is ignored as all cells have the same dimension
+          \return std::vector<double> size 2:
+          -# size in x
+          -# size in z
+      */
+      virtual std::vector<double> cellDimensions(const CellID& cellID) const;
+
+    protected:
+      /// the grid size in phi
+      double _gridSizePhi;
+      /// the coordinate offset in phi
+      double _offsetPhi;
+      /// the grid size in Z
+      double _gridSizeZ;
+      /// the coordinate offset in Z
+      double _offsetZ;
+      /// the radius
+      double _radius;
+      /// the field name used for phi
+      std::string _phiId;
+      /// the field name used for Z
+      std::string _zId;
+      /// encoding field used for the module
+    };
+
+  } /* namespace DDSegmentation */
+} /* namespace dd4hep */
+#endif // DDSEGMENTATION_CYLINDRICALGRIDPHIZ_H

--- a/DDCore/include/DDSegmentation/CylindricalSegmentation.h
+++ b/DDCore/include/DDSegmentation/CylindricalSegmentation.h
@@ -26,14 +26,14 @@
 namespace dd4hep {
   namespace DDSegmentation {
 
-    /// Segmentation base class describing a cyliondrical segmentation
+    /// Segmentation base class describing a cylindrical grid segmentation
     class CylindricalSegmentation: public Segmentation {
     public:
-      /// destructor
+      /// Destructor
       virtual ~CylindricalSegmentation();
 
     protected:
-      /// default constructor using an arbitrary type
+      /// Default constructor using an arbitrary type
       CylindricalSegmentation(const std::string& cellEncoding);
       /// Default constructor used by derived classes passing an existing decoder
       CylindricalSegmentation(const BitFieldCoder* decoder);

--- a/DDCore/src/CartesianGridXY.cpp
+++ b/DDCore/src/CartesianGridXY.cpp
@@ -80,15 +80,7 @@ const std::string& CartesianGridXY::fieldNameY() const {
   return access()->implementation->fieldNameY();
 }
 
-/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
-
-    Returns a vector of the cellDimensions of the given cell ID
-    \param cellID is ignored as all cells have the same dimension
-    \return vector<double> size 2:
-    -# size in x
-    -# size in y
-*/
+// Returns a vector<double> of the cellDimensions of the given cell ID
 std::vector<double> CartesianGridXY::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianGridXYZ.cpp
+++ b/DDCore/src/CartesianGridXYZ.cpp
@@ -105,16 +105,7 @@ const std::string& CartesianGridXYZ::fieldNameZ() const {
   return access()->implementation->fieldNameZ();
 }
 
-/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
-
-    Returns a vector of the cellDimensions of the given cell ID
-    \param cellID is ignored as all cells have the same dimension
-    \return vector<double> size 2:
-    -# size in x
-    -# size in y
-    -# size in z
-*/
+// Returns a vector<double> of the cellDimensions of the given cell ID
 std::vector<double> CartesianGridXYZ::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianGridXZ.cpp
+++ b/DDCore/src/CartesianGridXZ.cpp
@@ -80,15 +80,7 @@ const std::string& CartesianGridXZ::fieldNameZ() const {
   return access()->implementation->fieldNameZ();
 }
 
-/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
-
-    Returns a vector of the cellDimensions of the given cell ID
-    \param cellID is ignored as all cells have the same dimension
-    \return vector<double> size 2:
-    -# size in x
-    -# size in z
-*/
+// Returns a vector<double> of the cellDimensions of the given cell ID
 std::vector<double> CartesianGridXZ::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianGridYZ.cpp
+++ b/DDCore/src/CartesianGridYZ.cpp
@@ -80,15 +80,7 @@ const std::string& CartesianGridYZ::fieldNameZ() const {
   return access()->implementation->fieldNameZ();
 }
 
-/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
-
-    Returns a vector of the cellDimensions of the given cell ID
-    \param cellID is ignored as all cells have the same dimension
-    \return vector<double> size 2:
-    -# size in y
-    -# size in z
-*/
+// Returns a vector<double> of the cellDimensions of the given cell ID
 std::vector<double> CartesianGridYZ::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianStripX.cpp
+++ b/DDCore/src/CartesianStripX.cpp
@@ -45,15 +45,7 @@ void CartesianStripX::setOffsetX(double offset) const { access()->implementation
 /// access the field name used for X
 const std::string& CartesianStripX::fieldNameX() const { return access()->implementation->fieldNameX(); }
 
-/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
-
-    Returns a vector of the cellDimensions of the given cell ID
-    \param cellID is ignored as all cells have the same dimension
-    \return vector<double> size 2:
-    -# size in x
-    -# size in y
-*/
+// Returns a vector<double> of the cellDimensions of the given cell ID
 std::vector<double> CartesianStripX::cellDimensions(const CellID& id) const {
     return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianStripY.cpp
+++ b/DDCore/src/CartesianStripY.cpp
@@ -45,15 +45,7 @@ void CartesianStripY::setOffsetY(double offset) const { access()->implementation
 /// access the field name used for Y
 const std::string& CartesianStripY::fieldNameY() const { return access()->implementation->fieldNameY(); }
 
-/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
-
-    Returns a vector of the cellDimensions of the given cell ID
-    \param cellID is ignored as all cells have the same dimension
-    \return vector<double> size 2:
-    -# size in x
-    -# size in y
-*/
+// Returns a vector<double> of the cellDimensions of the given cell ID
 std::vector<double> CartesianStripY::cellDimensions(const CellID& id) const {
     return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CartesianStripZ.cpp
+++ b/DDCore/src/CartesianStripZ.cpp
@@ -45,15 +45,7 @@ void CartesianStripZ::setOffsetZ(double offset) const { access()->implementation
 /// access the field name used for Z
 const std::string& CartesianStripZ::fieldNameZ() const { return access()->implementation->fieldNameZ(); }
 
-/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
-
-    Returns a vector of the cellDimensions of the given cell ID
-    \param cellID is ignored as all cells have the same dimension
-    \return vector<double> size 2:
-    -# size in x
-    -# size in y
-*/
+// Returns a vector<double> of the cellDimensions of the given cell ID
 std::vector<double> CartesianStripZ::cellDimensions(const CellID& id) const {
     return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CylindricalGridPhiZ.cpp
+++ b/DDCore/src/CylindricalGridPhiZ.cpp
@@ -80,15 +80,7 @@ const std::string& CylindricalGridPhiZ::fieldNameZ() const {
   return access()->implementation->fieldNameZ();
 }
 
-/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
-    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
-
-    Returns a vector of the cellDimensions of the given cell ID
-    \param cellID is ignored as all cells have the same dimension
-    \return vector<double> size 2:
-    -# size in x
-    -# size in z
-*/
+// Returns a vector<double> of the cellDimensions of the given cell ID
 std::vector<double> CylindricalGridPhiZ::cellDimensions(const CellID& id) const  {
   return access()->implementation->cellDimensions(id);
 }

--- a/DDCore/src/CylindricalGridPhiZ.cpp
+++ b/DDCore/src/CylindricalGridPhiZ.cpp
@@ -1,0 +1,94 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+
+// Framework include files
+#include <DD4hep/CylindricalGridPhiZ.h>
+#include <DDSegmentation/CylindricalGridPhiZ.h>
+
+using namespace dd4hep;
+
+/// determine the position based on the cell ID
+Position CylindricalGridPhiZ::position(const CellID& id) const   {
+  return Position(access()->implementation->position(id));
+}
+
+/// determine the cell ID based on the position
+dd4hep::CellID CylindricalGridPhiZ::cellID(const Position& local,
+                               const Position& global,
+                               const VolumeID& volID) const
+{
+  return access()->implementation->cellID(local, global, volID);
+}
+
+/// access the grid size in phi
+double CylindricalGridPhiZ::gridSizePhi() const {
+  return access()->implementation->gridSizePhi();
+}
+
+/// access the grid size in Z
+double CylindricalGridPhiZ::gridSizeZ() const {
+  return access()->implementation->gridSizeZ();
+}
+
+/// set the grid size in phi
+void CylindricalGridPhiZ::setGridSizePhi(double cellSize) const   {
+  access()->implementation->setGridSizePhi(cellSize);
+}
+
+/// set the grid size in Z
+void CylindricalGridPhiZ::setGridSizeZ(double cellSize) const   {
+  access()->implementation->setGridSizeZ(cellSize);
+}
+
+/// access the coordinate offset in phi
+double CylindricalGridPhiZ::offsetPhi() const {
+  return access()->implementation->offsetPhi();
+}
+
+/// access the coordinate offset in Z
+double CylindricalGridPhiZ::offsetZ() const {
+  return access()->implementation->offsetZ();
+}
+
+/// set the coordinate offset in phi
+void CylindricalGridPhiZ::setOffsetPhi(double offset) const   {
+  access()->implementation->setOffsetPhi(offset);
+}
+
+/// set the coordinate offset in Z
+void CylindricalGridPhiZ::setOffsetZ(double offset) const   {
+  access()->implementation->setOffsetZ(offset);
+}
+
+/// access the field name used for phi
+const std::string& CylindricalGridPhiZ::fieldNamePhi() const {
+  return access()->implementation->fieldNamePhi();
+}
+
+/// access the field name used for Z
+const std::string& CylindricalGridPhiZ::fieldNameZ() const {
+  return access()->implementation->fieldNameZ();
+}
+
+/** \brief Returns a vector<double> of the cellDimensions of the given cell ID
+    in natural order of dimensions, e.g., dx/dy/dz, or dr/r*dPhi
+
+    Returns a vector of the cellDimensions of the given cell ID
+    \param cellID is ignored as all cells have the same dimension
+    \return vector<double> size 2:
+    -# size in x
+    -# size in z
+*/
+std::vector<double> CylindricalGridPhiZ::cellDimensions(const CellID& id) const  {
+  return access()->implementation->cellDimensions(id);
+}

--- a/DDCore/src/SegmentationDictionary.h
+++ b/DDCore/src/SegmentationDictionary.h
@@ -31,6 +31,7 @@
 #include <DDSegmentation/CartesianStripY.h>
 #include <DDSegmentation/CartesianStripZ.h>
 #include <DDSegmentation/CylindricalSegmentation.h>
+#include <DDSegmentation/CylindricalGridPhiZ.h>
 #include <DDSegmentation/GridPhiEta.h>
 #include <DDSegmentation/GridRPhiEta.h>
 #include <DDSegmentation/MegatileLayerGridXY.h>
@@ -77,6 +78,7 @@ typedef dd4hep::DDSegmentation::CellID CellID;
 #pragma link C++ class dd4hep::DDSegmentation::CartesianStripY+;
 #pragma link C++ class dd4hep::DDSegmentation::CartesianStripZ+;
 #pragma link C++ class dd4hep::DDSegmentation::CylindricalSegmentation+;
+#pragma link C++ class dd4hep::DDSegmentation::CylindricalGridPhiZ+;
 #pragma link C++ class dd4hep::DDSegmentation::GridPhiEta+;
 #pragma link C++ class dd4hep::DDSegmentation::GridRPhiEta+;
 #pragma link C++ class dd4hep::DDSegmentation::MegatileLayerGridXY+;

--- a/DDCore/src/Segmentations.cpp
+++ b/DDCore/src/Segmentations.cpp
@@ -173,3 +173,6 @@ DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::ProjectiveCylinder);
 
 #include <DDSegmentation/MultiSegmentation.h>
 DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::MultiSegmentation);
+
+#include <DDSegmentation/CylindricalGridPhiZ.h>
+DD4HEP_INSTANTIATE_SEGMENTATION_HANDLE(DDSegmentation::CylindricalGridPhiZ);

--- a/DDCore/src/plugins/ReadoutSegmentations.cpp
+++ b/DDCore/src/plugins/ReadoutSegmentations.cpp
@@ -81,3 +81,6 @@ DECLARE_SEGMENTATION(MultiSegmentation,create_segmentation<dd4hep::DDSegmentatio
 
 #include <DDSegmentation/HexGrid.h>
 DECLARE_SEGMENTATION(HexGrid,create_segmentation<dd4hep::DDSegmentation::HexGrid>)
+
+#include <DDSegmentation/CylindricalGridPhiZ.h>
+DECLARE_SEGMENTATION(CylindricalGridPhiZ,create_segmentation<dd4hep::DDSegmentation::CylindricalGridPhiZ>)

--- a/DDCore/src/segmentations/CylindricalGridPhiZ.cpp
+++ b/DDCore/src/segmentations/CylindricalGridPhiZ.cpp
@@ -1,0 +1,106 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//==========================================================================
+/*
+ * CylindricalGridPhiZ.cpp
+ *
+ *  Created on: Jun 28, 2024
+ *      Author: Yann Bedfer, ePIC/Saclay
+ */
+
+#include <DDSegmentation/CylindricalGridPhiZ.h>
+
+namespace dd4hep {
+namespace DDSegmentation {
+
+using std::make_pair;
+using std::vector;
+
+/// default constructor using an encoding string
+CylindricalGridPhiZ::CylindricalGridPhiZ(const std::string& cellEncoding) :
+	CylindricalSegmentation(cellEncoding) {
+	// define type and description
+	_type = "CylindricalGridPhiZ";
+	_description = "Cylindrical segmentation in the local PhiZ-cylinder";
+
+	// register all necessary parameters
+	registerParameter("grid_size_phi", "Cell size in phi", _gridSizePhi, 1., SegmentationParameter::AngleUnit);
+	registerParameter("grid_size_z",   "Cell size in Z",   _gridSizeZ,   1., SegmentationParameter::LengthUnit);
+	registerParameter("offset_phi", "Cell offset in phi", _offsetPhi,    0., SegmentationParameter::AngleUnit, true);
+	registerParameter("offset_z",   "Cell offset in Z",   _offsetZ,      0., SegmentationParameter::LengthUnit, true);
+	registerParameter("radius",     "Radius of Cylinder", _radius,       0., SegmentationParameter::LengthUnit);
+	registerIdentifier("identifier_phi", "Cell ID identifier for phi", _phiId, "phi");
+	registerIdentifier("identifier_z",   "Cell ID identifier for Z",   _zId,   "z");
+}
+
+/// Default constructor used by derived classes passing an existing decoder
+CylindricalGridPhiZ::CylindricalGridPhiZ(const BitFieldCoder* decode) :
+	CylindricalSegmentation(decode) {
+	// define type and description
+	_type = "CylindricalGridPhiZ";
+	_description = "Cylindrical segmentation in the local PhiZ-cylinder";
+
+	// register all necessary parameters
+	registerParameter("grid_size_phi", "Cell size in phi", _gridSizePhi, 1., SegmentationParameter::AngleUnit);
+	registerParameter("grid_size_z",   "Cell size in Z",   _gridSizeZ,   1., SegmentationParameter::LengthUnit);
+	registerParameter("offset_phi", "Cell offset in phi", _offsetPhi,    0., SegmentationParameter::AngleUnit, true);
+	registerParameter("offset_z",   "Cell offset in Z",   _offsetZ,      0., SegmentationParameter::LengthUnit, true);
+	registerParameter("radius",     "Radius of Cylinder", _radius,       0., SegmentationParameter::LengthUnit);
+	registerIdentifier("identifier_phi", "Cell ID identifier for phi", _phiId, "phi");
+	registerIdentifier("identifier_z",   "Cell ID identifier for Z",   _zId,   "z");
+}
+
+/// destructor
+CylindricalGridPhiZ::~CylindricalGridPhiZ() {
+
+}
+
+/// determine the position based on the cell ID
+Vector3D CylindricalGridPhiZ::position(const CellID& cID) const {
+	vector<double> localPosition(3);
+	Vector3D cellPosition;
+	double phi =
+	  binToPosition( _decoder->get(cID,_phiId ), _gridSizePhi, _offsetPhi);
+	cellPosition.Z =
+	  binToPosition( _decoder->get(cID,_zId ),   _gridSizeZ,   _offsetZ);
+	const double &R = _radius;
+	cellPosition.X = R*cos(phi); cellPosition.Y = R*sin(phi);
+
+	return cellPosition;
+}
+
+/// determine the cell ID based on the position
+  CellID CylindricalGridPhiZ::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */, const VolumeID& vID) const {
+	double phi = atan2(localPosition.Y,localPosition.X);
+	double Z = localPosition.Z;
+	if ( phi < _offsetPhi) {
+	  phi += 2*M_PI;
+	}
+        CellID cID = vID ;
+        _decoder->set( cID,_phiId, positionToBin(phi, _gridSizePhi, _offsetPhi) );
+	_decoder->set( cID,_zId,   positionToBin(Z,   _gridSizeZ,   _offsetZ) );
+
+	return cID ;
+}
+
+std::vector<double> CylindricalGridPhiZ::cellDimensions(const CellID&) const {
+#if __cplusplus >= 201103L
+  return {_gridSizePhi, _gridSizeZ};
+#else
+  std::vector<double> cellDims(2,0.0);
+  cellDims[0] = _radius*_gridSizePhi;
+  cellDims[1] = _gridSizeZ;
+  return cellDims;
+#endif
+}
+
+
+} /* namespace DDSegmentation */
+} /* namespace dd4hep */

--- a/DDCore/src/segmentations/CylindricalGridPhiZ.cpp
+++ b/DDCore/src/segmentations/CylindricalGridPhiZ.cpp
@@ -91,14 +91,7 @@ Vector3D CylindricalGridPhiZ::position(const CellID& cID) const {
 }
 
 std::vector<double> CylindricalGridPhiZ::cellDimensions(const CellID&) const {
-#if __cplusplus >= 201103L
   return {_radius*_gridSizePhi, _gridSizeZ};
-#else
-  std::vector<double> cellDims(2,0.0);
-  cellDims[0] = _radius*_gridSizePhi;
-  cellDims[1] = _gridSizeZ;
-  return cellDims;
-#endif
 }
 
 

--- a/DDCore/src/segmentations/CylindricalGridPhiZ.cpp
+++ b/DDCore/src/segmentations/CylindricalGridPhiZ.cpp
@@ -92,7 +92,7 @@ Vector3D CylindricalGridPhiZ::position(const CellID& cID) const {
 
 std::vector<double> CylindricalGridPhiZ::cellDimensions(const CellID&) const {
 #if __cplusplus >= 201103L
-  return {_gridSizePhi, _gridSizeZ};
+  return {_radius*_gridSizePhi, _gridSizeZ};
 #else
   std::vector<double> cellDims(2,0.0);
   cellDims[0] = _radius*_gridSizePhi;


### PR DESCRIPTION
Segmentation , plugin and dictionary are modified to include "CylindricalGridPhiZ".
- "CylindricalGridPhiZ" is needed for my cylindrically shaped MPGD detector in ePIC at EIC.
- The class derives from the "CylindricalSegmentation" class.
- It reads its "gridSize" parameters the usual way. Optional "offset" parameters, the same.
- It has an extra type of parameter, viz. "radius", used by the "position" and "cellDimensions" methods, to transform from the phi,Z representation to X,Y.


BEGINRELEASENOTES
- Adding a "CylindricalGridPhiZ" segmentation class.
   - N.B.: the class has a "radius" data member, registered by the constructors.

ENDRELEASENOTES