### PR TITLE
Add a signal handler for SIGINT when building a detector

### DIFF
--- a/DDCore/src/DetectorLoad.cpp
+++ b/DDCore/src/DetectorLoad.cpp
@@ -50,7 +50,6 @@ DetectorLoad::~DetectorLoad() {
 
 /// Process XML unit and adopt all data from source structure.
 void DetectorLoad::processXML(const std::string& xmlfile, xml::UriReader* entity_resolver) {
-
   try {
     xml::DocumentHolder doc(xml::DocumentHandler().load(xmlfile,entity_resolver));
     if ( doc )   {

--- a/DDCore/src/DetectorLoad.cpp
+++ b/DDCore/src/DetectorLoad.cpp
@@ -51,18 +51,6 @@ DetectorLoad::~DetectorLoad() {
 /// Process XML unit and adopt all data from source structure.
 void DetectorLoad::processXML(const std::string& xmlfile, xml::UriReader* entity_resolver) {
 
-  // Install signal handler for SIGINT (Ctrl-C)
-  struct sigaction sigIntHandler;
-
-  sigIntHandler.sa_handler = [](int) {
-    std::cerr << "Caught signal SIGINT, exiting..." << std::endl;
-    exit(1);
-  };
-  sigemptyset(&sigIntHandler.sa_mask);
-  sigIntHandler.sa_flags = 0;
-
-  sigaction(SIGINT, &sigIntHandler, NULL);
-
   try {
     xml::DocumentHolder doc(xml::DocumentHandler().load(xmlfile,entity_resolver));
     if ( doc )   {
@@ -143,6 +131,19 @@ void DetectorLoad::processXMLString(const char* xmldata, xml::UriReader* entity_
 
 /// Process a given DOM (sub-) tree
 void DetectorLoad::processXMLElement(const std::string& xmlfile, const xml::Handle_t& xml_root) {
+
+  // Install signal handler for SIGINT (Ctrl-C)
+  struct sigaction sigIntHandler;
+
+  sigIntHandler.sa_handler = [](int) {
+    std::cerr << "Caught signal SIGINT, exiting..." << std::endl;
+    exit(1);
+  };
+  sigemptyset(&sigIntHandler.sa_mask);
+  sigIntHandler.sa_flags = 0;
+
+  sigaction(SIGINT, &sigIntHandler, NULL);
+
   if ( xml_root.ptr() )   {
     std::string tag = xml_root.tag();
     std::string type = tag + "_XML_reader";
@@ -167,6 +168,19 @@ void DetectorLoad::processXMLElement(const std::string& xmlfile, const xml::Hand
 
 /// Process a given DOM (sub-) tree
 void DetectorLoad::processXMLElement(const xml::Handle_t& xml_root, DetectorBuildType /* type */) {
+
+  // Install signal handler for SIGINT (Ctrl-C)
+  struct sigaction sigIntHandler;
+
+  sigIntHandler.sa_handler = [](int) {
+    std::cerr << "Caught signal SIGINT, exiting..." << std::endl;
+    exit(1);
+  };
+  sigemptyset(&sigIntHandler.sa_mask);
+  sigIntHandler.sa_flags = 0;
+
+  sigaction(SIGINT, &sigIntHandler, NULL);
+
   if ( xml_root.ptr() )   {
     std::string tag = xml_root.tag();
     std::string type = tag + "_XML_reader";

--- a/DDCore/src/DetectorLoad.cpp
+++ b/DDCore/src/DetectorLoad.cpp
@@ -20,10 +20,10 @@
 #include <XML/DocumentHandler.h>
 
 // C/C++ include files
-#include <stdexcept>
 #include <csignal>
 #include <cstdlib>
 #include <iostream>
+#include <stdexcept>
 
 #ifndef __TIXML__
 #include <xercesc/dom/DOMException.hpp>

--- a/DDCore/src/DetectorLoad.cpp
+++ b/DDCore/src/DetectorLoad.cpp
@@ -21,6 +21,9 @@
 
 // C/C++ include files
 #include <stdexcept>
+#include <csignal>
+#include <cstdlib>
+#include <iostream>
 
 #ifndef __TIXML__
 #include <xercesc/dom/DOMException.hpp>
@@ -47,6 +50,19 @@ DetectorLoad::~DetectorLoad() {
 
 /// Process XML unit and adopt all data from source structure.
 void DetectorLoad::processXML(const std::string& xmlfile, xml::UriReader* entity_resolver) {
+
+  // Install signal handler for SIGINT (Ctrl-C)
+  struct sigaction sigIntHandler;
+
+  sigIntHandler.sa_handler = [](int) {
+    std::cerr << "Caught signal SIGINT, exiting..." << std::endl;
+    exit(1);
+  };
+  sigemptyset(&sigIntHandler.sa_mask);
+  sigIntHandler.sa_flags = 0;
+
+  sigaction(SIGINT, &sigIntHandler, NULL);
+
   try {
     xml::DocumentHolder doc(xml::DocumentHandler().load(xmlfile,entity_resolver));
     if ( doc )   {


### PR DESCRIPTION
To cancel while building a geometry it seems I have to kill the process or the terminal where it's running. With this change it's possible to cancel by doing a Ctrl-C, and it seems to be working both in Python and C++:

``` python
import dd4hep
det = dd4hep.Detector.getInstance()
det.fromCompact(f'{os.environ["k4geo"]}/FCCee/CLD/compact/CLD_o2_v05/CLD_o2_v05.xml')
```
And then press Ctrl-C:
```
Compact          INFO  ++ Converted subdetector:LumiCalBackShield of type LumiCal_o1_v01 [calorimeter]
Calling Converter<Compact>::operator() with element: lccdd
Utilities        INFO  +++ setDetectorTypeFlags for detector: Vertex not set.
Compact          INFO  ++ Converted subdetector:Vertex of type DD4hep_SubdetectorAssembly
Compact          INFO  ++ Converted subdetector:VertexBarrel of type ZPlanarTracker [tracker]
XXX Vertex endcap layers: 6
Compact          INFO  ++ Converted subdetector:VertexEndcap of type VertexEndcap_o1_v06 [tracker]
Compact          INFO  ++ Converted subdetector:VertexVerticalCable of type TrackerEndcapSupport_o1_v02
VertexEndcap     INFO  +++ Processing SurfaceInstaller for subdetector: 'VertexEndcap'
DD4hep_GenericSurfaceInstallerPlugin: argument[1] = dimension = 2
DD4hep_GenericSurfaceInstallerPlugin: argument[2] = u_x = -1
DD4hep_GenericSurfaceInstallerPlugin: argument[3] = v_z = 1
DD4hep_GenericSurfaceInstallerPlugin: argument[4] = n_y = 1
DD4hep_GenericSurfaceInstallerPlugin: vectors: u( -1 , 0 , 0) v( 0 , 0 , 1) n( 0 , 1 , 0) o( 0 , 0 , 0)
Calling Converter<Compact>::operator() with element: lccdd
Utilities        INFO  +++ setDetectorTypeFlags for detector: InnerTrackers not set.
Compact          INFO  ++ Converted subdetector:InnerTrackers of type DD4hep_SubdetectorAssembly
^CCaught signal SIGINT, exiting...
```

BEGINRELEASENOTES
- Add a signal handler for SIGINT when building a detector, allowing to cancel with Ctrl-C

ENDRELEASENOTES