### PR TITLE
VolumeManager: prevent duplicated add_entry call

### DIFF
--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -187,8 +187,10 @@ namespace dd4hep {
                 // used e.g. to model a very fine grained sensitive volume structure
                 // without always having DetElements.
               }
-              add_entry(sd, parent, e, node, vol_encoding, chain);
-              ++count;
+              if (is_sensitive) {
+                add_entry(sd, parent, e, node, vol_encoding, chain);
+                ++count;
+              }
               if ( m_debug )  {
                 IDDescriptor id(sd.readout().idSpec());
                 printout(INFO,"VolumeManager","Parent: %-44s id:%016llx Encoding: %s",


### PR DESCRIPTION
As far as I understand we only want to call `add_entry` once per cellID. If we call it more than once nothing happens because we guard against that with the `m_entries` set. However, currently we call it many additional times, in the worst case twice for every module. Just not doing this seems to reduce the overall initialization time of the VolumeManager by ~20% in our case (CLD).

For example when initially called in `populate()` on a generic tracking detector like `DD4hep_SiTrackerBarrel` the following happens:
- The recursion steps all the way down to iterate over the components of a module (slices of material of the chip)
- `add_entry` is called successfully for the sensitive silicon layer with the cellID 
- after the iteration over the components is finished, `add_entry` is called for the module with the ID of the silicon layer
- `add_entry` call does nothing as that cellID is already in the `m_entries` set.
- an additional useless `add_entry` call is also performed at every other step up in the recursion (stave, layer, side)...

This PR should get rid of these cases, without causing any other behavioural changes.

BEGINRELEASENOTES
- Thank you for writing the text to appear in the release notes. It will show up
  exactly as it appears between the two bold lines
- ...

ENDRELEASENOTES