### PR TITLE
Building Documentation with el9 container

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,7 +108,7 @@ usermanuals:
       - docker
     image: ghcr.io/aidasoft/el9:latest
     script:
-        - yum install -y ghostscript poppler-utils perl
+        - yum install -y ghostscript poppler-utils perl libxcrypt-compat
         - source /cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt/setup.sh
         - export PATH=/cvmfs/sft.cern.ch/lcg/external/texlive/2024/bin/x86_64-linux:$PATH
         - export max_print_line=200

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,9 +86,9 @@ doxygen:
     needs: []
     tags:
         - docker
-    image: ghcr.io/aidasoft/centos7:latest
+    image: ghcr.io/aidasoft/el9:latest
     script:
-        - source /cvmfs/sft.cern.ch/lcg/views/LCG_102/x86_64-centos7-gcc11-opt/setup.sh
+        - source /cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt/setup.sh
         - mkdir -p public
         - mkdir build
         - cd build
@@ -106,11 +106,11 @@ usermanuals:
     needs: []
     tags:
       - docker
-    image: ghcr.io/aidasoft/centos7:latest
+    image: ghcr.io/aidasoft/el9:latest
     script:
         - yum install -y ghostscript poppler-utils perl
-        - source /cvmfs/sft.cern.ch/lcg/views/LCG_102/x86_64-centos7-gcc11-opt/setup.sh
-        - export PATH=/cvmfs/sft.cern.ch/lcg/external/texlive/2017/bin/x86_64-linux:$PATH
+        - source /cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt/setup.sh
+        - export PATH=/cvmfs/sft.cern.ch/lcg/external/texlive/2024/bin/x86_64-linux:$PATH
         - export max_print_line=200
         - mkdir -p public/usermanuals
         - mkdir build


### PR DESCRIPTION

BEGINRELEASENOTES
- GitlabCI: Use an el9 container to build documentation for the webpage

ENDRELEASENOTES

Installing the centos7 packages started failing.