### PR TITLE
Cylinder segment surface

### DIFF
--- a/DDRec/include/DDRec/Surface.h
+++ b/DDRec/include/DDRec/Surface.h
@@ -166,8 +166,10 @@ namespace dd4hep {
       /// Checks if the given point lies within the surface
       virtual bool insideBounds(const Vector3D& point, double epsilon=1e-4 ) const ;
 
+      /** Width in radian of surface */
       virtual double phiTot() const;
 
+      /** Offset in radian of surface position */
       virtual double phi0() const;
 
       virtual std::vector< std::pair<Vector3D, Vector3D> > getLines(unsigned nMax=100) ;
@@ -265,8 +267,10 @@ namespace dd4hep {
       /** Thickness of outer material */
       virtual double outerThickness() const ;
 
+      /** Width in radian of surface */
       virtual double phiTot() const;
 
+      /** Offset in radian of surface position */
       virtual double phi0() const;
 
       /** The length of the surface along direction u at the origin. For 'regular' boundaries, like rectangles, 
@@ -584,8 +588,10 @@ namespace dd4hep {
       /** Thickness of outer material */
       virtual double outerThickness() const ;
 
+      /** Width in radian of surface */
       virtual double phiTot() const;
 
+      /** Offset in radian of surface position */
       virtual double phi0() const;
       
       /// Access to the material in opposite direction of the normal

--- a/DDRec/include/DDRec/Surface.h
+++ b/DDRec/include/DDRec/Surface.h
@@ -56,6 +56,8 @@ namespace dd4hep {
       MaterialData _outerMat {};    
       Volume _vol {};
       long64 _id {0};
+      double _phiTot {};
+      double _phi0 {};
       unsigned _refCount {0};
 
       /// setter for daughter classes
@@ -78,7 +80,8 @@ namespace dd4hep {
       VolSurfaceBase( SurfaceType typ, 
                       double thickness_inner ,double thickness_outer, 
                       Vector3D u_val ,Vector3D v_val ,
-                      Vector3D n ,Vector3D o, Volume vol,int identifier ) : 
+                      Vector3D n ,Vector3D o, Volume vol,int identifier,
+                      double phiTot, double phi0 ) : 
         _type(typ ) ,
         _u( u_val ) ,
         _v( v_val ) ,
@@ -87,7 +90,9 @@ namespace dd4hep {
         _th_i( thickness_inner ),
         _th_o( thickness_outer ),  
         _vol(vol) ,
-        _id( identifier ) {
+        _id( identifier ),
+        _phiTot( phiTot ),
+        _phi0( phi0 ) {
       }
       
       
@@ -95,7 +100,8 @@ namespace dd4hep {
       VolSurfaceBase(const VolSurfaceBase& c) 
         : _type(c._type), _u(c._u), _v(c._v), _n(c._n), _o(c._o),
           _th_i(c._th_i), _th_o(c._th_o), _innerMat(c._innerMat),
-          _outerMat(c._innerMat), _vol(c._vol), _id(c._id)
+          _outerMat(c._innerMat), _vol(c._vol), _id(c._id),
+          _phiTot(c._phiTot), _phi0(c._phi0)
       {
       }
 
@@ -160,6 +166,9 @@ namespace dd4hep {
       /// Checks if the given point lies within the surface
       virtual bool insideBounds(const Vector3D& point, double epsilon=1e-4 ) const ;
 
+      virtual double phiTot() const;
+
+      virtual double phi0() const;
 
       virtual std::vector< std::pair<Vector3D, Vector3D> > getLines(unsigned nMax=100) ;
  
@@ -256,6 +265,9 @@ namespace dd4hep {
       /** Thickness of outer material */
       virtual double outerThickness() const ;
 
+      virtual double phiTot() const;
+
+      virtual double phi0() const;
 
       /** The length of the surface along direction u at the origin. For 'regular' boundaries, like rectangles, 
        *  this can be used to speed up the computation of inSideBounds.
@@ -337,9 +349,9 @@ namespace dd4hep {
 
       /// standard c'tor with all necessary arguments - origin is (0,0,0) if not given.
       VolPlaneImpl( SurfaceType typ, double thickness_inner ,double thickness_outer, 
-                    Vector3D u_val ,Vector3D v_val ,Vector3D n_val , Vector3D o_val, Volume vol, int id_val  ) :
+                    Vector3D u_val ,Vector3D v_val ,Vector3D n_val , Vector3D o_val, Volume vol, int id_val ) :
 	
-        VolSurfaceBase( typ, thickness_inner, thickness_outer, u_val,v_val, n_val, o_val, vol, id_val ) {
+        VolSurfaceBase( typ, thickness_inner, thickness_outer, u_val,v_val, n_val, o_val, vol, id_val, 2.*M_PI, 0. ) {
 	
         _type.setProperty( SurfaceType::Plane    , true ) ;
         _type.setProperty( SurfaceType::Cylinder , false ) ;
@@ -370,7 +382,7 @@ namespace dd4hep {
        *  its rho defining the radius of the cylinder. The measurement direction v is set to be (0,0,1), the normal is
        *  chosen to be parallel to the origin vector and u = n X v. 
        */
-      VolCylinderImpl( Volume vol, SurfaceType type, double thickness_inner ,double thickness_outer,  Vector3D origin ) ;
+      VolCylinderImpl( Volume vol, SurfaceType type, double thickness_inner ,double thickness_outer,  Vector3D origin, double phiTot=2.*M_PI, double phi0=0. ) ;
 
       /** First direction of measurement U - rotated to point projected onto the cylinder.
        *  No check is done whether the point actually is on the cylinder surface
@@ -476,8 +488,8 @@ namespace dd4hep {
 
     class VolCylinder : public VolSurface{
     public:
-      VolCylinder( Volume vol, SurfaceType typ_val, double thickness_inner ,double thickness_outer,  Vector3D origin_val ) :
-        VolSurface( new VolCylinderImpl( vol,  typ_val,  thickness_inner , thickness_outer, origin_val ) ) {}
+      VolCylinder( Volume vol, SurfaceType typ_val, double thickness_inner ,double thickness_outer,  Vector3D origin_val, double phiTot=2.*M_PI, double phi0=0. ) :
+        VolSurface( new VolCylinderImpl( vol,  typ_val,  thickness_inner , thickness_outer, origin_val, phiTot, phi0 ) ) {}
     } ;
 
     class VolCone : public VolSurface{
@@ -510,6 +522,9 @@ namespace dd4hep {
       Vector3D _v {};
       Vector3D _n {};
       Vector3D _o {};
+
+      double _phiTot {2.*M_PI};
+      double _phi0 {0.};
 
       /// default c'tor etc. removed
       Surface() = delete;
@@ -569,6 +584,10 @@ namespace dd4hep {
       /** Thickness of outer material */
       virtual double outerThickness() const ;
 
+      virtual double phiTot() const;
+
+      virtual double phi0() const;
+      
       /// Access to the material in opposite direction of the normal
       virtual const IMaterial& innerMaterial() const ;
      

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -75,6 +75,8 @@ namespace dd4hep {
     double VolSurfaceBase::innerThickness() const { return _th_i ; }
     double VolSurfaceBase::outerThickness() const { return _th_o ; }
     
+    double VolSurfaceBase::phiTot() const { return _phiTot ; }
+    double VolSurfaceBase::phi0() const { return _phi0 ; }
 
     double VolSurfaceBase::length_along_u() const {
       
@@ -235,7 +237,7 @@ namespace dd4hep {
     }
 
 
-    std::vector< std::pair<Vector3D, Vector3D> > VolSurfaceBase::getLines(unsigned ) {
+    std::vector< std::pair<Vector3D, Vector3D> > VolSurfaceBase::getLines(unsigned) {
       // dummy implementation returning empty set
       std::vector< std::pair<Vector3D, Vector3D> >  lines ;
       return lines ;
@@ -256,6 +258,8 @@ namespace dd4hep {
     const IMaterial&  VolSurface::outerMaterial() const  { return _surf->outerMaterial()  ; }
     double VolSurface::innerThickness() const { return _surf->innerThickness() ; }
     double VolSurface::outerThickness() const { return _surf->outerThickness() ; }
+    double VolSurface::phiTot() const { return _surf->phiTot() ; }
+    double VolSurface::phi0() const { return _surf->phi0() ; }
     double VolSurface::length_along_u() const { return _surf->length_along_u() ; }
     double VolSurface::length_along_v() const { return _surf->length_along_v() ; }
     double VolSurface::distance(const Vector3D& point ) const  {  return _surf->distance( point ) ; }
@@ -275,9 +279,8 @@ namespace dd4hep {
     //======================================================================================================
 
     VolCylinderImpl::VolCylinderImpl( Volume vol, SurfaceType typ, 
-                                      double thickness_inner ,double thickness_outer,  Vector3D o ) :
-
-      VolSurfaceBase(typ, thickness_inner, thickness_outer, Vector3D() , Vector3D() , Vector3D() , o , vol, 0) {
+                                      double thickness_inner ,double thickness_outer,  Vector3D o, double phiTot, double phi0 ) :
+      VolSurfaceBase(typ, thickness_inner, thickness_outer, Vector3D() , Vector3D() , Vector3D() , o , vol, 0, phiTot, phi0) {
       Vector3D v_val( 0., 0., 1. ) ;
       Vector3D o_rphi( o.x() , o.y() , 0. ) ;
       Vector3D n =  o_rphi.unit() ; 
@@ -341,7 +344,7 @@ namespace dd4hep {
     VolConeImpl::VolConeImpl( Volume vol, SurfaceType typ, 
                               double thickness_inner ,double thickness_outer, Vector3D v_val,  Vector3D o_val ) :
       
-      VolSurfaceBase(typ, thickness_inner, thickness_outer, Vector3D() , v_val ,  Vector3D() , Vector3D() , vol, 0) {
+      VolSurfaceBase(typ, thickness_inner, thickness_outer, Vector3D() , v_val ,  Vector3D() , Vector3D() , vol, 0, 2.*M_PI, 0. ) {
 
       Vector3D o_rphi( o_val.x() , o_val.y() , 0. ) ;
 
@@ -618,6 +621,8 @@ namespace dd4hep {
     const Vector3D& Surface::origin() const { return _o ;}
     double Surface::innerThickness() const { return _volSurf.innerThickness() ; }
     double Surface::outerThickness() const { return _volSurf.outerThickness() ; }
+    double Surface::phiTot() const { return _volSurf.phiTot() ; }
+    double Surface::phi0() const { return _volSurf.phi0() ; }
     double Surface::length_along_u() const { return _volSurf.length_along_u() ; }
     double Surface::length_along_v() const { return _volSurf.length_along_v() ; }
 
@@ -1182,12 +1187,14 @@ namespace dd4hep {
 
 
           unsigned n = nMax / 4 ;
-          double dPhi = 2.* ROOT::Math::Pi() / double( n ) ; 
+          double dPhi = phiTot() / double( n ) ; 
+
+          std::cout << "Using phiTot=" << phiTot() << " and phi0=" << phi0() << std::endl;
 
           for( unsigned i = 0 ; i < n ; ++i ) {
-
-            Vector3D rv0(  r*sin(  i   *dPhi ) , r*cos(  i   *dPhi )  , 0. ) ;
-            Vector3D rv1(  r*sin( (i+1)*dPhi ) , r*cos( (i+1)*dPhi )  , 0. ) ;
+            double phi_offset = phi0();
+            Vector3D rv0( r*sin( phi_offset +  i   *dPhi ) , r*cos( phi_offset + i   *dPhi )  , 0. ) ;
+            Vector3D rv1( r*sin( phi_offset + (i+1)*dPhi ) , r*cos( phi_offset + (i+1)*dPhi )  , 0. ) ;
 
             // 4 points on local cylinder
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Adding the capability to VolCylinder to be only a segment of a cylinder >2π needed for ultra-light curved vertex concept.
ENDRELEASENOTES

Hi everyone

I'm trying to make the ultra-light vertex detector concept working in full simulation, using[ k4geo from this PR](https://github.com/key4hep/k4geo/pull/363). As a first step I added the functionality to VolCylinder to feature less than 2π circumference, changing the getLines function. Is there something else needed? Have in the past cylindrical sensitive surfaces actually been used in reconstruction?

Thank you,
Armin