### PR TITLE
Fix constant exception from  Geometry.regexSensitiveDetector

### DIFF
--- a/DDG4/python/DDSim/Helper/Geometry.py
+++ b/DDG4/python/DDSim/Helper/Geometry.py
@@ -66,7 +66,8 @@ class Geometry(ConfigHelper):
       for value in val:
         self.__checkRegexKeys(value)
         self._regexSDDetectorList.append(value)
-    raise RuntimeError(f"Unsupported type for regexSensitiveDetector: {val!r}")
+    else:
+        raise RuntimeError(f"Unsupported type for regexSensitiveDetector: {val!r}")
 
   @staticmethod
   def __checkRegexKeys(val):


### PR DESCRIPTION
BEGINRELEASENOTES
- DDSim: prevent Geometry.regexSensitiveDetector from always throwing exception when called with argument.

ENDRELEASENOTES

Fixing a (likely) typo from PR #1308, otherwise the `DDSim` interface always throws a Runtime error.
(sorry that I didn't catch this earlier)