### PR TITLE
Do not install plugins in CMAKE_INSTALL_LIBDIR

### DIFF
--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -86,11 +86,7 @@ function(dd4hep_generate_rootmap library)
                      )
 
   add_custom_target(Components_${library} ALL DEPENDS ${rootmapfile})
-  SET( install_destination "lib" )
-  if( CMAKE_INSTALL_LIBDIR )
-    SET( install_destination ${CMAKE_INSTALL_LIBDIR} )
-  endif()
   install(FILES $<TARGET_FILE_DIR:${library}>/${rootmapfile}
-    DESTINATION ${install_destination}
+    DESTINATION lib
   )
 endfunction()

--- a/cmake/DD4hepBuild.cmake
+++ b/cmake/DD4hepBuild.cmake
@@ -675,13 +675,9 @@ function(dd4hep_add_plugin binary)
     dd4hep_generate_rootmap(${binary})
   ENDIF()
   if(NOT ${ARG_NOINSTALL})
-    set(install_destination "lib")
-    if(CMAKE_INSTALL_LIBDIR)
-      set(install_destination ${CMAKE_INSTALL_LIBDIR})
-    endif()
     install(TARGETS ${binary}
-      ARCHIVE DESTINATION ${install_destination}
-      LIBRARY DESTINATION ${install_destination}
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
       )
   endif()
 endfunction(dd4hep_add_plugin)


### PR DESCRIPTION
BEGINRELEASENOTES
- Cmake: Do not install plugins in `CMAKE_INSTALL_LIBDIR`, but always in `lib`

ENDRELEASENOTES

 `CMAKE_INSTALL_LIBDIR` can change between cmake versions for the same OS and since everything is hardcoded to use `lib` it is unexpected that the plugins are installed somewhere else. In practice it happens that `CMAKE_INSTALL_LIBDIR` is set almost always (but not always, sometimes it is set to `lib64`, see https://cmake.org/cmake/help/v3.30/module/GNUInstallDirs.html) to `lib`. This is something that can be of course solved from the packaging point of view, but I think it would be a good practice to either set everything to `CMAKE_INSTALL_LIBDIR` (which could change) or everything to `lib` (this PR).
 
 Given that the inclusion of both non-plugins libraries and plugins libraries in `LD_LIBRARY_PATH` to make DD4hep work fine having everything in the same directory I think is a good idea. Otherwise another variable could be added if someone wanted to install the plugins in a different location.