### PR TITLE
RegexSD: change ddsim interface to use a dictionary instead of a list, fix infinite loop 

### DIFF
--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -632,4 +632,18 @@ if (DD4HEP_USE_GEANT4)
       REGEX_PASS "ResourcesAfterConstruction       ConstructSD:   VmRSS"
       REGEX_FAIL "Error;ERROR; Exception"
   )
+
+  dd4hep_add_test_reg(ClientTests_ddsim_setup_BoxOfStraws
+      COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+      EXEC_ARGS  ddsim
+                 --steeringFile ${ClientTestsEx_INSTALL}/scripts/BoxOfStraws_DDSim.py
+                 --compactFile ${ClientTestsEx_INSTALL}/compact/BoxOfStraws.xml
+                 --enableGun
+                 --numberOfEvents 1
+                 --outputFile regex.slcio
+
+      REGEX_PASS "BoxOfStrawsDet Handled 1 nodes with 1 sensitive volume type"
+      REGEX_FAIL "Error;ERROR; Exception"
+  )
+
 endif(DD4HEP_USE_GEANT4)

--- a/examples/ClientTests/scripts/BoxOfStraws_DDSim.py
+++ b/examples/ClientTests/scripts/BoxOfStraws_DDSim.py
@@ -1,0 +1,16 @@
+from DDSim.DD4hepSimulation import DD4hepSimulation
+SIM = DD4hepSimulation()
+
+# make ddsim find the sensitive detector for box of straws
+SIM.action.calorimeterSDTypes = ['sensitive']
+
+SIM.filter.calo = ""
+
+# Configure the regexSD for the BoxOfStraws gas_
+SIM.geometry.regexSensitiveDetector['BoxOfStrawsDet'] = {'Match': ['gas_'],
+                                                         'OutputLevel': 4,
+                                                         }
+
+
+# Disable userParticleHander for box of straws
+SIM.part.userParticleHandler = ""


### PR DESCRIPTION
Too much hassle to ensure that the list was not duplicating the entries in the list

The original implementation also caused infinite loop by appending to the list that was iterated over causing ddsim to use up all the memory and not do anything

Added a test with an example ddsim steering file

@SanghyunKo @lopezzot: please note, but this time actually tested to run

BEGINRELEASENOTES
- DDSim: regexSD fix infinite loop, but change the interface from assignment to dictionary entries. Have to ensure only a single entry of a detector is given to the RegexSD

ENDRELEASENOTES