### PR TITLE
Edm4hep format as default when both edm4hep and lcio enabled

### DIFF
--- a/DDG4/python/DDSim/Helper/OutputConfig.py
+++ b/DDG4/python/DDSim/Helper/OutputConfig.py
@@ -12,9 +12,9 @@ DD4HEP_USE_EDM4HEP = "@DD4HEP_USE_EDM4HEP@" != "OFF"
 
 
 def defaultOutputFile():
-  if DD4HEP_USE_LCIO:
-    return "dummyOutput.slcio"
-  return "dummyOutput.root"
+  if DD4HEP_USE_LCIO and not DD4HEP_USE_EDM4HEP:
+    return "ddsimOutput.slcio"
+  return "ddsimOutput.root"
 
 
 class OutputConfig(ConfigHelper):


### PR DESCRIPTION
BEGINRELEASENOTES
- ddsim: Set `edm4hep` the default output format in case DD4hep is compiled with both `DDD4HEP_USE_LCIO` `DD4HEP_USE_EDM4HEP` ON
- ddsim: Change the name of the default output file from dummyOutput to ddsimOutput

ENDRELEASENOTES