### PR TITLE
conditions: use static unsigned long long int because ROOTs latest ll…

### DIFF
--- a/DDCore/include/DD4hep/Conditions.h
+++ b/DDCore/include/DD4hep/Conditions.h
@@ -101,10 +101,7 @@ namespace dd4hep {
       LAST_DET_KEY        = ~0x0U
     };
     /// Flags to indicate global conditions ranges
-    enum {
-      FIRST_KEY           =  0x0ULL,
-      LAST_KEY            = ~0x0ULL        
-    };
+    static constexpr unsigned long long int FIRST_KEY =  0x0ULL, LAST_KEY  = ~0x0ULL;
 
     /// Abstract base for processing callbacks to conditions objects
     /**


### PR DESCRIPTION
…vm otherwise causes assertion in debug mode about not being able to represent in 64 bit. 
(Not sure if bug in enum parsing???)

Otherwise this error shows up when ROOT is in debug mode 
```
python -c "import DDG4"
python: /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/ROOT-HEAD/src/ROOT/HEAD/interpreter/llvm-project/llvm/include/llvm/ADT/APSInt.h:99: int64_t llvm::APSInt::getExtValue() const: Assertion `isRepresentableByInt64() && "Too many bits for int64_t"' failed.
```


BEGINRELEASENOTES
- Conditions: change FIRST_KEY, LAST_KEY to constexpr instead of anonymous enum

ENDRELEASENOTES