### PR TITLE
Use edm4hep::labels::CellIDEncoding instead of "CellIDEncoding"

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -25,6 +25,7 @@
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/EDM4hepVersion.h>
+#include <edm4hep/Constants.h>
 /// podio include files
 #include <podio/CollectionBase.h>
 #include <podio/podioVersion.h>
@@ -267,7 +268,7 @@ void Geant4Output2EDM4hep::endRun(const G4Run* run)  {
 void Geant4Output2EDM4hep::saveFileMetaData() {
   podio::Frame metaFrame{};
   for (const auto& [name, encodingStr] : m_cellIDEncodingStrings) {
-    metaFrame.putParameter(name + "__CellIDEncoding", encodingStr);
+    metaFrame.putParameter(name + "__" + edm4hep::labels::CellIDEncoding, encodingStr);
   }
 
   m_file->writeFrame(metaFrame, "metadata");

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -30,6 +30,7 @@
 #include <podio/CollectionBase.h>
 #include <podio/podioVersion.h>
 #include <podio/Frame.h>
+#include <podio/FrameCategories.h>
 #if PODIO_BUILD_VERSION >= PODIO_VERSION(0, 99, 0)
 #include <podio/ROOTWriter.h>
 #else
@@ -268,7 +269,7 @@ void Geant4Output2EDM4hep::endRun(const G4Run* run)  {
 void Geant4Output2EDM4hep::saveFileMetaData() {
   podio::Frame metaFrame{};
   for (const auto& [name, encodingStr] : m_cellIDEncodingStrings) {
-    metaFrame.putParameter(name + "__" + edm4hep::labels::CellIDEncoding, encodingStr);
+    metaFrame.putParameter(podio::collMetadataParamName(name, edm4hep::labels::CellIDEncoding), encodingStr);
   }
 
   m_file->writeFrame(metaFrame, "metadata");


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `edm4hep::labels::CellIDEncoding` instead of "CellIDEncoding"
- Use `podio::collMetadataParamName` instead of hardcoding the convention of adding `__`

ENDRELEASENOTES

See https://github.com/key4hep/EDM4hep/blob/22e85d79eca00bbd4eb479a536f90b86e76ea726/include/edm4hep/Constants.h#L29. This is the only place I could find that is related to EDM4hep.