### PR TITLE
CMake: explicitly ask for ROOTEve component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,12 @@ dd4hep_configure_output( OUTPUT "${PROJECT_BINARY_DIR}" INSTALL "${CMAKE_INSTALL
 # Configure ROOT
 find_package (ROOT 6.08 REQUIRED CONFIG)
 DD4HEP_SETUP_ROOT_TARGETS()
+# ROOT no longer finds nlohmann_json unless we ask for the ROOTEve component, so we ask
+# for the ROOTEve component if the ROOTEve component exists.
+# DDEve and one executable in UtilityApps depend on this
+if(TARGET ROOT::ROOTEve)
+  find_package (ROOT REQUIRED COMPONENTS ROOTEve CONFIG)
+endif()
 
 # Configure BOOST
 find_package(Boost 1.49 REQUIRED)


### PR DESCRIPTION
ROOT no longer finds nlohmann_json unless we ask for the ROOTEve component, so we ask for the ROOTEve component if the ROOTEve component exists.  DDEve and one executable in UtilityApps depend on this

cf. https://github.com/root-project/root/pull/16703

BEGINRELEASENOTES
- CMake: explicitly ask for ROOTEve component if it exists so we potentially find the non-builtin nlohmann_json

ENDRELEASENOTES