### PR TITLE
Fix compilation error on MACOS

### DIFF
--- a/DDCore/src/SignalHandler.cpp
+++ b/DDCore/src/SignalHandler.cpp
@@ -212,7 +212,7 @@ void SignalHandler::implementation::handler(int signum, siginfo_t *info, void *p
   SigMap::iterator iter_handler = m.find(signum);
   s_exit_handler_active = true;
   if ( iter_handler != m.end() ) {
-    __sighandler_t hdlr = iter_handler->second.old_action.sa_handler;
+    auto hdlr = iter_handler->second.old_action.sa_handler;
     func_cast<void (*)(int)> dsc0(hdlr);
     func_cast<void (*)(int,siginfo_t*, void*)> dsc(dsc0.ptr);
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Addendum to MR https://github.com/AIDASoft/DD4hep/pull/1336 which fixes a compilation error on MACOS.
ENDRELEASENOTES