### PR TITLE
Remove override warnings from DDG4 compilation

### DIFF
--- a/DDG4/include/DDG4/Geant4DataConversion.h
+++ b/DDG4/include/DDG4/Geant4DataConversion.h
@@ -132,7 +132,7 @@ namespace dd4hep {
         this->self_t::conversions().emplace(&typeid(TAG),this);
         //std::cout << "Registered " << typeName(typeid(*this)) << std::endl;
       }
-      virtual OUTPUT* operator()(const ARGS& args) const;
+      virtual OUTPUT* operator()(const ARGS& args) const  override;
     };
 
   }    // End namespace sim

--- a/DDG4/include/DDG4/Geant4DetectorConstruction.h
+++ b/DDG4/include/DDG4/Geant4DetectorConstruction.h
@@ -143,7 +143,7 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4DetectorConstructionSequence();
       /// Set or update client context
-      virtual void updateContext(Geant4Context* ctxt);
+      virtual void updateContext(Geant4Context* ctxt)  override;
       /// Add an actor responding to all callbacks. Sequence takes ownership.
       void adopt(Geant4DetectorConstruction* action);
       /// Access an actor by name

--- a/DDG4/include/DDG4/Geant4EventAction.h
+++ b/DDG4/include/DDG4/Geant4EventAction.h
@@ -97,13 +97,13 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4SharedEventAction();
       /// Set or update client for the use in a new thread fiber
-      virtual void configureFiber(Geant4Context* thread_context);
+      virtual void configureFiber(Geant4Context* thread_context)  override;
       /// Underlying object to be used during the execution of this thread
       virtual void use(Geant4EventAction* action);
       /// Begin-of-event callback
-      virtual void begin(const G4Event* event);
+      virtual void begin(const G4Event* event)  override;
       /// End-of-event callback
-      virtual void end(const G4Event* event);
+      virtual void end(const G4Event* event)  override;
     };
 
     /// Concrete implementation of the Geant4 event action sequence
@@ -142,9 +142,9 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4EventActionSequence();
       /// Set or update client context
-      virtual void updateContext(Geant4Context* ctxt);
+      virtual void updateContext(Geant4Context* ctxt)  override;
       /// Set or update client for the use in a new thread fiber
-      virtual void configureFiber(Geant4Context* thread_context);
+      virtual void configureFiber(Geant4Context* thread_context)  override;
       /// Get an action by name
       Geant4EventAction* get(const std::string& name) const;
       /// Register begin-of-event callback

--- a/DDG4/include/DDG4/Geant4FastSimShowerModel.h
+++ b/DDG4/include/DDG4/Geant4FastSimShowerModel.h
@@ -103,11 +103,11 @@ namespace dd4hep  {
       virtual ~Geant4FastSimShowerModel();
 
       /// Geometry construction callback. Called at "Construct()"
-      virtual void constructGeo(Geant4DetectorConstructionContext* ctxt);
+      virtual void constructGeo(Geant4DetectorConstructionContext* ctxt)  override;
       /// Electromagnetic field construction callback. Called at "ConstructSDandField()"
-      virtual void constructField(Geant4DetectorConstructionContext* ctxt);
+      virtual void constructField(Geant4DetectorConstructionContext* ctxt)  override;
       /// Sensitive detector construction callback. Called at "ConstructSDandField()"
-      virtual void constructSensitives(Geant4DetectorConstructionContext* ctxt);
+      virtual void constructSensitives(Geant4DetectorConstructionContext* ctxt)  override;
 
       /// User callback to determine if the model is applicable for the particle type
       virtual bool check_applicability(const G4ParticleDefinition& particle);

--- a/DDG4/include/DDG4/Geant4Field.h
+++ b/DDG4/include/DDG4/Geant4Field.h
@@ -47,9 +47,9 @@ namespace dd4hep {
       /// Standard destructor
       virtual ~Geant4Field() {    }
       /// Access field values at a given point
-      virtual void GetFieldValue(const double pos[4], double *arr) const;
+      virtual void GetFieldValue(const double pos[4], double *arr) const  override;
       /// Does field change energy ?
-      virtual G4bool DoesFieldChangeEnergy() const;
+      virtual G4bool DoesFieldChangeEnergy() const  override;
     };
 
   }    // End namespace sim

--- a/DDG4/include/DDG4/Geant4GDMLDetector.h
+++ b/DDG4/include/DDG4/Geant4GDMLDetector.h
@@ -37,7 +37,7 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4GDMLDetector() {
       }
-      G4VPhysicalVolume* Construct();
+      G4VPhysicalVolume* Construct()  override;
     private:
       std::string m_fileName;
       G4VPhysicalVolume* m_world { nullptr };

--- a/DDG4/include/DDG4/Geant4GeneratorWrapper.h
+++ b/DDG4/include/DDG4/Geant4GeneratorWrapper.h
@@ -62,7 +62,7 @@ namespace dd4hep {
       /// Access the G4VPrimaryGenerator instance
       G4VPrimaryGenerator* generator();
       /// Event generation action callback
-      virtual void operator()(G4Event* event);
+      virtual void operator()(G4Event* event)  override;
     };
   }    // End namespace sim
 }      // End namespace dd4hep

--- a/DDG4/include/DDG4/Geant4HitCollection.h
+++ b/DDG4/include/DDG4/Geant4HitCollection.h
@@ -314,11 +314,11 @@ namespace dd4hep {
         return m_detector;
       }
       /// Access individual hits
-      virtual G4VHit* GetHit(size_t which) const {
+      virtual G4VHit* GetHit(size_t which) const  override {
         return (G4VHit*) &m_hits.at(which);
       }
       /// Access the collection size
-      virtual size_t GetSize() const {
+      virtual size_t GetSize() const  override {
         return m_hits.size();
       }
       /// Access the hit wrapper

--- a/DDG4/include/DDG4/Geant4InteractionMerger.h
+++ b/DDG4/include/DDG4/Geant4InteractionMerger.h
@@ -53,7 +53,7 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4InteractionMerger();
       /// Event generation action callback
-      virtual void operator()(G4Event* event);
+      virtual void operator()(G4Event* event)  override;
     };
   }    // End namespace sim
 }      // End namespace dd4hep

--- a/DDG4/include/DDG4/Geant4InteractionVertexBoost.h
+++ b/DDG4/include/DDG4/Geant4InteractionVertexBoost.h
@@ -64,7 +64,7 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4InteractionVertexBoost();
       /// Callback to generate primary particles
-      virtual void operator()(G4Event* event);
+      virtual void operator()(G4Event* event)  override;
     };
   }    // End namespace sim
 }      // End namespace dd4hep

--- a/DDG4/include/DDG4/Geant4IsotropeGenerator.h
+++ b/DDG4/include/DDG4/Geant4IsotropeGenerator.h
@@ -45,7 +45,7 @@ namespace dd4hep {
       /** Use this function to implement isotrop guns, multiple guns etc. 
           User must return a UNIT vector, which gets scaled with momentum.
       */
-      virtual void getParticleDirection(int num, ROOT::Math::XYZVector& direction, double& momentum) const;
+      virtual void getParticleDirection(int num, ROOT::Math::XYZVector& direction, double& momentum) const  override;
       /// e+e- --> ffbar particle distribution ~ 1 + cos^2(theta)
       void getParticleDirectionFFbar(int num, ROOT::Math::XYZVector& direction, double& momentum) const;
       /// e+e- --> ffbar particle distribution ~ 1 + cos^2(theta)

--- a/DDG4/include/DDG4/Geant4Kernel.h
+++ b/DDG4/include/DDG4/Geant4Kernel.h
@@ -43,14 +43,14 @@ namespace dd4hep {
     class DD4hep_End_Of_File : public std::exception {
     public:
       DD4hep_End_Of_File() : std::exception() {}
-      virtual const char* what() const noexcept { return "Reached end of input file"; }
+      virtual const char* what() const noexcept override { return "Reached end of input file"; }
     };
 
     /// Helper class to indicate the stop of processing
     class DD4hep_Stop_Processing : public std::exception {
     public:
       DD4hep_Stop_Processing() : std::exception() {}
-      virtual const char* what() const noexcept { return "Event loop STOP signalled. Processing stops"; }
+      virtual const char* what() const noexcept override { return "Event loop STOP signalled. Processing stops"; }
     };
 
     /// Class, which allows all Geant4Action derivatives to access the DDG4 kernel structures.
@@ -71,8 +71,8 @@ namespace dd4hep {
       using UserCallbacks = std::vector<std::function<void()> >;
 
       enum event_loop_status  {
-	EVENTLOOP_HALT = 0,
-	EVENTLOOP_RUNNING = 1,
+        EVENTLOOP_HALT = 0,
+        EVENTLOOP_RUNNING = 1,
       };
       
     protected:
@@ -349,7 +349,7 @@ namespace dd4hep {
       /// Run the simulation: Simulate the number of events "num_events" and modify the property "NumEvents"
       virtual int runEvents(int num_events);
       /// Run the simulation: Terminate Geant4
-      virtual int terminate();
+      virtual int terminate()  override;
     };
     /// Declare property
     template <typename T> Geant4Kernel& Geant4Kernel::declareProperty(const std::string& nam, T& val) {

--- a/DDG4/include/DDG4/Geant4MonteCarloTruth.h
+++ b/DDG4/include/DDG4/Geant4MonteCarloTruth.h
@@ -70,13 +70,13 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4DummyTruthHandler();
       /// Mark a Geant4 track to be kept for later MC truth analysis. Default flag: CREATED_HIT
-      virtual void mark(const G4Track* track);
+      virtual void mark(const G4Track* track)  override;
       /// Store a track, with a flag
-      virtual void mark(const G4Track* track, int reason);
+      virtual void mark(const G4Track* track, int reason)  override;
       /// Mark a Geant4 track of the step to be kept for later MC truth analysis. Default flag: CREATED_HIT
-      virtual void mark(const G4Step* step);
+      virtual void mark(const G4Step* step)  override;
       /// Store a track produced in a step to be kept for later MC truth analysis
-      virtual void mark(const G4Step* step, int reason);
+      virtual void mark(const G4Step* step, int reason)  override;
     };
 
   }    // End namespace sim

--- a/DDG4/include/DDG4/Geant4Output2ROOT.h
+++ b/DDG4/include/DDG4/Geant4Output2ROOT.h
@@ -72,14 +72,14 @@ namespace dd4hep {
       /// Close current output file
       virtual void closeOutput();
       /// Callback to store the Geant4 run information
-      virtual void beginRun(const G4Run* run);
+      virtual void beginRun(const G4Run* run)  override;
       /// Callback to store each Geant4 hit collection
-      virtual void saveCollection(OutputContext<G4Event>& ctxt, G4VHitsCollection* collection);
+      virtual void saveCollection(OutputContext<G4Event>& ctxt, G4VHitsCollection* collection)  override;
       /// Callback to store the Geant4 event
-      virtual void saveEvent(OutputContext<G4Event>& ctxt);
+      virtual void saveEvent(OutputContext<G4Event>& ctxt)  override;
 
       /// Commit data at end of filling procedure
-      virtual void commit(OutputContext<G4Event>& ctxt);
+      virtual void commit(OutputContext<G4Event>& ctxt)  override;
     };
 
   }    // End namespace sim

--- a/DDG4/include/DDG4/Geant4ParticleGenerator.h
+++ b/DDG4/include/DDG4/Geant4ParticleGenerator.h
@@ -83,7 +83,7 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4ParticleGenerator();
       /// Callback to generate primary particles
-      virtual void operator()(G4Event* event);
+      virtual void operator()(G4Event* event)  override;
     };
   }    // End namespace sim
 }      // End namespace dd4hep

--- a/DDG4/include/DDG4/Geant4ParticleHandler.h
+++ b/DDG4/include/DDG4/Geant4ParticleHandler.h
@@ -148,7 +148,7 @@ namespace dd4hep {
       /// Adopt the user particle handler
       bool adopt(Geant4Action* action);
       /// Event generation action callback
-      virtual void operator()(G4Event* event);
+      virtual void operator()(G4Event* event)  override;
       /// User stepping callback
       virtual void step(const G4Step* step, G4SteppingManager* mgr);
       /// Pre-event action callback
@@ -161,13 +161,13 @@ namespace dd4hep {
       virtual void end(const G4Track* track);
 
       /// Mark a Geant4 track to be kept for later MC truth analysis. Default flag: CREATED_HIT
-      virtual void mark(const G4Track* track);
+      virtual void mark(const G4Track* track)  override;
       /// Store a track
-      virtual void mark(const G4Track* track, int reason);
+      virtual void mark(const G4Track* track, int reason)  override;
       /// Mark a Geant4 track of the step to be kept for later MC truth analysis. Default flag: CREATED_HIT
-      virtual void mark(const G4Step* step);
+      virtual void mark(const G4Step* step)  override;
       /// Store a track produced in a step to be kept for later MC truth analysis
-      virtual void mark(const G4Step* step, int reason);
+      virtual void mark(const G4Step* step, int reason)  override;
 
       /// Default callback to be answered if the particle should be kept if NO user handler is installed
       static bool defaultKeepParticle(Particle& particle);

--- a/DDG4/include/DDG4/Geant4ParticlePrint.h
+++ b/DDG4/include/DDG4/Geant4ParticlePrint.h
@@ -69,9 +69,9 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4ParticlePrint();
       /// Pre-event action callback
-      virtual void begin(const G4Event* event);
+      virtual void begin(const G4Event* event)  override;
       /// Post-event action callback
-      virtual void end(const G4Event* event);
+      virtual void end(const G4Event* event)  override;
       /// Generation action callback
       virtual void operator()(G4Event* event);
 

--- a/DDG4/include/DDG4/Geant4PhysicsConstructor.h
+++ b/DDG4/include/DDG4/Geant4PhysicsConstructor.h
@@ -78,7 +78,7 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4PhysicsConstructor();
       /// constructPhysics callback
-      virtual void constructPhysics(G4VModularPhysicsList* physics);
+      virtual void constructPhysics(G4VModularPhysicsList* physics)  override;
       /// Callback to construct processes (uses the G4 particle table)
       virtual void constructProcess(Constructor& ctor);
       /// Callback to construct particles

--- a/DDG4/include/DDG4/Geant4PhysicsList.h
+++ b/DDG4/include/DDG4/Geant4PhysicsList.h
@@ -121,7 +121,7 @@ namespace dd4hep {
       void dump();
 
       /// Install command control messenger if wanted
-      virtual void installCommandMessenger();
+      virtual void installCommandMessenger()  override;
       /// Access all physics processes
       PhysicsProcesses& processes() {
         return m_processes;
@@ -253,7 +253,7 @@ namespace dd4hep {
       /// Dump content to stdout
       void dump();
       /// Install command control messenger if wanted
-      virtual void installCommandMessenger();
+      virtual void installCommandMessenger()  override;
       /// Update transportation flag
       void setTransportation(bool value) {
         m_transportation = value;

--- a/DDG4/include/DDG4/Geant4PrimaryHandler.h
+++ b/DDG4/include/DDG4/Geant4PrimaryHandler.h
@@ -69,7 +69,7 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4PrimaryHandler();
       /// Event generation action callback
-      virtual void operator()(G4Event* event);
+      virtual void operator()(G4Event* event)  override;
 
     public:
       Geant4PrimaryConfig m_primaryConfig{};

--- a/DDG4/include/DDG4/Geant4RunAction.h
+++ b/DDG4/include/DDG4/Geant4RunAction.h
@@ -90,13 +90,13 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4SharedRunAction();
       /// Set or update client for the use in a new thread fiber
-      virtual void configureFiber(Geant4Context* thread_context);
+      virtual void configureFiber(Geant4Context* thread_context)  override;
       /// Underlying object to be used during the execution of this thread
       virtual void use(Geant4RunAction* action);
       /// Begin-of-run callback
-      virtual void begin(const G4Run* run);
+      virtual void begin(const G4Run* run)  override;
       /// End-of-run callback
-      virtual void end(const G4Run* run);
+      virtual void end(const G4Run* run)  override;
     };
 
     /// Concrete basic implementation of the Geant4 run action sequencer.
@@ -134,9 +134,9 @@ namespace dd4hep {
       /// Default destructor
       virtual ~Geant4RunActionSequence();
       /// Set or update client context
-      virtual void updateContext(Geant4Context* ctxt);
+      virtual void updateContext(Geant4Context* ctxt)  override;
       /// Set or update client for the use in a new thread fiber
-      virtual void configureFiber(Geant4Context* thread_context);
+      virtual void configureFiber(Geant4Context* thread_context)  override;
       /// Get an action by name
       Geant4RunAction* get(const std::string& name) const;
       /// Register begin-of-run callback. Types Q and T must be polymorph!

--- a/DDG4/include/DDG4/Geant4TestActions.h
+++ b/DDG4/include/DDG4/Geant4TestActions.h
@@ -66,7 +66,7 @@ namespace dd4hep {
         /// Default destructor
         virtual ~Geant4TestGeneratorAction();
         /// Callback to generate primary particles
-        virtual void operator()(G4Event*);
+        virtual void operator()(G4Event*)  override;
       };
 
       /// Example run action doing nothing, but print
@@ -82,9 +82,9 @@ namespace dd4hep {
         /// Default destructor
         virtual ~Geant4TestRunAction();
         /// begin-of-run callback
-        void begin(const G4Run*);
+        void begin(const G4Run*)  override;
         /// End-of-run callback
-        void end(const G4Run*);
+        void end(const G4Run*)  override;
         /// begin-of-event callback
         void beginEvent(const G4Event*);
         /// End-of-event callback
@@ -104,9 +104,9 @@ namespace dd4hep {
         /// Default destructor
         virtual ~Geant4TestEventAction();
         /// begin-of-event callback
-        virtual void begin(const G4Event*);
+        virtual void begin(const G4Event*)  override;
         /// End-of-event callback
-        virtual void end(const G4Event*);
+        virtual void end(const G4Event*)  override;
         /// begin-of-run callback
         void beginRun(const G4Run*);
         /// End-of-run callback

--- a/DDG4/include/DDG4/Geant4UIMessenger.h
+++ b/DDG4/include/DDG4/Geant4UIMessenger.h
@@ -72,9 +72,9 @@ namespace dd4hep {
       /// Export all properties to the Geant4 UI
       void exportProperties(PropertyManager& mgr);
       /// Accept ne property value from Geant4 UI
-      void SetNewValue(G4UIcommand *c, G4String val);
+      void SetNewValue(G4UIcommand *c, G4String val)  override;
       /// Pass current property value to Geant4 UI
-      G4String GetCurrentValue(G4UIcommand *c);
+      G4String GetCurrentValue(G4UIcommand *c)  override;
     };
 
   }    // End namespace sim

--- a/DDG4/include/DDG4/Geant4UserInitialization.h
+++ b/DDG4/include/DDG4/Geant4UserInitialization.h
@@ -75,11 +75,11 @@ namespace dd4hep {
       void adopt(Geant4UserInitialization* action);
 
       /// Set client context
-      virtual void updateContext(Geant4Context* ctxt);
+      virtual void updateContext(Geant4Context* ctxt)  override;
       /// Callback function to build setup for the MT worker thread
-      virtual void build()  const;
+      virtual void build()  const  override;
       /// Callback function to build setup for the MT master thread
-      virtual void buildMaster()  const;
+      virtual void buildMaster()  const  override;
     };
 
   }    // End namespace sim

--- a/DDG4/include/DDG4/Geant4UserLimits.h
+++ b/DDG4/include/DDG4/Geant4UserLimits.h
@@ -78,26 +78,26 @@ namespace dd4hep {
       /// Update the object
       virtual void update(LimitSet limitset);
       /// Access the user tracklength for a G4 track object
-      virtual G4double GetMaxAllowedStep(const G4Track& track)
+      virtual G4double GetMaxAllowedStep(const G4Track& track)  override
       {  return maxStepLength.value(track);    }
       /// Access the user tracklength for a G4 track object
-      virtual G4double GetUserMaxTrackLength(const G4Track& track)
+      virtual G4double GetUserMaxTrackLength(const G4Track& track)  override
       {  return maxTrackLength.value(track);   }
       /// Access the proper time cut for a G4 track object
-      virtual G4double GetUserMaxTime (const G4Track& track)
+      virtual G4double GetUserMaxTime (const G4Track& track)  override
       {  return maxTime.value(track);          }
       /// Access the kinetic energy cut for a G4 track object
-      virtual G4double GetUserMinEkine(const G4Track& track)
+      virtual G4double GetUserMinEkine(const G4Track& track)  override
       {  return minEKine.value(track);         }
       /// Access the range cut for a G4 track object
-      virtual G4double GetUserMinRange(const G4Track& track)
+      virtual G4double GetUserMinRange(const G4Track& track)  override
       {  return minRange.value(track);         }
       /// Setters may not be called!
-      virtual void SetMaxAllowedStep(G4double ustepMax);    
-      virtual void SetUserMaxTrackLength(G4double utrakMax);
-      virtual void SetUserMaxTime(G4double utimeMax);
-      virtual void SetUserMinEkine(G4double uekinMin);
-      virtual void SetUserMinRange(G4double urangMin);
+      virtual void SetMaxAllowedStep(G4double ustepMax)  override;    
+      virtual void SetUserMaxTrackLength(G4double utrakMax)  override;
+      virtual void SetUserMaxTime(G4double utimeMax)  override;
+      virtual void SetUserMinEkine(G4double uekinMin)  override;
+      virtual void SetUserMinRange(G4double urangMin)  override;
       /// Allow for debugging user limits (very verbose)
       static bool enable_debug(bool value);
     };

--- a/DDG4/include/DDG4/Python/Geant4PythonDetectorConstruction.h
+++ b/DDG4/include/DDG4/Python/Geant4PythonDetectorConstruction.h
@@ -83,11 +83,11 @@ namespace dd4hep {
       /// Set the sensitive detector initialization command
       void setConstructSensitives(PyObject* callable, PyObject* args);
       /// Geometry construction callback. Called at "Construct()"
-      virtual void constructGeo(Geant4DetectorConstructionContext* ctxt);
+      virtual void constructGeo(Geant4DetectorConstructionContext* ctxt)  override;
       /// Electromagnetic field construction callback. Called at "ConstructSDandField()"
-      virtual void constructField(Geant4DetectorConstructionContext* ctxt);
+      virtual void constructField(Geant4DetectorConstructionContext* ctxt)  override;
       /// Sensitive detector construction callback. Called at "ConstructSDandField()"
-      virtual void constructSensitives(Geant4DetectorConstructionContext* ctxt);
+      virtual void constructSensitives(Geant4DetectorConstructionContext* ctxt)  override;
 
     };
   }    // End namespace sim

--- a/DDG4/lcio/LCIOEventReader.h
+++ b/DDG4/lcio/LCIOEventReader.h
@@ -44,7 +44,8 @@ namespace dd4hep  {
                                               Vertices& vertices,
                                               std::vector<Particle*>& particles);
       /// Read an event and return a LCCollectionVec of MCParticles.
-      virtual EventReaderStatus readParticleCollection(int event_number, EVENT::LCCollection** particles) = 0;
+      virtual EventReaderStatus readParticleCollection(int event_number,
+                                                       EVENT::LCCollection** particles) = 0;
     };
 
   }     /* End namespace sim   */

--- a/DDG4/lcio/LCIOStdHepReader.cpp
+++ b/DDG4/lcio/LCIOStdHepReader.cpp
@@ -53,9 +53,10 @@ namespace dd4hep  {
       /// Default destructor
       virtual ~LCIOStdHepReader();
       /// Read an event and fill a vector of MCParticles.
-      virtual EventReaderStatus readParticleCollection(int event_number, EVENT::LCCollection** particles);
-      virtual EventReaderStatus moveToEvent(int event_number);
-      virtual EventReaderStatus skipEvent() { return EVENT_READER_OK; }
+      virtual EventReaderStatus readParticleCollection(int event_number,
+                                                       EVENT::LCCollection** particles)  override;
+      virtual EventReaderStatus moveToEvent(int event_number)  override;
+      virtual EventReaderStatus skipEvent()  override { return EVENT_READER_OK; }
 
     };
   }     /* End namespace lcio   */

--- a/DDG4/src/IoStreams.cpp
+++ b/DDG4/src/IoStreams.cpp
@@ -31,11 +31,11 @@ namespace {
     virtual ~MyTFile() {}
   public:
     /// Basic write call
-    virtual Int_t SysWrite(Int_t fd, const void* buf, Int_t len)  { return TFile::SysWrite(fd, buf, len);  }
+    virtual Int_t SysWrite(Int_t fd, const void* buf, Int_t len)  override  { return TFile::SysWrite(fd, buf, len);  }
     /// Basic read call
-    virtual Int_t SysRead(Int_t fd, void* buf, Int_t len)         { return TFile::SysRead(fd,buf,len);     }
+    virtual Int_t SysRead(Int_t fd, void* buf, Int_t len)  override         { return TFile::SysRead(fd,buf,len);     }
     /// Basic seek call
-    virtual Long64_t SysSeek(Int_t fd, Long64_t off, Int_t way)   { return TFile::SysSeek(fd, off, way);   }
+    virtual Long64_t SysSeek(Int_t fd, Long64_t off, Int_t way)  override   { return TFile::SysSeek(fd, off, way);   }
   };
 }
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove plenty of override warnings from DDG4 compilation
- Spotted by accidence when checking LHCb nightly builds.
ENDRELEASENOTES