### PR TITLE
make inline definition of insertion operator of DCH_info class

### DIFF
--- a/DDRec/include/DDRec/DCH_info.h
+++ b/DDRec/include/DDRec/DCH_info.h
@@ -183,7 +183,7 @@ public:
 
 };
 typedef StructExtension<DCH_info_struct> DCH_info ;
-std::ostream& operator<<( std::ostream& io , const DCH_info& d ){d.Show_DCH_info_database(io); return io;}
+inline std::ostream& operator<<( std::ostream& io , const DCH_info& d ){d.Show_DCH_info_database(io); return io;}
 
 inline void DCH_info_struct::BuildLayerDatabase()
 {


### PR DESCRIPTION
BEGINRELEASENOTES
- DDRec/DCH_info.h: make inline definition of insertion operator of DCH_info class. This fixes 'multiple definition' compilation error when header is included more than once.

ENDRELEASENOTES