### PR TITLE
PythonPlugin: replace deprecated/removed Eval with Exec

### DIFF
--- a/DDCore/src/python/PythonPlugin.cpp
+++ b/DDCore/src/python/PythonPlugin.cpp
@@ -87,7 +87,8 @@ namespace  {
           result = TPython::Exec(c.second.c_str());
           break;
         case 'c':
-          TPython::Eval(c.second.c_str());
+          // we do not care about the result
+          TPython::Exec(c.second.c_str());
           result = kTRUE;
           break;
         case 'p':


### PR DESCRIPTION
It doesn't matter because we don't care about the result



BEGINRELEASENOTES
- PythonPlugin: replace deprecated Eval with Exec (root 6.36 need)

ENDRELEASENOTES