### PR TITLE
DDG4: add possibility to control verbosity for physics constructors

### DIFF
--- a/DDG4/include/DDG4/Geant4PhysicsList.h
+++ b/DDG4/include/DDG4/Geant4PhysicsList.h
@@ -244,6 +244,8 @@ namespace dd4hep {
       std::string m_extends;
       /// global range cut for secondary productions
       double m_rangecut;
+      /// verbosity level for the physics list
+      int m_verbosity = 1;
 
     public:
       /// Standard constructor

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -506,6 +506,7 @@ class DD4hepSimulation(object):
   # =================================================================================
     # Now build the physics list:
     _phys = self.physics.setupPhysics(kernel, name=self.physicsList)
+    _phys.verbosity = self.output.physics
 
     # add the G4StepLimiterPhysics to activate the max step limits in volumes
     ph = DDG4.PhysicsList(kernel, 'Geant4PhysicsList/Myphysics')

--- a/DDG4/python/DDSim/Helper/Output.py
+++ b/DDG4/python/DDSim/Helper/Output.py
@@ -52,6 +52,9 @@ class Output(ConfigHelper):
 
     self._geometry_EXTRA = {'choices': OUTPUT_CHOICES, 'type': outputLevelType}
     self._geometry = outputLevel('DEBUG')
+
+    self._physics_EXTRA = {'choices': (0, 1, 2), 'type': outputLevelType}
+    self._physics = outputLevel(1)
     self._closeProperties()
 
   @property
@@ -98,3 +101,12 @@ class Output(ConfigHelper):
   @geometry.setter
   def geometry(self, level):
     self._geometry = outputLevel(level)
+
+  @property
+  def physics(self):
+    """Output level for physics and physics constructors: 0 (silent), 1, 2"""
+    return self._physics
+
+  @physics.setter
+  def physics(self, level):
+    self._physics = int(level)

--- a/DDG4/src/Geant4PhysicsList.cpp
+++ b/DDG4/src/Geant4PhysicsList.cpp
@@ -28,6 +28,8 @@
 #include <G4RunManager.hh>
 #include <G4VProcess.hh>
 #include <G4Decay.hh>
+#include <G4EmParameters.hh>
+#include <G4HadronicParameters.hh>
 
 // C/C++ include files
 #include <stdexcept>
@@ -319,6 +321,7 @@ Geant4PhysicsListActionSequence::Geant4PhysicsListActionSequence(Geant4Context* 
   declareProperty("extends",  m_extends);
   declareProperty("decays",   m_decays);
   declareProperty("rangecut", m_rangecut);
+  declareProperty("verbosity", m_verbosity);
   m_needsControl = true;
   InstanceCount::increment(this);
 }
@@ -362,6 +365,12 @@ G4VUserPhysicsList* Geant4PhysicsListActionSequence::extensionList()    {
   // Ownership is transferred to the physics list.
   // Do not delete this pointer afterwards....
   physics->RegisterPhysics(new ParticlePhysics(this,physics));
+
+  //Setting verbosity for pieces of the physics
+  physics->SetVerboseLevel(m_verbosity);
+  G4EmParameters::Instance()->SetVerbose(m_verbosity);
+  G4HadronicParameters::Instance()->SetVerboseLevel(m_verbosity);
+
   return physics;
 }
 
@@ -377,6 +386,7 @@ void Geant4PhysicsListActionSequence::dump()    {
   printout(ALWAYS,name(),"+++ Transportation flag: %d",m_transportation);
   printout(ALWAYS,name(),"+++ Program decays:      %d",m_decays);
   printout(ALWAYS,name(),"+++ RangeCut:            %f",m_rangecut);
+  printout(ALWAYS,name(),"+++ Verbosity:           %i",m_verbosity);
   m_actors(&Geant4PhysicsList::dump);
 }
 


### PR DESCRIPTION

BEGINRELEASENOTES
- DDG4: add possibility to control verbosity for physics constructors
- DDSim: add new `--output.physics` parameter to control output level for physics constructors, fixes #1351 

ENDRELEASENOTES