### PR TITLE
Bug fix in Segmentation's CylindricalGridPhiZ: phi range

### DIFF
--- a/DDCore/include/DDSegmentation/CylindricalGridPhiZ.h
+++ b/DDCore/include/DDSegmentation/CylindricalGridPhiZ.h
@@ -104,6 +104,9 @@ namespace dd4hep {
       */
       virtual std::vector<double> cellDimensions(const CellID& cellID) const;
 
+      /// Set the underlying decoder (setting, inter alia, whether phi isSigned)
+      virtual void setDecoder(const BitFieldCoder* decoder);
+
     protected:
       /// the grid size in phi
       double _gridSizePhi;
@@ -119,7 +122,8 @@ namespace dd4hep {
       std::string _phiId;
       /// the field name used for Z
       std::string _zId;
-      /// encoding field used for the module
+      /// the isSigned attribute of the bitfield used for phi
+      bool _phiIsSigned;
     };
 
   } /* namespace DDSegmentation */

--- a/DDCore/src/segmentations/CylindricalGridPhiZ.cpp
+++ b/DDCore/src/segmentations/CylindricalGridPhiZ.cpp
@@ -62,6 +62,13 @@ CylindricalGridPhiZ::~CylindricalGridPhiZ() {
 
 }
 
+/// Set the underlying decoder and assign isSigned attribute to phi identifier
+void CylindricalGridPhiZ::setDecoder(const BitFieldCoder* newDecoder) {
+  this->Segmentation::setDecoder(newDecoder);
+  const BitFieldElement* m_phi = &((*_decoder)[_phiId]);
+  _phiIsSigned = m_phi->isSigned();
+}
+
 /// determine the position based on the cell ID
 Vector3D CylindricalGridPhiZ::position(const CellID& cID) const {
 	vector<double> localPosition(3);
@@ -80,7 +87,7 @@ Vector3D CylindricalGridPhiZ::position(const CellID& cID) const {
   CellID CylindricalGridPhiZ::cellID(const Vector3D& localPosition, const Vector3D& /* globalPosition */, const VolumeID& vID) const {
 	double phi = atan2(localPosition.Y,localPosition.X);
 	double Z = localPosition.Z;
-	if ( phi < _offsetPhi) {
+	if (!_phiIsSigned && phi < _offsetPhi) {
 	  phi += 2*M_PI;
 	}
         CellID cID = vID ;


### PR DESCRIPTION
    is now set to [-pi,pi] instead of [0,2pi] if phi IDdescriptor field is signed.

BEGINRELEASENOTES
 Bug fix in `CylindricalGridPhiZ`:
   - In the `cellId` member method, one now refrains from reducing the phi parameter modulo 2pi when its IDdescriptor is signed.
   - When the offset is null, this means that the phi range is now [-pi,pi], instead of the previously [0,2pi] which is not appropriate for a signed quantity.

ENDRELEASENOTES


Followup of #1353 