### PR TITLE
Increase the max number of particles allowed for hepevt input

### DIFF
--- a/DDG4/plugins/Geant4EventReaderHepEvt.cpp
+++ b/DDG4/plugins/Geant4EventReaderHepEvt.cpp
@@ -183,8 +183,8 @@ Geant4EventReaderHepEvt::readParticles(int /* event_number */,
   //check loop variable read from input file and chack that is reasonable
   // should fix coverity issue: "Using tainted variable NHEP as a loop boundary."
 
-  if( NHEP > 1e6 ){ 
-    printout(ERROR,"EventReaderHepEvt::readParticles","Cannot read in more than million particles, but  %d requested", NHEP );
+  if( NHEP > 5e7 ){
+    printout(ERROR,"EventReaderHepEvt::readParticles","Cannot read in too many particles, %d requested but an (arbitrary) limit has been set to 50 M", NHEP );
     return EVENT_READER_EOF; 
   }
 

--- a/DDG4/plugins/Geant4EventReaderHepEvt.cpp
+++ b/DDG4/plugins/Geant4EventReaderHepEvt.cpp
@@ -184,7 +184,7 @@ Geant4EventReaderHepEvt::readParticles(int /* event_number */,
   // should fix coverity issue: "Using tainted variable NHEP as a loop boundary."
 
   if( NHEP > 5e7 ){
-    printout(ERROR,"EventReaderHepEvt::readParticles","Cannot read in too many particles, %d requested but an (arbitrary) limit has been set to 50 M", NHEP );
+    printout(ERROR,"EventReaderHepEvt::readParticles","Cannot read in too many particles, %d requested but an arbitrary limit has been set to 50 M", NHEP );
     return EVENT_READER_EOF; 
   }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Increased the limit on the maximum number of particles one can provide with the hepevt format from 1 to 50 M, fixes #1356

ENDRELEASENOTES