### PR TITLE
Geant4AssemblyVolume: use the same copy ID for the Geant4 Volume as w…

### DIFF
--- a/DDG4/include/DDG4/Geant4AssemblyVolume.h
+++ b/DDG4/include/DDG4/Geant4AssemblyVolume.h
@@ -71,7 +71,6 @@ namespace dd4hep {
                    Geant4AssemblyVolume*  pAssembly,
                    G4LogicalVolume*       pMotherLV,
                    G4Transform3D&         transformation,
-                   G4int                  copyNumBase,
                    G4bool                 surfCheck );
     };
   }

--- a/DDG4/src/Geant4AssemblyVolume.cpp
+++ b/DDG4/src/Geant4AssemblyVolume.cpp
@@ -82,10 +82,7 @@ void Geant4AssemblyVolume::imprint(const Geant4Converter& cnv,
   TGeoVolume*       vol = parent->GetVolume();
   G4AssemblyVolume* par_ass = pParentAssembly->m_assembly;
   Geant4GeometryInfo&  info = cnv.data();
-  unsigned int numberOfDaughters = (copyNumBase == 0) ? pMotherLV->GetNoDaughters() : copyNumBase;
 
-  // We start from the first available index
-  numberOfDaughters++;
   _Wrap::imprintsCountPlus(par_ass);
 
   path = detail::tools::placementPath(chain);

--- a/DDG4/src/Geant4AssemblyVolume.cpp
+++ b/DDG4/src/Geant4AssemblyVolume.cpp
@@ -141,7 +141,7 @@ void Geant4AssemblyVolume::imprint(const Geant4Converter& cnv,
                                                   triplet.GetVolume(),
                                                   pMotherLV,
                                                   false,
-                                                  numberOfDaughters + i,
+                                                  node->GetNumber(),
                                                   surfCheck );
 
       info.g4VolumeImprints[vol].emplace_back(new_chain,pvPlaced.first);

--- a/DDG4/src/Geant4AssemblyVolume.cpp
+++ b/DDG4/src/Geant4AssemblyVolume.cpp
@@ -71,7 +71,6 @@ void Geant4AssemblyVolume::imprint(const Geant4Converter& cnv,
                                    Geant4AssemblyVolume*  pParentAssembly,
                                    G4LogicalVolume*       pMotherLV,
                                    G4Transform3D&         transformation,
-                                   G4int                  copyNumBase,
                                    G4bool                 surfCheck)
 {
   struct _Wrap : public G4AssemblyVolume  {
@@ -156,7 +155,7 @@ void Geant4AssemblyVolume::imprint(const Geant4Converter& cnv,
     }
     else if ( triplet.GetAssembly() )  {
       // Place volumes in this assembly with composed transformation
-      imprint(cnv, parent, std::move(new_chain), avol, pMotherLV, Tfinal, i*100+copyNumBase, surfCheck );
+      imprint(cnv, parent, std::move(new_chain), avol, pMotherLV, Tfinal, surfCheck );
     }
     else   {
       G4Exception("Geant4AssemblyVolume::imprint(..)", "GeomVol0003", FatalException,

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -1000,7 +1000,7 @@ void* Geant4Converter::handlePlacement(const std::string& name, const TGeoNode* 
         Geant4AssemblyVolume* ass = (Geant4AssemblyVolume*)info.g4AssemblyVolumes[node];
         Geant4AssemblyVolume::Chain chain;
         chain.emplace_back(node);
-        ass->imprint(*this, node, chain, ass, (*volIt).second, transform, copy, checkOverlaps);
+        ass->imprint(*this, node, chain, ass, (*volIt).second, transform, checkOverlaps);
         return nullptr;
       }
       else if ( node != info.manager->GetTopNode() && volIt == info.g4Volumes.end() )  {


### PR DESCRIPTION
…as set in DD4hep geometry construction



BEGINRELEASENOTES
- Geant4AssemblyVolume: use the same copy ID for the Geant4 Volume as was set in DD4hep geometry construction, fixes #1360 .


ENDRELEASENOTES

- [x] Check if this affects checksums or GDML output?
   - I don't think it can affect checksums, because those are calculated on the DD4hep/TGeo geometry
   - I didn't see any difference in the GDML ordering or copynumber tag in SiD gdml test