### PR TITLE
Fix user analysis test

### DIFF
--- a/examples/DDG4/src/HitTupleAction.cpp
+++ b/examples/DDG4/src/HitTupleAction.cpp
@@ -50,7 +50,7 @@ namespace myanalysis {
     /// We want to write a separate branch for all deposits of one container(sub-detector)
     typedef std::pair<double, std::vector<double> > Data;
     /// The intermediate storage of the hit deposits to be written to ROOT
-    std::map<std::string, std::pair<TBranch*, Data> > m_deposits;
+    std::map<std::string, std::pair<TBranch*, Data*> > m_deposits;
     
   public:
     /// Standard constructor
@@ -162,13 +162,13 @@ void myanalysis::HitTupleAction::end(const G4Event* event)    {
         // Seperate loop. We need fixed addresses when creating the branches
         for(const auto& c : m_containers)   {
           m_deposits[c].first = 0;
-          m_deposits[c].second.first = 0e0;
-          m_deposits[c].second.second.clear();
+          m_deposits[c].second = new Data();
+          m_deposits[c].second->first = 0e0;
+          m_deposits[c].second->second.clear();
         }
         for(const auto& c : m_containers)   {
-          std::pair<TBranch*, Data>& e = m_deposits[c];
-          TClass* cl = gROOT->GetClass(typeid(Data));
-          e.first = m_outTree->Branch(c.c_str(), cl->GetName(), (void*)0);
+          std::pair<TBranch*, Data*>& e = m_deposits[c];
+          e.first = m_outTree->Branch(c.c_str(), &e.second);
           e.first->SetAutoDelete(false);
           printout(ALWAYS,"HitTupleAction","+++ Prepare hit branch %s in root file.",c.c_str());
         }
@@ -186,13 +186,12 @@ void myanalysis::HitTupleAction::end(const G4Event* event)    {
       if ( find(m_containers.begin(),m_containers.end(),nam) != m_containers.end() )   {
         Geant4HitCollection* coll = dynamic_cast<Geant4HitCollection*>(hc);
         if ( coll )    {
-          std::pair<TBranch*, Data>& e = m_deposits[nam];
+          std::pair<TBranch*, Data*>& e = m_deposits[nam];
           size_t nhits = coll->GetSize();
-          Data* d = &e.second;
+          Data* d = e.second;
+          d->first = 0e0;
+          d->second.clear();
 
-          e.second.first = 0e0;
-          e.second.second.clear();
-          e.first->SetAddress(&d);
           for ( size_t j=0; j<nhits; ++j )   {
             double dep = 0e0;
             Geant4HitData* h = coll->hit(j);
@@ -208,8 +207,8 @@ void myanalysis::HitTupleAction::end(const G4Event* event)    {
                 continue;
             }
             if ( dep > 0 )  {
-              e.second.first += dep;
-              e.second.second.push_back(dep);
+              d->first += dep;
+              d->second.push_back(dep);
             }
           }
         }

--- a/examples/DDG4/src/HitTupleAction.cpp
+++ b/examples/DDG4/src/HitTupleAction.cpp
@@ -151,7 +151,7 @@ void myanalysis::HitTupleAction::end(const G4Event* event)    {
       //                      Name                   Option      Title
       m_outFile = TFile::Open(m_outFileName.c_str(), "RECREATE", "DDG4 User file");
       if ( m_outFile && !m_outFile->IsZombie() )   {
-        m_outTree = new TTree("DDG4 User Test","DDG4 data");
+        m_outTree = new TTree("DDG4_User_Test","DDG4_data");
         printout(ALWAYS,"HitTupleAction","+++ Successfully opened ROOT file %s and created TTree:%s",
                  m_outFile->GetName(), "DDG4 User Test");
         if ( m_containers.size() == 1 && (m_containers[0] == "*" || m_containers[0] == "ALL") )  {

--- a/examples/DDG4/src/HitTupleAction.cpp
+++ b/examples/DDG4/src/HitTupleAction.cpp
@@ -50,7 +50,7 @@ namespace myanalysis {
     /// We want to write a separate branch for all deposits of one container(sub-detector)
     typedef std::pair<double, std::vector<double> > Data;
     /// The intermediate storage of the hit deposits to be written to ROOT
-    std::map<std::string, std::pair<TBranch*, Data*> > m_deposits;
+    std::map<std::string, std::pair<TBranch*, Data> > m_deposits;
     
   public:
     /// Standard constructor
@@ -162,12 +162,11 @@ void myanalysis::HitTupleAction::end(const G4Event* event)    {
         // Seperate loop. We need fixed addresses when creating the branches
         for(const auto& c : m_containers)   {
           m_deposits[c].first = 0;
-          m_deposits[c].second = new Data();
-          m_deposits[c].second->first = 0e0;
-          m_deposits[c].second->second.clear();
+          m_deposits[c].second.first = 0e0;
+          m_deposits[c].second.second.clear();
         }
         for(const auto& c : m_containers)   {
-          std::pair<TBranch*, Data*>& e = m_deposits[c];
+          std::pair<TBranch*, Data>& e = m_deposits[c];
           e.first = m_outTree->Branch(c.c_str(), &e.second);
           e.first->SetAutoDelete(false);
           printout(ALWAYS,"HitTupleAction","+++ Prepare hit branch %s in root file.",c.c_str());
@@ -186,11 +185,11 @@ void myanalysis::HitTupleAction::end(const G4Event* event)    {
       if ( find(m_containers.begin(),m_containers.end(),nam) != m_containers.end() )   {
         Geant4HitCollection* coll = dynamic_cast<Geant4HitCollection*>(hc);
         if ( coll )    {
-          std::pair<TBranch*, Data*>& e = m_deposits[nam];
+          std::pair<TBranch*, Data>& e = m_deposits[nam];
           size_t nhits = coll->GetSize();
-          Data* d = e.second;
-          d->first = 0e0;
-          d->second.clear();
+          Data& d = e.second;
+          d.first = 0e0;
+          d.second.clear();
 
           for ( size_t j=0; j<nhits; ++j )   {
             double dep = 0e0;
@@ -207,8 +206,8 @@ void myanalysis::HitTupleAction::end(const G4Event* event)    {
                 continue;
             }
             if ( dep > 0 )  {
-              d->first += dep;
-              d->second.push_back(dep);
+              d.first += dep;
+              d.second.push_back(dep);
             }
           }
         }


### PR DESCRIPTION

We are observing segmentation faults in LCG stack builds
https://lcgapp-services.cern.ch/cdash3/tests/21384288

BEGINRELEASENOTES
- HitTupleAction: change how the tree is written and filled, because that caused segfaults in LCG stack runs of dd4hep example tests.

ENDRELEASENOTES

These changes fix the segfault in my local tests.