### PR TITLE
Do not set or read the color flow for MCParticles from EDM4hep

### DIFF
--- a/DDDigi/io/DigiIO.cpp
+++ b/DDDigi/io/DigiIO.cpp
@@ -202,7 +202,6 @@ namespace dd4hep {
       mcp.setGeneratorStatus( p.getGeneratorStatus() );
       mcp.setSimulatorStatus( p.getSimulatorStatus() );
       mcp.setSpin(p.getSpin());
-      mcp.setColorFlow(p.getColorFlow());
     }
 
     template <> template <>
@@ -588,7 +587,6 @@ namespace dd4hep {
         mcp.setGeneratorStatus( 0 );
 
       mcp.setSpin(p.spin);
-      mcp.setColorFlow(p.colorFlow);
     }
 
     template <> template <> 

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -394,7 +394,6 @@ void Geant4Output2EDM4hep::saveParticles(Geant4ParticleMap* particles)    {
         mcp.setGeneratorStatus( 0 )  ;
 
       mcp.setSpin(p->spin);
-      mcp.setColorFlow(p->colorFlow);
 
       p_ids[id] = cnt++;
       p_part.push_back(p);


### PR DESCRIPTION
BEGINRELEASENOTES
- Do not set or read the color flow for MCParticles from EDM4hep, 
needed after https://github.com/key4hep/EDM4hep/pull/389

ENDRELEASENOTES