### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/DDDigi/io/DigiEdm4hepOutput.h
+++ b/DDDigi/io/DigiEdm4hepOutput.h
@@ -68,7 +68,7 @@ namespace dd4hep {
       /// Standard constructor
       DigiEdm4hepOutput(const kernel_t& kernel, const std::string& nam);
       /// Initialization callback
-      virtual void initialize();
+      virtual void initialize() override;
       /// Check for valid output stream
       virtual bool have_output()  const  override final;
       /// Open new output stream

--- a/DDDigi/io/DigiIO.cpp
+++ b/DDDigi/io/DigiIO.cpp
@@ -171,8 +171,8 @@ namespace dd4hep {
       mcp.setCharge(3.0*p.charge);
       mcp.setVertex( _toVectorD(p.start_position) );
       mcp.setEndpoint( _toVectorD(p.end_position) );
-      mcp.setMomentum( _toVectorF(p.momentum) );
-      mcp.setMomentumAtEndpoint( _toVectorF(p.momentum) );
+      mcp.setMomentum( _toVectorD(p.momentum) );
+      mcp.setMomentumAtEndpoint( _toVectorD(p.momentum) );
     }
 
     template <> template <>
@@ -552,8 +552,8 @@ namespace dd4hep {
       const PropertyMask mask(status);
       mcp.setPDG(p.pdgID);
 
-      mcp.setMomentum( _toVectorF( { p.psx, p.psy, p.psz } ) );
-      mcp.setMomentumAtEndpoint( _toVectorF( {p.pex, p.pey, p.pez} ) );
+      mcp.setMomentum( _toVectorD( { p.psx, p.psy, p.psz } ) );
+      mcp.setMomentumAtEndpoint( _toVectorD( {p.pex, p.pey, p.pez} ) );
       mcp.setVertex( _toVectorD( { p.vsx, p.vsy, p.vsz } ) );
       mcp.setEndpoint( _toVectorD( { p.vex, p.vey, p.vez } ) );
 

--- a/examples/ClientTests/src/FCC_Mask_o1_v01_geo.cpp
+++ b/examples/ClientTests/src/FCC_Mask_o1_v01_geo.cpp
@@ -14,9 +14,7 @@
 #define endmsg std::endl
 #define lLog std::cout
 namespace MSG {
-const std::string ERROR = " Error: ";
 const std::string DEBUG = " Debug: ";
-const std::string INFO  = " Info: ";
 }
 
 #include "DD4hep/DD4hepUnits.h"

--- a/examples/Conditions/src/ConditionAnyExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionAnyExampleObjects.cpp
@@ -21,7 +21,6 @@ using namespace std;
 using namespace dd4hep;
 using namespace dd4hep::ConditionExamples;
 using cond::DependencyBuilder;
-using cond::ConditionsLoadInfo;
 
 namespace {
   static int num_any_ingredients = 0;
@@ -209,7 +208,7 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
   ConditionKey key_derived3    (de,"derived_data/derived_3");
   ConditionKey key_derived4    (de,"derived_data/derived_4");
   ConditionKey key_path        (de,"de_path");
-  int result = 0, count = 0;
+  int count = 0;
 
   // Let's go for the deltas....
   for( auto condition : conditions )  {
@@ -221,7 +220,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
     }
    
     if ( cond.item_key() == key_path.item_key() )  {
-      result += int(cond.as<string>().length());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_temperature.toString().c_str(),
 	       typeName(typeid(cond.get())).c_str(), 
@@ -230,7 +228,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
       ++num_any_ingredients;
     }
     else if ( cond.item_key() == key_temperature.item_key() )  {
-      result += int(cond.as<double>());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_temperature.toString().c_str(),
 	       typeName(typeid(cond.get())).c_str(), 
@@ -239,7 +236,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
       ++num_any_ingredients;
     }
     else if ( cond.item_key() == key_pressure.item_key() )  {
-      result += int(cond.as<double>());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_pressure.toString().c_str(), 
 	       typeName(typeid(cond.get())).c_str(),
@@ -248,7 +244,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
       ++num_any_ingredients;
     }
     else if ( cond.item_key() == key_double_table.item_key() )  {
-      result += int(cond.as<vector<double> >().size());
       __prt(str,cond.as<vector<double> >());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_double_table.toString().c_str(),
@@ -258,7 +253,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
       ++num_any_ingredients;
     }
     else if ( cond.item_key() == key_int_table.item_key() )  {
-      result += int(cond.as<vector<int> >().size());
       __prt(str,cond.as<vector<int> >());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_int_table.toString().c_str(),
@@ -268,7 +262,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
       ++num_any_ingredients;
     }
     else if ( cond.item_key() == key_derived_data.item_key() )  {
-      result += int(cond.as<int>());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_derived_data.toString().c_str(),
 	       typeName(typeid(cond.get())).c_str(),
@@ -277,7 +270,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
       ++num_any_ingredients;
     }
     else if ( cond.item_key() == key_derived1.item_key() )  {
-      result += int(cond.as<vector<int> >().size());
       __prt(str,cond.as<vector<int> >());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_derived1.toString().c_str(),
@@ -287,7 +279,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
       ++num_any_ingredients;
     }
     else if ( cond.item_key() == key_derived2.item_key() )  {
-      result += int(cond.as<vector<int> >().size());
       __prt(str,cond.as<vector<int> >());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_derived2.toString().c_str(),
@@ -297,7 +288,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
       ++num_any_ingredients;
     }
     else if ( cond.item_key() == key_derived3.item_key() )  {
-      result += int(cond.as<vector<int> >().size());
       __prt(str,cond.as<vector<int> >());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_derived3.toString().c_str(),
@@ -307,7 +297,6 @@ int ConditionsAnyDataAccess::accessConditions(DetElement de, const std::vector<C
       ++num_any_ingredients;
     }
     else if ( cond.item_key() == key_derived4.item_key() )  {
-      result += int(cond.as<vector<int> >().size());
       __prt(str,cond.as<vector<int> >());
       printout(printLevel, "accessConditions", "Condition: %s type: %s [%s]",
 	       key_derived4.toString().c_str(),

--- a/examples/DDCMS/src/plugins/DDCMSDetElementCreator.cpp
+++ b/examples/DDCMS/src/plugins/DDCMSDetElementCreator.cpp
@@ -127,7 +127,7 @@ DDCMSDetElementCreator::~DDCMSDetElementCreator()   {
   printout(INFO,"DDCMSDetElementCreator",  "++ Summary:     %-24s %7d DetElements %7d sensitives out of %7d volumes",
            "Grand Total:",total.elements,total.sensitives,total.volumes);
   printout(INFO,"DDCMSDetElementCreator","+++++++++++++++ Summary of geometry depth analysis  ++++++++++++++++++");
-  int total_cnt = 0, total_depth = 0;
+  int total_cnt = 0;
   map<DetElement, vector<pair<int,int> > > fields;
   for ( const auto& l : leafCount )  {
     DetElement de = l.first.first;
@@ -135,7 +135,6 @@ DDCMSDetElementCreator::~DDCMSDetElementCreator()   {
              (de.name()+string(":")).c_str(), de.id(),
              l.first.second, l.second.second, l.second.first);
     fields[de].push_back(make_pair(l.first.second,l.second.first));
-    total_depth += l.second.second;
     ++total_cnt;
   }
   printout(INFO,"DDCMSDetElementCreator","++ Summary:     %-24s  %d.","Total DetElements:",total_cnt);

--- a/examples/DDCMS/src/plugins/DDEcalEndcapAlgo.cpp
+++ b/examples/DDCMS/src/plugins/DDEcalEndcapAlgo.cpp
@@ -30,8 +30,8 @@ namespace {
 
   constexpr long double piRadians(M_PI);
   constexpr long double degPerRad = 180. / piRadians;  // Degrees per radian
-  constexpr double operator"" _mm(long double length) { return length * 0.1; }
-  constexpr long double operator"" _deg(long double value) { return value / degPerRad; }
+  constexpr double operator""_mm(long double length) { return length * 0.1; }
+  constexpr long double operator""_deg(long double value) { return value / degPerRad; }
 
   // Define Endcap Supercrystal class
   class DDEcalEndcapTrap {

--- a/examples/DDCodex/src/CODEXb_det.cpp
+++ b/examples/DDCodex/src/CODEXb_det.cpp
@@ -137,7 +137,6 @@ static Ref_t create_element(Detector& description, xml_h e, Ref_t sens)  {
 
     printout(INFO, "CODEX-b super station size"," Thick: % g, width: % g, height: % g", super_thick, super_width+30.0, super_height+30.0);
     double     face_x = -super_height;
-    double     super_x = -super_thick + st_thick;
     double     inner_x = -st_dist*((super_repeat-1)/2.0); 
     for (int j=0; j < super_repeat; ++j )    {
       if( super_name.compare("face_station") == 0 && j < 2 ) { 
@@ -161,7 +160,6 @@ static Ref_t create_element(Detector& description, xml_h e, Ref_t sens)  {
       pv.addPhysVolID("station", j+1);
       printout(INFO, "CODEX-b-station"," Station: %d x=%g y=%g z=%g", j+1, inner_x);
       super_stations[st_vol].push_back(pv);
-      super_x += st_dist + 2.0*st_thick;
       //inner_x += st_dist + 2.0*st_thick;
       inner_x += st_dist;
       face_x += 2.0*super_height + st_thick/10.;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a few compiler warnings (clang 18) about:
  - Set but unused variables and unused variables or declarations
  - Deprecated constructor for a Vector3d from a Vector3f from EDM4hep
  - Missing override
  - Having a space after `operator""` is deprecated

ENDRELEASENOTES