### PR TITLE
DD4hepSimulation: pass self to the steeringFile eval

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -108,7 +108,7 @@ class DD4hepSimulation(object):
     DD4hepSimulation object present in the steering file.
     """
     globs = {}
-    locs = {}
+    locs = {"SIM": self}
     if not self.steeringFile:
       return
     sFileTemp = self.steeringFile

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -114,7 +114,7 @@ class DD4hepSimulation(object):
     sFileTemp = self.steeringFile
     exec(compile(io.open(self.steeringFile).read(), self.steeringFile, 'exec'), globs, locs)
     for _name, obj in locs.items():
-      if isinstance(obj, DD4hepSimulation):
+      if isinstance(obj, DD4hepSimulation) and obj is not self:
         self.__dict__ = obj.__dict__
     self.steeringFile = os.path.abspath(sFileTemp)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- DDSim: Steering files can now omit instantiating a new `SIM = DD4hepSimulation()`, and instead use a pre-defined variable with name `SIM`. This allows for steering files that preserve the existing state of `DD4hepSimulation` that a custom user code had set prior to the `parseOptions()` call.

ENDRELEASENOTES

At ePIC we use an entry point like
```python
SIM = DD4hepSimulation()

SIM.Foo = "Xyz"
# ... other common options

SIM.parseOptions()
SIM.run()
```
https://github.com/eic/npsim/blob/01d54e67c7bbd671d1f87180e55c296286e639c5/src/dd4pod/python/npsim.py

However using this with `--steeringFile` unconditionally unsets our settings as new DD4hepSimulation object has to be created in the steering. The proposed change allows to write steering files without the
```python
from DDSim.DD4hepSimulation import DD4hepSimulation
SIM = DD4hepSimulation()
```

This is optional and should not break any existing use case. A next step could be to remove those two lines from output of the `--dumpSteeringFile`.