### PR TITLE
Restore compatibility with EDM4hep 0.10

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,7 @@ jobs:
               "LCG_102/x86_64-centos9-gcc11-opt",    # g4 11
               "LCG_104/x86_64-el9-gcc13-opt",         # g4 11
               "LCG_105/x86_64-ubuntu2204-gcc11-opt",  # g4 11
+              "LCG_106/x86_64-el9-gcc13-opt",  # g4 11
               "dev3/x86_64-el9-gcc13-opt",
               "dev3/x86_64-el9-clang16-opt",          # g4 11
               "dev4/x86_64-el9-gcc13-opt"]
@@ -66,6 +67,10 @@ jobs:
           if [[ ${{ matrix.LCG }} =~ dev3 ]]; then
             echo "::group::CMakeConfig 2"
             cmake -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON ..
+          fi
+          if [[ ${{ matrix.LCG }} =~ 106 ]]; then
+            echo "::group::CMakeConfig Enable EDM4hep"
+            cmake -DDD4HEP_USE_EDM4HEP=ON ..
           fi
           echo "::group::Compile"
           ninja install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,6 +68,7 @@ jobs:
             echo "::group::CMakeConfig 2"
             cmake -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON ..
           fi
+          # Make sure DD4hep can be built with an older version of EDM4hep (0.10.5 for LCG_106)
           if [[ ${{ matrix.LCG }} =~ 106 ]]; then
             echo "::group::CMakeConfig Enable EDM4hep"
             cmake -DDD4HEP_USE_EDM4HEP=ON ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,7 +69,7 @@ jobs:
             cmake -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON ..
           fi
           # Make sure DD4hep can be built with an older version of EDM4hep (0.10.5 for LCG_106)
-          if [[ ${{ matrix.LCG }} =~ 106 ]]; then
+          if [[ ${{ matrix.LCG }} =~ 106 ||${{ matrix.LCG }} =~ 104 ]]; then
             echo "::group::CMakeConfig Enable EDM4hep"
             cmake -DDD4HEP_USE_EDM4HEP=ON ..
           fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,7 +69,7 @@ jobs:
             cmake -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON ..
           fi
           # Make sure DD4hep can be built with an older version of EDM4hep (0.10.5 for LCG_106)
-          if [[ ${{ matrix.LCG }} =~ 106 ||${{ matrix.LCG }} =~ 104 ]]; then
+          if [[ ${{ matrix.LCG }} =~ 106 || ${{ matrix.LCG }} =~ 104 ]]; then
             echo "::group::CMakeConfig Enable EDM4hep"
             cmake -DDD4HEP_USE_EDM4HEP=ON ..
           fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,9 +68,8 @@ jobs:
             echo "::group::CMakeConfig 2"
             cmake -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON ..
           fi
-          # Make sure DD4hep can be built with an older version of EDM4hep,
-          # 0.10.5 for LCG_106 and 0.10.0 for LCG_104
-          if [[ ${{ matrix.LCG }} =~ 106 || ${{ matrix.LCG }} =~ 104 ]]; then
+          # Make sure DD4hep can be built with an older version of EDM4hep, 0.10.5 for LCG_106
+          if [[ ${{ matrix.LCG }} =~ 106 ]]; then
             echo "::group::CMakeConfig Enable EDM4hep"
             cmake -DDD4HEP_USE_EDM4HEP=ON ..
           fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,7 +68,8 @@ jobs:
             echo "::group::CMakeConfig 2"
             cmake -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON ..
           fi
-          # Make sure DD4hep can be built with an older version of EDM4hep (0.10.5 for LCG_106)
+          # Make sure DD4hep can be built with an older version of EDM4hep,
+          # 0.10.5 for LCG_106 and 0.10.0 for LCG_104
           if [[ ${{ matrix.LCG }} =~ 106 || ${{ matrix.LCG }} =~ 104 ]]; then
             echo "::group::CMakeConfig Enable EDM4hep"
             cmake -DDD4HEP_USE_EDM4HEP=ON ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ if(DD4HEP_USE_LCIO)
 endif()
 
 if(DD4HEP_USE_EDM4HEP)
-  find_package(EDM4HEP 0.10.0 REQUIRED)
+  find_package(EDM4HEP 0.10.5 REQUIRED)
   # we need podio with Frame support (>=0.16.3)
   # podio is "SameMajorVersion" compatible
   find_package(podio 0.16.7)  # this will not find 1.0 and newer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if(DD4HEP_USE_EDM4HEP)
   find_package(EDM4HEP 0.10.0 REQUIRED)
   # we need podio with Frame support (>=0.16.3)
   # podio is "SameMajorVersion" compatible
-  find_package(podio 0.16.3)  # this will not find 1.0 and newer
+  find_package(podio 0.16.7)  # this will not find 1.0 and newer
   if(NOT podio_FOUND)
     # we try to find a newer version now
     find_package(podio 1.0 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ if(DD4HEP_USE_LCIO)
 endif()
 
 if(DD4HEP_USE_EDM4HEP)
-  find_package(EDM4HEP REQUIRED)
+  find_package(EDM4HEP 0.10.0 REQUIRED)
   # we need podio with Frame support (>=0.16.3)
   # podio is "SameMajorVersion" compatible
   find_package(podio 0.16.3)  # this will not find 1.0 and newer

--- a/DDDigi/io/DigiIO.cpp
+++ b/DDDigi/io/DigiIO.cpp
@@ -16,6 +16,8 @@
 #include <DD4hep/Printout.h>
 #include "DigiIO.h"
 
+#include <edm4hep/EDM4hepVersion.h>
+
 /// C/C++ include files
 #include <limits>
 
@@ -171,8 +173,13 @@ namespace dd4hep {
       mcp.setCharge(3.0*p.charge);
       mcp.setVertex( _toVectorD(p.start_position) );
       mcp.setEndpoint( _toVectorD(p.end_position) );
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 0)
       mcp.setMomentum( _toVectorF(p.momentum) );
       mcp.setMomentumAtEndpoint( _toVectorF(p.momentum) );
+#else
+      mcp.setMomentum( _toVectorD(p.momentum) );
+      mcp.setMomentumAtEndpoint( _toVectorD(p.momentum) );
+#endif
     }
 
     template <> template <>
@@ -552,8 +559,13 @@ namespace dd4hep {
       const PropertyMask mask(status);
       mcp.setPDG(p.pdgID);
 
+#if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 0)
       mcp.setMomentum( _toVectorF( { p.psx, p.psy, p.psz } ) );
       mcp.setMomentumAtEndpoint( _toVectorF( {p.pex, p.pey, p.pez} ) );
+#else
+      mcp.setMomentum( _toVectorD( { p.psx, p.psy, p.psz } ) );
+      mcp.setMomentumAtEndpoint( _toVectorD( {p.pex, p.pey, p.pez} ) );
+#endif
       mcp.setVertex( _toVectorD( { p.vsx, p.vsy, p.vsz } ) );
       mcp.setEndpoint( _toVectorD( { p.vex, p.vey, p.vez } ) );
 

--- a/DDDigi/io/DigiIO.cpp
+++ b/DDDigi/io/DigiIO.cpp
@@ -16,7 +16,6 @@
 #include <DD4hep/Printout.h>
 #include "DigiIO.h"
 
-#include <edm4hep/EDM4hepVersion.h>
 
 /// C/C++ include files
 #include <limits>
@@ -42,6 +41,7 @@ namespace edm4hep {
 #include <edm4hep/CalorimeterHitCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/EventHeaderCollection.h>
+#include <edm4hep/EDM4hepVersion.h>
 #include <podio/GenericParameters.h>
 
 /// Namespace for the AIDA detector description toolkit

--- a/DDDigi/io/DigiIO.cpp
+++ b/DDDigi/io/DigiIO.cpp
@@ -171,8 +171,8 @@ namespace dd4hep {
       mcp.setCharge(3.0*p.charge);
       mcp.setVertex( _toVectorD(p.start_position) );
       mcp.setEndpoint( _toVectorD(p.end_position) );
-      mcp.setMomentum( _toVectorD(p.momentum) );
-      mcp.setMomentumAtEndpoint( _toVectorD(p.momentum) );
+      mcp.setMomentum( _toVectorF(p.momentum) );
+      mcp.setMomentumAtEndpoint( _toVectorF(p.momentum) );
     }
 
     template <> template <>
@@ -552,8 +552,8 @@ namespace dd4hep {
       const PropertyMask mask(status);
       mcp.setPDG(p.pdgID);
 
-      mcp.setMomentum( _toVectorD( { p.psx, p.psy, p.psz } ) );
-      mcp.setMomentumAtEndpoint( _toVectorD( {p.pex, p.pey, p.pez} ) );
+      mcp.setMomentum( _toVectorF( { p.psx, p.psy, p.psz } ) );
+      mcp.setMomentumAtEndpoint( _toVectorF( {p.pex, p.pey, p.pez} ) );
       mcp.setVertex( _toVectorD( { p.vsx, p.vsy, p.vsz } ) );
       mcp.setEndpoint( _toVectorD( { p.vex, p.vey, p.vez } ) );
 

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -26,6 +26,11 @@
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/Constants.h>
+#if EDM4HEP_VERSION_MAJOR == 0 && EDM4HEP_VERSION_MINOR < 99
+  using edm4hep::CellIDEncoding;
+#else
+  using edm4hep::labels::CellIDEncoding;
+#endif
 /// podio include files
 #include <podio/CollectionBase.h>
 #include <podio/podioVersion.h>
@@ -269,7 +274,7 @@ void Geant4Output2EDM4hep::endRun(const G4Run* run)  {
 void Geant4Output2EDM4hep::saveFileMetaData() {
   podio::Frame metaFrame{};
   for (const auto& [name, encodingStr] : m_cellIDEncodingStrings) {
-    metaFrame.putParameter(podio::collMetadataParamName(name, edm4hep::labels::CellIDEncoding), encodingStr);
+    metaFrame.putParameter(podio::collMetadataParamName(name, CellIDEncoding), encodingStr);
   }
 
   m_file->writeFrame(metaFrame, "metadata");

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -25,10 +25,13 @@
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
 #include <edm4hep/EDM4hepVersion.h>
-#include <edm4hep/Constants.h>
-#if EDM4HEP_VERSION_MAJOR == 0 && EDM4HEP_VERSION_MINOR < 99
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 2)
+  constexpr const char* CellIDEncoding = "CellIDEncoding";
+#elif EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 0)
+  #include <edm4hep/Constants.h>
   using edm4hep::CellIDEncoding;
 #else
+  #include <edm4hep/Constants.h>
   using edm4hep::labels::CellIDEncoding;
 #endif
 /// podio include files


### PR DESCRIPTION
BEGINRELEASENOTES
- Revert some of the changes of https://github.com/AIDASoft/DD4hep/pull/1375 to build a vector of floats instead of doubles since the necessary constructor doesn't exist in 0.10.X.
- Use `edm4hep::labels::CellIDEncoding` only when they are available (starting at version 0.99)

ENDRELEASENOTES

See https://github.com/AIDASoft/DD4hep/pull/1333#issuecomment-2573680487