### PR TITLE
g4GraphicalScan.py: fix incorrect assumption about data format

### DIFF
--- a/DDG4/python/bin/g4GraphicalScan.py
+++ b/DDG4/python/bin/g4GraphicalScan.py
@@ -339,7 +339,7 @@ for line in result.stdout.splitlines():
         continue
     elif r"| Layer \ " in line:          # comment line
         continue
-    elif inScan and len(line.split()) == 16 and line.split()[0] == '|':   # this line contains material information
+    elif inScan and '(' in line and len(line.split('(')[0].split()) == 12 and line.split()[0] == '|': # this line contains material information
         index = int(line.split()[1])
         material = line.split()[2]
         radlen = 10 * float(line.split()[6])     # cm->mm

--- a/DDG4/python/bin/g4GraphicalScan.py
+++ b/DDG4/python/bin/g4GraphicalScan.py
@@ -339,7 +339,10 @@ for line in result.stdout.splitlines():
         continue
     elif r"| Layer \ " in line:          # comment line
         continue
-    elif inScan and '(' in line and len(line.split('(')[0].split()) == 12 and line.split()[0] == '|': # this line contains material information
+    elif inScan and \
+         '(' in line and \
+         len(line.split('(')[0].split()) == 12 and \
+         line.split()[0] == '|':  # this line contains material information
         index = int(line.split()[1])
         material = line.split()[2]
         radlen = 10 * float(line.split()[6])     # cm->mm


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixes incorrect assumption in g4GraphicalScan.py when parsing output of Geant4MaterialScanner.
ENDRELEASENOTES

Had assumed that position values ( the last 3 fields, within () ) are separated by both comma and space, while comma-only can occur.
for reference, format definition is at https://github.com/AIDASoft/DD4hep/blob/8f88ea1ca4d53f591bbaac8165589acbf9a93460/DDG4/plugins/Geant4MaterialScanner.cpp#L174
