### PR TITLE
Have more consistent test naming

### DIFF
--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -151,7 +151,7 @@ if (DD4HEP_USE_GEANT4)
   #
   # Basic DDG4 component/unit tests
   foreach(script testDDPython CLICMagField CLICPhysics CLICRandom CLICSiDScan)
-    dd4hep_add_test_reg( CLICSiD_DDG4_${script}_LONGTEST
+    dd4hep_add_test_reg( CLICSiD_sim_DDG4_${script}_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${CLICSiDEx_INSTALL}/scripts/${script}.py
       REGEX_PASS "TEST_PASSED"
@@ -166,14 +166,14 @@ if (DD4HEP_USE_GEANT4)
   #    REGEX_FAIL "Exception;EXCEPTION;ERROR" )
   #
   # Material scan
-  dd4hep_add_test_reg( CLICSiD_DDG4_g4material_scan_LONGTEST
+  dd4hep_add_test_reg( CLICSiD_sim_DDG4_g4material_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4MaterialScan --compact=${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
                       "--position=0,0,0" "--direction=0,1,0"
     REGEX_PASS " Terminate Geant4 and delete associated actions." )
   #
   # Geometry scan
-  dd4hep_add_test_reg( CLICSiD_DDG4_g4geometry_scan_LONGTEST
+  dd4hep_add_test_reg( CLICSiD_sim_DDG4_g4geometry_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4GeometryScan --compact=${DD4hep_ROOT}/DDDetectors/compact/SiD.xml
                       "--position=0,0,0" "--direction=0,1,0"
@@ -183,15 +183,15 @@ if (DD4HEP_USE_GEANT4)
   foreach(script CLICSiDXML CLICSiDAClick)
     #
     # Build AClick from the source file
-    dd4hep_add_test_reg( CLICSiD_DDG4_${script}_as_AClick_LONGTEST
+    dd4hep_add_test_reg( CLICSiD_sim_DDG4_${script}_as_AClick_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
       EXEC_ARGS  root.exe -b -x -n -q -l "${DD4hep_ROOT}/examples/DDG4/examples/run.C(\"${CLICSiDEx_INSTALL}/scripts/${script}\")"
       REGEX_PASS "UserEvent_1      INFO  Geant4TestEventAction> calling end.event_id=2"
       REGEX_FAIL "EXCEPTION;ERROR;Error" )
-    set_property(TEST t_CLICSiD_DDG4_${script}_as_AClick_LONGTEST PROPERTY RESOURCE_LOCK "INIT_SID_ACLICK")
+    set_property(TEST t_CLICSiD_sim_DDG4_${script}_as_AClick_LONGTEST PROPERTY RESOURCE_LOCK "INIT_SID_ACLICK")
     #
     # Execute identical source linked executable 
-    dd4hep_add_test_reg( CLICSiD_DDG4_${script}_as_exe_LONGTEST
+    dd4hep_add_test_reg( CLICSiD_sim_DDG4_${script}_as_exe_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
       EXEC_ARGS  ${script}
       REGEX_PASS "UserEvent_1      INFO  Geant4TestEventAction> calling end.event_id=2"

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -339,7 +339,7 @@ foreach (test Assemblies BoxTrafos CaloEndcapReflection
   #
   # Geant4 material scan. From position=0,0,0 to end-of-world 
   if (DD4HEP_USE_GEANT4)
-    dd4hep_add_test_reg( ClientTests_g4material_scan_${test}_LONGTEST
+    dd4hep_add_test_reg( ClientTests_sim_geant4_g4material_scan_${test}_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4MaterialScan
       		  --compact=file:${ClientTestsEx_INSTALL}/compact/${test}.xml
@@ -487,7 +487,7 @@ dd4hep_add_test_reg( ClientTests_interrupt_geometry_construction
 if (DD4HEP_USE_GEANT4)
   #
   #  Test Setting temperature and pressure to material
-  dd4hep_add_test_reg( ClientTests_sim_Check_Temp_Pressure_Air
+  dd4hep_add_test_reg( ClientTests_sim_geant4_Check_Temp_Pressure_Air
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/Check_Air.py
     	              -geometry  ${ClientTestsEx_INSTALL}/compact/Check_Air.xml batch
@@ -495,7 +495,7 @@ if (DD4HEP_USE_GEANT4)
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
   #
   # Geant4 test with gdml input file (LHCb:FT)
-  dd4hep_add_test_reg( ClientTests_g4_gdml_detector
+  dd4hep_add_test_reg( ClientTests_sim_geant4_gdml_detector
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4GeometryScan
     	              --compact=${ClientTestsEx_INSTALL}/compact/GdmlDetector.xml
@@ -504,7 +504,7 @@ if (DD4HEP_USE_GEANT4)
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
   #
   # Geant4 test with gdml input file (LHCb:MT)
-  dd4hep_add_test_reg( ClientTests_g4_gdml_MT
+  dd4hep_add_test_reg( ClientTests_sim_geant4_gdml_MT
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4GeometryScan
     	              --compact=${ClientTestsEx_INSTALL}/compact/MT.xml
@@ -513,14 +513,14 @@ if (DD4HEP_USE_GEANT4)
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error;FATAL" )
   #
   # Geant4 test if production cuts are processed
-  dd4hep_add_test_reg( ClientTests_sim_MiniTel_prod_cuts
+  dd4hep_add_test_reg( ClientTests_sim_geant4_MiniTel_prod_cuts
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTelRegions.py batch
     REGEX_PASS "minitel_region_1: Set cut  \\[gamma/0\\] = 5.000"
     REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
   #
   # Geant4 test if production cuts are processed
-  dd4hep_add_test_reg( ClientTests_sim_MiniTel_limitset
+  dd4hep_add_test_reg( ClientTests_sim_geant4_MiniTel_limitset
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTelRegions.py batch
     REGEX_PASS "LimitSet:    Particle type: mu-                PDG: 13     : 3.000000"
@@ -532,14 +532,14 @@ if (DD4HEP_USE_GEANT4)
   #           Isomer level 9 may be ambiguous.
   #       *** This is just a warning message. ***
   # This is NOT an error!
-  dd4hep_add_test_reg( ClientTests_sim_UserAnalysis
+  dd4hep_add_test_reg( ClientTests_sim_geant4_UserAnalysis
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTelEnergyDeposits.py batch
     REGEX_PASS "Entries :      200 "
     REGEX_FAIL "EXCEPTION;ERROR;Error" )
   #
   # Test of an example user analysis creating an N-tuple instead of an output file with events
-  dd4hep_add_test_reg( ClientTests_sim_TrackingRegion
+  dd4hep_add_test_reg( ClientTests_sim_geant4_TrackingRegion
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/TrackingRegion.py batch
     REGEX_PASS "Placement tracking_volume_1 not converted \\[Veto'ed for simulation\\]"
@@ -547,7 +547,7 @@ if (DD4HEP_USE_GEANT4)
   #
   # Geant4 full simulation checks of simple detectors
   foreach(script Assemblies LheD_tracker MiniTel MiniTel_hepmc NestedDetectors )
-    dd4hep_add_test_reg( ClientTests_sim_${script}
+    dd4hep_add_test_reg( ClientTests_sim_geant4_${script}
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/${script}.py -batch
       REGEX_PASS NONE
@@ -556,7 +556,7 @@ if (DD4HEP_USE_GEANT4)
   #
   # Geant4 full simulation checks of multi-collection/segmentation detectors
   foreach(script MultiCollections MultiSegmentations MultiSegmentCollections )
-    dd4hep_add_test_reg( ClientTests_sim_${script}
+    dd4hep_add_test_reg( ClientTests_sim_geant4_${script}
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MultiCollections.py 
                  -compact ${ClientTestsEx_INSTALL}/compact/${script}.xml -batch
@@ -565,7 +565,7 @@ if (DD4HEP_USE_GEANT4)
   endforeach(script)
   #
   # Test setting properties to a single sub-detector
-  dd4hep_add_test_reg( minitel_config_region_subdet_geant4
+  dd4hep_add_test_reg( ClientTests_sim_geant4_minitel_config_region_subdet
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTel.py
     	       -batch -debug -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml
@@ -574,7 +574,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   # Test setting properties to the world volume
-  dd4hep_add_test_reg( minitel_config_region_world_geant4
+  dd4hep_add_test_reg( ClientTests_sim_geant4_minitel_config_region_world
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTel.py
     	       -batch -debug -events 1 -geometry /examples/ClientTests/compact/WorldSettings.xml
@@ -583,7 +583,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   # Test importing a geometry from ROOT and placing DetElements
-  dd4hep_add_test_reg( import_geo_place_det_elements
+  dd4hep_add_test_reg( ClientTests_import_geo_place_det_elements
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS geoPluginRun -destroy -input ${ClientTestsEx_INSTALL}/compact/lhcbfull_plugins.xml
     WORKING_DIRECTORY ${ClientTestsEx_INSTALL}/compact
@@ -597,7 +597,7 @@ if (DD4HEP_USE_GEANT4)
     # Geant4 full simulation checks of multi-collection/segmentation detectors
     dd4hep_print("|++> Geant4 fast simulation tests enabled for Geant4 ${Geant4_VERSION}")
     foreach(script SiliconBlockGFlash SiliconBlockFastSim)
-      dd4hep_add_test_reg( ClientTests_sim_${script}_LONGTEST
+      dd4hep_add_test_reg( ClientTests_sim_geant4_${script}_LONGTEST
         COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
         EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/${script}.py -batch -events 2
 		   -geometry ${ClientTestsEx_INSTALL}/compact/SiliconBlock.xml -batch -events 2
@@ -607,7 +607,7 @@ if (DD4HEP_USE_GEANT4)
   endif()
   #
   foreach(script ParamVolume1D ParamVolume2D ParamVolume3D)
-    dd4hep_add_test_reg( ClientTests_sim_${script}_LONGTEST
+    dd4hep_add_test_reg( ClientTests_sim_geant4_${script}_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/ParamVolume.py
       		 -geometry ${script}.xml -batch -events 2
@@ -619,7 +619,7 @@ if (DD4HEP_USE_GEANT4)
   # Test EDM4HEP output module
   if (DD4HEP_USE_EDM4HEP)
     # Test EDM4HEP write (needs to be expanded)
-    dd4hep_add_test_reg(ClientTests_sim_MinitTel_edm4hep_write
+    dd4hep_add_test_reg(ClientTests_sim_geant4_MinitTel_edm4hep_write
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/MiniTelGenerate.py
                  -batch -events 5 -output MiniTel_ddg4_edm4hep.edm4hep.root
@@ -629,7 +629,7 @@ if (DD4HEP_USE_GEANT4)
   endif()
   #
   # Test Geant4VolumeManager resource usage
-  dd4hep_add_test_reg(ClientTests_g4_setup_BoxOfStraws_sensitive
+  dd4hep_add_test_reg(ClientTests_sim_g4_setup_BoxOfStraws_sensitive
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/BoxOfStraws.py
                  -print_level 3 -sensitive
@@ -638,7 +638,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   # Test without Geant4VolumeManager, but sensitive detector assignment using regex
-  dd4hep_add_test_reg(ClientTests_g4_setup_BoxOfStraws_non_sensitive
+  dd4hep_add_test_reg(ClientTests_sim_geant4_setup_BoxOfStraws_non_sensitive
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/BoxOfStraws.py
                  -print_level 3
@@ -647,7 +647,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   #
-  dd4hep_add_test_reg(ClientTests_ddsim_setup_BoxOfStraws
+  dd4hep_add_test_reg(ClientTests_sim_geant4_ddsim_setup_BoxOfStraws
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
       EXEC_ARGS  ddsim
                  --steeringFile ${ClientTestsEx_INSTALL}/scripts/BoxOfStraws_DDSim.py
@@ -660,7 +660,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   #  Test Changing Geant4 voxelization
-  dd4hep_add_test_reg( ClientTests_geant4_change_voxelization
+  dd4hep_add_test_reg( ClientTests_sim_geant4_change_voxelization
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${ClientTestsEx_INSTALL}/scripts/DriftChamber.py
     	       -verbose 2 -events 1

--- a/examples/DDCAD/CMakeLists.txt
+++ b/examples/DDCAD/CMakeLists.txt
@@ -165,7 +165,7 @@ dd4hep_add_test_reg( DDCAD_Issue1134_overlap_check
 if(TARGET DD4hep::DDG4)
   #
   #  Overlap check of Armin Ilg's example
-  dd4hep_add_test_reg( DDCAD_Issue1134_g4overlap_check
+  dd4hep_add_test_reg( DDCAD_sim_Issue1134_g4overlap_check
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDCAD.sh"
     EXEC_ARGS  ddsim --compactFile ${DDCADEx_INSTALL}/compact/DD4hep_Issue_1134.xml
     --enableG4Gun --runType run
@@ -175,7 +175,7 @@ if(TARGET DD4hep::DDG4)
   )
   #
   #  Geometry scan of Armin Ilg's example
-  dd4hep_add_test_reg( DDCAD_Issue1134_g4geometry_scan
+  dd4hep_add_test_reg( DDCAD_sim_Issue1134_g4geometry_scan
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDCAD.sh"
     EXEC_ARGS  g4GeometryScan
     --compact=file:${DDCADEx_INSTALL}/compact/DD4hep_Issue_1134.xml

--- a/examples/DDDigi/CMakeLists.txt
+++ b/examples/DDDigi/CMakeLists.txt
@@ -63,7 +63,7 @@ dd4hep_add_test_reg(DDDigi_properties
 #
 if (DD4HEP_USE_GEANT4)
   # Generate test data
-  dd4hep_add_test_reg(DDDigi_generate_ddg4_data
+  dd4hep_add_test_reg(DDDigi_sim_generate_ddg4_data
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/ClientTests/scripts/MiniTelGenerate.py
          -batch -events 30 -runs 8
@@ -72,147 +72,147 @@ if (DD4HEP_USE_GEANT4)
     REGEX_FAIL "Error;ERROR;FATAL; Exception"
   )
   # Test basic input reading from DDG4
-  dd4hep_add_test_reg(DDDigi_test_input_reading
+  dd4hep_add_test_reg(DDDigi_sim_test_input_reading
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestInput.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test DDDigi exception while processing
-  dd4hep_add_test_reg(DDDigi_test_processing_exception
+  dd4hep_add_test_reg(DDDigi_sim_test_processing_exception
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestInput.py
                -num_events 1000
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+ Terminate Digi and delete associated actions."
   )
   # Test signal attenuation for spillover
-  dd4hep_add_test_reg(DDDigi_test_attenuate
+  dd4hep_add_test_reg(DDDigi_sim_test_attenuate
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestAttenuate.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test moving IP
-  dd4hep_add_test_reg(DDDigi_test_move_IP
+  dd4hep_add_test_reg(DDDigi_sim_test_move_IP
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestIPMove.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test deposit count
-  dd4hep_add_test_reg(DDDigi_test_deposit_count
+  dd4hep_add_test_reg(DDDigi_sim_test_deposit_count
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestDepositCount.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test weighted deposit overlay
-  dd4hep_add_test_reg(DDDigi_test_weighted_deposit_overlay
+  dd4hep_add_test_reg(DDDigi_sim_test_weighted_deposit_overlay
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestDepositWeighted.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test deposit energy smearing
-  dd4hep_add_test_reg(DDDigi_test_deposit_smear_energy
+  dd4hep_add_test_reg(DDDigi_sim_test_deposit_smear_energy
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestDepositSmearEnergy.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test deposit time resolution smearing
-  dd4hep_add_test_reg(DDDigi_test_deposit_smear_time
+  dd4hep_add_test_reg(DDDigi_sim_test_deposit_smear_time
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestDepositSmearTime.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test deposit position resolution smearing
-  dd4hep_add_test_reg(DDDigi_test_smear_position
+  dd4hep_add_test_reg(DDDigi_sim_test_smear_position
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestPositionSmearResolution.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test deposit track position resolution smearing
-  dd4hep_add_test_reg(DDDigi_test_smear_track
+  dd4hep_add_test_reg(DDDigi_sim_test_smear_track
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestPositionSmearTrack.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test multiple interaction input
-  dd4hep_add_test_reg(DDDigi_test_multi_interactions
+  dd4hep_add_test_reg(DDDigi_sim_test_multi_interactions
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestMultiInteractions.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test spillover input (multi interactions with attenuation)
-  dd4hep_add_test_reg(DDDigi_test_spillover
+  dd4hep_add_test_reg(DDDigi_sim_test_spillover
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestSpillover.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test container parellization
-  dd4hep_add_test_reg(DDDigi_test_containers_parallel
+  dd4hep_add_test_reg(DDDigi_sim_test_containers_parallel
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestMultiContainerParallel.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test hit resegmentation
-  dd4hep_add_test_reg(DDDigi_test_detector_resegmentation
+  dd4hep_add_test_reg(DDDigi_sim_test_detector_resegmentation
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestResegmentation.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test work splitting by segmentation
-  dd4hep_add_test_reg(DDDigi_test_segmentation_split_1
+  dd4hep_add_test_reg(DDDigi_sim_test_segmentation_split_1
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestSegmentationSplit.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test work splitting by segmentation (2)
-  dd4hep_add_test_reg(DDDigi_test_segmentation_split_2
+  dd4hep_add_test_reg(DDDigi_sim_test_segmentation_split_2
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestSegmentationSplit2.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   # Test simple ADC response
-  dd4hep_add_test_reg(DDDigi_test_simple_adc_response
+  dd4hep_add_test_reg(DDDigi_sim_test_simple_adc_response
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestSimpleADCResponse.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
   #
   # Test raw digi write
-  dd4hep_add_test_reg(DDDigi_test_digi_root_write
+  dd4hep_add_test_reg(DDDigi_sim_test_digi_root_write
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestWriteDigi.py
-    DEPENDS    DDDigi_generate_ddg4_data
+    DEPENDS    DDDigi_sim_generate_ddg4_data
     REGEX_PASS "\\+\\+\\+ Closing ROOT output file dddigi_write_digi_00000000.root after 5 events"
     REGEX_FAIL "Error;ERROR;FATAL;Exception"
   )
@@ -220,31 +220,31 @@ if (DD4HEP_USE_GEANT4)
   # Test EDM4HEP output module
   if (DD4HEP_USE_EDM4HEP)
     # Generate edm4hep test data
-    dd4hep_add_test_reg(DDDigi_generate_edm4hep_data
+    dd4hep_add_test_reg(DDDigi_sim_generate_edm4hep_data
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/ClientTests/scripts/MiniTelGenerate.py
       -batch -events 30 -runs 3 -output MiniTel_DDG4_edm4hep_data.root
-      DEPENDS    DDDigi_generate_ddg4_data
+      DEPENDS    DDDigi_sim_generate_ddg4_data
       REGEX_PASS "\\+\\+\\+ Finished run 2 after 30 events \\(90 events in total\\)."
       REGEX_FAIL "Error;ERROR;FATAL; Exception"
     )
     # Test reading EDM4HEP input written with DDG4
-    dd4hep_add_test_reg(DDDigi_test_edm4hep_read
+    dd4hep_add_test_reg(DDDigi_sim_test_edm4hep_read
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestEdm4hepInput.py
                    -num_events 15 -num_threads 10 -events_parallel 5
-      DEPENDS    DDDigi_generate_edm4hep_data
+      DEPENDS    DDDigi_sim_generate_edm4hep_data
       REGEX_PASS "\\+\\+\\+ 15 Events out of 15 processed."
       REGEX_FAIL "ERROR;FATAL;Exception"
     )
     #
     # Test EDM4HEP writing OUTPUT from ddg4 input (needs to be expanded)
-    dd4hep_add_test_reg(DDDigi_test_edm4hep_output
+    dd4hep_add_test_reg(DDDigi_sim_test_edm4hep_output
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDDigi.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_INSTALL_PREFIX}/examples/DDDigi/scripts/TestEdm4hepOutput.py
                    -num_events 5 -num_threads 10 -events_parallel 4
-      DEPENDS    DDDigi_generate_ddg4_data
-      DEPENDS    DDDigi_generate_edm4hep_data
+      DEPENDS    DDDigi_sim_generate_ddg4_data
+      DEPENDS    DDDigi_sim_generate_edm4hep_data
       REGEX_PASS "\\+\\+\\+ 5 Events out of 5 processed."
       REGEX_FAIL "ERROR;FATAL;Exception"
     )

--- a/examples/DDG4/CMakeLists.txt
+++ b/examples/DDG4/CMakeLists.txt
@@ -51,21 +51,21 @@ if (DD4HEP_USE_GEANT4)
   dd4hep_configure_scripts (DDG4 DEFAULT_SETUP WITH_TESTS)
   #
   # Test HepMC input reader
-  dd4hep_add_test_reg( DDG4_HepMC_reader
+  dd4hep_add_test_reg( DDG4_sim_HepMC_reader
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/examples/DDG4/examples/readHEPMC.py
                       ${DDG4examples_INSTALL}/data/hepmc_geant4.dat
     REGEX_PASS "Geant4InputAction\\[Input\\]: Event 10 Error when moving to event -  EOF")
   #
   # Test HepMC input reader with slightly non-standard HEPMC file
-  dd4hep_add_test_reg( DDG4_HepMC_reader_minbias
+  dd4hep_add_test_reg( DDG4_sim_HepMC_reader_minbias
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/examples/DDG4/examples/readHEPMC.py
                       ${DDG4examples_INSTALL}/data/LHCb_MinBias_HepMC.txt
     REGEX_PASS "Geant4InputAction\\[Input\\]: Event 27 Error when moving to event -  EOF")
   #
   # Test property types with specialized action
-  dd4hep_add_test_reg( DDG4_Test_property_types
+  dd4hep_add_test_reg( DDG4_sim_Test_property_types
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DDG4examples_INSTALL}/scripts/TestProperties.py
     REGEX_PASS "Test PASSED"
@@ -81,7 +81,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   # Test G4 creation of G4ExtendedMaterial and G4LogicalCrystalVolume
-  dd4hep_add_test_reg( DDG4_G4ExtendedMaterial_G4LogicalCrystalVolume
+  dd4hep_add_test_reg( DDG4_sim_G4ExtendedMaterial_G4LogicalCrystalVolume
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DDG4examples_INSTALL}/scripts/Channeling.py -batch -events 3
     REGEX_PASS "Created specialize logical volume \\[G4LogicalCrystalVolume\\]: ChannelingDevice_vol"
@@ -89,7 +89,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   # Test G4 stacking action
-  dd4hep_add_test_reg( DDG4_TestStackingAction
+  dd4hep_add_test_reg( DDG4_sim_TestStackingAction
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DDG4examples_INSTALL}/scripts/TestStacking.py -batch -events 3
     REGEX_PASS " \\[2\\] Calling classifyNewTrack. StackManager"
@@ -97,7 +97,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   # Test G4 stepping action
-  dd4hep_add_test_reg( DDG4_TestSteppingAction
+  dd4hep_add_test_reg( DDG4_sim_TestSteppingAction
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DDG4examples_INSTALL}/scripts/TestStepping.py -batch -events 3
     REGEX_PASS " Track Calls Suspended: [1-9][0-9]*"
@@ -105,7 +105,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   # Test G4 command UI
-  dd4hep_add_test_reg( DDG4_UIManager
+  dd4hep_add_test_reg( DDG4_sim_UIManager
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DDG4examples_INSTALL}/scripts/TestUserCommands.py
     REGEX_PASS " Parameter value at call 13 is 'terminate-command-2'"
@@ -113,7 +113,7 @@ if (DD4HEP_USE_GEANT4)
   )
   #
   # Test G4 SIGINT handler
-  dd4hep_add_test_reg( DDG4_SIGINT_handler
+  dd4hep_add_test_reg( DDG4_sim_SIGINT_handler
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DDG4examples_INSTALL}/scripts/TestSIGINT.py
     REGEX_PASS "Event loop STOP signalled. Processing stops"

--- a/examples/DDG4_MySensDet/CMakeLists.txt
+++ b/examples/DDG4_MySensDet/CMakeLists.txt
@@ -52,7 +52,7 @@ if (DD4HEP_USE_GEANT4)
   install(TARGETS DDG4_MySensDet DESTINATION lib)
   
   # Geant4 material scan. From position=0,0,0 to end-of-world 
-  dd4hep_add_test_reg( DDG4_MySensDet_g4material_scan_SiliconBlock_LONGTEST
+  dd4hep_add_test_reg( DDG4_MySensDet_sim_g4material_scan_SiliconBlock_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_DDG4_MySensDet.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4MaterialScan --compact=file:${CMAKE_INSTALL_PREFIX}/examples/ClientTests/compact/SiliconBlock.xml
                "--position=0,0,0" "--direction=0,1,0"

--- a/examples/LHeD/CMakeLists.txt
+++ b/examples/LHeD/CMakeLists.txt
@@ -86,7 +86,7 @@ if (DD4HEP_USE_GEANT4)
   #
   # Basic DDG4 component/unit tests
   foreach(script LHeDMagField LHeDPhysics LHeDRandom LHeDScan)
-    dd4hep_add_test_reg( LHeD_DDG4_${script}_LONGTEST
+    dd4hep_add_test_reg( LHeD_DDG4_sim_${script}_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
       EXEC_ARGS  ${Python_EXECUTABLE} ${LHeDEx_INSTALL}/scripts/${script}.py
       REGEX_PASS "TEST_PASSED"
@@ -94,7 +94,7 @@ if (DD4HEP_USE_GEANT4)
   endforeach(script)
   #
   # Material scan
-  dd4hep_add_test_reg( LHeD_DDG4_g4material_scan_LONGTEST
+  dd4hep_add_test_reg( LHeD_DDG4_sim_g4material_scan_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${DD4hep_ROOT}/bin/g4MaterialScan --compact=file:${LHeDEx_INSTALL}/compact/compact.xml
                       "--position=0,0,0" "--direction=0,1,0"
@@ -104,15 +104,15 @@ if (DD4HEP_USE_GEANT4)
   foreach(script LHeDXML LHeDACLick)
     #
     # Build ACLick from the source file
-    dd4hep_add_test_reg( LHeD_DDG4_${script}_as_ACLick_LONGTEST
+    dd4hep_add_test_reg( LHeD_DDG4_sim_${script}_as_ACLick_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
       EXEC_ARGS  root.exe -b -x -n -q -l "${LHeDEx_INSTALL}/scripts/run.C(\"${LHeDEx_INSTALL}/scripts/${script}\")"
       REGEX_PASS "UserEvent_1      INFO  Geant4TestEventAction> calling end.event_id=2"
       REGEX_FAIL "Exception;EXCEPTION;ERROR;Error" )
-    set_property(TEST t_LHeD_DDG4_${script}_as_ACLick_LONGTEST PROPERTY RESOURCE_LOCK "INIT_ACLICK")
+    set_property(TEST t_LHeD_DDG4_sim_${script}_as_ACLick_LONGTEST PROPERTY RESOURCE_LOCK "INIT_ACLICK")
     #
     # Execute identical source linked executable 
-    dd4hep_add_test_reg( LHeD_DDG4_${script}_as_exe_LONGTEST
+    dd4hep_add_test_reg( LHeD_DDG4_sim_${script}_as_exe_LONGTEST
       COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_LHeD.sh"
       EXEC_ARGS  ${script}
       REGEX_PASS "UserEvent_1      INFO  Geant4TestEventAction> calling end.event_id=2"

--- a/examples/Persistency/CMakeLists.txt
+++ b/examples/Persistency/CMakeLists.txt
@@ -218,7 +218,7 @@ if (DD4HEP_USE_GEANT4)
   #
   #
   #  Test restoring geometry from ROOT file and start Geant4
-  dd4hep_add_test_reg( Persist_CLICSiD_Geant4_LONGTEST
+  dd4hep_add_test_reg( Persist_sim_CLICSiD_Geant4_LONGTEST
     COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_Persistency.sh"
     EXEC_ARGS  ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../CLICSiD/scripts/CLICSiD_LoadROOTGeo.py  batch
     DEPENDS    Persist_CLICSiD_Save_LONGTEST

--- a/examples/RICH/CMakeLists.txt
+++ b/examples/RICH/CMakeLists.txt
@@ -44,30 +44,30 @@ if(NOT TARGET DD4hep::DDG4)
 endif()
 
 # ---Test: run simulation
-dd4hep_add_test_reg( RICH_simulation
+dd4hep_add_test_reg( RICH_sim_simulation
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_RICH.sh"
   EXEC_ARGS  ${Python_EXECUTABLE} ${RICH_INSTALL}/scripts/richsim.py
              --outputFile "${RICH_INSTALL}/sim.root"
   REGEX_PASS "TEST: passed"
   REGEX_FAIL " Exception; EXCEPTION;ERROR;Error;FATAL"
-  )
+)
 
 # ---Test: Number of raw photon hits
-dd4hep_add_test_reg( RICH_number_of_hits
+dd4hep_add_test_reg( RICH_sim_number_of_hits
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_RICH.sh"
   EXEC_ARGS  root.exe -b -x -n -q -l
              "${RICH_INSTALL}/scripts/test_number_of_hits.C(\"${RICH_INSTALL}/sim.root\")"
   REGEX_PASS "TEST: passed"
   REGEX_FAIL "TEST: failed"
-  DEPENDS RICH_simulation
-  )
+  DEPENDS RICH_sim_simulation
+)
 
 # ---Test: Energy deposition
-dd4hep_add_test_reg( RICH_energy_deposition
+dd4hep_add_test_reg( RICH_sim_energy_deposition
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_RICH.sh"
   EXEC_ARGS  root.exe -b -x -n -q -l
              "${RICH_INSTALL}/scripts/test_energy_deposition.C(\"${RICH_INSTALL}/sim.root\")"
   REGEX_PASS "TEST: passed"
   REGEX_FAIL "TEST: failed"
-  DEPENDS RICH_simulation
-  )
+  DEPENDS RICH_sim_simulation
+)


### PR DESCRIPTION

BEGINRELEASENOTES
- All tests in the examples directory using geant4 simulation and dependencies of these tests have the following convention:
  `<test-directory>_sim_<other unique name>`, where `test_directory` is `CLICSiD, ClientTests, DDDigi, DDG4, MySensDet, etc`.
- This allows to consistently exclude all tests which require simulation as an input by running:
  `$> ctest -E _sim_`




ENDRELEASENOTES