### PR TITLE
Update ROOT_LIBRARY_PATH in thisdd4hep.sh

### DIFF
--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -109,6 +109,8 @@ dd4hep_add_library_path    ${THIS}/lib;
 dd4hep_add_path PYTHONPATH ${THIS}/@DD4HEP_PYTHON_INSTALL_DIR@;
 #----ROOT_INCLUDE_PATH--------------------------------------------------------
 dd4hep_add_path ROOT_INCLUDE_PATH ${THIS}/include;
+#----ROOT_LIBRARY_PATH--------------------------------------------------------
+dd4hep_add_path ROOT_LIBRARY_PATH ${THIS}/lib;
 #-----------------------------------------------------------------------------
 if [ @APPLE@ ];
 then


### PR DESCRIPTION

BEGINRELEASENOTES
- `ROOT_LIBRARY_PATH` will now be updated by thisdd4hep.sh.
ENDRELEASENOTES

This is needed to instruct Cling to prefer a particular dd4hep path.