### PR TITLE
HTML User Docs: move Table of Content toc to absolute position at 150…

### DIFF
--- a/doc/usermanuals/DD4hep/html/css/custom.css
+++ b/doc/usermanuals/DD4hep/html/css/custom.css
@@ -43,11 +43,10 @@ div.lstlisting {
 
 /* customize sidebar and toolbar */
 .sidebar {
-    position:fixed;
+    position:absolute;
     width:18em;
     top:120px;
-    left:100%;
-    margin-left:-20em;
+    left:150%;
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;

--- a/doc/usermanuals/DDAlign/html/css/custom.css
+++ b/doc/usermanuals/DDAlign/html/css/custom.css
@@ -43,11 +43,10 @@ div.lstlisting {
 
 /* customize sidebar and toolbar */
 .sidebar {
-    position:fixed;
+    position:absolute;
     width:18em;
     top:120px;
-    left:100%;
-    margin-left:-20em;
+    left:150%;
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;

--- a/doc/usermanuals/DDCond/html/css/custom.css
+++ b/doc/usermanuals/DDCond/html/css/custom.css
@@ -43,11 +43,10 @@ div.lstlisting {
 
 /* customize sidebar and toolbar */
 .sidebar {
-    position:fixed;
+    position:absolute;
     width:18em;
     top:120px;
-    left:100%;
-    margin-left:-20em;
+    left:150%;
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;

--- a/doc/usermanuals/DDEve/html/css/custom.css
+++ b/doc/usermanuals/DDEve/html/css/custom.css
@@ -43,11 +43,10 @@ div.lstlisting {
 
 /* customize sidebar and toolbar */
 .sidebar {
-    position:fixed;
+    position:absolute;
     width:18em;
     top:120px;
-    left:100%;
-    margin-left:-20em;
+    left:150%;
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;

--- a/doc/usermanuals/DDG4/html/css/custom.css
+++ b/doc/usermanuals/DDG4/html/css/custom.css
@@ -43,11 +43,10 @@ div.lstlisting {
 
 /* customize sidebar and toolbar */
 .sidebar {
-    position:fixed;
+    position:absolute;
     width:18em;
     top:120px;
-    left:100%;
-    margin-left:-20em;
+    left:150%;
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;

--- a/doc/usermanuals/DDRec/html/css/custom.css
+++ b/doc/usermanuals/DDRec/html/css/custom.css
@@ -43,11 +43,10 @@ div.lstlisting {
 
 /* customize sidebar and toolbar */
 .sidebar {
-    position:fixed;
+    position:absolute;
     width:18em;
     top:120px;
-    left:100%;
-    margin-left:-20em;
+    left:150%;
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;


### PR DESCRIPTION




BEGINRELEASENOTES
- HTML User Docs: move Table of Content toc to absolute position at 150% of page width. Let's table of content scroll along with the page.


ENDRELEASENOTES