### PR TITLE
HTML User Docs: remove margin from sectionToc

### DIFF
--- a/doc/usermanuals/DD4hep/html/css/custom.css
+++ b/doc/usermanuals/DD4hep/html/css/custom.css
@@ -50,8 +50,6 @@ div.lstlisting {
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;
-    margin-top:-1em;
-    margin-bottom:0px;
 }
 .sidebar .sectionTOCS br {
     display:none;

--- a/doc/usermanuals/DDAlign/html/css/custom.css
+++ b/doc/usermanuals/DDAlign/html/css/custom.css
@@ -50,8 +50,6 @@ div.lstlisting {
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;
-    margin-top:-1em;
-    margin-bottom:0px;
 }
 .sidebar .sectionTOCS br {
     display:none;

--- a/doc/usermanuals/DDCond/html/css/custom.css
+++ b/doc/usermanuals/DDCond/html/css/custom.css
@@ -50,8 +50,6 @@ div.lstlisting {
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;
-    margin-top:-1em;
-    margin-bottom:0px;
 }
 .sidebar .sectionTOCS br {
     display:none;

--- a/doc/usermanuals/DDEve/html/css/custom.css
+++ b/doc/usermanuals/DDEve/html/css/custom.css
@@ -50,8 +50,6 @@ div.lstlisting {
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;
-    margin-top:-1em;
-    margin-bottom:0px;
 }
 .sidebar .sectionTOCS br {
     display:none;

--- a/doc/usermanuals/DDG4/html/css/custom.css
+++ b/doc/usermanuals/DDG4/html/css/custom.css
@@ -50,8 +50,6 @@ div.lstlisting {
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;
-    margin-top:-1em;
-    margin-bottom:0px;
 }
 .sidebar .sectionTOCS br {
     display:none;

--- a/doc/usermanuals/DDRec/html/css/custom.css
+++ b/doc/usermanuals/DDRec/html/css/custom.css
@@ -50,8 +50,6 @@ div.lstlisting {
 }
 .sidebar .sectionToc, .sidebar .subsectionToc {
     display:block;
-    margin-top:-1em;
-    margin-bottom:0px;
 }
 .sidebar .sectionTOCS br {
     display:none;


### PR DESCRIPTION
BEGINRELEASENOTES
- HTML User Docs: remove margin from sectionToc, online this squashes the Toc lines more than offline for some reason


ENDRELEASENOTES