### PR TITLE
Improve help replies (See issue 1409)

### DIFF
--- a/UtilityApps/src/display.cpp
+++ b/UtilityApps/src/display.cpp
@@ -23,7 +23,9 @@ int main(int argc,char** argv)  {
     if ( i==1 && argv[i][0] != '-' ) av.emplace_back("-input");
     if      ( strncmp(argv[i],"-load-only",4) == 0 ) dry  = true, av.emplace_back(argv[i]);
     else if ( strncmp(argv[i],"-dry-run",4)   == 0 ) dry  = true, av.emplace_back(argv[i]);
-    else if ( strncmp(argv[i],"-help",4)      == 0 ) help = true, av.emplace_back(argv[i]);
+    else if ( strncmp(argv[i],"-h",2)         == 0 ) help = true;
+    else if ( strncmp(argv[i],"-help",4)      == 0 ) help = true;
+    else if ( strncmp(argv[i],"--help",4)     == 0 ) help = true;
     else if ( strncmp(argv[i],"-visopt",4)    == 0 ) visopt   = argv[++i];
     else if ( strncmp(argv[i],"-level", 4)    == 0 ) level    = argv[++i];
     else if ( strncmp(argv[i],"-option",4)    == 0 ) opt      = argv[++i];


### PR DESCRIPTION

BEGINRELEASENOTES
- Improve the response of geoDisplay when invoked for help.
- This PR fixes issue: https://github.com/AIDASoft/DD4hep/issues/1409
- Now geoDisplay -h / -help / --help gives the following output:
```
$ geoDisplay -h
PersistencyIO    INFO  +++ Set Streamer to dd4hep::OpaqueDataBlock
DD4hep           INFO  ++ Using globally Geant4 unit system (mm,ns,MeV)
Info in <TGeoManager>: Changing system of units to Geant4 units (mm, ns, MeV).
Info in <TGeoManager::TGeoManager>: Geometry default, Detector Geometry created
Info in <TGeoNavigator::BuildCache>: --- Maximum geometry depth set to 100
geoPluginRun: No geometry input supplied. No geometry will be loaded.
   ------------------------------------------------------------------
  | Welcome to ROOT 6.35.01                        https://root.cern |
  | (c) 1995-2024, The ROOT Team; conception: R. Brun, F. Rademakers |
  | Built for linuxx8664gcc on Jan 20 2025, 14:50:44                 |
  | From heads/master@v6-31-01-4781-gce5f87d2f4                      |
  | With g++-12 (Ubuntu 12.3.0-17ubuntu1) 12.3.0                     |
  | Try '.help'/'.?', '.demo', '.license', '.credits', '.quit'/'.q'  |
   ------------------------------------------------------------------

Usage: -plugin DD4hep_GeometryDisplay  -arg [-arg]                                

     Invoke the ROOT geometry display using the factory mechanism.                

     -detector <string> Top level DetElement path. Default: '/world'                
     -option   <string> ROOT Draw option.    Default: 'ogl'                         
     -level    <number> Visualization level  [TGeoManager::SetVisLevel]  Default: 4 
     -visopt   <number> Visualization option [TGeoManager::SetVisOption] Default: 1
     -load              Only load the geometry. Do not invoke the display          
     -help              Print this help output  
     Arguments given: -help

```
- Unfortunately we were not really following the linux rules concerning options:
  - one letter options:     `-<letter> <value>` or
  - multi letter options:  `--<options>=<value>`
 - maybe we should at some time make an effort to homogenize the behavior.
ENDRELEASENOTES