### PR TITLE
Support multithreading in Geant4EDM4hepOutput plugin

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -319,7 +319,7 @@ void Geant4Output2EDM4hep::commit( OutputContext<G4Event>& /* ctxt */)   {
       m_frame.put( std::move(calorimeterHits.second), colName + "Contributions");
     }
     m_file->writeFrame(m_frame, m_section_name);
-    m_particles = std::move(edm4hep::MCParticleCollection());
+    m_particles = { };
     m_trackerHits.clear();
     m_calorimeterHits.clear();
     m_frame = {};


### PR DESCRIPTION
This PR adds multithreading support to Geant4EDM4hepOutput. This is approached by:
- ensuring the `m_file` unique_ptr to podio::ROOTWriter is only made once,
- keeping track of the use count of the file in an atomic_size_t,
- ensuring the G4AutoLock is acquired in scope before each m_file access,
- closing the file when the last file user gives up access.

Additional notes:
- `context()->run()` fails because `runPtr()` is null in multithreaded running; this leads to missing `runs` and `meta` frames. *EDIT: this is not consistent... not sure why not...*
- After moving `m_particles` into the frame, the collection is left with a null `m_storageMtx` mutex pointer; this is avoided by not using `clear()` but ~~moving~~ assigning a clean new collection in place (Line 322). I suspect the `clear()` was added in analogy to the `clear()` calls below, but those are on `maps`, not podio collections.

Testing:
- There is currently no trivial way to test this out (this is a prereq for #1240), so this was tested with `DG4/examples/SiDSim_MT.py` with the following diff:
```diff
index 2a340914..736f190e 100644
--- a/DDG4/examples/SiDSim_MT.py
+++ b/DDG4/examples/SiDSim_MT.py
@@ -53,8 +53,7 @@ def setupWorker(geant4):
   logger.info("\n#PYTHON:  Configure I/O\n")
   # evt_lcio = geant4.setupLCIOOutput('LcioOutput','CLICSiD_'+time.strftime('%Y-%m-%d_%H-%M'))
   # evt_lcio.OutputLevel = Output.ERROR
-
-  geant4.setupROOTOutput('RootOutput', 'CLICSiD_' + time.strftime('%Y-%m-%d_%H-%M'))
+  geant4.setupEDM4hepOutput('EDM4hepOutput', 'CLICSiD_' + time.strftime('%Y-%m-%d_%H-%M') + ".edm4hep.root")
 
   gen = DDG4.GeneratorAction(kernel, "Geant4GeneratorActionInit/GenerationInit")
   kernel.generatorAction().adopt(gen)
```

TODO:
- [ ] I'd like to add this to one of the tests, but neither `SiDSim.py` nor `SiDSim_MT.py` is already used for tests. Suggestions welcome.

BEGINRELEASENOTES
- Support multithreading in Geant4EDM4hepOutput plugin

ENDRELEASENOTES