### PR TITLE
Allow to selectively disable DD4HEP sub-packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,28 +78,28 @@ option(DD4HEP_USE_EDM4HEP       "Build edm4hep extensions"                      
 option(DD4HEP_USE_HEPMC3        "Build hepmc3 extensions"                       OFF)
 option(DD4HEP_USE_TBB           "Build features that require TBB"               OFF)
 option(DD4HEP_LOAD_ASSIMP       "Download and build ASSIMP from github"         OFF)
-option(DD4HEP_DISABLE           "Selectively disable DD4HEP sub-packages"       OFF)
+option(DD4HEP_DISABLE_PACKAGES  "Selectively disable DD4HEP sub-packages [Separate multiples by space]"  OFF)
 option(BUILD_TESTING            "Enable and build tests"                        ON)
 option(BUILD_SHARED_LIBS        "If OFF build STATIC Libraries"                 ON)
 option(DD4HEP_SET_RPATH         "Link libraries with built-in RPATH (run-time search path)" ON)
 option(DD4HEP_RELAX_PYVER       "Do not require exact python version match with ROOT" OFF)
 #
+OPTION(DD4HEP_BUILD_EXAMPLES    "Build all the examples"                        OFF)
+OPTION(DD4HEP_DEBUG_CMAKE       "Print debugging information for DD4hep CMAKE"  OFF)
 #
 SET(DD4HEP_BUILD_PACKAGES "DDRec DDDetectors DDCond DDAlign DDCAD DDDigi DDG4 DDEve UtilityApps"
     CACHE STRING "List of DD4hep packages to build")
 #
 SEPARATE_ARGUMENTS(DD4HEP_BUILD_PACKAGES)
 IF( DD4HEP_DISABLE )
-    STRING(REPLACE "," ";" DISABLED_PACKAGES "${DD4HEP_DISABLE}" )
+    STRING(REPLACE " " ";" DISABLED_PACKAGES "${DD4HEP_DISABLE_PACKAGES}" )
+    STRING(REPLACE "," ";" DISABLED_PACKAGES "${DISABLED_PACKAGES}" )
     FOREACH( PKG ${DISABLED_PACKAGES} )
       LIST(REMOVE_ITEM DD4HEP_BUILD_PACKAGES ${PKG})
       MESSAGE(STATUS "Disable package: ${PKG}" )
     ENDFOREACH()
 ENDIF()
 MESSAGE(STATUS "Will be building these packages: ${DD4HEP_BUILD_PACKAGES}")
-
-OPTION(DD4HEP_BUILD_EXAMPLES "Build all the examples" OFF)
-OPTION(DD4HEP_DEBUG_CMAKE "Print debugging information for DD4hep CMAKE" OFF)
 
 SET(DD4HEP_USE_EXISTING_DD4HEP "" CACHE STRING "Build some parts of DD4hep against an existing installation")
 SET(DD4HEP_HIGH_MEM_POOL_DEPTH "${DD4HEP_HIGH_MEM_POOL_DEPTH}" CACHE STRING "Number of build slots for high memory compile units (DDParsers), Ninja only")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,14 +78,24 @@ option(DD4HEP_USE_EDM4HEP       "Build edm4hep extensions"                      
 option(DD4HEP_USE_HEPMC3        "Build hepmc3 extensions"                       OFF)
 option(DD4HEP_USE_TBB           "Build features that require TBB"               OFF)
 option(DD4HEP_LOAD_ASSIMP       "Download and build ASSIMP from github"         OFF)
+option(DD4HEP_DISABLE           "Selectively disable DD4HEP sub-packages"       OFF)
 option(BUILD_TESTING            "Enable and build tests"                        ON)
 option(BUILD_SHARED_LIBS        "If OFF build STATIC Libraries"                 ON)
 option(DD4HEP_SET_RPATH         "Link libraries with built-in RPATH (run-time search path)" ON)
 option(DD4HEP_RELAX_PYVER       "Do not require exact python version match with ROOT" OFF)
-
+#
+#
 SET(DD4HEP_BUILD_PACKAGES "DDRec DDDetectors DDCond DDAlign DDCAD DDDigi DDG4 DDEve UtilityApps"
-  CACHE STRING "List of DD4hep packages to build")
+    CACHE STRING "List of DD4hep packages to build")
+#
 SEPARATE_ARGUMENTS(DD4HEP_BUILD_PACKAGES)
+IF( DD4HEP_DISABLE )
+    STRING(REPLACE "," ";" DISABLED_PACKAGES "${DD4HEP_DISABLE}" )
+    FOREACH( PKG ${DISABLED_PACKAGES} )
+      LIST(REMOVE_ITEM DD4HEP_BUILD_PACKAGES ${PKG})
+      MESSAGE(STATUS "Disable package: ${PKG}" )
+    ENDFOREACH()
+ENDIF()
 MESSAGE(STATUS "Will be building these packages: ${DD4HEP_BUILD_PACKAGES}")
 
 OPTION(DD4HEP_BUILD_EXAMPLES "Build all the examples" OFF)


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix for issue https://github.com/AIDASoft/DD4hep/issues/1418.
  Individual DD4HEP sub-packages can be disable from the cmake command line:
  ```
  $> cmake <other options> -DDD4HEP_DISABLE_PACKAGES="DDRec DDEve DDDigi"  ../DD4hep
  ```
  This will disable the sub-packages DDRec,DDEve,DDDigi:
  ```
  $> cmake -DDD4HEP_DISABLE_PACKAGES="DDRec DDEve DDDigi"  ../DD4hep
       -- Could NOT find LATEX (missing: LATEX_COMPILER) 
       -- No LaTeX/Biber found, cannot compile user manual.
       -- Disable package: DDEve
       -- Disable package: DDDigi
       -- Disable package: DDRec
       -- Will be building these packages: DDDetectors;DDCond;DDAlign;DDCAD;DDG4;UtilityApps
       -- Including DD4hepBuild.cmake
  ```
   Clearly no prevision can be done concerning package dependencies. This is up to the user.
   For example `DDG4` cannot be disabled if `DDDigi` should be kept.
ENDRELEASENOTES