### PR TITLE
Clean up header includes

### DIFF
--- a/DDCore/include/DD4hep/Callback.h
+++ b/DDCore/include/DD4hep/Callback.h
@@ -14,7 +14,6 @@
 #define DD4HEP_CALLBACK_H
 
 // C/C++ include files
-#include <algorithm>
 #include <typeinfo>
 #include <vector>
 

--- a/DDCore/include/DD4hep/ComponentProperties.h
+++ b/DDCore/include/DD4hep/ComponentProperties.h
@@ -18,10 +18,7 @@
 
 // C/C++ include files
 #include <algorithm>
-#include <stdexcept>
 #include <typeinfo>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <map>
 

--- a/DDCore/include/DD4hep/DetElement.h
+++ b/DDCore/include/DD4hep/DetElement.h
@@ -25,7 +25,6 @@
 
 // C/C++ include files
 #include <map>
-#include <typeinfo>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/include/DD4hep/DetectorLoad.h
+++ b/DDCore/include/DD4hep/DetectorLoad.h
@@ -17,7 +17,6 @@
 #include <DD4hep/Detector.h>
 
 // C/C++ include files
-#include <stdexcept>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/include/DD4hep/ExtensionEntry.h
+++ b/DDCore/include/DD4hep/ExtensionEntry.h
@@ -24,9 +24,6 @@
 // Framework include files
 #include <DD4hep/Primitives.h>
 
-// C/C++ include files
-#include <typeinfo>
-
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
 

--- a/DDCore/include/DD4hep/Filter.h
+++ b/DDCore/include/DD4hep/Filter.h
@@ -32,7 +32,6 @@
 #include <memory>
 #include <vector>
 #include <regex>
-#include <unordered_map>
 
 namespace dd4hep {
   struct SpecPar;

--- a/DDCore/include/DD4hep/Grammar.h
+++ b/DDCore/include/DD4hep/Grammar.h
@@ -27,7 +27,6 @@
 
 // C/C++ include files
 #include <string>
-#include <iostream>
 #include <typeinfo>
 
 // Forward declarations

--- a/DDCore/include/DD4hep/Handle.h
+++ b/DDCore/include/DD4hep/Handle.h
@@ -18,8 +18,6 @@
 
 #include <string>
 #include <typeinfo>
-#include <stdexcept>
-#include <type_traits>
 
 // Conversion factor from radians to degree: 360/(2*PI)
 #ifndef RAD_2_DEGREE

--- a/DDCore/include/DD4hep/IDDescriptor.h
+++ b/DDCore/include/DD4hep/IDDescriptor.h
@@ -20,7 +20,6 @@
 // C++ include files
 #include <string>
 #include <vector>
-#include <map>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/include/DD4hep/IOV.h
+++ b/DDCore/include/DD4hep/IOV.h
@@ -16,7 +16,6 @@
 // C/C++ include files
 #include <string>
 #include <limits>
-#include <algorithm>
 #include <utility>
 #include <cstdint>
 

--- a/DDCore/include/DD4hep/Objects.h
+++ b/DDCore/include/DD4hep/Objects.h
@@ -56,7 +56,6 @@ class TGeoIdentity;
 // C/C++ include files
 #include <set>
 #include <cmath>
-#include <limits>
 #include <vector>
 
 #define _USE_MATH_DEFINES

--- a/DDCore/include/DD4hep/OpaqueData.h
+++ b/DDCore/include/DD4hep/OpaqueData.h
@@ -18,7 +18,6 @@
 
 // C/C++ include files
 #include <typeinfo>
-#include <vector>
 #include <string>
 
 /// Namespace for the AIDA detector description toolkit

--- a/DDCore/include/DD4hep/Plugins.h
+++ b/DDCore/include/DD4hep/Plugins.h
@@ -19,7 +19,6 @@
 // ROOT include files
 #ifndef __CINT__
 #include <string>
-#include <vector>
 #include <typeinfo>
 
 #if __cplusplus >= 201703

--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -21,6 +21,7 @@
 
 // C/C++ include files
 #include <vector>
+#include <string>
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push

--- a/DDCore/include/DD4hep/SignalHandler.h
+++ b/DDCore/include/DD4hep/SignalHandler.h
@@ -15,7 +15,6 @@
 
 /// System include files
 #include <csignal>
-#include <memory>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -20,8 +20,9 @@
 #include <DD4hep/BitField64.h>
 
 // C/C++ include files
-#include <map>
-#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 // ROOT include file (includes TGeoVolume + TGeoShape)
 #include <TGeoNode.h>

--- a/DDCore/include/DD4hep/detail/AlignmentsInterna.h
+++ b/DDCore/include/DD4hep/detail/AlignmentsInterna.h
@@ -27,7 +27,7 @@
 #include <DD4hep/detail/ConditionsInterna.h>
 
 // C/C++ include files
-#include <map>
+#include <string>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/include/DD4hep/detail/ConditionsInterna.h
+++ b/DDCore/include/DD4hep/detail/ConditionsInterna.h
@@ -28,7 +28,7 @@
 #include <DD4hep/NamedObject.h>
 
 // C/C++ include files
-#include <map>
+#include <string>
 
 
 /// Namespace for the AIDA detector description toolkit

--- a/DDCore/include/DDSegmentation/BitField64.h
+++ b/DDCore/include/DDSegmentation/BitField64.h
@@ -12,12 +12,9 @@
 #ifndef DDSEGMENTATION_BITFIELD64_H
 #define DDSEGMENTATION_BITFIELD64_H 1
 
-#include <iostream>
+#include <ostream>
 
 #include <string>
-#include <vector>
-#include <map>
-#include <sstream>
 
 #include <DDSegmentation/BitFieldCoder.h>
 

--- a/DDCore/include/DDSegmentation/BitFieldCoder.h
+++ b/DDCore/include/DDSegmentation/BitFieldCoder.h
@@ -15,7 +15,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <sstream>
 #include <cstdint>
 
 namespace dd4hep {

--- a/DDCore/include/DDSegmentation/CylindricalSegmentation.h
+++ b/DDCore/include/DDSegmentation/CylindricalSegmentation.h
@@ -21,8 +21,6 @@
 
 #include <DDSegmentation/Segmentation.h>
 
-#include <map>
-
 namespace dd4hep {
   namespace DDSegmentation {
 

--- a/DDCore/include/DDSegmentation/Segmentation.h
+++ b/DDCore/include/DDSegmentation/Segmentation.h
@@ -24,7 +24,6 @@
 #include <DDSegmentation/SegmentationParameter.h>
 
 #include <map>
-#include <utility>
 #include <set>
 #include <string>
 #include <vector>

--- a/DDCore/include/DDSegmentation/SegmentationUtil.h
+++ b/DDCore/include/DDSegmentation/SegmentationUtil.h
@@ -21,7 +21,6 @@
 #include <DDSegmentation/Segmentation.h>
 
 #include <cmath>
-#include <vector>
 
 namespace dd4hep {
 namespace DDSegmentation {

--- a/DDCore/include/JSON/Elements.h
+++ b/DDCore/include/JSON/Elements.h
@@ -17,7 +17,6 @@
 #include <cmath>
 #include <string>
 #include <vector>
-#include <stdexcept>
 
 // Framework include files
 #include <JSON/config.h>

--- a/DDCore/include/Parsers/Primitives.h
+++ b/DDCore/include/Parsers/Primitives.h
@@ -18,12 +18,8 @@
 
 // C/C++ include files
 #include <map>
-#include <list>
 #include <vector>
 #include <string>
-#if __cplusplus >= 201703 || (__clang__ && __APPLE__)
-#include <string_view>
-#endif
 #include <limits>
 #include <cstdint>
 

--- a/DDCore/include/Parsers/detail/Conversions.h
+++ b/DDCore/include/Parsers/detail/Conversions.h
@@ -22,12 +22,6 @@
  */
 
 
-// C/C++ include files
-#include <map>
-#include <iostream>
-
-// Framework include files
-
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/include/XML/Utilities.h
+++ b/DDCore/include/XML/Utilities.h
@@ -21,8 +21,6 @@
 #include <DD4hep/Detector.h>
 
 // C/C++ include files
-#include <set>
-#include <map>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/include/XML/XMLElements.h
+++ b/DDCore/include/XML/XMLElements.h
@@ -17,7 +17,7 @@
 #include <cmath>
 #include <string>
 #include <vector>
-#include <stdexcept>
+#include <exception>
 
 // Framework include files
 #include <XML/config.h>

--- a/DDCore/include/XML/config.h
+++ b/DDCore/include/XML/config.h
@@ -25,7 +25,6 @@
 
 // C/C++ include files
 #include <cstdlib>
-#include <cstdint>
 
 #ifndef  __TIXML__
 // This is the absolute minimal include necessary to comply with XercesC

--- a/DDCore/src/Alignments.cpp
+++ b/DDCore/src/Alignments.cpp
@@ -17,7 +17,7 @@
 #include <DD4hep/detail/ConditionsInterna.h>
 
 // C/C++ include files
-#include <sstream>
+#include <string>
 
 using namespace dd4hep;
 

--- a/DDCore/src/ConditionAny.cpp
+++ b/DDCore/src/ConditionAny.cpp
@@ -17,7 +17,8 @@
 #include <DD4hep/detail/ConditionsInterna.h>
 
 // C/C++ include files
-#include <iomanip>
+#include <any>
+#include <string>
 
 using namespace dd4hep;
 

--- a/DDCore/src/Conditions.cpp
+++ b/DDCore/src/Conditions.cpp
@@ -17,7 +17,6 @@
 
 // C/C++ include files
 #include <climits>
-#include <iomanip>
 #include <cstdio>
 
 using namespace dd4hep;

--- a/DDCore/src/DetectorTools.cpp
+++ b/DDCore/src/DetectorTools.cpp
@@ -20,7 +20,8 @@
 
 // C/C++ include files
 #include <stdexcept>
-#include <memory>
+#include <sstream>
+#include <string>
 
 // ROOT include files
 #include <TGeoMatrix.h>

--- a/DDCore/src/Filter.cpp
+++ b/DDCore/src/Filter.cpp
@@ -17,9 +17,8 @@
 #include <DD4hep/Filter.h>
 
 // C/C++ include files
-#include <functional>
 #include <regex>
-#include <iostream>
+#include <string>
 
 namespace dd4hep {
   

--- a/DDCore/src/GeoHandler.cpp
+++ b/DDCore/src/GeoHandler.cpp
@@ -23,8 +23,6 @@
 #include <TClass.h>
 
 // C/C++ include files
-#include <algorithm>
-#include <iostream>
 
 using namespace dd4hep;
 
@@ -196,9 +194,8 @@ detail::GeoScan::GeoScan(DetElement e, bool propagate) {
 
 /// Default destructor
 detail::GeoScan::~GeoScan() {
-  if (m_data)
-    delete m_data;
-  m_data = 0;
+  delete m_data;
+  m_data = nullptr;
 }
 
 /// Work callback

--- a/DDCore/src/GeometryTreeDump.h
+++ b/DDCore/src/GeometryTreeDump.h
@@ -20,7 +20,6 @@
 
 // C/C++ include files
 #include <set>
-#include <map>
 #include <vector>
 
 class TGeoVolume;

--- a/DDCore/src/Grammar.cpp
+++ b/DDCore/src/Grammar.cpp
@@ -23,10 +23,9 @@
 #include <TROOT.h>
 
 // C/C++ include files
-#include <algorithm>
-#include <stdexcept>
 #include <mutex>
 #include <map>
+#include <string>
 
 #if defined(DD4HEP_PARSER_HEADER)
 

--- a/DDCore/src/IOV.cpp
+++ b/DDCore/src/IOV.cpp
@@ -18,8 +18,8 @@
 
 // C/C++ include files
 #include <climits>
-#include <iomanip>
 #include <cstring>
+#include <ctime>
 
 using namespace dd4hep;
 

--- a/DDCore/src/JSON/Elements.cpp
+++ b/DDCore/src/JSON/Elements.cpp
@@ -16,10 +16,10 @@
 #include <JSON/Elements.h>
 
 // C/C++ include files
-#include <iostream>
-#include <stdexcept>
 #include <cstdio>
-#include <map>
+#include <stdexcept>
+#include <string>
+#include <stdexcept>
 
 using namespace dd4hep::json;
 static const size_t INVALID_NODE = ~0U;

--- a/DDCore/src/Objects.cpp
+++ b/DDCore/src/Objects.cpp
@@ -29,7 +29,6 @@
 // C/C++ include files
 #include <cmath>
 #include <sstream>
-#include <iomanip>
 
 using namespace dd4hep;
 

--- a/DDCore/src/OpticalSurfaceManager.cpp
+++ b/DDCore/src/OpticalSurfaceManager.cpp
@@ -19,8 +19,7 @@
 #include <DD4hep/Printout.h>
 
 // C/C++ includes
-#include <sstream>
-#include <iomanip>
+#include <string>
 
 using namespace dd4hep;
 

--- a/DDCore/src/OpticalSurfaceManagerInterna.cpp
+++ b/DDCore/src/OpticalSurfaceManagerInterna.cpp
@@ -16,8 +16,6 @@
 #include <DD4hep/detail/Handle.inl>
 
 // C/C++ includes
-#include <sstream>
-#include <iomanip>
 
 using namespace dd4hep;
 

--- a/DDCore/src/OpticalSurfaces.cpp
+++ b/DDCore/src/OpticalSurfaces.cpp
@@ -21,8 +21,6 @@
 #include <DD4hep/detail/Handle.inl>
 
 // C/C++ includes
-#include <sstream>
-#include <iomanip>
 
 using namespace dd4hep;
 

--- a/DDCore/src/PropertyTable.cpp
+++ b/DDCore/src/PropertyTable.cpp
@@ -20,8 +20,6 @@
 #include <DD4hep/detail/Handle.inl>
 
 // C/C++ includes
-#include <sstream>
-#include <iomanip>
 
 using namespace dd4hep;
 

--- a/DDCore/src/RootDictionary.h
+++ b/DDCore/src/RootDictionary.h
@@ -42,7 +42,7 @@
 // C/C++ include files
 #include <vector>
 #include <map>
- #include <string>
+#include <string>
 
 #include <TRint.h>
 

--- a/DDCore/src/Segmentations.cpp
+++ b/DDCore/src/Segmentations.cpp
@@ -20,8 +20,6 @@
 #include <DD4hep/detail/SegmentationsInterna.h>
 
 // C/C++ include files
-#include <iostream>
-#include <stdexcept>
 
 using namespace dd4hep;
 

--- a/DDCore/src/ShapesInterna.cpp
+++ b/DDCore/src/ShapesInterna.cpp
@@ -17,7 +17,6 @@
 
 // C/C++ include files
 #include <climits>
-#include <iomanip>
 #include <cstdio>
 
 using namespace dd4hep;

--- a/DDCore/src/SignalHandler.cpp
+++ b/DDCore/src/SignalHandler.cpp
@@ -16,9 +16,9 @@
 #include <DD4hep/SignalHandler.h>
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <iostream>
 #include <unistd.h>
 #include <execinfo.h>
 

--- a/DDCore/src/XML/DocumentHandler.cpp
+++ b/DDCore/src/XML/DocumentHandler.cpp
@@ -19,7 +19,6 @@
 // C/C++ include files
 #include <memory>
 #include <iostream>
-#include <stdexcept>
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifndef _WIN32

--- a/DDCore/src/XML/XMLElements.cpp
+++ b/DDCore/src/XML/XMLElements.cpp
@@ -29,9 +29,13 @@
 #include <XML/XMLTags.h>
 
 // C/C++ include files
-#include <iostream>
-#include <stdexcept>
 #include <cstdio>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace dd4hep::xml;
 static const size_t INVALID_NODE = ~0U;

--- a/DDCore/src/XML/XMLElements.cpp
+++ b/DDCore/src/XML/XMLElements.cpp
@@ -32,7 +32,6 @@
 #include <iostream>
 #include <stdexcept>
 #include <cstdio>
-#include <map>
 
 using namespace dd4hep::xml;
 static const size_t INVALID_NODE = ~0U;

--- a/DDCore/src/XML/XMLParsers.cpp
+++ b/DDCore/src/XML/XMLParsers.cpp
@@ -25,7 +25,6 @@
 
 
 // C/C++ include files
-#include <stdexcept>
 
 using std::string;
 using namespace dd4hep;

--- a/DDCore/src/XML/tinyxml_inl.h
+++ b/DDCore/src/XML/tinyxml_inl.h
@@ -30,8 +30,6 @@
 */
 
 
-#include <ctype.h>
-
 #ifdef TIXML_USE_STL
 #include <sstream>
 #include <iostream>

--- a/DDCore/src/plugins/CodeGenerator.cpp
+++ b/DDCore/src/plugins/CodeGenerator.cpp
@@ -23,10 +23,12 @@
 #include <DD4hep/detail/DetectorInterna.h>
 
 // C/C++ include files
-#include <stdexcept>
 #include <iostream>
-#include <iomanip>
 #include <fstream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
 
 // ROOT includes
 #include <TClass.h>

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -48,7 +48,6 @@
 // C/C++ include files
 #include <filesystem>
 #include <iostream>
-#include <iomanip>
 #include <climits>
 #include <set>
 

--- a/DDCore/src/plugins/DetectorCheck.cpp
+++ b/DDCore/src/plugins/DetectorCheck.cpp
@@ -23,8 +23,6 @@
 #include <DD4hep/detail/VolumeManagerInterna.h>
 
 // C/C++ include files
-#include <stdexcept>
-#include <algorithm>
 #include <cstdlib>
 
 using namespace dd4hep;

--- a/DDCore/src/plugins/DetectorHelperTest.cpp
+++ b/DDCore/src/plugins/DetectorHelperTest.cpp
@@ -18,8 +18,6 @@
 #include <DD4hep/DetectorHelper.h>
 
 // C/C++ include files
-#include <stdexcept>
-#include <algorithm>
 
 using namespace dd4hep;
 

--- a/DDCore/src/plugins/GeometryWalk.cpp
+++ b/DDCore/src/plugins/GeometryWalk.cpp
@@ -21,7 +21,7 @@
 
 // C/C++ include files
 #include <stdexcept>
-#include <algorithm>
+#include <string>
 
 using namespace dd4hep;
 

--- a/DDCore/src/plugins/JsonProcessor.cpp
+++ b/DDCore/src/plugins/JsonProcessor.cpp
@@ -38,7 +38,6 @@
 #include <DD4hep/detail/ObjectsInterna.h>
 
 // C/C++ include files
-#include <iostream>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace {

--- a/DDCore/src/plugins/LCDD2Output.cpp
+++ b/DDCore/src/plugins/LCDD2Output.cpp
@@ -27,7 +27,6 @@
 
 /// C/C++ include files
 #include <iostream>
-#include <iomanip>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {

--- a/DDCore/src/plugins/LCDDConverter.cpp
+++ b/DDCore/src/plugins/LCDDConverter.cpp
@@ -55,7 +55,6 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <iomanip>
 
 using namespace dd4hep;
 using namespace dd4hep::detail;

--- a/DDCore/src/plugins/LCDDConverter.h
+++ b/DDCore/src/plugins/LCDDConverter.h
@@ -22,7 +22,6 @@
 // C/C++ include files
 #include <set>
 #include <map>
-#include <vector>
 
 // Forward declarations
 class TGeoVolume;

--- a/DDCore/src/plugins/ShapePlugins.cpp
+++ b/DDCore/src/plugins/ShapePlugins.cpp
@@ -23,7 +23,6 @@
 
 // C/C++ include files
 #include <fstream>
-#include <memory>
 
 using namespace dd4hep;
 using namespace dd4hep::detail;

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -42,7 +42,6 @@
 // C/C++ include files
 #include <cerrno>
 #include <cstdlib>
-#include <fstream>
 #include <sstream>
 
 using namespace dd4hep;

--- a/DDCore/src/plugins/TGeoCodeGenerator.cpp
+++ b/DDCore/src/plugins/TGeoCodeGenerator.cpp
@@ -20,9 +20,7 @@
 #include <DD4hep/Path.h>
 
 // C/C++ include files
-#include <stdexcept>
 #include <iostream>
-#include <iomanip>
 #include <fstream>
 
 // ROOT includes

--- a/DDCore/src/segmentations/BitField64.cpp
+++ b/DDCore/src/segmentations/BitField64.cpp
@@ -11,8 +11,9 @@
 #include <DDSegmentation/BitField64.h>
 
 #include <cmath>
-#include <algorithm>
-#include <stdexcept>
+#include <ostream>
+#include <sstream>
+#include <string>
 
 namespace dd4hep{
 

--- a/DDCore/src/segmentations/BitFieldCoder.cpp
+++ b/DDCore/src/segmentations/BitFieldCoder.cpp
@@ -12,6 +12,7 @@
 
 #include <cmath>
 #include <algorithm>
+#include <sstream>
 #include <stdexcept>
 
 namespace dd4hep{

--- a/DDCore/src/segmentations/MegatileLayerGridXY.cpp
+++ b/DDCore/src/segmentations/MegatileLayerGridXY.cpp
@@ -22,7 +22,6 @@
 #undef NDEBUG
 #include <cmath>
 #include <cassert>
-#include <algorithm>
 
 namespace dd4hep {
   namespace DDSegmentation {

--- a/DDCore/src/segmentations/MultiSegmentation.cpp
+++ b/DDCore/src/segmentations/MultiSegmentation.cpp
@@ -17,8 +17,7 @@
 #include <DD4hep/Printout.h>
 
 /// C/C++ include files
-#include <iomanip>
-#include <stdexcept>
+#include <string>
 
 namespace dd4hep {
 

--- a/DDCore/src/segmentations/TiledLayerGridXY.cpp
+++ b/DDCore/src/segmentations/TiledLayerGridXY.cpp
@@ -19,10 +19,8 @@
 #include <DD4hep/Printout.h>
 
 // C/C++ includes
-#include <algorithm>
-#include <sstream>
-#include <stdexcept>
 #include <cmath>
+#include <string>
 
 namespace dd4hep {
 namespace DDSegmentation {

--- a/DDDigi/python/DDDigiDict.C
+++ b/DDDigi/python/DDDigiDict.C
@@ -39,6 +39,8 @@
 #include <DDDigi/DigiEventAction.h>
 #include <DDDigi/DigiContainerProcessor.h>
 
+#include <list>
+
 struct DDDigiDict  {};
 
 /// Namespace for the AIDA detector description toolkit

--- a/DDDigi/src/DigiAction.cpp
+++ b/DDDigi/src/DigiAction.cpp
@@ -18,6 +18,7 @@
 
 // C/C++ include files
 #include <algorithm>
+#include <list>
 
 using namespace dd4hep::digi;
 

--- a/DDParsers/include/Evaluator/DD4hepUnits.h
+++ b/DDParsers/include/Evaluator/DD4hepUnits.h
@@ -27,8 +27,6 @@
 #ifndef EVALUATOR_DD4HEPUNITS_H
 #define EVALUATOR_DD4HEPUNITS_H
 
-#include "RVersion.h"
-
 /// Main dd4hep namespace. We must import here the ROOT TGeo units
 namespace dd4hep {
 

--- a/examples/ClientTests/src/Property_test.cpp
+++ b/examples/ClientTests/src/Property_test.cpp
@@ -18,6 +18,7 @@
 /// C/C++ include files
 #include <iostream>
 #include <deque>
+#include <list>
 
 using namespace dd4hep;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove headers that are not being used in the current file and add headers that are being used.

ENDRELEASENOTES

The removal is quite complete since they are marked by clangd and it's precise. For addition there are many places where something is being used but not being included in the current file - this is harder to add. Removing includes from header files helps reducing compile times a bit.