### PR TITLE
make timeout configurable in g4GraphicalScan

### DIFF
--- a/DDG4/python/bin/g4GraphicalScan.py
+++ b/DDG4/python/bin/g4GraphicalScan.py
@@ -280,7 +280,7 @@ if not noPilot:
     for cc in cmd:
         print(cc, end=' ')
     print('\n')
-    pilotresult = subprocess.run(cmd, capture_output=True, text=True, timeout=int(opt.timeOutValue))
+    pilotresult = subprocess.run(cmd, capture_output=True, text=True, timeout=int(opts.timeOutValue))
     print('done, checking pilot result')
     has_Material_scan_between = 0
     has_Finished_run = 0
@@ -301,7 +301,7 @@ if not noPilot:
 cmd = ['ddsim', '--compactFile', infileName, '--runType', 'run', '--enableG4Gun',
        '--action.step', 'Geant4MaterialScanner/MaterialScan', '-M', steerName]
 print('now running main ddsim job..this may take some time')
-result = subprocess.run(cmd, capture_output=True, text=True, timeout=int(opt.timeOutValue))
+result = subprocess.run(cmd, capture_output=True, text=True, timeout=int(opts.timeOutValue))
 #
 # parse the results
 #

--- a/DDG4/python/bin/g4GraphicalScan.py
+++ b/DDG4/python/bin/g4GraphicalScan.py
@@ -71,6 +71,10 @@ parser.add_option('-o', '--outputFile',
 parser.add_option("-P", "--noPilot",
                   action="store_true", dest="noPilot", default=False,
                   help="don't run the pilot job (e.g. if you're sure the geometry is good)")
+parser.add_option('-t', '--timeOut',
+                  dest='timeOutValue', default='600',
+                  help='Time-out for a single scan',
+                  metavar='<int>')
 
 (opts, args) = parser.parse_args()
 #
@@ -276,7 +280,7 @@ if not noPilot:
     for cc in cmd:
         print(cc, end=' ')
     print('\n')
-    pilotresult = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
+    pilotresult = subprocess.run(cmd, capture_output=True, text=True, timeout=int(opt.timeOutValue))
     print('done, checking pilot result')
     has_Material_scan_between = 0
     has_Finished_run = 0
@@ -297,7 +301,7 @@ if not noPilot:
 cmd = ['ddsim', '--compactFile', infileName, '--runType', 'run', '--enableG4Gun',
        '--action.step', 'Geant4MaterialScanner/MaterialScan', '-M', steerName]
 print('now running main ddsim job..this may take some time')
-result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+result = subprocess.run(cmd, capture_output=True, text=True, timeout=int(opt.timeOutValue))
 #
 # parse the results
 #

--- a/DDG4/python/bin/g4GraphicalScan.py
+++ b/DDG4/python/bin/g4GraphicalScan.py
@@ -73,7 +73,7 @@ parser.add_option("-P", "--noPilot",
                   help="don't run the pilot job (e.g. if you're sure the geometry is good)")
 parser.add_option('-t', '--timeOut',
                   dest='timeOutValue', default='600',
-                  help='Time-out for a single scan',
+                  help='Time-out for a single scan [in seconds]',
                   metavar='<int>')
 
 (opts, args) = parser.parse_args()


### PR DESCRIPTION
BEGINRELEASENOTES
- g4GraphicalScan: add option `-t` `--timeout` to make timeout configurable, fixes #1435 

ENDRELEASENOTES

I have marked this as WIP because I have not tested it yet.