### PR TITLE
Fix, Optical physics option invokeSD require poststep info only

### DIFF
--- a/DDG4/src/Geant4SensDetAction.cpp
+++ b/DDG4/src/Geant4SensDetAction.cpp
@@ -263,10 +263,7 @@ long long int Geant4Sensitive::volumeID(const G4VTouchable* touchable) {
 long long int Geant4Sensitive::cellID(const G4Step* step) {
   Geant4StepHandler h(step);
   Geant4VolumeManager volMgr = Geant4Mapping::instance().volumeManager();
-  bool OpticsInvokeSD = G4OpticalParameters::Instance()?
-                        G4OpticalParameters::Instance()->GetBoundaryInvokeSD() : false;
-  bool IsOpticalPhoton = step->GetTrack()->GetDefinition() == G4OpticalPhoton::Definition();
-  bool UsePostStepOnly = IsOpticalPhoton && OpticsInvokeSD;
+  bool UsePostStepOnly = G4OpticalParameters::Instance() && G4OpticalParameters::Instance()->GetBoundaryInvokeSD() && (step->GetTrack()->GetDefinition() == G4OpticalPhoton::Definition());
   VolumeID volID = volMgr.volumeID(UsePostStepOnly? h.postTouchable() : h.preTouchable());
   if ( m_segmentation.isValid() )  {
     std::exception_ptr eptr;


### PR DESCRIPTION
BEGINRELEASENOTES
- Modification of `Geant4Sensitive::cellID` base class function to handle properly the cases when the step corresponds to an optical photon and the option InvokeSD is enable, so only post-step information is used to calculate the volume/cell ID.

ENDRELEASENOTES

Hi,

I have tested it with ARC, and now it seems to work without errors. Is there any optical physics test that may cover the changes introduced in this PR? Also, is there any test that performs some kind of benchmarking? I am concerned about worsening the overall performance

Please let me know if you think this fix can be done in a better way.

If you think the fix is too specific for optical physics, alternatively we can patch the optical-related sensitive detector actions. I have tried with the optical tracker SD action, and it works.