### PR TITLE
fix: adopt properties of underlying Geant4GeneratorAction in Geant4SharedGeneratorAction

### DIFF
--- a/DDG4/src/Geant4GeneratorAction.cpp
+++ b/DDG4/src/Geant4GeneratorAction.cpp
@@ -59,6 +59,7 @@ void Geant4SharedGeneratorAction::configureFiber(Geant4Context* thread_context) 
 void Geant4SharedGeneratorAction::use(Geant4GeneratorAction* action)   {
   if (action) {
     action->addRef();
+    m_properties.adopt(action->properties());
     m_action = action;
     return;
   }


### PR DESCRIPTION
This PR addresses the issue outlined in https://github.com/AIDASoft/DD4hep/pull/1240#issuecomment-2749160918
> making the GeneratorAction shared with `DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=True)` fails because the properties (`Parameters`, `Input`) that are subsequently set are [...] not exposed to the GeneratorAction handle `gen`.

This PR brings the handling of the `Geant4SharedGeneratorAction` in line with other shared actions. With this PR, the following diff functions without runtime exceptions now.
```diff
diff --git a/DDG4/python/DDSim/DD4hepSimulation.py b/DDG4/python/DDSim/DD4hepSimulation.py
index 11ed0e83..9fe46eda 100644
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -390,11 +390,11 @@ class DD4hepSimulation(object):
         gen.Input = "Geant4EventReaderHepEvtLong|" + inputFile
       elif inputFile.endswith(tuple([".hepmc"] + HEPMC3_SUPPORTED_EXTENSIONS)):
         if self.hepmc3.useHepMC3:
-          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index)
+          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=True)
           gen.Parameters = self.hepmc3.getParameters()
           gen.Input = "HEPMC3FileReader|" + inputFile
         else:
-          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index)
+          gen = DDG4.GeneratorAction(kernel, "Geant4InputAction/hepmc%d" % index, shared=True)
           gen.Input = "Geant4EventReaderHepMC|" + inputFile
```

BEGINRELEASENOTES
- adopt properties of underlying Geant4GeneratorAction in Geant4SharedGeneratorAction

ENDRELEASENOTES