### PR TITLE
DDCore: drop RootHistDraw, no longer exists

### DIFF
--- a/DDCore/CMakeLists.txt
+++ b/DDCore/CMakeLists.txt
@@ -110,7 +110,7 @@ dd4hep_add_plugin(DDCorePlugins SOURCES src/plugins/*.cpp USES DDCore)
 # Graphics DDCore plugins---------------------------------------------------------
 dd4hep_add_plugin(DDCoreGraphics
   SOURCES src/graphics/*.cpp
-  USES DDCore ROOT::Core ROOT::Rint ROOT::Gui ROOT::Hist ROOT::HistPainter ROOT::ROOTHistDraw)
+  USES DDCore ROOT::Core ROOT::Rint ROOT::Gui ROOT::Hist ROOT::HistPainter)
 
 # This plugins depends on the ROOT GDML readers. Hence, extra library
 IF(TARGET ROOT::Gdml)


### PR DESCRIPTION
Target was dropped https://github.com/root-project/root/pull/18191
I want to see if we need it for older versions of ROOT.

BEGINRELEASENOTES
- CMake: drop use of ROOT:ROOTHistDraw

ENDRELEASENOTES