### PR TITLE
feat: allow event readers with pre-existing (Event,Run)Parameters

### DIFF
--- a/DDG4/edm4hep/EDM4hepFileReader.cpp
+++ b/DDG4/edm4hep/EDM4hepFileReader.cpp
@@ -148,7 +148,6 @@ namespace dd4hep::sim {
       } catch(std::invalid_argument&) {
         // we ignore if we do not have runs information
       }
-      context()->run().addExtension<RunParameters>(parameters);
     } catch(std::exception &e) {
       printout(ERROR,"EDM4hepFileReader::registerRunParameters","Failed to register run parameters: %s", e.what());
     }

--- a/DDG4/edm4hep/EDM4hepFileReader.cpp
+++ b/DDG4/edm4hep/EDM4hepFileReader.cpp
@@ -134,7 +134,12 @@ namespace dd4hep::sim {
 
   void EDM4hepFileReader::registerRunParameters() {
     try {
-      auto *parameters = new RunParameters();
+      // get RunParameters or create new if not existent yet
+      auto* parameters = context()->run().extension<RunParameters>(false);
+      if (!parameters) {
+        parameters = new RunParameters();
+        context()->run().addExtension<RunParameters>(parameters);
+      }
       try {
         podio::Frame runFrame = m_reader.readFrame("runs", 0);
         parameters->ingestParameters(runFrame.getParameters());

--- a/DDG4/hepmc/HepMC3FileReader.cpp
+++ b/DDG4/hepmc/HepMC3FileReader.cpp
@@ -146,9 +146,13 @@ HEPMC3FileReader::HEPMC3FileReader(const std::string& nam)
 
 void HEPMC3FileReader::registerRunParameters() {
   try {
-    auto *parameters = new RunParameters();
+    // get RunParameters or create new if not existent yet
+    auto *parameters = context()->run().extension<RunParameters>(false);
+    if (!parameters) {
+      parameters = new RunParameters();
+      context()->run().addExtension<RunParameters>(parameters);
+    }
     parameters->ingestParameters(*(m_reader->run_info()));
-    context()->run().addExtension<RunParameters>(parameters);
   } catch(std::exception &e) {
     printout(ERROR,"HEPMC3FileReader::registerRunParameters","Failed to register run parameters: %s", e.what());
   }
@@ -183,11 +187,15 @@ HEPMC3FileReader::readGenEvent(int /*event_number*/, HepMC3::GenEvent& genEvent)
     printout(INFO,"HEPMC3FileReader","Read event from file");
     // Create input event parameters context
     try {
+      // get EventParameters or create new if not existent yet
       Geant4Context* ctx = context();
-      EventParameters *parameters = new EventParameters();
+      auto* parameters = ctx->event().extension<EventParameters>(false);
+      if (!parameters) {
+        parameters = new EventParameters();
+        ctx->event().addExtension<EventParameters>(parameters);
+      }
       parameters->setEventNumber(genEvent.event_number());
       parameters->ingestParameters(genEvent);
-      ctx->event().addExtension<EventParameters>(parameters);
     }
     catch(std::exception &)
     {

--- a/DDG4/lcio/LCIOFileReader.cpp
+++ b/DDG4/lcio/LCIOFileReader.cpp
@@ -152,12 +152,16 @@ dd4hep::sim::LCIOFileReader::readParticleCollection(int /*event_number*/, EVENT:
       
       // Create input event parameters context
       try {
+        // get EventParameters or create new if not existent yet
         Geant4Context* ctx = context();
-        EventParameters *parameters = new EventParameters();
+        auto* parameters = ctx->event().extension<EventParameters>(false);
+        if (!parameters) {
+          parameters = new EventParameters();
+          ctx->event().addExtension<EventParameters>(parameters);
+        }
         parameters->setRunNumber(evt->getRunNumber());
         parameters->setEventNumber(evt->getEventNumber());
         parameters->ingestParameters(evt->parameters());
-        ctx->event().addExtension<EventParameters>(parameters);
       }
       catch(std::exception &) 
       {


### PR DESCRIPTION
In EIC we use a run action plugin to write additional information to the RunParameters. Due to the sequence in which the plugins are loaded, this only works when the event reader is loaded first since the current event reader fails when the (Event,Run)Parameters already exist. 

This PR makes the event readers work whether a (Event,Run)Parameters already exists or not. If the (Event,Run)Parameters already exist, they are added to.

BEGINRELEASENOTES
- DDG4: Allow event readers to work with pre-existing (Event,Run)Parameters, written by other plugins.

ENDRELEASENOTES