### PR TITLE
Geant4InputAction: add Alternative Stable Statuses to allow marking p…

### DIFF
--- a/DDG4/include/DDG4/Geant4InputAction.h
+++ b/DDG4/include/DDG4/Geant4InputAction.h
@@ -182,6 +182,9 @@ namespace dd4hep  {
       /// Property: set of alternative decay statuses that MC generators might use for unstable particles
       std::set<int> m_alternativeDecayStatuses = {};
 
+      /// Property: set of alternative stable statuses that MC generators might use for stable particles
+      std::set<int> m_alternativeStableStatuses = {};
+
       /// Perform some actions before the run starts, like opening the event inputs
       void beginRun(const G4Run*);
 

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -459,6 +459,7 @@ class DD4hepSimulation(object):
         # this should never happen because we already check at the top, but in case of some LogicError...
         raise RuntimeError("Unknown input file type: %s" % inputFile)
       gen.AlternativeDecayStatuses = self.physics.alternativeDecayStatuses
+      gen.AlternativeStableStatuses = self.physics.alternativeStableStatuses
       gen.Sync = self.skipNEvents
       gen.Mask = index
       actionList.append(gen)

--- a/DDG4/python/DDSim/Helper/Physics.py
+++ b/DDG4/python/DDSim/Helper/Physics.py
@@ -27,6 +27,7 @@ class Physics(ConfigHelper):
                         5101, 5103, 5201, 5203, 5301, 5303, 5401, 5403, 5503}  # b? diquarks
     self._zeroTimePDGs = {11, 13, 15, 17}
     self._alternativeDecayStatuses = set()
+    self._alternativeStableStatuses = set()
     self._userFunctions = []
     self._closeProperties()
     Physics.__doc__ += "\n\n" + self.setupUserPhysics.__doc__
@@ -64,6 +65,16 @@ class Physics(ConfigHelper):
   @alternativeDecayStatuses.setter
   def alternativeDecayStatuses(self, val):
     self._alternativeDecayStatuses = self.makeSet(val)
+
+  @property
+  def alternativeStableStatuses(self):
+    """Set of Generator Statuses that are used to mark stable particles that should be forwarded to Geant4.
+    """
+    return self._alternativeStableStatuses
+
+  @alternativeStableStatuses.setter
+  def alternativeStableStatuses(self, val):
+    self._alternativeStableStatuses = self.makeSet(val)
 
   @property
   def rangecut(self):

--- a/DDG4/src/Geant4InputAction.cpp
+++ b/DDG4/src/Geant4InputAction.cpp
@@ -126,6 +126,7 @@ Geant4InputAction::Geant4InputAction(Geant4Context* ctxt, const std::string& nam
   declareProperty("HaveAbort",      m_abort = true);
   declareProperty("Parameters",     m_parameters = {});
   declareProperty("AlternativeDecayStatuses", m_alternativeDecayStatuses = {});
+  declareProperty("AlternativeStableStatuses", m_alternativeStableStatuses = {});
   m_needsControl = true;
 
   runAction().callAtBegin(this, &Geant4InputAction::beginRun);
@@ -293,6 +294,7 @@ void Geant4InputAction::setGeneratorStatus(int genStatus, PropertyMask& status) 
   else if ( genStatus == 3 ) status.set(G4PARTICLE_GEN_DOCUMENTATION);
   else if ( genStatus == 4 ) status.set(G4PARTICLE_GEN_BEAM);
   else if ( m_alternativeDecayStatuses.count(genStatus) ) status.set(G4PARTICLE_GEN_DECAYED);
+  else if ( m_alternativeStableStatuses.count(genStatus) ) status.set(G4PARTICLE_GEN_STABLE);
   else
     status.set(G4PARTICLE_GEN_OTHER);
 


### PR DESCRIPTION
…articles as stable with statuses other than 1

These will be forwarded to Geant4 as stable particles

- [x] Testing needed

BEGINRELEASENOTES
- ddsim: add physics.alternativeStableStatus option to allow defining alternative stable status of MCParticles meant to be treated by Geant4, fixes #1446
ENDRELEASENOTES