### PR TITLE
Prevent new TColor allocation in VisAttr::color()

### DIFF
--- a/DDCore/src/Objects.cpp
+++ b/DDCore/src/Objects.cpp
@@ -380,7 +380,7 @@ int VisAttr::color() const {
 void VisAttr::setColor(float alpha, float red, float green, float blue) {
   Object& o  = object<Object>();
   const auto num_before = gROOT->GetListOfColors()->GetLast();
-  // Set tolerance high enough to always lookup from existing pallete. This
+  // Set tolerance high enough to always lookup from existing palette. This
   // helps to preserve colors when saving TGeo to .root files.
   TColor::SetColorThreshold(1.0f/31.0f);
   Int_t col  = TColor::GetColor(red, green, blue);

--- a/DDCore/src/Objects.cpp
+++ b/DDCore/src/Objects.cpp
@@ -379,7 +379,16 @@ int VisAttr::color() const {
 /// Set object color
 void VisAttr::setColor(float alpha, float red, float green, float blue) {
   Object& o  = object<Object>();
+  const auto num_before = gROOT->GetListOfColors()->GetLast();
+  // Set tolerance high enough to always lookup from existing pallete. This
+  // helps to preserve colors when saving TGeo to .root files.
+  TColor::SetColorThreshold(1.0f/31.0f);
   Int_t col  = TColor::GetColor(red, green, blue);
+  const auto num_after = gROOT->GetListOfColors()->GetLast();
+  if (num_before != num_after) {
+    printout(WARNING,"VisAttr","+++ %s Allocated a Color: r:%02X g:%02X b:%02X, this will not save to a ROOT file",
+	     this->name(), int(red*255.), int(green*255.), int(blue*255));
+  }
   o.alpha    = alpha;
   o.color    = gROOT->GetColor(col);
   if ( !o.color )    {


### PR DESCRIPTION
We are observing a regression when using geoConvert (and a similar private tool) to do TGeo export.
### Expected:
![image](https://github.com/user-attachments/assets/a6f59eae-3348-4652-b6d7-b606fc9df1c0)
### Actual:
![image](https://github.com/user-attachments/assets/040cb78b-f7cc-4b84-a4e7-e1a682f8307c)
(certain color replaced with black)

This traces to an upstream change https://github.com/root-project/root/pull/14063.
It appears that after this change many of our colors will get allocated as new instead of being picked from the pallete. They will still work in teveDisplay and geoDisplay, but not when saving to file (to show in JSROOT or other display).

BEGINRELEASENOTES
- Fix a regression with certain colors not saved to .root files when using ROOT 6.32.0+.

ENDRELEASENOTES