### PR TITLE
Gcc15 bind

### DIFF
--- a/DDCore/include/DD4hep/OpaqueData.h
+++ b/DDCore/include/DD4hep/OpaqueData.h
@@ -184,8 +184,12 @@ namespace dd4hep {
 
   /// Initializing constructor binding data to buffer with move
   template <typename OBJECT> OpaqueDataBlock::OpaqueDataBlock(OBJECT&& obj)    {
+#if __cplusplus >= 202302L
+    bind(std::move(obj));
+#else
     this->bind(&BasicGrammar::instance<OBJECT>());
     new(this->pointer) OBJECT(std::move(obj));
+#endif
   }
 
   /// Construct conditions object and bind the data

--- a/DDCore/src/Objects.cpp
+++ b/DDCore/src/Objects.cpp
@@ -386,7 +386,7 @@ void VisAttr::setColor(float alpha, float red, float green, float blue) {
   Int_t col  = TColor::GetColor(red, green, blue);
   const auto num_after = gROOT->GetListOfColors()->GetLast();
   if (num_before != num_after) {
-    printout(WARNING,"VisAttr","+++ %s Allocated a Color: r:%02X g:%02X b:%02X, this will not save to a ROOT file",
+    printout(INFO,"VisAttr","+++ %s Allocated a Color: r:%02X g:%02X b:%02X, this will not save to a ROOT file",
 	     this->name(), int(red*255.), int(green*255.), int(blue*255));
   }
   o.alpha    = alpha;


### PR DESCRIPTION
BEGINRELEASENOTES
- Objects: change printout for color creation from WARNING to INFO (fixup for #1449)
- OpaqueData: fix compilation error with c++23 and gcc15. 


ENDRELEASENOTES

```[ 31%] Building CXX object DDCore/CMakeFiles/DDCore.dir/G__DD4hepGeo.cxx.o
In file included from /build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/Conditions.h:19,
                 from /build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/Alignments.h:19,
                 from /build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/DetElement.h:22,
                 from /build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/AlignmentData.h:18,
                 from /build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep-master-build/DDCore/G__DD4hep.cxx:38:
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/OpaqueData.h: In instantiation of 'dd4hep::OpaqueDataBlock::OpaqueDataBlock(OBJECT&&) [with OBJECT = dd4hep::OpaqueDataBlock&]':
/cvmfs/sft.cern.ch/lcg/releases/gcc/15.1.0-5b2b0/x86_64-el9/include/c++/15.1.0/bits/stl_pair.h:514:22:   required from 'constexpr std::pair<_T1, _T2>::pair(std::pair<_U1, _U2>&) [with _U1 = const std::__cxx11::basic_string<char>; _U2 = dd4hep::OpaqueDataBlock; _T1 = const std::__cxx11::basic_string<char>; _T2 = dd4hep::OpaqueDataBlock]'
  514 |         : first(__p.first), second(__p.second)
      |                             ^~~~~~~~~~~~~~~~~~
/build/jenkins/workspace/lcg_nightly_pipeline/install/dev3/ROOT/HEAD/x86_64-el9-gcc15-dbg/include/TCollectionProxyInfo.h:346:13:   required from 'static void* ROOT::Detail::TCollectionProxyInfo::Type<T>::collect(void*, void*) [with T = std::map<std::__cxx11::basic_string<char>, dd4hep::OpaqueDataBlock>]'
  346 |             ::new(m) Value_t(*i);
      |             ^~~~~~~~~~~~~~~~~~~~
/build/jenkins/workspace/lcg_nightly_pipeline/install/dev3/ROOT/HEAD/x86_64-el9-gcc15-dbg/include/TCollectionProxyInfo.h:573:17:   required from 'static ROOT::Detail::TCollectionProxyInfo* ROOT::Detail::TCollectionProxyInfo::Generate(const T&) [with T = MapInsert<std::map<std::__cxx11::basic_string<char>, dd4hep::OpaqueDataBlock> >]'
  573 |          return new TCollectionProxyInfo(typeid(TYPENAME T::Cont_t),
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  574 |                                                sizeof(TYPENAME T::Iter_t),
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  575 |                                                (((char*)&p->second)-((char*)&p->first)),
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  576 |                                                T::value_offset(),
      |                                                ~~~~~~~~~~~~~~~~~~
  577 |                                                T::size,
      |                                                ~~~~~~~~
  578 |                                                T::resize,
      |                                                ~~~~~~~~~~
  579 |                                                T::clear,
      |                                                ~~~~~~~~~
  580 |                                                T::first,
      |                                                ~~~~~~~~~
  581 |                                                T::next,
      |                                                ~~~~~~~~
  582 |                                                T::construct,
      |                                                ~~~~~~~~~~~~~
  583 |                                                T::destruct,
      |                                                ~~~~~~~~~~~~
  584 |                                                T::feed,
      |                                                ~~~~~~~~
  585 |                                                T::collect,
      |                                                ~~~~~~~~~~~
  586 |                                                T::Env_t::Create,
      |                                                ~~~~~~~~~~~~~~~~~
  587 |                                                T::Iterators_t::create,
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~
  588 |                                                T::Iterators_t::copy,
      |                                                ~~~~~~~~~~~~~~~~~~~~~
  589 |                                                T::Iterators_t::next,
      |                                                ~~~~~~~~~~~~~~~~~~~~~
  590 |                                                T::Iterators_t::destruct1,
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~
  591 |                                                T::Iterators_t::destruct2);
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep-master-build/DDCore/G__DD4hep.cxx:9746:71:   required from here
 9746 |       instance.AdoptCollectionProxyInfo(TCollectionProxyInfo::Generate(TCollectionProxyInfo::MapInsert< map<string,dd4hep::OpaqueDataBlock> >()));
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/jenkins/workspace/lcg_nightly_pipeline/build/frameworks/DD4hep-master/src/DD4hep/master/DDCore/include/DD4hep/OpaqueData.h:188:5: error: new cannot be applied to a reference type
  188 |     new(this->pointer) OBJECT(std::move(obj));
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```