### PR TITLE
CI: add gcc15 dbg dev3 builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,7 +63,7 @@ jobs:
               -DBUILD_TESTING=ON \
               -DDD4HEP_DEBUG_CMAKE=ON \
               -DDD4HEP_USE_XERCESC=ON \
-              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_BUILD_TYPE=Debug \
               -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_STANDARD=23 ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,7 @@ jobs:
               "LCG_106/x86_64-el9-gcc13-opt",  # g4 11
               "dev3/x86_64-el9-gcc13-opt",
               "dev3/x86_64-el9-clang16-opt",          # g4 11
+              "dev3/x86_64-el9-gcc15-dbg",
               "dev4/x86_64-el9-gcc13-opt"]
     steps:
     - uses: actions/checkout@v4
@@ -49,7 +50,24 @@ jobs:
               -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_STANDARD=20 ..
-            else
+          elif [[ ${{ matrix.LCG }} =~ gcc15 ]]; then
+            echo "::group::CMakeConfig C++23"
+            cmake -GNinja \
+              -DDD4HEP_USE_GEANT4=ON \
+              -DBoost_NO_BOOST_CMAKE=ON \
+              -DDD4HEP_USE_LCIO=ON \
+              -DDD4HEP_USE_EDM4HEP=OFF \
+              -DDD4HEP_USE_TBB=ON \
+              -DDD4HEP_USE_HEPMC3=ON \
+              -DDD4HEP_BUILD_DEBUG=OFF \
+              -DBUILD_TESTING=ON \
+              -DDD4HEP_DEBUG_CMAKE=ON \
+              -DDD4HEP_USE_XERCESC=ON \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_STANDARD=23 ..
+          else
               echo "::group::CMakeConfig C++17"
               cmake -GNinja \
                 -DDD4HEP_USE_GEANT4=ON \


### PR DESCRIPTION
This adds builds using the Debug build mode, since there were errors triggered in the tests when DD4hep was build with Debug mode. Probably this is slower than the other instances of the CI builds.
To be seen and decided.

Also should decide which older builds to drop.