### PR TITLE
TGeoTrd1 generic surfaces

### DIFF
--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -1059,52 +1059,51 @@ namespace dd4hep {
           bool isXZ = std::fabs(  ln.y() - 1.0 ) < epsilon  ; // normal parallel to y
           bool isXY = std::fabs(  ln.z() - 1.0 ) < epsilon  ; // normal parallel to z
 	  
-          if( isYZ || isXZ || isXY ) {  // plane is parallel to one of the trapezoid' sides -> need 4 vertices from box dimensions
-	    
-            Vector3D ubl, vbl;
+					if(not (isYZ || isXZ || isXY)) {
+					   std::stringstream sst ; 
+					   sst << " ***** ERROR: Trapezoid surface cannot be defined, normal not parallel to x, y, or z axis";
+					   throw std::runtime_error( sst.str() ) ;
+					}
+					
+					Vector3D ubl, vbl;
 
-            if(isYZ) {
-              ubl.fill( 0., 1., 0. ) ;
-              vbl.fill( 0., 0., 1. ) ;
-            } else if( isXZ ) {
-              ubl.fill( 1., 0., 0. ) ;
-              vbl.fill( 0., 0., 1. ) ;        
-            } else if( isXY ) {
-              ubl.fill( 1., 0., 0. ) ;
-              vbl.fill( 0., 1., 0. ) ;
-            } 
+					if(isYZ) {
+						ubl.fill( 0., 1., 0. ) ;
+						vbl.fill( 0., 0., 1. ) ;
+					} else if( isXZ ) {
+						ubl.fill( 1., 0., 0. ) ;
+						vbl.fill( 0., 0., 1. ) ;        
+					} else if( isXY ) {
+						ubl.fill( 1., 0., 0. ) ;
+						vbl.fill( 0., 1., 0. ) ;
+					} 
 
-            Vector3D ub ;
-            Vector3D vb ;
-            _wtM->LocalToMasterVect( ubl , ub.array() ) ;
-            _wtM->LocalToMasterVect( vbl , vb.array() ) ;
-	    
-            //the trapezoid is drawn as a set of four lines connecting its four corners
-            lines.reserve(4) ;
-            //_o is vector to the origin
+					Vector3D ub ;
+					Vector3D vb ;
+					_wtM->LocalToMasterVect( ubl , ub.array() ) ;
+					_wtM->LocalToMasterVect( vbl , vb.array() ) ;
+		
+					//the trapezoid is drawn as a set of four lines connecting its four corners
+					lines.reserve(4) ;
+					//_o is vector to the origin
 
-            if( isYZ ) {
-              lines.emplace_back( _o + dy * ub  - dz * vb ,  _o + dy * ub  + dz * vb);
-              lines.emplace_back( _o + dy * ub  + dz * vb ,  _o - dy * ub  + dz * vb);
-              lines.emplace_back( _o - dy * ub  + dz * vb ,  _o - dy * ub  - dz * vb);
-              lines.emplace_back( _o - dy * ub  - dz * vb ,  _o + dy * ub  - dz * vb);	      
-            } else if( isXZ ) {
-              lines.emplace_back( _o + dx1 * ub  - dz * vb ,  _o + dx2 * ub  + dz * vb);
-              lines.emplace_back( _o + dx2 * ub  + dz * vb ,  _o - dx2 * ub  + dz * vb);
-              lines.emplace_back( _o - dx2 * ub  + dz * vb ,  _o - dx1 * ub  - dz * vb);
-              lines.emplace_back( _o - dx1 * ub  - dz * vb ,  _o + dx1 * ub  - dz * vb);	      
-            } else if( isXY ) {
-              lines.emplace_back( _o + dx1 * ub  - dy * vb ,  _o + dx2 * ub  + dy * vb);
-              lines.emplace_back( _o + dx2 * ub  + dy * vb ,  _o - dx2 * ub  + dy * vb);
-              lines.emplace_back( _o - dx2 * ub  + dy * vb ,  _o - dx1 * ub  - dy * vb);
-              lines.emplace_back( _o - dx1 * ub  - dy * vb ,  _o + dx1 * ub  - dy * vb);	      
-            }
-            return lines ;
-          }	
-          else{
-            std::stringstream sst ; sst << " ***** ERROR: Trapezoid surface cannot be defined, normal not parallel to x, y, or z axis";
-            throw std::runtime_error( sst.str() ) ;
-          }          
+					if( isYZ ) {
+						lines.emplace_back( _o + dy * ub  - dz * vb ,  _o + dy * ub  + dz * vb);
+						lines.emplace_back( _o + dy * ub  + dz * vb ,  _o - dy * ub  + dz * vb);
+						lines.emplace_back( _o - dy * ub  + dz * vb ,  _o - dy * ub  - dz * vb);
+						lines.emplace_back( _o - dy * ub  - dz * vb ,  _o + dy * ub  - dz * vb);	      
+					} else if( isXZ ) {
+						lines.emplace_back( _o + dx1 * ub  - dz * vb ,  _o + dx2 * ub  + dz * vb);
+						lines.emplace_back( _o + dx2 * ub  + dz * vb ,  _o - dx2 * ub  + dz * vb);
+						lines.emplace_back( _o - dx2 * ub  + dz * vb ,  _o - dx1 * ub  - dz * vb);
+						lines.emplace_back( _o - dx1 * ub  - dz * vb ,  _o + dx1 * ub  - dz * vb);	      
+					} else if( isXY ) {
+						lines.emplace_back( _o + dx1 * ub  - dy * vb ,  _o + dx2 * ub  + dy * vb);
+						lines.emplace_back( _o + dx2 * ub  + dy * vb ,  _o - dx2 * ub  + dy * vb);
+						lines.emplace_back( _o - dx2 * ub  + dy * vb ,  _o - dx1 * ub  - dy * vb);
+						lines.emplace_back( _o - dx1 * ub  - dy * vb ,  _o + dx1 * ub  - dy * vb);	      
+					}
+					return lines ;
         }
         //added code by Thorben Quast for simplified set of lines for trapezoids with unequal lengths in x AND y
         else if(shape->IsA() == TGeoTrd2::Class()){

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -1062,28 +1062,18 @@ namespace dd4hep {
 	  
           if( isYZ || isXZ || isXY ) {  // plane is parallel to one of the trapezoid' sides -> need 4 vertices from box dimensions
 	    
-            // if isYZ :
-            unsigned uidx = 1 ;
-            unsigned vidx = 2 ;
-	    
-            Vector3D ubl(  0., 1., 0. ) ; 
-            Vector3D vbl(  0., 0., 1. ) ;
-	    
-            if( isXZ ) {
-	      
-              ubl.fill( 1., 0., 0. ) ;
-              vbl.fill( 0., 0., 1. ) ;
-              uidx = 0 ;
-              vidx = 2 ;
+            Vector3D ubl, vbl;
 
-              
+            if(isYZ) {
+              ubl.fill( 0., 1., 0. ) ;
+              vbl.fill( 0., 0., 1. ) ;
+            } else if( isXZ ) {
+              ubl.fill( 1., 0., 0. ) ;
+              vbl.fill( 0., 0., 1. ) ;        
             } else if( isXY ) {
-	      
               ubl.fill( 1., 0., 0. ) ;
               vbl.fill( 0., 1., 0. ) ;
-              uidx = 0 ;
-              vidx = 1 ;
-            }
+            } 
 
             Vector3D ub ;
             Vector3D vb ;
@@ -1095,11 +1085,11 @@ namespace dd4hep {
             //_o is vector to the origin
 
             if( isYZ ) {
-              lines.emplace_back( _o + dx1 * ub  - dz * vb ,  _o + dx2 * ub  + dz * vb);
-              lines.emplace_back( _o + dx2 * ub  + dz * vb ,  _o - dx2 * ub  + dz * vb);
-              lines.emplace_back( _o - dx2 * ub  + dz * vb ,  _o - dx1 * ub  - dz * vb);
-              lines.emplace_back( _o - dx1 * ub  - dz * vb ,  _o + dx1 * ub  - dz * vb);	      
-            } else if( isXZ ) { // not yet correct
+              lines.emplace_back( _o + dy * ub  - dz * vb ,  _o + dy * ub  + dz * vb);
+              lines.emplace_back( _o + dy * ub  + dz * vb ,  _o - dy * ub  + dz * vb);
+              lines.emplace_back( _o - dy * ub  + dz * vb ,  _o - dy * ub  - dz * vb);
+              lines.emplace_back( _o - dy * ub  - dz * vb ,  _o + dy * ub  - dz * vb);	      
+            } else if( isXZ ) {
               lines.emplace_back( _o + dx1 * ub  - dz * vb ,  _o + dx2 * ub  + dz * vb);
               lines.emplace_back( _o + dx2 * ub  + dz * vb ,  _o - dx2 * ub  + dz * vb);
               lines.emplace_back( _o - dx2 * ub  + dz * vb ,  _o - dx1 * ub  - dz * vb);
@@ -1112,6 +1102,10 @@ namespace dd4hep {
             }
             return lines ;
           }	
+          else{
+            std::stringstream sst ; sst << " ***** ERROR: Trapezoid surface cannot be defined, normal not parallel to x, y, or z axis";
+            throw std::runtime_error( sst.str() ) ;
+          }          
         }
         //added code by Thorben Quast for simplified set of lines for trapezoids with unequal lengths in x AND y
         else if(shape->IsA() == TGeoTrd2::Class()){

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -1055,7 +1055,6 @@ namespace dd4hep {
 
 
           
-          // Code added by armin
           bool isYZ = std::fabs(  ln.x() - 1.0 ) < epsilon  ; // normal parallel to x
           bool isXZ = std::fabs(  ln.y() - 1.0 ) < epsilon  ; // normal parallel to y
           bool isXY = std::fabs(  ln.z() - 1.0 ) < epsilon  ; // normal parallel to z

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -1053,8 +1053,6 @@ namespace dd4hep {
           double dy = trapezoid->GetDy();
           double dz = trapezoid->GetDz();
 
-
-          
           bool isYZ = std::fabs(  ln.x() - 1.0 ) < epsilon  ; // normal parallel to x
           bool isXZ = std::fabs(  ln.y() - 1.0 ) < epsilon  ; // normal parallel to y
           bool isXY = std::fabs(  ln.z() - 1.0 ) < epsilon  ; // normal parallel to z
@@ -1082,7 +1080,6 @@ namespace dd4hep {
           Vector3D vb ;
           _wtM->LocalToMasterVect( ubl , ub.array() ) ;
           _wtM->LocalToMasterVect( vbl , vb.array() ) ;
-          
           //the trapezoid is drawn as a set of four lines connecting its four corners
           lines.reserve(4) ;
           //_o is vector to the origin

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -1059,51 +1059,51 @@ namespace dd4hep {
           bool isXZ = std::fabs(  ln.y() - 1.0 ) < epsilon  ; // normal parallel to y
           bool isXY = std::fabs(  ln.z() - 1.0 ) < epsilon  ; // normal parallel to z
 	  
-					if(not (isYZ || isXZ || isXY)) {
-					   std::stringstream sst ; 
-					   sst << " ***** ERROR: Trapezoid surface cannot be defined, normal not parallel to x, y, or z axis";
-					   throw std::runtime_error( sst.str() ) ;
-					}
-					
-					Vector3D ubl, vbl;
+          if(not (isYZ || isXZ || isXY)) {
+            std::stringstream sst ; 
+            sst << " ***** ERROR: Trapezoid surface cannot be defined, normal not parallel to x, y, or z axis";
+            throw std::runtime_error( sst.str() ) ;
+          }
+          
+          Vector3D ubl, vbl;
 
-					if(isYZ) {
-						ubl.fill( 0., 1., 0. ) ;
-						vbl.fill( 0., 0., 1. ) ;
-					} else if( isXZ ) {
-						ubl.fill( 1., 0., 0. ) ;
-						vbl.fill( 0., 0., 1. ) ;        
-					} else if( isXY ) {
-						ubl.fill( 1., 0., 0. ) ;
-						vbl.fill( 0., 1., 0. ) ;
-					} 
-
-					Vector3D ub ;
-					Vector3D vb ;
-					_wtM->LocalToMasterVect( ubl , ub.array() ) ;
-					_wtM->LocalToMasterVect( vbl , vb.array() ) ;
-		
-					//the trapezoid is drawn as a set of four lines connecting its four corners
-					lines.reserve(4) ;
-					//_o is vector to the origin
-
-					if( isYZ ) {
-						lines.emplace_back( _o + dy * ub  - dz * vb ,  _o + dy * ub  + dz * vb);
-						lines.emplace_back( _o + dy * ub  + dz * vb ,  _o - dy * ub  + dz * vb);
-						lines.emplace_back( _o - dy * ub  + dz * vb ,  _o - dy * ub  - dz * vb);
-						lines.emplace_back( _o - dy * ub  - dz * vb ,  _o + dy * ub  - dz * vb);	      
-					} else if( isXZ ) {
-						lines.emplace_back( _o + dx1 * ub  - dz * vb ,  _o + dx2 * ub  + dz * vb);
-						lines.emplace_back( _o + dx2 * ub  + dz * vb ,  _o - dx2 * ub  + dz * vb);
-						lines.emplace_back( _o - dx2 * ub  + dz * vb ,  _o - dx1 * ub  - dz * vb);
-						lines.emplace_back( _o - dx1 * ub  - dz * vb ,  _o + dx1 * ub  - dz * vb);	      
-					} else if( isXY ) {
-						lines.emplace_back( _o + dx1 * ub  - dy * vb ,  _o + dx2 * ub  + dy * vb);
-						lines.emplace_back( _o + dx2 * ub  + dy * vb ,  _o - dx2 * ub  + dy * vb);
-						lines.emplace_back( _o - dx2 * ub  + dy * vb ,  _o - dx1 * ub  - dy * vb);
-						lines.emplace_back( _o - dx1 * ub  - dy * vb ,  _o + dx1 * ub  - dy * vb);	      
-					}
-					return lines ;
+          if(isYZ) {
+            ubl.fill( 0., 1., 0. ) ;
+            vbl.fill( 0., 0., 1. ) ;
+          } else if( isXZ ) {
+            ubl.fill( 1., 0., 0. ) ;
+            vbl.fill( 0., 0., 1. ) ;        
+          } else if( isXY ) {
+            ubl.fill( 1., 0., 0. ) ;
+            vbl.fill( 0., 1., 0. ) ;
+          } 
+          
+          Vector3D ub ;
+          Vector3D vb ;
+          _wtM->LocalToMasterVect( ubl , ub.array() ) ;
+          _wtM->LocalToMasterVect( vbl , vb.array() ) ;
+          
+          //the trapezoid is drawn as a set of four lines connecting its four corners
+          lines.reserve(4) ;
+          //_o is vector to the origin
+          
+          if( isYZ ) {
+            lines.emplace_back( _o + dy * ub  - dz * vb ,  _o + dy * ub  + dz * vb);
+            lines.emplace_back( _o + dy * ub  + dz * vb ,  _o - dy * ub  + dz * vb);
+            lines.emplace_back( _o - dy * ub  + dz * vb ,  _o - dy * ub  - dz * vb);
+            lines.emplace_back( _o - dy * ub  - dz * vb ,  _o + dy * ub  - dz * vb);	      
+          } else if( isXZ ) {
+            lines.emplace_back( _o + dx1 * ub  - dz * vb ,  _o + dx2 * ub  + dz * vb);
+            lines.emplace_back( _o + dx2 * ub  + dz * vb ,  _o - dx2 * ub  + dz * vb);
+            lines.emplace_back( _o - dx2 * ub  + dz * vb ,  _o - dx1 * ub  - dz * vb);
+            lines.emplace_back( _o - dx1 * ub  - dz * vb ,  _o + dx1 * ub  - dz * vb);	      
+          } else if( isXY ) {
+            lines.emplace_back( _o + dx1 * ub  - dy * vb ,  _o + dx2 * ub  + dy * vb);
+            lines.emplace_back( _o + dx2 * ub  + dy * vb ,  _o - dx2 * ub  + dy * vb);
+            lines.emplace_back( _o - dx2 * ub  + dy * vb ,  _o - dx1 * ub  - dy * vb);
+            lines.emplace_back( _o - dx1 * ub  - dy * vb ,  _o + dx1 * ub  - dy * vb);	      
+          }
+          return lines ;
         }
         //added code by Thorben Quast for simplified set of lines for trapezoids with unequal lengths in x AND y
         else if(shape->IsA() == TGeoTrd2::Class()){


### PR DESCRIPTION
This MR is to have surfaces for TGeoTrd1's that are not in y direction. This is needed for an update of the detailed vertex barrel constructor (upcoming MR in k4geo), which describes curved layers by segments of TGeoTrd1 trapezoidals.

BEGINRELEASENOTES
- Enable surfaces of TGeoTrd1 with normal vectors that are not pointing in y direction
ENDRELEASENOTES