### PR TITLE
fix: avoid exit codes in thisdd4hep.sh for `set -e` support

### DIFF
--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -34,7 +34,7 @@ dd4hep_add_path()   {
     local path_prefix=${2}
     eval path_value=\$$path_name
     # Prevent duplicates
-    path_value=`echo ${path_value} | tr : '\n' | grep -v "^${path_prefix}$" | tr '\n' : | sed 's|:$||'`
+    path_value=`echo ${path_value} | tr : '\n' | (grep -v "^${path_prefix}$" || true) | tr '\n' : | sed 's|:$||'`
     path_value="${path_prefix}${path_value:+:${path_value}}"
     eval export ${path_name}='${path_value}'
     unset path_value

--- a/cmake/thisdd4hep_only.sh
+++ b/cmake/thisdd4hep_only.sh
@@ -36,7 +36,7 @@ dd4hep_add_path()   {
     local path_prefix=${2}
     eval path_value=\$$path_name
     # Prevent duplicates
-    path_value=`echo ${path_value} | tr : '\n' | grep -v "^${path_prefix}$" | tr '\n' : | sed 's|:$||'`
+    path_value=`echo ${path_value} | tr : '\n' | (grep -v "^${path_prefix}$" || true) | tr '\n' : | sed 's|:$||'`
     path_value="${path_prefix}${path_value:+:${path_value}}"
     eval export ${path_name}='${path_value}'
     unset path_value


### PR DESCRIPTION

BEGINRELEASENOTES
- Wrap calls to grep in thisdd4hep.sh to make it source'able in scripts with `set -e`

ENDRELEASENOTES

Edge case is when $path_prefix is already in $path_value:
```output
# echo a | grep -v a; echo $?
1
```
if there is another path it just works
```
# (echo a; echo b) | grep -v a; echo $?
b
0
```