### PR TITLE
Add run level metadata to output from edm4hep output plugin

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -83,6 +83,9 @@ namespace dd4hep {
       intmap_t                      m_eventParametersInt;
       floatmap_t                    m_eventParametersFloat;
       stringmap_t                   m_eventParametersString;
+      stringmap_t                   m_runParametersInt;
+      stringmap_t                   m_runParametersFloat;
+      stringmap_t                   m_runParametersString;
       stringmap_t                   m_cellIDEncodingStrings{};
       std::string                   m_section_name      { "events" };
       int                           m_runNo             { 0 };
@@ -251,6 +254,9 @@ Geant4Output2EDM4hep::Geant4Output2EDM4hep(Geant4Context* ctxt, const std::strin
   declareProperty("EventParametersInt",    m_eventParametersInt);
   declareProperty("EventParametersFloat",  m_eventParametersFloat);
   declareProperty("EventParametersString", m_eventParametersString);
+  declareProperty("RunParametersInt",      m_runParametersInt);
+  declareProperty("RunParametersFloat",    m_runParametersFloat);
+  declareProperty("RunParametersString",   m_runParametersString);
   declareProperty("RunNumberOffset",       m_runNumberOffset);
   declareProperty("EventNumberOffset",     m_eventNumberOffset);
   declareProperty("SectionName",           m_section_name);

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -83,8 +83,8 @@ namespace dd4hep {
       intmap_t                      m_eventParametersInt;
       floatmap_t                    m_eventParametersFloat;
       stringmap_t                   m_eventParametersString;
-      stringmap_t                   m_runParametersInt;
-      stringmap_t                   m_runParametersFloat;
+      intmap_t                      m_runParametersInt;
+      floatmap_t                    m_runParametersFloat;
       stringmap_t                   m_runParametersString;
       stringmap_t                   m_cellIDEncodingStrings{};
       std::string                   m_section_name      { "events" };

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -350,6 +350,15 @@ void Geant4Output2EDM4hep::saveRun(const G4Run* run)   {
   for (const auto& [key, value] : m_runHeader)
     runHeader.putParameter(key, value);
 
+  for (const auto& [key, value] : m_runParametersInt)
+    runHeader.putParameter(key, value);
+
+  for (const auto& [key, value] : m_runParametersFloat)
+    runHeader.putParameter(key, value);
+
+  for (const auto& [key, value] : m_runParametersString)
+    runHeader.putParameter(key, value);
+
   m_runNo = m_runNumberOffset > 0 ? m_runNumberOffset + run->GetRunID() : run->GetRunID();
   runHeader.putParameter("runNumber", m_runNo);
   runHeader.putParameter("GEANT4Version", G4Version);

--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -40,25 +40,25 @@ class Meta(ConfigHelper):
     for string, int and float parameters
     """
     stringParameters, intParameters, floatParameters, allParameters = {}, {}, {}, []
-    metaParameters = self.eventParameters if parameterType == "event" else self.runParameters
-    for p in metaParameters:
+    
+    for p in getattr(self, parameterType+"Parameters", []):
       parameterAndValue = p.split("=", 1)
       if len(parameterAndValue) != 2:
-        raise SyntaxError("ERROR: Couldn't decode event parameter '%s'" % (p))
+        raise SyntaxError("ERROR: Couldn't decode %s parameter '%s'" % (parameterType, p))
       parameterAndType = parameterAndValue[0].split("/", 1)
       if len(parameterAndType) != 2:
-        raise SyntaxError("ERROR: Couldn't decode event parameter '%s'" % (p))
+        raise SyntaxError("ERROR: Couldn't decode %s parameter '%s'" % (parameterType, p))
       pname = parameterAndType[0]
       ptype = parameterAndType[1]
       pvalue = parameterAndValue[1]
       if ptype.lower() not in ["c", "f", "i"]:
-        raise ValueError("ERROR: Event parameter '%s' with invalid type '%s'" % (pname, ptype))
+        raise ValueError("ERROR: %s parameter '%s' with invalid type '%s'" % (parameterType, pname, ptype))
       if pname in allParameters:
-        raise RuntimeError("ERROR: Event parameter '%s' specified twice" % (pname))
+        raise RuntimeError("ERROR: %s parameter '%s' specified twice" % (parameterType, pname))
       if not pvalue:
-        raise RuntimeError("ERROR: Event parameter '%s' has empty value" % (pname))
+        raise RuntimeError("ERROR: %s parameter '%s' has empty value" % (parameterType, pname))
       allParameters.append(pname)
-      logger.info("Event parameter '%s', type '%s', value='%s'" % (pname, ptype, pvalue))
+      logger.info("%s parameter '%s', type '%s', value='%s'" % (parameterType, pname, ptype, pvalue))
       if ptype.lower() == "c":
         stringParameters[pname] = pvalue
       elif ptype.lower() == "f":

--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -34,13 +34,14 @@ class Meta(ConfigHelper):
     self.eventNumberOffset = 0
     # no closeProperties, allow adding arbitrary information to runHeader
 
-  def parseEventParameters(self):
+  def parseMetaParameters(self, parameterType="event"):
     """
     Parse the event parameters and return 3 event parameter dictionaries, respectively
     for string, int and float parameters
     """
     stringParameters, intParameters, floatParameters, allParameters = {}, {}, {}, []
-    for p in self.eventParameters:
+    metaParameters = self.eventParameters if parameterType == "event" else self.runParameters
+    for p in metaParameters:
       parameterAndValue = p.split("=", 1)
       if len(parameterAndValue) != 2:
         raise SyntaxError("ERROR: Couldn't decode event parameter '%s'" % (p))
@@ -58,38 +59,6 @@ class Meta(ConfigHelper):
         raise RuntimeError("ERROR: Event parameter '%s' has empty value" % (pname))
       allParameters.append(pname)
       logger.info("Event parameter '%s', type '%s', value='%s'" % (pname, ptype, pvalue))
-      if ptype.lower() == "c":
-        stringParameters[pname] = pvalue
-      elif ptype.lower() == "f":
-        floatParameters[pname] = pvalue
-      elif ptype.lower() == "i":
-        intParameters[pname] = pvalue
-    return stringParameters, intParameters, floatParameters
-
-  def parseRunParameters(self):
-    """
-    Parse the run parameters and return 3 run parameter dictionaries, respectively
-    for string, int and float parameters
-    """
-    stringParameters, intParameters, floatParameters, allParameters = {}, {}, {}, []
-    for p in self.runParameters:
-      parameterAndValue = p.split("=", 1)
-      if len(parameterAndValue) != 2:
-        raise SyntaxError("ERROR: Couldn't decode run parameter '%s'" % (p))
-      parameterAndType = parameterAndValue[0].split("/", 1)
-      if len(parameterAndType) != 2:
-        raise SyntaxError("ERROR: Couldn't decode run parameter '%s'" % (p))
-      pname = parameterAndType[0]
-      ptype = parameterAndType[1]
-      pvalue = parameterAndValue[1]
-      if ptype.lower() not in ["c", "f", "i"]:
-        raise ValueError("ERROR: Run parameter '%s' with invalid type '%s'" % (pname, ptype))
-      if pname in allParameters:
-        raise RuntimeError("ERROR: Run parameter '%s' specified twice" % (pname))
-      if not pvalue:
-        raise RuntimeError("ERROR: Run parameter '%s' has empty value" % (pname))
-      allParameters.append(pname)
-      logger.info("Run parameter '%s', type '%s', value='%s'" % (pname, ptype, pvalue))
       if ptype.lower() == "c":
         stringParameters[pname] = pvalue
       elif ptype.lower() == "f":

--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -40,7 +40,7 @@ class Meta(ConfigHelper):
     for string, int and float parameters
     """
     stringParameters, intParameters, floatParameters, allParameters = {}, {}, {}, []
-    
+
     for p in getattr(self, f"{parameterType}Parameters", []):
       parameterAndValue = p.split("=", 1)
       if len(parameterAndValue) != 2:

--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -36,7 +36,7 @@ class Meta(ConfigHelper):
 
   def parseMetaParameters(self, parameterType="event"):
     """
-    Parse the event parameters and return 3 event parameter dictionaries, respectively
+    Parse the metadata parameters and return 3 parameter dictionaries, respectively
     for string, int and float parameters
     """
     stringParameters, intParameters, floatParameters, allParameters = {}, {}, {}, []

--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -44,7 +44,7 @@ class Meta(ConfigHelper):
     for p in getattr(self, f"{parameterType}Parameters", []):
       parameterAndValue = p.split("=", 1)
       if len(parameterAndValue) != 2:
-        raise SyntaxError("ERROR: Couldn't decode %s parameter '%s'" % (parameterType, p))
+        raise SyntaxError(f"ERROR: Couldn't decode {parameterType} parameter '{p}'")
       parameterAndType = parameterAndValue[0].split("/", 1)
       if len(parameterAndType) != 2:
         raise SyntaxError("ERROR: Couldn't decode %s parameter '%s'" % (parameterType, p))

--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -41,7 +41,7 @@ class Meta(ConfigHelper):
     """
     stringParameters, intParameters, floatParameters, allParameters = {}, {}, {}, []
     
-    for p in getattr(self, parameterType+"Parameters", []):
+    for p in getattr(self, f"{parameterType}Parameters", []):
       parameterAndValue = p.split("=", 1)
       if len(parameterAndValue) != 2:
         raise SyntaxError("ERROR: Couldn't decode %s parameter '%s'" % (parameterType, p))

--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -47,18 +47,18 @@ class Meta(ConfigHelper):
         raise SyntaxError(f"ERROR: Couldn't decode {parameterType} parameter '{p}'")
       parameterAndType = parameterAndValue[0].split("/", 1)
       if len(parameterAndType) != 2:
-        raise SyntaxError("ERROR: Couldn't decode %s parameter '%s'" % (parameterType, p))
+        raise SyntaxError(f"ERROR: Couldn't decode {parameterType} parameter '{p}'")
       pname = parameterAndType[0]
       ptype = parameterAndType[1]
       pvalue = parameterAndValue[1]
       if ptype.lower() not in ["c", "f", "i"]:
-        raise ValueError("ERROR: %s parameter '%s' with invalid type '%s'" % (parameterType, pname, ptype))
+        raise ValueError(f"ERROR: {parameterType} parameter '{pname}' with invalid type '{ptype}'")
       if pname in allParameters:
-        raise RuntimeError("ERROR: %s parameter '%s' specified twice" % (parameterType, pname))
+        raise RuntimeError(f"ERROR: {parameterType} parameter '{pname}' specified twice")
       if not pvalue:
-        raise RuntimeError("ERROR: %s parameter '%s' has empty value" % (parameterType, pname))
+        raise RuntimeError(f"ERROR: {parameterType} parameter '{pname}' has empty value")
       allParameters.append(pname)
-      logger.info("%s parameter '%s', type '%s', value='%s'" % (parameterType, pname, ptype, pvalue))
+      logger.info(f"{parameterType} parameter '{pname}', type='{ptype}', value='{pvalue}'")
       if ptype.lower() == "c":
         stringParameters[pname] = pvalue
       elif ptype.lower() == "f":

--- a/DDG4/python/DDSim/Helper/OutputConfig.py
+++ b/DDG4/python/DDSim/Helper/OutputConfig.py
@@ -144,7 +144,7 @@ class OutputConfig(ConfigHelper):
     lcOut.RunHeader = dds.meta.addParametersToRunHeader(dds)
     eventPars = dds.meta.parseEventParameters()
     lcOut.EventParametersString, lcOut.EventParametersInt, lcOut.EventParametersFloat = eventPars
-    runPars = dds.meta.parseRunParameters(parameterType="run")
+    runPars = dds.meta.parseMetaParameters(parameterType="run")
     lcOut.RunParametersString, lcOut.RunParametersInt, lcOut.RunParametersFloat = runPars
     lcOut.RunNumberOffset = dds.meta.runNumberOffset if dds.meta.runNumberOffset > 0 else 0
     lcOut.EventNumberOffset = dds.meta.eventNumberOffset if dds.meta.eventNumberOffset > 0 else 0

--- a/DDG4/python/DDSim/Helper/OutputConfig.py
+++ b/DDG4/python/DDSim/Helper/OutputConfig.py
@@ -144,7 +144,7 @@ class OutputConfig(ConfigHelper):
     lcOut.RunHeader = dds.meta.addParametersToRunHeader(dds)
     eventPars = dds.meta.parseEventParameters()
     lcOut.EventParametersString, lcOut.EventParametersInt, lcOut.EventParametersFloat = eventPars
-    runPars = dds.meta.parseRunParameters()
+    runPars = dds.meta.parseRunParameters(parameterType="run")
     lcOut.RunParametersString, lcOut.RunParametersInt, lcOut.RunParametersFloat = runPars
     lcOut.RunNumberOffset = dds.meta.runNumberOffset if dds.meta.runNumberOffset > 0 else 0
     lcOut.EventNumberOffset = dds.meta.eventNumberOffset if dds.meta.eventNumberOffset > 0 else 0
@@ -153,10 +153,10 @@ class OutputConfig(ConfigHelper):
   def _configureEDM4HEP(self, dds, geant4):
     logger.info("++++ Setting up EDM4hep ROOT Output ++++")
     e4Out = geant4.setupEDM4hepOutput('EDM4hepOutput', dds.outputFile)
-    eventPars = dds.meta.parseEventParameters()
+    eventPars = dds.meta.parseMetaParameters()
     e4Out.RunHeader = dds.meta.addParametersToRunHeader(dds)
     e4Out.EventParametersString, e4Out.EventParametersInt, e4Out.EventParametersFloat = eventPars
-    runPars = dds.meta.parseRunParameters()
+    runPars = dds.meta.parseMetaParameters(parameterType="run")
     e4Out.RunParametersString, e4Out.RunParametersInt, e4Out.RunParametersFloat = runPars
     e4Out.RunNumberOffset = dds.meta.runNumberOffset if dds.meta.runNumberOffset > 0 else 0
     e4Out.EventNumberOffset = dds.meta.eventNumberOffset if dds.meta.eventNumberOffset > 0 else 0

--- a/DDG4/python/DDSim/Helper/OutputConfig.py
+++ b/DDG4/python/DDSim/Helper/OutputConfig.py
@@ -144,6 +144,8 @@ class OutputConfig(ConfigHelper):
     lcOut.RunHeader = dds.meta.addParametersToRunHeader(dds)
     eventPars = dds.meta.parseEventParameters()
     lcOut.EventParametersString, lcOut.EventParametersInt, lcOut.EventParametersFloat = eventPars
+    runPars = dds.meta.parseRunParameters()
+    lcOut.RunParametersString, lcOut.RunParametersInt, lcOut.RunParametersFloat = runPars
     lcOut.RunNumberOffset = dds.meta.runNumberOffset if dds.meta.runNumberOffset > 0 else 0
     lcOut.EventNumberOffset = dds.meta.eventNumberOffset if dds.meta.eventNumberOffset > 0 else 0
     return

--- a/DDG4/python/DDSim/Helper/OutputConfig.py
+++ b/DDG4/python/DDSim/Helper/OutputConfig.py
@@ -156,6 +156,8 @@ class OutputConfig(ConfigHelper):
     eventPars = dds.meta.parseEventParameters()
     e4Out.RunHeader = dds.meta.addParametersToRunHeader(dds)
     e4Out.EventParametersString, e4Out.EventParametersInt, e4Out.EventParametersFloat = eventPars
+    runPars = dds.meta.parseRunParameters()
+    e4Out.RunParametersString, e4Out.RunParametersInt, e4Out.RunParametersFloat = runPars
     e4Out.RunNumberOffset = dds.meta.runNumberOffset if dds.meta.runNumberOffset > 0 else 0
     e4Out.EventNumberOffset = dds.meta.eventNumberOffset if dds.meta.eventNumberOffset > 0 else 0
     return

--- a/DDG4/python/DDSim/Helper/OutputConfig.py
+++ b/DDG4/python/DDSim/Helper/OutputConfig.py
@@ -144,8 +144,6 @@ class OutputConfig(ConfigHelper):
     lcOut.RunHeader = dds.meta.addParametersToRunHeader(dds)
     eventPars = dds.meta.parseMetaParameters()
     lcOut.EventParametersString, lcOut.EventParametersInt, lcOut.EventParametersFloat = eventPars
-    runPars = dds.meta.parseMetaParameters(parameterType="run")
-    lcOut.RunParametersString, lcOut.RunParametersInt, lcOut.RunParametersFloat = runPars
     lcOut.RunNumberOffset = dds.meta.runNumberOffset if dds.meta.runNumberOffset > 0 else 0
     lcOut.EventNumberOffset = dds.meta.eventNumberOffset if dds.meta.eventNumberOffset > 0 else 0
     return

--- a/DDG4/python/DDSim/Helper/OutputConfig.py
+++ b/DDG4/python/DDSim/Helper/OutputConfig.py
@@ -142,7 +142,7 @@ class OutputConfig(ConfigHelper):
     logger.info("++++ Setting up LCIO Output ++++")
     lcOut = geant4.setupLCIOOutput('LcioOutput', dds.outputFile)
     lcOut.RunHeader = dds.meta.addParametersToRunHeader(dds)
-    eventPars = dds.meta.parseEventParameters()
+    eventPars = dds.meta.parseMetaParameters()
     lcOut.EventParametersString, lcOut.EventParametersInt, lcOut.EventParametersFloat = eventPars
     runPars = dds.meta.parseMetaParameters(parameterType="run")
     lcOut.RunParametersString, lcOut.RunParametersInt, lcOut.RunParametersFloat = runPars


### PR DESCRIPTION

BEGINRELEASENOTES
- Add run level metadata to output in ddsim helper plugin

ENDRELEASENOTES

```
Example:
 ./install/bin/ddsim --compactFile <xml> --meta.runParameters "TestVersion/C=1.0" "Detector/C=ODD" -G -N 10 --outputFile ddsim.edm4hep.root

podio-dump dd4hep/ddsim.edm4hep.root -c runs -d
input file: dd4hep/ddsim.edm4hep.root
            (written with podio version: 1.2.0)

datamodel model definitions stored in this file:
 - edm4hep (0.99.1)

Frame categories in this file:
Name        Entries
--------  ---------
runs              1
metadata          1
meta              1
events           10
#################################### runs: 0 #####################################
Collections:

Parameters:
int parameters

Key                           Value
--------------------------------------------------------------------------------
runNumber                     [0]

float parameters
Key                           Value
--------------------------------------------------------------------------------

double parameters
Key                           Value
--------------------------------------------------------------------------------

std::string parameters
Key                           Value
--------------------------------------------------------------------------------
CommandLine                   [./install/bin/ddsim --compactFile ../OpenDataDetector/install/share/OpenDataDetector/xml/OpenDataDetector.xml --meta.runParameters TestVersion/C=1.0 Detector/C=ODD --meta.eventParameters TestVersion/C=1.0 Dectector/C=ODD -G -N 10 --outputFile ddsim.edm4hep.root]
DD4hepVersion                 [v01-32]
DateUTC                       [2025-06-09 16:20:38.250878 UTC]
GEANT4Version                 [$Name: geant4-11-02-patch-02 [MT]$]
ILCSoft_location              [Unknown]
User                          [rahmans]
WorkingDirectory              [/gpfs02/eic/rahmans/DD4hep/dd4hep]
_argv                         [['./install/bin/ddsim', '--compactFile', '../OpenDataDetector/install/share/OpenDataDetector/xml/OpenDataDetector.xml', '--meta.runParameters', 'TestVersion/C=1.0', 'Detector/C=ODD', '--meta.eventParameters', 'TestVersion/C=1.0', 'Dectector/C=ODD', '-G', '-N', '10', '--outputFile', 'ddsim.edm4hep.root']]
_dumpParameter                [False]
_dumpSteeringFile             [False]
_errorMessages                [[]]
_g4gps                        [None]
_g4gun                        [None]
action.calo                   [Geant4ScintillatorCalorimeterAction]
action.calorimeterSDTypes     [['calorimeter']]
action.event                  [[]]
action.mapActions             [{}]
action.run                    [[]]
action.stack                  [[]]
action.step                   [[]]
action.track                  [[]]
action.tracker                [('Geant4TrackerWeightedAction', {'HitPositionCombination': 2, 'CollectSingleDeposits': False})]
action.trackerSDTypes         [['tracker']]
compactFile                   [['../OpenDataDetector/install/share/OpenDataDetector/xml/OpenDataDetector.xml']]
crossingAngleBoost            [0.0]
detectorName                  [Open Data Detector - HCal]
disableSignalHandler          [False]
enableDetailedShowerMode      [False]
enableG4GPS                   [False]
enableG4Gun                   [False]
enableGun                     [True]
field.delta_chord             [0.25]
field.delta_intersection      [0.001]
field.delta_one_step          [0.01]
field.eps_max                 [0.001]
field.eps_min                 [5e-05]
field.equation                [Mag_UsualEqRhs]
field.largest_step            [10000.0]
field.min_chord_step          [0.01]
field.stepper                 [ClassicalRK4]
filter.calo                   [edep0]
filter.filters                [{'geantino': {'name': 'GeantinoRejectFilter/GeantinoRejector', 'parameter': {}}, 'edep1kev': {'name': 'EnergyDepositMinimumCut', 'parameter': {'Cut': 0.001}}, 'edep0': {'name': 'EnergyDepositMinimumCut/Cut0', 'parameter': {'Cut': 0.0}}}]
filter.mapDetFilter           [{}]
filter.tracker                [edep1kev]
geometry.dumpGDML             []
geometry.dumpHierarchy        [0]
geometry.enableDebugElements  [False]
geometry.enableDebugMaterials [False]
geometry.enableDebugPlacements[False]
geometry.enableDebugReflections[False]
geometry.enableDebugRegions   [False]
geometry.enableDebugShapes    [False]
geometry.enableDebugSurfaces  [False]
geometry.enableDebugVolumes   [False]
geometry.enablePrintPlacements[False]
geometry.enablePrintSensitives[False]
geometry.regexSensitiveDetector[{}]
guineapig._parameters         [{'ParticlesPerEvent': '-1'}]
guineapig.particlesPerEvent   [-1]
gun.direction                 [(0, 0, 1)]
gun.distribution              [None]
gun.energy                    [None]
gun.etaMax                    [None]
gun.etaMin                    [None]
gun.isotrop                   [False]
gun.momentumMax               [10000.0]
gun.momentumMin               [0.0]
gun.multiplicity              [1]
gun.particle                  [mu-]
gun.phiMax                    [None]
gun.phiMin                    [None]
gun.position                  [(0.0, 0.0, 0.0)]
gun.thetaMax                  [None]
gun.thetaMin                  [None]
hepmc3.Flow1                  [flow1]
hepmc3.Flow2                  [flow2]
hepmc3._parameters            [{'Flow1': 'flow1', 'Flow2': 'flow2'}]
hepmc3.useHepMC3              [True]
inputConfig.userInputPlugin   [[]]
inputFiles                    [[]]
lcgeo_location                [Unknown]
lcio._parameters              [{'MCParticleCollectionName': 'MCParticle'}]
lcio.mcParticleCollectionName [MCParticle]
macroFile                     []
meta.eventNumberOffset        [0]
meta.eventParameters          []
meta.runNumberOffset          [0]
meta.runParameters            [['TestVersion/C=1.0', 'Detector/C=ODD']]
numberOfEvents                [10]
output.geometry               [2]
output.inputStage             [3]
output.kernel                 [3]
output.part                   [3]
output.physics                [1]
output.random                 [6]
outputConfig.forceDD4HEP      [False]
outputConfig.forceEDM4HEP     [False]
outputConfig.forceLCIO        [False]
outputConfig.userOutputPlugin [None]
outputFile                    [ddsim.edm4hep.root]
part.enableDetailedHitsAndParticleInfo[False]
part.keepAllParticles         [False]
part.minDistToParentVertex    [2.2e-14]
part.minimalKineticEnergy     [1.0]
part.printEndTracking         [False]
part.printStartTracking       [False]
part.saveProcesses            [['Decay']]
part.userParticleHandler      [Geant4TCUserParticleHandler]
physics.alternativeDecayStatuses[set()]
physics.alternativeStableStatuses[set()]
physics.decays                [False]
physics.list                  [FTFP_BERT]
physics.pdgfile               [None]
physics.rangecut              [0.7]
physics.rejectPDGs            [{3201, 1, 3203, 2, 4101, 3, 4103, 4, 5, 6, 21, 23, 24, 5401, 25, 2203, 5403, 3101, 3103, 4403, 2101, 5301, 2103, 5303, 4301, 1103, 4303, 5201, 5203, 3303, 4201, 4203, 5101, 5103, 5503}]
physics.zeroTimePDGs          [{17, 11, 13, 15}]
physicsList                   [None]
printLevel                    [3]
random.enableEventSeed        [False]
random.file                   [None]
random.luxury                 [1]
random.replace_gRandom        [True]
random.seed                   [1742735666]
random.type                   [None]
runType                       [batch]
skipNEvents                   [0]
steeringFile                  [None]
ui.commandsConfigure          [[]]
ui.commandsInitialize         [[]]
ui.commandsPostRun            [[]]
ui.commandsPreRun             [[]]
ui.commandsTerminate          [[]]
vertexOffset                  [[0.0, 0.0, 0.0, 0.0]]
vertexSigma                   [[0.0, 0.0, 0.0, 0.0]]
```
