### PR TITLE
Explicitly mention in ddsim -h that EDM4hep format is a supported input

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -160,7 +160,8 @@ class DD4hepSimulation(object):
                         "\nshell: enable interactive session")
 
     parser.add_argument("--inputFiles", "-I", nargs='+', action="store", default=self.inputFiles,
-                        help="InputFiles for simulation %s files are supported\nEDM4hep files are also supported under the .root extension" % ", ".join(POSSIBLEINPUTFILES))
+                        help="InputFiles for simulation %s files are supported"
+                        "\nEDM4hep files are also supported under the .root extension" % ", ".join(POSSIBLEINPUTFILES))
 
     parser.add_argument("--outputFile", "-O", action="store", default=self.outputFile,
                         help="Outputfile from the simulation: .slcio, edm4hep.root and .root"

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -160,7 +160,7 @@ class DD4hepSimulation(object):
                         "\nshell: enable interactive session")
 
     parser.add_argument("--inputFiles", "-I", nargs='+', action="store", default=self.inputFiles,
-                        help="InputFiles for simulation %s files are supported" % ", ".join(POSSIBLEINPUTFILES))
+                        help="InputFiles for simulation %s files are supported\nEDM4hep files are also supported under the .root extension" % ", ".join(POSSIBLEINPUTFILES))
 
     parser.add_argument("--outputFile", "-O", action="store", default=self.outputFile,
                         help="Outputfile from the simulation: .slcio, edm4hep.root and .root"


### PR DESCRIPTION

BEGINRELEASENOTES
- Explicitly mention in ddsim -h that EDM4hep format is a supported input

ENDRELEASENOTES

It prints like: 

<img width="1623" alt="Screenshot 2025-06-13 at 3 04 58 PM" src="https://github.com/user-attachments/assets/262be37f-7775-4420-9d08-98b2c7a81fec" />
