### PR TITLE
Fixes around memory leaks

### DIFF
--- a/DDCore/include/DD4hep/DetElement.h
+++ b/DDCore/include/DD4hep/DetElement.h
@@ -464,4 +464,8 @@ namespace dd4hep {
 
 #include <DD4hep/AlignmentData.h>
 
+// Needed so that end users can call destroyHandle on a DetElement without risking undefined behavior
+// and memory leaks. See comment in destroyHandle in file Handle.h for more details
+#include <DD4hep/detail/DetectorInterna.h>
+
 #endif // DD4HEP_DETELEMENT_H

--- a/DDCore/include/DD4hep/Handle.h
+++ b/DDCore/include/DD4hep/Handle.h
@@ -181,6 +181,15 @@ namespace dd4hep {
   namespace detail  {
     /// Helper to delete objects from heap and reset the handle  \ingroup DD4HEP_CORE
     template <typename T> inline void destroyHandle(T& handle) {
+      // make sure we get a compiler error if this is used in a context where T::Object
+      // is not complete, as this is undefined behavior.
+      // If you see this, you are probably missing an include in the file where you
+      // call destroyHandle. You need the internal object behind the handle to be
+      // fully defined. E.g. you need to include DD4hep/detail/DetectorInterna.h
+      // (despite the name) to be able to destroy a DetElement.
+      // Not doing this leads to undefined behavior and practically with gcc lack
+      // of destruction of the internal object and thus memory leak
+      static_assert( sizeof(typename T::Object) > 0, "destroyHandle called on incomplete type. Missing include ?");
       deletePtr(handle.m_element);
     }
     /// Functor to destroy handles and delete the cached object  \ingroup DD4HEP_CORE

--- a/DDCore/include/DD4hep/World.h
+++ b/DDCore/include/DD4hep/World.h
@@ -13,8 +13,7 @@
 #ifndef DD4HEP_WORLD_H
 #define DD4HEP_WORLD_H
 
-// Framework include files
-#include <DD4hep/DetElement.h>
+#include <DD4hep/Handle.h>
 
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
@@ -48,4 +47,5 @@ namespace dd4hep {
 #endif
   };
 } /* End namespace dd4hep            */
+
 #endif // DD4HEP_WORLD_H


### PR DESCRIPTION
This fixes issues around using destroyHandle.

## Overview

The Handle mechanism as implemented currently makes it easy to have undefined behavior when using `destroyHandle`. It's actually the default if users do not include internal files they should not even have to know. These commit try to fix the DetElement case and make sure that users get a compilation error when the situation arise. Before this commit, the undefined behavior turned out to be a silent memory leak.

## More detailed explanation

The problem is due to the fact that `destroyHandle` calls delete on the underlying Object behind the Handle without this object being necessaritly complete (it's only forward declared most of the time). From the C++ specification : 

> 7.6.2.9 [expr.delete] Delete
> “If the object being deleted has incomplete class type at the point of deletion and the complete class has a
> non-trivial destructor or a deallocation function, the behavior is undefined.”

As header for Handles are not including the corresponding Object header (e.g. DetElement.h does not include Detectorinterna.h"), the undefined behavior is the de facto standard, and in case of gcc it translates to silent memory leak, as if `destroyHandle` were never called.

This pull requests does mainly 2 things :
 - fix the DetElement case by including DetectorInterna.h in DetElement.h
 - make sure we get a compiler error for other cases via a static_assert (so only in debug mode)
Note that the second bullet will probably break user code. But only when they were facing the issue, so it's probably a good thing.

It would be good to fix all other cases but it's hard to identify them, plus the DD4hep include files are hard to manipulate, with a number of cycles making them non trivial to change.

BEGINRELEASENOTES
- Fixed destroyHandle usage for DetElement
- Made sure once gets a compilation error in case destroyHandle is used when the underlying object type is not complete

ENDRELEASENOTES