### PR TITLE
Add concurrency to the workflows

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,5 +1,9 @@
 name: clang-tidy-guards
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,5 +1,9 @@
 name: coverity
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   schedule:
     - cron:  '2 0 * * *'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,9 @@
 name: linux
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,5 +1,9 @@
 name: macOS
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,5 +1,9 @@
 name: python
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/test-result-comment.yml
+++ b/.github/workflows/test-result-comment.yml
@@ -1,5 +1,9 @@
 name: Test Summary PR comment
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_run:
     # do NOT use quotes: https://stackoverflow.com/a/72551795/17876693


### PR DESCRIPTION
This means previous runs will be stopped if there are new commits, freeing runners to finish runs for the current workflows

BEGINRELEASENOTES
- Add concurrency to the CI workflows, to stop previous runs if there are new commits

ENDRELEASENOTES