### PR TITLE
Improve the Linux workflows

### DIFF
--- a/.github/scripts/common_cmake_opts.sh
+++ b/.github/scripts/common_cmake_opts.sh
@@ -14,3 +14,9 @@ export COMMON_CMAKE_OPTS="-GNinja \
   -DDD4HEP_USE_XERCESC=ON \
   -DCMAKE_CXX_FLAGS=\"-fdiagnostics-color=always\" \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+
+# Common CMake options for building examples
+export COMMON_EXAMPLES_CMAKE_OPTS="-GNinja \
+  -DBoost_NO_BOOST_CMAKE=ON \
+  -DDD4HEP_USE_XERCESC=ON \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"

--- a/.github/scripts/common_cmake_opts.sh
+++ b/.github/scripts/common_cmake_opts.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Common CMake options for DD4hep CI builds
+export COMMON_CMAKE_OPTS="-GNinja \
+  -DDD4HEP_USE_GEANT4=ON \
+  -DBoost_NO_BOOST_CMAKE=ON \
+  -DDD4HEP_USE_LCIO=ON \
+  -DDD4HEP_USE_EDM4HEP=OFF \
+  -DDD4HEP_USE_TBB=ON \
+  -DDD4HEP_USE_HEPMC3=ON \
+  -DDD4HEP_BUILD_DEBUG=OFF \
+  -DBUILD_TESTING=ON \
+  -DDD4HEP_DEBUG_CMAKE=ON \
+  -DDD4HEP_USE_XERCESC=ON \
+  -DCMAKE_CXX_FLAGS=\"-fdiagnostics-color=always\" \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,57 +35,29 @@ jobs:
           cd build
           unset CPATH
           echo "::group::CMakeConfig"
+          # Common CMake options
+          COMMON_CMAKE_OPTS="-GNinja \
+            -DDD4HEP_USE_GEANT4=ON \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DDD4HEP_USE_LCIO=ON \
+            -DDD4HEP_USE_EDM4HEP=OFF \
+            -DDD4HEP_USE_TBB=ON \
+            -DDD4HEP_USE_HEPMC3=ON \
+            -DDD4HEP_BUILD_DEBUG=OFF \
+            -DBUILD_TESTING=ON \
+            -DDD4HEP_DEBUG_CMAKE=ON \
+            -DDD4HEP_USE_XERCESC=ON \
+            -DCMAKE_CXX_FLAGS=\"-fdiagnostics-color=always\" \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
           if [[ ${{ matrix.LCG }} =~ gcc13|clang19 ]]; then
             echo "::group::CMakeConfig C++20"
-            cmake -GNinja \
-              -DDD4HEP_USE_GEANT4=ON \
-              -DBoost_NO_BOOST_CMAKE=ON \
-              -DDD4HEP_USE_LCIO=ON \
-              -DDD4HEP_USE_EDM4HEP=OFF \
-              -DDD4HEP_USE_TBB=ON \
-              -DDD4HEP_USE_HEPMC3=ON \
-              -DDD4HEP_BUILD_DEBUG=OFF \
-              -DBUILD_TESTING=ON \
-              -DDD4HEP_DEBUG_CMAKE=ON \
-              -DDD4HEP_USE_XERCESC=ON \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_CXX_STANDARD=20 ..
+            cmake $COMMON_CMAKE_OPTS -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 ..
           elif [[ ${{ matrix.LCG }} =~ gcc15 ]]; then
             echo "::group::CMakeConfig C++23"
-            cmake -GNinja \
-              -DDD4HEP_USE_GEANT4=ON \
-              -DBoost_NO_BOOST_CMAKE=ON \
-              -DDD4HEP_USE_LCIO=ON \
-              -DDD4HEP_USE_EDM4HEP=OFF \
-              -DDD4HEP_USE_TBB=ON \
-              -DDD4HEP_USE_HEPMC3=ON \
-              -DDD4HEP_BUILD_DEBUG=OFF \
-              -DBUILD_TESTING=ON \
-              -DDD4HEP_DEBUG_CMAKE=ON \
-              -DDD4HEP_USE_XERCESC=ON \
-              -DCMAKE_BUILD_TYPE=Debug \
-              -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_CXX_STANDARD=23 ..
+            cmake $COMMON_CMAKE_OPTS -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=23 ..
           else
-              echo "::group::CMakeConfig C++17"
-              cmake -GNinja \
-                -DDD4HEP_USE_GEANT4=ON \
-                -DBoost_NO_BOOST_CMAKE=ON \
-                -DDD4HEP_USE_LCIO=ON \
-                -DDD4HEP_USE_EDM4HEP=OFF \
-                -DDD4HEP_USE_TBB=ON \
-                -DDD4HEP_USE_HEPMC3=ON \
-                -DDD4HEP_BUILD_DEBUG=OFF \
-                -DBUILD_TESTING=ON \
-                -DDD4HEP_DEBUG_CMAKE=ON \
-                -DDD4HEP_USE_XERCESC=ON \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-                -DCMAKE_CXX_STANDARD=17 ..
+            echo "::group::CMakeConfig C++17"
+            cmake $COMMON_CMAKE_OPTS -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 ..
           fi
           if [[ ${{ matrix.LCG }} =~ dev3 ]]; then
             echo "::group::CMakeConfig 2"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,18 +65,11 @@ jobs:
           cd ../examples/
           mkdir build
           cd build
+          source ../../.github/scripts/common_cmake_opts.sh
           if [[ ${{ matrix.LCG }} =~ gcc13|clang16 ]]; then
-          cmake -GNinja \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DDD4HEP_USE_XERCESC=ON \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_STANDARD=20 ..
+            cmake $COMMON_EXAMPLES_CMAKE_OPTS -DCMAKE_CXX_STANDARD=20 ..
           else
-            cmake -GNinja \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DDD4HEP_USE_XERCESC=ON \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_STANDARD=17 ..
+            cmake $COMMON_EXAMPLES_CMAKE_OPTS -DCMAKE_CXX_STANDARD=17 ..
           fi
           echo "::group::CompileExamples"
           ninja install
@@ -133,12 +126,8 @@ jobs:
           cd ../examples/
           mkdir build
           cd build
-          cmake -GNinja \
-            -D CMAKE_INSTALL_LIBDIR=lib \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DDD4HEP_USE_XERCESC=ON \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_STANDARD=20 ..
+          source ../../.github/scripts/common_cmake_opts.sh
+          cmake $COMMON_EXAMPLES_CMAKE_OPTS -D CMAKE_INSTALL_LIBDIR=lib -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"
@@ -216,11 +205,8 @@ jobs:
           cd ../examples/
           mkdir build
           cd build
-          cmake -GNinja \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DDD4HEP_USE_XERCESC=ON \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_STANDARD=20 ..
+          source ../../.github/scripts/common_cmake_opts.sh
+          cmake $COMMON_EXAMPLES_CMAKE_OPTS -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -60,7 +60,7 @@ jobs:
           ninja install
           . ../bin/thisdd4hep.sh
           echo "::group::Test"
-          ctest --output-on-failure -j4 --output-junit TestResults_1.xml
+          ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_1.xml
           echo "::group::CMakeExamples"
           cd ../examples/
           mkdir build
@@ -74,7 +74,7 @@ jobs:
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"
-          ctest --output-on-failure -j2 --output-junit TestResults_2.xml
+          ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_2.xml
     - name: Prepare Artifact Name
       if: success() || failure()
       run: |
@@ -121,7 +121,7 @@ jobs:
           ninja install
           . ../bin/thisdd4hep.sh
           echo "::group::Test"
-          ctest --output-on-failure -j4 --output-junit TestResults_1.xml
+          ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_1.xml
           echo "::group::CMakeExamples"
           cd ../examples/
           mkdir build
@@ -131,7 +131,7 @@ jobs:
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"
-          ctest --output-on-failure -j2 --output-junit TestResults_2.xml
+          ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_2.xml
     - name: Prepare Artifact Name
       if: success() || failure()
       run: |
@@ -200,7 +200,7 @@ jobs:
           ninja install
           . ../bin/thisdd4hep.sh
           echo "::group::Test"
-          ctest --output-on-failure -j4 --output-junit TestResults_1.xml
+          ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_1.xml
           echo "::group::CMakeExamples"
           cd ../examples/
           mkdir build
@@ -210,7 +210,7 @@ jobs:
           echo "::group::CompileExamples"
           ninja install
           echo "::group::TestExamples"
-          ctest --output-on-failure -j2 --output-junit TestResults_2.xml
+          ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_2.xml
     - name: Prepare Artifact Name
       if: success() || failure()
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,6 +58,7 @@ jobs:
           fi
           echo "::group::Compile"
           ninja install
+          ccache -s
           . ../bin/thisdd4hep.sh
           echo "::group::Test"
           ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_1.xml
@@ -73,6 +74,7 @@ jobs:
           fi
           echo "::group::CompileExamples"
           ninja install
+          ccache -s
           echo "::group::TestExamples"
           ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_2.xml
     - name: Prepare Artifact Name
@@ -119,6 +121,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::Compile"
           ninja install
+          ccache -s
           . ../bin/thisdd4hep.sh
           echo "::group::Test"
           ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_1.xml
@@ -130,6 +133,7 @@ jobs:
           cmake $COMMON_EXAMPLES_CMAKE_OPTS -D CMAKE_INSTALL_LIBDIR=lib -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::CompileExamples"
           ninja install
+          ccache -s
           echo "::group::TestExamples"
           ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_2.xml
     - name: Prepare Artifact Name
@@ -172,6 +176,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::Compile"
           ninja
+          ccache -s
 
   g4units:
     runs-on: ubuntu-latest
@@ -198,6 +203,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::Compile"
           ninja install
+          ccache -s
           . ../bin/thisdd4hep.sh
           echo "::group::Test"
           ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_1.xml
@@ -209,6 +215,7 @@ jobs:
           cmake $COMMON_EXAMPLES_CMAKE_OPTS -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::CompileExamples"
           ninja install
+          ccache -s
           echo "::group::TestExamples"
           ctest --output-on-failure -j"$(nproc)" --output-junit TestResults_2.xml
     - name: Prepare Artifact Name

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,19 +36,7 @@ jobs:
           unset CPATH
           echo "::group::CMakeConfig"
           # Common CMake options
-          COMMON_CMAKE_OPTS="-GNinja \
-            -DDD4HEP_USE_GEANT4=ON \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DDD4HEP_USE_LCIO=ON \
-            -DDD4HEP_USE_EDM4HEP=OFF \
-            -DDD4HEP_USE_TBB=ON \
-            -DDD4HEP_USE_HEPMC3=ON \
-            -DDD4HEP_BUILD_DEBUG=OFF \
-            -DBUILD_TESTING=ON \
-            -DDD4HEP_DEBUG_CMAKE=ON \
-            -DDD4HEP_USE_XERCESC=ON \
-            -DCMAKE_CXX_FLAGS=\"-fdiagnostics-color=always\" \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          source ../.github/scripts/common_cmake_opts.sh
           if [[ ${{ matrix.LCG }} =~ gcc13|clang19 ]]; then
             echo "::group::CMakeConfig C++20"
             cmake $COMMON_CMAKE_OPTS -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 ..
@@ -129,21 +117,12 @@ jobs:
           cd build
           unset CPATH
           echo "::group::CMakeConfig"
-          cmake -GNinja \
+          source ../.github/scripts/common_cmake_opts.sh
+          cmake $COMMON_CMAKE_OPTS \
             -D CMAKE_INSTALL_LIBDIR=lib \
-            -DDD4HEP_USE_GEANT4=ON \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DDD4HEP_USE_LCIO=ON \
             -DDD4HEP_USE_EDM4HEP=ON \
             -DDD4HEP_USE_TBB=OFF \
-            -DDD4HEP_USE_HEPMC3=ON \
-            -DDD4HEP_BUILD_DEBUG=OFF \
-            -DBUILD_TESTING=ON \
-            -DDD4HEP_DEBUG_CMAKE=ON \
-            -DDD4HEP_USE_XERCESC=ON \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always"  \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::Compile"
           ninja install
@@ -197,21 +176,10 @@ jobs:
           cd build
           unset CPATH
           echo "::group::CMakeConfig"
-          cmake -GNinja \
-            -DDD4HEP_USE_GEANT4=ON \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DDD4HEP_USE_LCIO=ON \
-            -DDD4HEP_USE_EDM4HEP=OFF \
-            -DDD4HEP_USE_TBB=ON \
-            -DDD4HEP_USE_HEPMC3=ON \
-            -DDD4HEP_BUILD_DEBUG=OFF \
-            -DBUILD_TESTING=ON \
-            -DDD4HEP_DEBUG_CMAKE=ON \
+          source ../.github/scripts/common_cmake_opts.sh
+          cmake $COMMON_CMAKE_OPTS \
             -DBUILD_SHARED_LIBS=OFF \
-            -DDD4HEP_USE_XERCESC=ON \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always"  \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::Compile"
           ninja
@@ -234,21 +202,10 @@ jobs:
           cd build
           unset CPATH
           echo "::group::CMakeConfig"
-          cmake -GNinja \
+          source ../.github/scripts/common_cmake_opts.sh
+          cmake $COMMON_CMAKE_OPTS \
             -DDD4HEP_USE_GEANT4_UNITS=ON \
-            -DDD4HEP_USE_GEANT4=ON \
-            -DBoost_NO_BOOST_CMAKE=ON \
-            -DDD4HEP_USE_LCIO=ON \
-            -DDD4HEP_USE_EDM4HEP=OFF \
-            -DDD4HEP_USE_TBB=ON \
-            -DDD4HEP_USE_HEPMC3=ON \
-            -DDD4HEP_BUILD_DEBUG=OFF \
-            -DBUILD_TESTING=ON \
-            -DDD4HEP_DEBUG_CMAKE=ON \
-            -DDD4HEP_USE_XERCESC=ON \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always"  \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_STANDARD=20 ..
           echo "::group::Compile"
           ninja install


### PR DESCRIPTION
BEGINRELEASENOTES
- Improve the Linux workflows:
  - Add scripts with the common build options to avoid repetitions
  - Display ccache stats to see if it's working
  - Use nproc instead of hardcoding the number of jobs

ENDRELEASENOTES

Since I think the runners have 4 threads, this shoud speed up running the tests in the examples, that are being run with 2 threads