### PR TITLE
Remove from __future__ import since we are using Python 3

### DIFF
--- a/DDCore/python/dd4hep.py
+++ b/DDCore/python/dd4hep.py
@@ -8,6 +8,5 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 from dd4hep_base import *  # noqa: F403
 import_units(__import__(__name__))  # noqa: F405

--- a/DDCore/python/dd4hepFactories.py
+++ b/DDCore/python/dd4hepFactories.py
@@ -10,7 +10,6 @@
 #
 # ==========================================================================
 
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import optparse

--- a/DDCore/python/dd4hep_base.py
+++ b/DDCore/python/dd4hep_base.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import cppyy
 import importlib
 import types

--- a/DDDigi/python/dddigi.py
+++ b/DDDigi/python/dddigi.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import cppyy
 from dd4hep_base import *  # noqa: F401, F403
 

--- a/DDDigi/python/digitize.py
+++ b/DDDigi/python/digitize.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 import dd4hep
 import dddigi
 

--- a/DDG4/examples/CLICSidSimuLCIO.py
+++ b/DDG4/examples/CLICSidSimuLCIO.py
@@ -6,7 +6,6 @@
     @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/DDG4/examples/CLICSidSimuMarkus.py
+++ b/DDG4/examples/CLICSidSimuMarkus.py
@@ -1,6 +1,5 @@
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import logging

--- a/DDG4/examples/SiDSim.py
+++ b/DDG4/examples/SiDSim.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import time

--- a/DDG4/examples/SiDSim_MT.py
+++ b/DDG4/examples/SiDSim_MT.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import logging

--- a/DDG4/examples/SiD_Markus.py
+++ b/DDG4/examples/SiD_Markus.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import logging

--- a/DDG4/examples/readHEPMC.py
+++ b/DDG4/examples/readHEPMC.py
@@ -6,7 +6,6 @@ dd4hep simulation example setup using the python configuration
 @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import os
 import logging
 

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import logging
 import signal
 import cppyy

--- a/DDG4/python/DDSim/Helper/InputConfig.py
+++ b/DDG4/python/DDSim/Helper/InputConfig.py
@@ -1,6 +1,5 @@
 """Class for input plugin configuration"""
 
-from __future__ import absolute_import, unicode_literals
 from DDSim.Helper.ConfigHelper import ConfigHelper
 
 

--- a/DDG4/python/g4units.py
+++ b/DDG4/python/g4units.py
@@ -48,7 +48,6 @@
 #
 # Length [L]
 #
-from __future__ import absolute_import, unicode_literals, division
 
 millimeter = 1.
 millimeter2 = millimeter * millimeter

--- a/DDRec/python/DDRec.py
+++ b/DDRec/python/DDRec.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import dd4hep as core
 import logging
 

--- a/DDRec/python/dumpDetectorData.py
+++ b/DDRec/python/dumpDetectorData.py
@@ -10,7 +10,6 @@
 #
 # ==========================================================================
 
-from __future__ import absolute_import, unicode_literals
 import sys
 import errno
 import optparse

--- a/DDTest/python/test_import.py
+++ b/DDTest/python/test_import.py
@@ -3,7 +3,6 @@
 Some imports to make sure that the DD4hep environment is complete.
 Since it can be disabled in CMake, the import of DDG4 is tested in another file.
 """
-from __future__ import absolute_import, unicode_literals, print_function
 import traceback
 import warnings
 import pytest

--- a/DDTest/python/test_import_ddg4.py
+++ b/DDTest/python/test_import_ddg4.py
@@ -4,7 +4,6 @@
 # This file adds a test for the DDG4 python module.
 #
 #
-from __future__ import absolute_import
 from test_import import test_module
 
 

--- a/GaudiPluginService/python/GaudiPluginService/cpluginsvc.py
+++ b/GaudiPluginService/python/GaudiPluginService/cpluginsvc.py
@@ -1,5 +1,4 @@
 # cpluginsvc is a ctypes-based wrapper for the C-exposed API of GaudiPluginService
-from __future__ import absolute_import, unicode_literals, print_function
 __doc__ = '''
 cpluginsvc is a ctypes-based wrapper for the C-API of the GaudiPluginService.
 

--- a/etc/CreateParsers.py
+++ b/etc/CreateParsers.py
@@ -12,7 +12,6 @@ python CreateParsers.py
 
 """
 
-from __future__ import absolute_import, unicode_literals
 import io
 import os
 

--- a/examples/AlignDet/drivers/BoxSegment.py
+++ b/examples/AlignDet/drivers/BoxSegment.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 
 
 def detector_BoxSegment(description, det):

--- a/examples/AlignDet/drivers/Shelf.py
+++ b/examples/AlignDet/drivers/Shelf.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 
 
 def detector_Shelf(description, det):

--- a/examples/AlignDet/scripts/AlephTPC.py
+++ b/examples/AlignDet/scripts/AlephTPC.py
@@ -11,7 +11,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import DDG4
 from DDG4 import OutputLevel as Output

--- a/examples/CLICSiD/scripts/CLICMagField.py
+++ b/examples/CLICSiD/scripts/CLICMagField.py
@@ -16,7 +16,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 if __name__ == "__main__":
   import CLICSid
   sid = CLICSid.CLICSid().loadGeometry()

--- a/examples/CLICSiD/scripts/CLICPhysics.py
+++ b/examples/CLICSiD/scripts/CLICPhysics.py
@@ -16,7 +16,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 if __name__ == "__main__":
   import CLICSid
   sid = CLICSid.CLICSid().loadGeometry()

--- a/examples/CLICSiD/scripts/CLICRandom.py
+++ b/examples/CLICSiD/scripts/CLICRandom.py
@@ -16,7 +16,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 from ROOT import gRandom
 
 import logging

--- a/examples/CLICSiD/scripts/CLICSiDScan.py
+++ b/examples/CLICSiD/scripts/CLICSiDScan.py
@@ -17,7 +17,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/CLICSiD/scripts/CLICSiD_LoadROOTGeo.py
+++ b/examples/CLICSiD/scripts/CLICSiD_LoadROOTGeo.py
@@ -18,7 +18,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/CLICSiD/scripts/CLICSid.py
+++ b/examples/CLICSiD/scripts/CLICSid.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import sys
 import logging
 import DDG4

--- a/examples/CLICSiD/scripts/CLIC_G4Gun.py
+++ b/examples/CLICSiD/scripts/CLIC_G4Gun.py
@@ -18,7 +18,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 
 import logging
 

--- a/examples/CLICSiD/scripts/CLIC_G4hepmc.py
+++ b/examples/CLICSiD/scripts/CLIC_G4hepmc.py
@@ -17,7 +17,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 
 import logging
 

--- a/examples/CLICSiD/scripts/CLIC_GDML.py
+++ b/examples/CLICSiD/scripts/CLIC_GDML.py
@@ -17,7 +17,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 from g4units import GeV
 
 

--- a/examples/CLICSiD/scripts/SiD_ECAL_Parallel_Readout.py
+++ b/examples/CLICSiD/scripts/SiD_ECAL_Parallel_Readout.py
@@ -18,7 +18,6 @@
 #   @version 1.0
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import DDG4
 import CLICSid
 import logging

--- a/examples/CLICSiD/scripts/testDDPython.py
+++ b/examples/CLICSiD/scripts/testDDPython.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import traceback
 import sys
 from ROOT import gSystem

--- a/examples/ClientTests/scripts/Assemblies.py
+++ b/examples/ClientTests/scripts/Assemblies.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/ClientTests/scripts/BoxOfStraws.py
+++ b/examples/ClientTests/scripts/BoxOfStraws.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/ClientTests/scripts/Check_Air.py
+++ b/examples/ClientTests/scripts/Check_Air.py
@@ -15,7 +15,6 @@
    \version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 import sys
 

--- a/examples/ClientTests/scripts/Check_reflection.py
+++ b/examples/ClientTests/scripts/Check_reflection.py
@@ -15,7 +15,6 @@
    \version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 import math
 import time

--- a/examples/ClientTests/scripts/Check_shape.py
+++ b/examples/ClientTests/scripts/Check_shape.py
@@ -15,7 +15,6 @@
    \version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 import math
 import time

--- a/examples/ClientTests/scripts/DDG4TestSetup.py
+++ b/examples/ClientTests/scripts/DDG4TestSetup.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import sys
 import logging
 import DDG4

--- a/examples/ClientTests/scripts/DriftChamber.py
+++ b/examples/ClientTests/scripts/DriftChamber.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/ClientTests/scripts/FCC_Hcal.py
+++ b/examples/ClientTests/scripts/FCC_Hcal.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/ClientTests/scripts/FiberTubeCalorimeter.py
+++ b/examples/ClientTests/scripts/FiberTubeCalorimeter.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/ClientTests/scripts/GdmlDetector.py
+++ b/examples/ClientTests/scripts/GdmlDetector.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import DDG4

--- a/examples/ClientTests/scripts/Issue_786.py
+++ b/examples/ClientTests/scripts/Issue_786.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import time

--- a/examples/ClientTests/scripts/LheD_tracker.py
+++ b/examples/ClientTests/scripts/LheD_tracker.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/ClientTests/scripts/MiniTel.py
+++ b/examples/ClientTests/scripts/MiniTel.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import DDG4
 #
 """

--- a/examples/ClientTests/scripts/MiniTelEnergyDeposits.py
+++ b/examples/ClientTests/scripts/MiniTelEnergyDeposits.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import sys
 import time
 import DDG4

--- a/examples/ClientTests/scripts/MiniTelGenerate.py
+++ b/examples/ClientTests/scripts/MiniTelGenerate.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import DDG4
 #
 """

--- a/examples/ClientTests/scripts/MiniTelRegions.py
+++ b/examples/ClientTests/scripts/MiniTelRegions.py
@@ -15,7 +15,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/ClientTests/scripts/MiniTelSetup.py
+++ b/examples/ClientTests/scripts/MiniTelSetup.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4TestSetup

--- a/examples/ClientTests/scripts/MiniTel_hepmc.py
+++ b/examples/ClientTests/scripts/MiniTel_hepmc.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import os
 import DDG4
 #

--- a/examples/ClientTests/scripts/MultiCollections.py
+++ b/examples/ClientTests/scripts/MultiCollections.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import time

--- a/examples/ClientTests/scripts/MultiSegmentCollections.py
+++ b/examples/ClientTests/scripts/MultiSegmentCollections.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import time

--- a/examples/ClientTests/scripts/NestedBoxReflection.py
+++ b/examples/ClientTests/scripts/NestedBoxReflection.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import time

--- a/examples/ClientTests/scripts/NestedDetectors.py
+++ b/examples/ClientTests/scripts/NestedDetectors.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/ClientTests/scripts/ParamVolume.py
+++ b/examples/ClientTests/scripts/ParamVolume.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import logging
 #
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/ClientTests/scripts/SiliconBlock.py
+++ b/examples/ClientTests/scripts/SiliconBlock.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/ClientTests/scripts/SiliconBlockFastSim.py
+++ b/examples/ClientTests/scripts/SiliconBlockFastSim.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/ClientTests/scripts/SiliconBlockGFlash.py
+++ b/examples/ClientTests/scripts/SiliconBlockGFlash.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import logging
 #
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/ClientTests/scripts/TrackingRegion.py
+++ b/examples/ClientTests/scripts/TrackingRegion.py
@@ -10,7 +10,6 @@
 # ==========================================================================
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import DDG4

--- a/examples/DDCAD/scripts/DD4hep_Issue_1134.py
+++ b/examples/DDCAD/scripts/DD4hep_Issue_1134.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/DDCMS/scripts/CMSEcalSim.py
+++ b/examples/DDCMS/scripts/CMSEcalSim.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import time

--- a/examples/DDCMS/scripts/CMSTrackerSim.py
+++ b/examples/DDCMS/scripts/CMSTrackerSim.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import time

--- a/examples/DDCodex/python/CODEX-b-alone.py
+++ b/examples/DDCodex/python/CODEX-b-alone.py
@@ -1,6 +1,5 @@
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import time

--- a/examples/DDCodex/python/GeoExtract.py
+++ b/examples/DDCodex/python/GeoExtract.py
@@ -4,7 +4,6 @@
 # Syntax is:
 #   gaudirun.py Brunel-Default.py <someDataFiles>.py
 ###############################################################################
-from __future__ import absolute_import, unicode_literals
 import os
 from GaudiConf import IOHelper
 from Gaudi.Configuration import *  # noqa: F403

--- a/examples/DDDigi/scripts/DigiTest.py
+++ b/examples/DDDigi/scripts/DigiTest.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 import os
 import dddigi
 import logging

--- a/examples/DDDigi/scripts/TestAttenuate.py
+++ b/examples/DDDigi/scripts/TestAttenuate.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 from g4units import ns
 
 

--- a/examples/DDDigi/scripts/TestDepositCount.py
+++ b/examples/DDDigi/scripts/TestDepositCount.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestDepositSmearEnergy.py
+++ b/examples/DDDigi/scripts/TestDepositSmearEnergy.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestDepositSmearTime.py
+++ b/examples/DDDigi/scripts/TestDepositSmearTime.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestDepositWeighted.py
+++ b/examples/DDDigi/scripts/TestDepositWeighted.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestEdm4hepInput.py
+++ b/examples/DDDigi/scripts/TestEdm4hepInput.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestEdm4hepOutput.py
+++ b/examples/DDDigi/scripts/TestEdm4hepOutput.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 # ---------------------------------------------------------------------------

--- a/examples/DDDigi/scripts/TestFramework.py
+++ b/examples/DDDigi/scripts/TestFramework.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import dddigi
 import os
 

--- a/examples/DDDigi/scripts/TestHitHistory.py
+++ b/examples/DDDigi/scripts/TestHitHistory.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestHitProcessing.py
+++ b/examples/DDDigi/scripts/TestHitProcessing.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestIPMove.py
+++ b/examples/DDDigi/scripts/TestIPMove.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestInput.py
+++ b/examples/DDDigi/scripts/TestInput.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestMultiContainerParallel.py
+++ b/examples/DDDigi/scripts/TestMultiContainerParallel.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 import dddigi
 
 

--- a/examples/DDDigi/scripts/TestMultiInteractions.py
+++ b/examples/DDDigi/scripts/TestMultiInteractions.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestPositionSmearResolution.py
+++ b/examples/DDDigi/scripts/TestPositionSmearResolution.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestPositionSmearTrack.py
+++ b/examples/DDDigi/scripts/TestPositionSmearTrack.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestProperties.py
+++ b/examples/DDDigi/scripts/TestProperties.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def yes_no(val):

--- a/examples/DDDigi/scripts/TestResegmentation.py
+++ b/examples/DDDigi/scripts/TestResegmentation.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestSegmentationSplit.py
+++ b/examples/DDDigi/scripts/TestSegmentationSplit.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestSegmentationSplit2.py
+++ b/examples/DDDigi/scripts/TestSegmentationSplit2.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestSimpleADCResponse.py
+++ b/examples/DDDigi/scripts/TestSimpleADCResponse.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 def run():

--- a/examples/DDDigi/scripts/TestSpillover.py
+++ b/examples/DDDigi/scripts/TestSpillover.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 from g4units import ns
 
 

--- a/examples/DDDigi/scripts/TestWriteDigi.py
+++ b/examples/DDDigi/scripts/TestWriteDigi.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import
 
 
 # ---------------------------------------------------------------------------

--- a/examples/DDG4/scripts/Channeling.py
+++ b/examples/DDG4/scripts/Channeling.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import logging
 #
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/DDG4/scripts/TestProperties.py
+++ b/examples/DDG4/scripts/TestProperties.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 #
 # ==========================================================================
-from __future__ import absolute_import, unicode_literals
 import logging
 import DDG4
 import os

--- a/examples/DDG4/scripts/TestSIGINT.py
+++ b/examples/DDG4/scripts/TestSIGINT.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import logging
 #
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/DDG4/scripts/TestStacking.py
+++ b/examples/DDG4/scripts/TestStacking.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import logging
 #
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/DDG4/scripts/TestStepping.py
+++ b/examples/DDG4/scripts/TestStepping.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import logging
 #
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/DDG4/scripts/TestUserCommands.py
+++ b/examples/DDG4/scripts/TestUserCommands.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import logging
 #
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/DDG4_MySensDet/scripts/MyTrackerSD_sim.py
+++ b/examples/DDG4_MySensDet/scripts/MyTrackerSD_sim.py
@@ -1,6 +1,5 @@
 #
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import time
 import DDG4

--- a/examples/LHeD/scripts/LHeD.py
+++ b/examples/LHeD/scripts/LHeD.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, unicode_literals
 import sys
 import logging
 import DDG4

--- a/examples/LHeD/scripts/LHeDMagField.py
+++ b/examples/LHeD/scripts/LHeDMagField.py
@@ -5,7 +5,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 if __name__ == "__main__":
   import LHeD
   lhed = LHeD.LHeD().loadGeometry()

--- a/examples/LHeD/scripts/LHeDPhysics.py
+++ b/examples/LHeD/scripts/LHeDPhysics.py
@@ -5,7 +5,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 if __name__ == "__main__":
   import LHeD
   lhed = LHeD.LHeD().loadGeometry()

--- a/examples/LHeD/scripts/LHeDRandom.py
+++ b/examples/LHeD/scripts/LHeDRandom.py
@@ -5,7 +5,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 from ROOT import gRandom
 import logging
 

--- a/examples/LHeD/scripts/LHeDScan.py
+++ b/examples/LHeD/scripts/LHeDScan.py
@@ -6,7 +6,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/LHeD/scripts/LHeD_G4Gun.py
+++ b/examples/LHeD/scripts/LHeD_G4Gun.py
@@ -7,7 +7,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/LHeD/scripts/LheSimu.py
+++ b/examples/LHeD/scripts/LheSimu.py
@@ -7,7 +7,6 @@
    modified for LHeC
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/examples/OpticalSurfaces/scripts/OpNovice.py
+++ b/examples/OpticalSurfaces/scripts/OpNovice.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import DDG4

--- a/examples/OpticalSurfaces/scripts/OpNovice_GDML.py
+++ b/examples/OpticalSurfaces/scripts/OpNovice_GDML.py
@@ -17,7 +17,6 @@
    @version 1.0
 
 """
-from __future__ import absolute_import, unicode_literals
 import os
 import DDG4
 

--- a/examples/OpticalSurfaces/scripts/ReadMaterialProperties.py
+++ b/examples/OpticalSurfaces/scripts/ReadMaterialProperties.py
@@ -9,7 +9,6 @@
 #
 # ==========================================================================
 #
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import DDG4

--- a/examples/RICH/scripts/richsim.py
+++ b/examples/RICH/scripts/richsim.py
@@ -6,7 +6,6 @@ Based on M. Frank and F. Gaede runSim.py
 
 Modified with settings for RICH simulation
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 import sys
 import os


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove `from __future__ import` since we are using Python 3

ENDRELEASENOTES

I don't see other Python 2 stuff, maybe here https://github.com/AIDASoft/DD4hep/blob/master/DDG4/tpython/DDPython.cpp#L30 some lines could be removed.