### PR TITLE
Make some test optional, fix EventParameter type for EDM4hepOutput

### DIFF
--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -67,6 +67,8 @@ namespace dd4hep {
     class Geant4Output2EDM4hep : public Geant4OutputAction  {
     protected:
       using writer_t = podio::ROOTWriter;
+      using floatmap_t = std::map< std::string, float >;
+      using intmap_t = std::map< std::string, int >;
       using stringmap_t = std::map< std::string, std::string >;
       using trackermap_t = std::map< std::string, edm4hep::SimTrackerHitCollection >;
       using calorimeterpair_t = std::pair< edm4hep::SimCalorimeterHitCollection, edm4hep::CaloHitContributionCollection >;
@@ -78,8 +80,8 @@ namespace dd4hep {
       trackermap_t                  m_trackerHits;
       calorimetermap_t              m_calorimeterHits;
       stringmap_t                   m_runHeader;
-      stringmap_t                   m_eventParametersInt;
-      stringmap_t                   m_eventParametersFloat;
+      intmap_t                      m_eventParametersInt;
+      floatmap_t                    m_eventParametersFloat;
       stringmap_t                   m_eventParametersString;
       stringmap_t                   m_cellIDEncodingStrings{};
       std::string                   m_section_name      { "events" };
@@ -117,9 +119,13 @@ namespace dd4hep {
     protected:
       /// Fill event parameters in EDM4hep event
       template <typename T>
-      void saveEventParameters(const std::map<std::string, std::string >& parameters)   {
-        for(const auto& p : parameters)   {
-          info("Saving event parameter: %-32s = %s", p.first.c_str(), p.second.c_str());
+      void saveEventParameters(const std::map<std::string, T >& parameters)   {
+        for(const auto& p : parameters) {
+          std::stringstream output;
+          output << "Saving event parameter: "
+                 << std::setw(32) << p.first
+                 << std::setw(20) << p.second;
+          info(output.str().c_str());
           m_frame.putParameter(p.first, p.second);
         }
       }

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -49,6 +49,9 @@ foreach(TEST_NAME
 endforeach()
 
 find_program(HAVE_PYTEST pytest)
+if(NOT HAVE_PYTEST)
+  message(WARNING "pytest not found! Skipping pytest tests.")
+endif()
 
 if(HAVE_PYTEST)
   ADD_TEST( t_test_python_import "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"

--- a/DDTest/CMakeLists.txt
+++ b/DDTest/CMakeLists.txt
@@ -48,16 +48,20 @@ foreach(TEST_NAME
   set_tests_properties(t_${TEST_NAME} PROPERTIES FAIL_REGULAR_EXPRESSION "TEST_FAILED")
 endforeach()
 
-ADD_TEST( t_test_python_import "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-  pytest ${PROJECT_SOURCE_DIR}/DDTest/python/test_import.py)
-SET_TESTS_PROPERTIES( t_test_python_import PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+find_program(HAVE_PYTEST pytest)
+
+if(HAVE_PYTEST)
+  ADD_TEST( t_test_python_import "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+    pytest ${PROJECT_SOURCE_DIR}/DDTest/python/test_import.py)
+  SET_TESTS_PROPERTIES( t_test_python_import PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+endif()
 
 if (DD4HEP_USE_GEANT4)
-
-  ADD_TEST( t_test_python_import_ddg4 "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
-    pytest ${PROJECT_SOURCE_DIR}/DDTest/python/test_import_ddg4.py)
-  SET_TESTS_PROPERTIES( t_test_python_import_ddg4 PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
-
+  if(HAVE_PYTEST)
+    ADD_TEST( t_test_python_import_ddg4 "${CMAKE_INSTALL_PREFIX}/bin/run_test.sh"
+      pytest ${PROJECT_SOURCE_DIR}/DDTest/python/test_import_ddg4.py)
+    SET_TESTS_PROPERTIES( t_test_python_import_ddg4 PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+  endif()
   if(DD4HEP_USE_HEPMC3)
     set(TEST_HEPMC3_EXTENSIONS)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Tests: make some tests that need pytest only run when pytest is available
- Geant4Output2EDM4hep: fix type categorisation for EventParameters, previously all parameters ended up in the string parameter section.

ENDRELEASENOTES