### PR TITLE
State that the physicsList argument is deprecated

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -181,7 +181,7 @@ class DD4hepSimulation(object):
                         help="Skip first N events when reading a file")
 
     parser.add_argument("--physicsList", action="store", dest="physicsList", default=self.physicsList,
-                        help="Physics list to use in simulation")
+                        help="Physics list to use in simulation. Deprecated, use physics.list")
 
     parser.add_argument("--crossingAngleBoost", action="store", dest="crossingAngleBoost",
                         default=self.crossingAngleBoost,


### PR DESCRIPTION
BEGINRELEASENOTES
- DDSim: State in the helper message that the physicsList argument is deprecated

ENDRELEASENOTES

Following the comment here: https://github.com/AIDASoft/DD4hep/blob/master/DDG4/python/DDSim/DD4hepSimulation.py#L74