### PR TITLE
Remove an include of a folder that does not exist in ClientTests

### DIFF
--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -24,7 +24,6 @@ if(TARGET XercesC::XercesC)
   SET(OPT_XERCESC XercesC::XercesC)
 endif()
 
-include_directories(./include)
 #--------------------------------------------------------------------------
 if(TARGET Boost::boost)
   SET(CT_BOOST_SOURCES src_boost/*.cpp)


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the inclusion of `./include` for ClientTests since this folder doesn't exist

ENDRELEASENOTES