### PR TITLE
Add warning message about unreliable material scans 

### DIFF
--- a/DDRec/include/DDRec/MaterialManager.h
+++ b/DDRec/include/DDRec/MaterialManager.h
@@ -41,6 +41,9 @@ namespace dd4hep {
     class MaterialManager {
 
     public:
+      static constexpr const double epsilon = 1e-4;
+      
+    public:
 
       /// Instantiate the MaterialManager for this (world) volume
       MaterialManager(Volume world);
@@ -52,17 +55,29 @@ namespace dd4hep {
 #endif
 
       ~MaterialManager();
+
+      class ScanData  {
+      public:
+        const MaterialVec&  materials;
+        const PlacementVec& places;
+      };
       
       /** Get a vector with all the materials between the two points p0 and p1 with the corresponding thicknesses -
        *  element type is  std::pair< Material, double >. Materials with a thickness smaller than epsilon (default 1e-4=1mu)
        *  are ignored. Avoid calling this method in inner loops as the computation is not cheap. Ideally the result should be cached,
        *  for example as an averaged material @see createAveragedMaterial().
        */
-      const MaterialVec& materialsBetween(const Vector3D& p0, const Vector3D& p1 , double epsilon=1e-4 );
+      const MaterialVec& materialsBetween(const Vector3D& p0,
+                                          const Vector3D& p1,
+                                          double eps = MaterialManager::epsilon);
+      /// As above, but optionally allow access to traversed placements
+      const ScanData     entriesBetween(const Vector3D& p0,
+                                        const Vector3D& p1,
+                                        double eps = MaterialManager::epsilon);
 
       /** Get a vector with all the placements between the two points p0 and p1
        */
-      const PlacementVec& placementsBetween(const Vector3D& p0, const Vector3D& p1 , double epsilon=1e-4 );
+      const PlacementVec& placementsBetween(const Vector3D& p0, const Vector3D& p1 , double eps = MaterialManager::epsilon );
       
       /** Get the material at the given position.
        */

--- a/DDRec/src/MaterialManager.cpp
+++ b/DDRec/src/MaterialManager.cpp
@@ -32,12 +32,19 @@ namespace dd4hep {
       
     }
     
-    const PlacementVec& MaterialManager::placementsBetween(const Vector3D& p0, const Vector3D& p1 , double epsilon) {
-      materialsBetween(p0,p1,epsilon);
+    const PlacementVec& MaterialManager::placementsBetween(const Vector3D& p0, const Vector3D& p1 , double eps) {
+      materialsBetween(p0,p1,eps);
       return _placeV;
     }
 
-    const MaterialVec& MaterialManager::materialsBetween(const Vector3D& p0, const Vector3D& p1 , double epsilon) {
+    const MaterialManager::ScanData MaterialManager::entriesBetween(const Vector3D& p0,
+                                                                    const Vector3D& p1,
+                                                                    double eps)  {
+      const auto& materials = this->materialsBetween(p0, p1, eps);
+      return { materials, this->_placeV };
+    }
+
+    const MaterialVec& MaterialManager::materialsBetween(const Vector3D& p0, const Vector3D& p1 , double eps) {
       if( ( p0 != _p0 ) || ( p1 != _p1 ) ) {	
         // A backup is needed to restore the state of the navigator after the track is done
         // see https://github.com/AIDASoft/DD4hep/issues/1413
@@ -128,7 +135,7 @@ namespace dd4hep {
             track->AddPoint( endpoint[0], endpoint[1], endpoint[2], 0. );
 	    
 	    
-            if( length > epsilon )   {
+            if( length > eps )   {
               _mV.emplace_back(node1->GetMedium(), length ); 
               _placeV.emplace_back(node1,length);
             }
@@ -137,7 +144,7 @@ namespace dd4hep {
 	  
           track->AddPoint( position[0], position[1], position[2], 0.);
 	  
-          if( length > epsilon )   {
+          if( length > eps )   {
             _mV.emplace_back(node1->GetMedium(), length); 
             _placeV.emplace_back(node1,length);
           }


### PR DESCRIPTION
BEGINRELEASENOTES

if tessellated shapes are encountered ROOT material scans are unreliable, because tessellated shapes do not 
participate in tracking. For the graphical scan a warning message is issued to warn the user that the scan
results are not reliable.
This was mentioned in Issue https://github.com/AIDASoft/DD4hep/issues/1490 but there nothing 
we can do about in dd4hep, because this is a deficiency, which must be resolved in the ROOT geometry package.

ENDRELEASENOTES