### PR TITLE
fix: avoid double deduce/open for HEPMC3FileReader when not ReaderAscii

### DIFF
--- a/DDG4/hepmc/HepMC3FileReader.cpp
+++ b/DDG4/hepmc/HepMC3FileReader.cpp
@@ -129,17 +129,19 @@ HEPMC3FileReader::HEPMC3FileReader(const std::string& nam)
   printout(INFO,"HEPMC3FileReader","Created file reader. Try to open input %s", nam.c_str());
   m_reader = HepMC3::deduce_reader(nam);
 #if HEPMC3_VERSION_CODE >= 3002006
-  // to get the runInfo in the Ascii reader we have to force HepMC to read the first event
-  HepMC3::GenEvent dummy;
-  m_reader->read_event(dummy);
-  // then we get the run info (shared pointer)
-  auto runInfo = m_reader->run_info();
-  // and deallocate the reader
-  m_reader.reset();
-  // so we can open the file again from the start
-  m_reader = HepMC3::deduce_reader(nam);
-  // and set the run info object now
-  m_reader->set_run_info(std::move(runInfo));
+  if (std::dynamic_pointer_cast<HepMC3::ReaderAscii>(m_reader) != nullptr) {
+    // to get the runInfo in the Ascii reader we have to force HepMC to read the first event
+    HepMC3::GenEvent dummy;
+    m_reader->read_event(dummy);
+    // then we get the run info (shared pointer)
+    auto runInfo = m_reader->run_info();
+    // and deallocate the reader
+    m_reader.reset();
+    // so we can open the file again from the start
+    m_reader = HepMC3::deduce_reader(nam);
+    // and set the run info object now
+    m_reader->set_run_info(std::move(runInfo));
+  }
 #endif
   m_directAccess = false;
 }


### PR DESCRIPTION
In HEPMC3FileReader, we deduce the reader and open the file twice since we need to read the first event to get the run info, which is required for the case of ReaderAscii only (!).

However, for ReaderRootTree this double deduce/open has started to cause issues since ROOT 6.36, giving confused errors like this (on files that are able to be read just fine with HepMC3 example code in isolation):
```
Error in <TTree::SetBranchAddress>: The pointer type given (HepMC3::GenRunInfoData) does not correspond to the class needed (HepMC3::GenEventData) by the branch: hepmc3_event
ERROR::ReaderRootTree: problem reading branch tree:  hepmc3_tree
```
This error seems to occur only inside DD4hep, not outside of it...

But, this error only occurs for ROOT IO in HepMC3 and the double deduce/open is not needed in that case anyway, so this PR removes the double deduce/open except for ReaderAscii.

For reference, here is a sample file on which these errors occur: 
[pythia8NCDIS_10x100_minQ2=1_beamEffects_xAngle=-0.025_hiDiv_1.hepmc3.tree.root.gz](https://github.com/user-attachments/files/22178402/pythia8NCDIS_10x100_minQ2.1_beamEffects_xAngle.-0.025_hiDiv_1.hepmc3.tree.root.gz)
Sample command:
```
ddsim --compactFile $DD4hepINSTALL/DDDetectors/compact/SiD.xml -N1 --inputFiles pythia8NCDIS_10x100_minQ2=1_beamEffects_xAngle=-0.025_hiDiv_1.hepmc3.tree.root
```

BEGINRELEASENOTES
- Remove double type deduce/open to avoid spurious errors with ROOT 6.36

ENDRELEASENOTES