### PR TITLE
fix: Remove logging of constants (name and ptr) in checkOverlaps.py

### DIFF
--- a/DDCore/python/bin/checkOverlaps.py
+++ b/DDCore/python/bin/checkOverlaps.py
@@ -72,8 +72,6 @@ description = dd4hep.Detector.getInstance()
 for xmlfile in args.compact:
   description.fromXML(xmlfile)
 
-logger.info(str(description.constants()))
-
 description.manager().CheckOverlaps(args.tolerance, args.option)
 #
 #


### PR DESCRIPTION
This PR removes the logging of the geometry constants (name and ptr), before checking overlaps. This used to not be printed (pre-1.22), and was likely a debugging change that got committed unintentionally (https://github.com/AIDASoft/DD4hep/pull/941, @kjvbrt).

This removes largely useless output like:
```
 TrackerSupportDRICHConeSegmentB_zmax" => @0x5efafbd809b0, "TrackerSupportDRICHConeSegmentB_zmin" =>
 @0x5efafbd80830, "TrackerSupportDRICHCylSegmentAl_thickness" => @0x5efafbd815d0,
 "TrackerSupportDRICHCylSegment_deltaphi" => @0x5efafbd81960, "TrackerSupportDRICHCylSegment_length" =>
 @0x5efafbd82640, "TrackerSupportDRICHCylSegment_rmin" => @0x5efafbd81f40,
 "TrackerSupportDRICHCylSegment_thickness" => @0x5efafbd81790, "TrackerSupportDRICHCylSegment_z" =>
 @0x5efafbd82100, "TrackerSupportDRICHCylSegment_zmax" => @0x5efafbd81d80,
 "TrackerSupportDRICHCylSegment_zmin" => @0x5efafbd81b80, "TrackerSupportDiskEndcapCF_thickness" =>
 @0x5efafbd7c0c0, "TrackerSupportDiskEndcapPAl_thickness" => @0x5efafbd7c2d0, "TrackerSupportDiskEndcapP_rmax"
 => @0x5efafbd7cde0, "TrackerSupportDiskEndcapP_rmin" => @0x5efafbd7cc00, "TrackerSupportDiskEndcapP_thickness"
 => @0x5efafbd7c490, "TrackerSupportDiskEndcapP_z" => @0x5efafbd7d320, "TrackerSupportDiskEndcapP_zmax" =>
 @0x5efafbd7cd90, "TrackerSupportDiskEndcapP_zmin" => @0x5efafbd7c4e0, "TrackerSupport_0_ID" =>
 @0x5efafb782600, "TrackerSupport_1_ID" => @0x5efafb782790, "VacuumMagnetElement_1_ID" => @0x5efafb780790,
 "Vacuum_BB_MaxX" => @0x5efafb835d90, "Vacuum_BB_MaxY" => @0x5efafb835ff0, "Vacuum_BB_MaxZ" =>
 @0x5efafb836250, "Vacuum_BB_MinX" => @0x5efafb835c20, "Vacuum_BB_MinY" => @0x5efafb835ec0,
 "Vacuum_BB_MinZ" => @0x5efafb836120, "VertexBarrelEnvelope_length" => @0x5efafbc47b50,
 "VertexBarrelLayer1_rmax" => @0x5efafbc755b0, "VertexBarrelLayer1_rmin" => @0x5efafb754da0,
 "VertexBarrelLayer2_rmax" => @0x5efafb8ce770, "VertexBarrelLayer2_rmin" => @0x5efafb8cf2c0,
 "VertexBarrelLayer3_rmax" => @0x5efafbc76ea0, "VertexBarrelLayer3_rmin" => @0x5efafb8ce660,
 "VertexBarrelLayer_length" => @0x5efafbc47a00, "VertexBarrelLayer_thickness
```

BEGINRELEASENOTES
- Remove logging of constants in checkOverlaps

ENDRELEASENOTES