### PR TITLE
Increase tolerance of a test to avoid failures

### DIFF
--- a/examples/RICH/scripts/test_number_of_hits.C
+++ b/examples/RICH/scripts/test_number_of_hits.C
@@ -2,7 +2,7 @@ void test_number_of_hits(TString sim_file_name="sim.root") {
 
   // test requirements
   const Double_t expected_number_of_hits = 230.0;
-  const Double_t allowed_deviation       = 16.0;
+  const Double_t allowed_deviation       = 20.0;
 
   // get average number of hits
   auto sim_file = new TFile(sim_file_name);


### PR DESCRIPTION
BEGINRELEASENOTES
- Increase tolerance of a test to avoid failures

ENDRELEASENOTES

I saw this test failing recently so I ran it 1000 times and plotted the distribution. From 1000 runs, the minimum is 222 and the maximum is 246 (which is already an average).

[hist.pdf](https://github.com/user-attachments/files/22215378/hist.pdf)
