### PR TITLE
Modernize code related to Surfaces and the SurfaceManager

### DIFF
--- a/DDRec/include/DDRec/DetectorSurfaces.h
+++ b/DDRec/include/DDRec/DetectorSurfaces.h
@@ -25,23 +25,19 @@ namespace dd4hep {
      * @date Apr, 10 2014
      * @version $Id$
      */
-    class DetectorSurfaces: virtual public DetElement {
+    class DetectorSurfaces {
 
     public:
-      typedef DetElement DetElement;
-
       DetectorSurfaces(const DetElement& e);
-
-      virtual ~DetectorSurfaces();
 
       /// get the list of surfaces added to this DetElement
       const SurfaceList& surfaceList() { return *_sL ; }
 
     protected :
-      SurfaceList* _sL ;
+      SurfaceList* _sL { nullptr };
 
       /// initializes surfaces from VolSurfaces assigned to this DetElement in detector construction
-      void initialize() ;
+      void initialize(const DetElement& det) ;
 
     };
 

--- a/DDRec/include/DDRec/Surface.h
+++ b/DDRec/include/DDRec/Surface.h
@@ -290,7 +290,7 @@ namespace dd4hep {
     /** Helper function for accessing the list assigned to a DetElement - attaches
      * empty list if needed.
      */
-    VolSurfaceList* volSurfaceList( DetElement& det) ;
+    VolSurfaceList* volSurfaceList( const DetElement& det) ;
 
     /** std::list of VolSurfaces that takes ownership.
      * @author F.Gaede, DESY
@@ -299,10 +299,10 @@ namespace dd4hep {
      */
     struct VolSurfaceList : std::list< VolSurface > {
     
-      VolSurfaceList() {}
+      VolSurfaceList() = default;
 
       // required c'tor for extension mechanism
-      VolSurfaceList(DetElement& det){
+      VolSurfaceList(const DetElement& det){
 
         VolSurfaceList* sL = volSurfaceList( det ) ; 
 
@@ -311,13 +311,11 @@ namespace dd4hep {
 
 
       // required c'tor for extension mechanism
-      VolSurfaceList(const VolSurfaceList& vsl, DetElement& /*det*/ ){
+      VolSurfaceList(const VolSurfaceList& vsl, const DetElement& /*det*/ ){
 	
         this->insert( this->end() , vsl.begin() , vsl.end() ) ;
       }
     
-      virtual ~VolSurfaceList() ;
-
     } ;
   
 
@@ -518,7 +516,7 @@ namespace dd4hep {
 
     public:
     
-      virtual ~Surface() {} 
+      virtual ~Surface() = default;
 
       /** Standard c'tor initializes the surface from the parameters of the VolSurface and the 
        *  transform (placement) of the corresponding volume, if found in DetElement 

--- a/DDRec/include/DDRec/Surface.h
+++ b/DDRec/include/DDRec/Surface.h
@@ -69,7 +69,7 @@ namespace dd4hep {
 
     public:
     
-      virtual ~VolSurfaceBase() = default;
+      virtual ~VolSurfaceBase() override = default;
 
       ///default c'tor
 
@@ -103,62 +103,62 @@ namespace dd4hep {
       Volume volume() const { return _vol ; }
 
       /// The id of this surface 
-      virtual long64 id() const  ;
+      virtual long64 id() const override ;
 
       /** properties of the surface encoded in Type.
        * @see SurfaceType
        */
-      virtual const SurfaceType& type() const ;
+      virtual const SurfaceType& type() const override ;
     
       //==== geometry ====
       
       /** First direction of measurement U */
-      virtual Vector3D u( const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D u( const Vector3D& point = Vector3D() ) const override ;
     
       /** Second direction of measurement V */
-      virtual Vector3D v(const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D v(const Vector3D& point = Vector3D() ) const override ;
     
       /// Access to the normal direction at the given point
-      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const override ;
     
       /** Get Origin of local coordinate system on surface */
-      virtual const Vector3D& origin() const ;
+      virtual const Vector3D& origin() const override ;
       
       /** Convert the global position to the local position (u,v) on the surface */
-      virtual Vector2D globalToLocal( const Vector3D& point) const ;
+      virtual Vector2D globalToLocal( const Vector3D& point) const override ;
       
       /** Convert the local position (u,v) on the surface to the global position */
-      virtual Vector3D localToGlobal( const Vector2D& point) const ;
+      virtual Vector3D localToGlobal( const Vector2D& point) const override ;
       
       /// Access to the material in opposite direction of the normal
-      virtual const IMaterial& innerMaterial() const ;
+      virtual const IMaterial& innerMaterial() const override ;
 
       /// Access to the material in direction of the normal
-      virtual const IMaterial& outerMaterial() const ;
+      virtual const IMaterial& outerMaterial() const override ;
     
       /** Thickness of inner material */
-      virtual double innerThickness() const ;
+      virtual double innerThickness() const override ;
 
       /** Thickness of outer material */
-      virtual double outerThickness() const ;
+      virtual double outerThickness() const override ;
 
 
       /** The length of the surface along direction u at the origin. For 'regular' boundaries, like rectangles, 
        *  this can be used to speed up the computation of inSideBounds.
        */
-      virtual double length_along_u() const ;
+      virtual double length_along_u() const override ;
 
       /** The length of the surface along direction v at the origin. For 'regular' boundaries, like rectangles, 
        *  this can be used to speed up the computation of inSideBounds.
        */
-      virtual double length_along_v() const ;
+      virtual double length_along_v() const override ;
 
 
       /** Distance to surface */
-      virtual double distance(const Vector3D& point ) const ;
+      virtual double distance(const Vector3D& point ) const override ;
       
       /// Checks if the given point lies within the surface
-      virtual bool insideBounds(const Vector3D& point, double epsilon=1e-4 ) const ;
+      virtual bool insideBounds(const Vector3D& point, double epsilon=1e-4 ) const override ;
 
 
       virtual std::vector< std::pair<Vector3D, Vector3D> > getLines(unsigned nMax=100) ;
@@ -186,14 +186,14 @@ namespace dd4hep {
 
     public:
     
-      virtual ~VolSurface(){
+      virtual ~VolSurface() override {
         if( _surf ) {
           -- _surf->_refCount ;
           if(  _surf->_refCount == 0 ) delete _surf ;
         }
       } 
       ///default c'tor
-      VolSurface() : _surf(0) { }
+      VolSurface() : _surf(nullptr) { }
 
       /// Constructor to be used with an existing object
       VolSurface(VolSurfaceBase* p) : _surf( p ) { ++ _surf->_refCount ; }
@@ -217,61 +217,61 @@ namespace dd4hep {
       VolSurfaceBase* ptr() const { return _surf ; }	
       
       /// The id of this surface - always 0 for VolSurfaces
-      virtual long64 id() const  ;
+      virtual long64 id() const override ;
 
       /** properties of the surface encoded in Type.
        * @see SurfaceType
        */
-      virtual const SurfaceType& type() const ;
+      virtual const SurfaceType& type() const override ;
     
       //==== geometry ====
       
       /** First direction of measurement U */
-      virtual Vector3D u( const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D u( const Vector3D& point = Vector3D() ) const override ;
     
       /** Second direction of measurement V */
-      virtual Vector3D v(const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D v(const Vector3D& point = Vector3D() ) const override ;
     
       /// Access to the normal direction at the given point
-      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const override ;
     
       /** Get Origin of local coordinate system on surface */
-      virtual const Vector3D& origin() const ;
+      virtual const Vector3D& origin() const override ;
       
       /** Convert the global position to the local position (u,v) on the surface */
-      virtual Vector2D globalToLocal( const Vector3D& point) const ;
+      virtual Vector2D globalToLocal( const Vector3D& point) const override ;
       
       /** Convert the local position (u,v) on the surface to the global position */
-      virtual Vector3D localToGlobal( const Vector2D& point) const ;
+      virtual Vector3D localToGlobal( const Vector2D& point) const override ;
       
       /// Access to the material in opposite direction of the normal
-      virtual const IMaterial& innerMaterial() const ;
+      virtual const IMaterial& innerMaterial() const override ;
 
       /// Access to the material in direction of the normal
-      virtual const IMaterial& outerMaterial() const ;
+      virtual const IMaterial& outerMaterial() const override ;
     
       /** Thickness of inner material */
-      virtual double innerThickness() const ;
+      virtual double innerThickness() const override ;
 
       /** Thickness of outer material */
-      virtual double outerThickness() const ;
+      virtual double outerThickness() const override ;
 
 
       /** The length of the surface along direction u at the origin. For 'regular' boundaries, like rectangles, 
        *  this can be used to speed up the computation of inSideBounds.
        */
-      virtual double length_along_u() const ;
+      virtual double length_along_u() const override ;
 
       /** The length of the surface along direction v at the origin. For 'regular' boundaries, like rectangles, 
        *  this can be used to speed up the computation of inSideBounds.
        */
-      virtual double length_along_v() const ;
+      virtual double length_along_v() const override ;
 
       /** Distance to surface */
-      virtual double distance(const Vector3D& point ) const ;
+      virtual double distance(const Vector3D& point ) const override ;
       
       /// Checks if the given point lies within the surface
-      virtual bool insideBounds(const Vector3D& point, double epsilon=1e-4 ) const ;
+      virtual bool insideBounds(const Vector3D& point, double epsilon=1e-4 ) const override ;
 
       virtual std::vector< std::pair<Vector3D, Vector3D> > getLines(unsigned nMax=100) ;
  
@@ -279,7 +279,7 @@ namespace dd4hep {
       void setInnerMaterial( const IMaterial& mat ){ _surf->setInnerMaterial( mat ) ; }
 
       /// set the outer Materal
-      void setOuterMaterial( const IMaterial& mat ){  _surf->setOuterMaterial( mat ) ; }
+      void setOuterMaterial( const IMaterial& mat ){ _surf->setOuterMaterial( mat ) ; }
 
     };
 
@@ -347,7 +347,7 @@ namespace dd4hep {
       }      
       
       /** Distance to surface */
-      virtual double distance(const Vector3D& point ) const  ;
+      virtual double distance(const Vector3D& point ) const override ;
     } ;
 
     //======================================================================================================
@@ -373,21 +373,21 @@ namespace dd4hep {
       /** First direction of measurement U - rotated to point projected onto the cylinder.
        *  No check is done whether the point actually is on the cylinder surface
        */
-      virtual Vector3D u( const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D u( const Vector3D& point = Vector3D() ) const override ;
       
       /** The normal direction at the given point, projected  onto the cylinder.
        *  No check is done whether the point actually is on the cylinder surface
        */
-      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const override ;
 
       /** Distance to surface */
-      virtual double distance(const Vector3D& point ) const  ;
+      virtual double distance(const Vector3D& point ) const override ;
       
       /** Convert the global position to the local position (u,v) on the surface - v runs along the axis of the cylinder, u is r*phi */
-      virtual Vector2D globalToLocal( const Vector3D& point) const ;
+      virtual Vector2D globalToLocal( const Vector3D& point) const override ;
       
       /** Convert the local position (u,v) on the surface to the global position  - v runs along the axis of the cylinder, u is r*phi*/
-      virtual Vector3D localToGlobal( const Vector2D& point) const ;
+      virtual Vector3D localToGlobal( const Vector2D& point) const override ;
     } ;
 
     //======================================================================================================
@@ -421,28 +421,28 @@ namespace dd4hep {
       /** First direction of measurement U - rotated to point projected onto the cone.
        *  No check is done whether the point actually is on the cone surface
        */
-      virtual Vector3D u( const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D u( const Vector3D& point = Vector3D() ) const override ;
 
       /** Second direction of measurement V - rotated to point projected onto the cone.
        *  No check is done whether the point actually is on the cone surface
        */
-      virtual Vector3D v( const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D v( const Vector3D& point = Vector3D() ) const override ;
       
       /** The normal direction at the given point, projected  onto the cone.
        *  No check is done whether the point actually is on the cone surface
        */
-      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const override ;
 
       /** Distance to surface */
-      virtual double distance(const Vector3D& point ) const  ;
+      virtual double distance(const Vector3D& point ) const  override ;
       
       /** Convert the global position to the local position (u,v) on the surface - v runs along the axis of the cone, u is r*phi */
-      virtual Vector2D globalToLocal( const Vector3D& point) const ;
+      virtual Vector2D globalToLocal( const Vector3D& point) const override ;
       
       /** Convert the local position (u,v) on the surface to the global position  - v runs along the axis of the cone, u is r*phi*/
-      virtual Vector3D localToGlobal( const Vector2D& point) const ;
+      virtual Vector3D localToGlobal( const Vector2D& point) const override ;
 
-      virtual std::vector< std::pair<Vector3D, Vector3D> > getLines(unsigned nMax=100) ;
+      virtual std::vector< std::pair<Vector3D, Vector3D> > getLines(unsigned nMax=100) override ;
     } ;
 
 
@@ -516,7 +516,7 @@ namespace dd4hep {
 
     public:
     
-      virtual ~Surface() = default;
+      virtual ~Surface() override = default;
 
       /** Standard c'tor initializes the surface from the parameters of the VolSurface and the 
        *  transform (placement) of the corresponding volume, if found in DetElement 
@@ -524,12 +524,12 @@ namespace dd4hep {
       Surface( DetElement det, VolSurface volSurf ) ;      
     
       /// The id of this surface - corresponds to DetElement id.
-      virtual long64 id() const ;
+      virtual long64 id() const override ;
 
       /** properties of the surface encoded in Type.
        * @see SurfaceType
        */
-      virtual const SurfaceType& type() const ;
+      virtual const SurfaceType& type() const override ;
     
       /// The volume that has the surface attached.
       Volume volume() const { return _volSurf.volume()  ; }
@@ -544,40 +544,40 @@ namespace dd4hep {
       //==== geometry ====
       
       /** First direction of measurement U */
-      virtual Vector3D u( const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D u( const Vector3D& point = Vector3D() ) const override ;
     
       /** Second direction of measurement V */
-      virtual Vector3D v(const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D v(const Vector3D& point = Vector3D() ) const override ;
     
       /// Access to the normal direction at the given point
-      virtual  Vector3D normal(const Vector3D& point = Vector3D() ) const ;
+      virtual  Vector3D normal(const Vector3D& point = Vector3D() ) const override ;
     
       /** Get Origin of local coordinate system on surface */
-      virtual const Vector3D& origin() const ;
+      virtual const Vector3D& origin() const override ;
 
       /** Convert the global position to the local position (u,v) on the surface */
-      virtual Vector2D globalToLocal( const Vector3D& point) const ;
+      virtual Vector2D globalToLocal( const Vector3D& point) const override ;
       
       /** Convert the local position (u,v) on the surface to the global position*/
-      virtual Vector3D localToGlobal( const Vector2D& point) const ;
+      virtual Vector3D localToGlobal( const Vector2D& point) const override ;
 
       /** Thickness of inner material */
-      virtual double innerThickness() const ;
+      virtual double innerThickness() const override ;
 
       /** Thickness of outer material */
-      virtual double outerThickness() const ;
+      virtual double outerThickness() const override ;
 
       /// Access to the material in opposite direction of the normal
-      virtual const IMaterial& innerMaterial() const ;
+      virtual const IMaterial& innerMaterial() const override ;
      
       /// Access to the material in direction of the normal
-      virtual const IMaterial& outerMaterial() const ;
+      virtual const IMaterial& outerMaterial() const override ;
           
       /** Distance to surface */
-      virtual double distance(const Vector3D& point ) const  ;
+      virtual double distance(const Vector3D& point ) const override ;
       
       /// Checks if the given point lies within the surface
-      virtual bool insideBounds(const Vector3D& point, double epsilon=1.e-4) const ;
+      virtual bool insideBounds(const Vector3D& point, double epsilon=1.e-4) const override ;
 
       /** Get Origin of local coordinate system of the associated volume */
       virtual Vector3D volumeOrigin() const  ; 
@@ -585,12 +585,12 @@ namespace dd4hep {
       /** The length of the surface along direction u at the origin. For 'regular' boundaries, like rectangles, 
        *  this can be used to speed up the computation of inSideBounds.
        */
-      virtual double length_along_u() const ;
+      virtual double length_along_u() const override ;
 
       /** The length of the surface along direction v at the origin. For 'regular' boundaries, like rectangles, 
        *  this can be used to speed up the computation of inSideBounds.
        */
-      virtual double length_along_v() const ;
+      virtual double length_along_v() const override ;
 
       /** Get lines constraining the surface for drawing ( might not be exact boundaries) -
        *  at most nMax lines are returned.
@@ -619,29 +619,29 @@ namespace dd4hep {
       /** First direction of measurement U - rotated to point projected onto the cylinder.
        *  No check is done whether the point actually is on the cylinder surface
        */
-      virtual Vector3D u( const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D u( const Vector3D& point = Vector3D() ) const override ;
     
       /** Second direction of measurement V - rotated to point projected onto the cylinder.
        *  No check is done whether the point actually is on the cylinder surface
        */
-      virtual Vector3D v(const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D v(const Vector3D& point = Vector3D() ) const override ;
     
       /** The normal direction at the given point - rotated to point projected onto the cylinder.
        *  No check is done whether the point actually is on the cylinder surface
        */
-      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const ;
+      virtual Vector3D normal(const Vector3D& point = Vector3D() ) const override ;
  
       /** Convert the global position to the local position (u,v) on the surface - u runs along the axis of the cylinder, v is r*phi */
-      virtual Vector2D globalToLocal( const Vector3D& point) const ;
+      virtual Vector2D globalToLocal( const Vector3D& point) const override ;
       
       /** Convert the local position (u,v) on the surface to the global position  - u runs along the axis of the cylinder, v is r*phi*/
-      virtual Vector3D localToGlobal( const Vector2D& point) const ;
+      virtual Vector3D localToGlobal( const Vector2D& point) const override ;
 
       /// the radius of the cylinder (rho of the origin vector)
-      virtual double radius() const ;
+      virtual double radius() const override ;
 
       /// the center of the cylinder 
-      virtual Vector3D center() const ;
+      virtual Vector3D center() const override ;
 
     } ;
     //======================================================================================================
@@ -655,19 +655,19 @@ namespace dd4hep {
       ConeSurface( DetElement det, VolSurface volSurf ) : CylinderSurface( det, volSurf ) { }      
       
       /// the start radius of the cone
-      virtual double radius0() const ;
+      virtual double radius0() const override ;
       
       /// the end radius of the cone
-      virtual double radius1() const ;
+      virtual double radius1() const override ;
 
       /// the start z of the cone
-      virtual double z0() const ;
+      virtual double z0() const override ;
       
       /// the end z of the cone
-      virtual double z1() const ;
+      virtual double z1() const override ;
       
       /// the center of the cone 
-      virtual Vector3D center() const ;
+      virtual Vector3D center() const override ;
      
     };
     //======================================================================================================

--- a/DDRec/include/DDRec/SurfaceHelper.h
+++ b/DDRec/include/DDRec/SurfaceHelper.h
@@ -32,7 +32,11 @@ namespace dd4hep {
 
       SurfaceHelper(const DetElement& e);
       
-      ~SurfaceHelper();
+      ~SurfaceHelper() = default;
+      SurfaceHelper(const SurfaceHelper&) = delete;
+      SurfaceHelper& operator=(const SurfaceHelper&) = delete;
+      SurfaceHelper(SurfaceHelper&&) = default;
+      SurfaceHelper& operator=(SurfaceHelper&&) = delete;
       
       /** Get the list of all surfaces added to this DetElement and all its daughters -
        *  instantiate SurfaceHelper with description.world() to get all surfaces.

--- a/DDRec/include/DDRec/SurfaceManager.h
+++ b/DDRec/include/DDRec/SurfaceManager.h
@@ -46,20 +46,19 @@ namespace dd4hep {
 #else
       SurfaceManager() = delete ;
 #endif
-      /// No copy constructor
-      SurfaceManager(const SurfaceManager& copy) = delete;
       
-      /// Default destructor
-      ~SurfaceManager();
+      ~SurfaceManager() = default;
+      SurfaceManager(const SurfaceManager&) = delete;
+      SurfaceManager& operator=(const SurfaceManager&) = delete;
+      SurfaceManager(SurfaceManager&&) = default;
+      SurfaceManager& operator=(SurfaceManager&&) = default;
 
-      /// No assignment operator
-      SurfaceManager& operator=(const SurfaceManager& copy) = delete;
-      
+
       /** Get the maps of all surfaces associated to the given detector or
        *  type of detectors, e.g. map("tracker") returns a map with all surfaces
        *  assigned to tracking detectors. Returns 0 if no map exists.
        */
-      const SurfaceMap* map( const std::string name ) const ;
+      const SurfaceMap* map( const std::string& name ) const ;
 
       
       ///create a string with all available maps and their size (number of surfaces)

--- a/DDRec/src/DetectorSurfaces.cpp
+++ b/DDRec/src/DetectorSurfaces.cpp
@@ -16,69 +16,52 @@ namespace dd4hep {
   namespace rec {
     
 
+    DetectorSurfaces::DetectorSurfaces(dd4hep::DetElement const& e) {
 
-    DetectorSurfaces::DetectorSurfaces(dd4hep::DetElement const& e) : DetElement(e) , _sL( 0 ) {
-
-      initialize() ;
+      initialize(e) ;
     }
     
-    DetectorSurfaces::~DetectorSurfaces(){
-      // nothing to do: SurfaceList is added as extension
-      // and is deleted automatically
-    }
-    
-    
-    void DetectorSurfaces::initialize() {
-      
-      DetElement det = *this ;
+    void DetectorSurfaces::initialize(dd4hep::DetElement const& det) {
       
       const VolSurfaceList* vsL = volSurfaceList(det) ;
 
-      try {
-        _sL = det.extension< SurfaceList >(false) ;
-        if (not _sL) {
-          _sL = det.addExtension<SurfaceList >(  new SurfaceList( true )  ) ;
-        }
-      } catch(const std::exception& e) { 
-        _sL = det.addExtension<SurfaceList >(  new SurfaceList( true )  ) ; 
+      _sL = det.extension< SurfaceList >(false) ;
+      if (! _sL) {
+        _sL = det.addExtension<SurfaceList >(  new SurfaceList( true )  ) ;
       }
 
-      if( ! vsL->empty() && _sL->empty() ) {  // only fill surfaces for this DetElement once
+      if( ! _sL->empty() ) {  // only fill surfaces for this DetElement once
+        return ;
+      }
 	
-	// std::cout <<  "     detector  " << det.name() << " id: " << det.id() << " has " <<  vsL->size() << " surfaces "  << std::endl ;
-	
-	// std::cout << " ------------------------- " 
-	// 	  << " 	DetectorSurfaces::initialize()  adding surfaces : " 
-	// 	  << std::endl ;
-	
-	for( VolSurfaceList::const_iterator it = vsL->begin() ; it != vsL->end() ; ++it ){
-	  
-	  VolSurface volSurf =  *it ;
-	  
-	  Surface* surf = 0 ;
-	  
-	  if( volSurf.type().isCylinder() )
-	    surf = new CylinderSurface(  det,  volSurf ) ;
-	  
-	  else if( volSurf.type().isCone() ) 
-	    surf = new ConeSurface( det, volSurf ) ;
-	  
-	  else
-	    surf = new Surface(  det,  volSurf ) ;
-	
-	  // std::cout << " ------------------------- " 
-	  //   	    << " surface: "   << *surf        << std::endl
-	  //   	    << " ------------------------- "  << std::endl ;
-	  
-	  _sL->push_back( surf ) ;
-	  
-	}
+      // std::cout <<  "     detector  " << det.name() << " id: " << det.id() << " has " <<  vsL->size() << " surfaces "  << std::endl ;
 
+      // std::cout << " ------------------------- "
+      // 	  << " 	DetectorSurfaces::initialize()  adding surfaces : "
+      // 	  << std::endl ;
+
+      for( const auto& volSurf : *vsL ) {
+
+        Surface* surf = nullptr ;
+
+        if( volSurf.type().isCylinder() )
+          surf = new CylinderSurface(  det,  volSurf ) ;
+
+        else if( volSurf.type().isCone() )
+          surf = new ConeSurface( det, volSurf ) ;
+
+        else
+          surf = new Surface(  det,  volSurf ) ;
+
+        // std::cout << " ------------------------- "
+        //   	    << " surface: "   << *surf        << std::endl
+        //   	    << " ------------------------- "  << std::endl ;
+
+        _sL->push_back( surf ) ;
 
       }
 
     }
-    
 
 
   } // namespace

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -507,15 +507,6 @@ namespace dd4hep {
     
     //================================================================================================================
     
-
-    VolSurfaceList::~VolSurfaceList(){
-      // // delete all surfaces attached to this volume
-      // for( VolSurfaceList::iterator i=begin(), n=end() ; i !=n ; ++i ) {
-      //   i->clear() ;
-      // }
-    }
-    //=======================================================
-
     SurfaceList::~SurfaceList(){
       if( _isOwner ) {
         // delete all surfaces attached to this volume
@@ -525,7 +516,7 @@ namespace dd4hep {
 
     //================================================================================================================
 
-    VolSurfaceList* volSurfaceList( DetElement& det ) {
+    VolSurfaceList* volSurfaceList( const DetElement& det ) {
       VolSurfaceList* list = det.extension< VolSurfaceList >(false);
       if ( !list )  {
         list = det.addExtension<VolSurfaceList >(new VolSurfaceList);

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -617,7 +617,7 @@ namespace dd4hep {
       
       const IMaterial& mat = _volSurf.innerMaterial() ;
       
-      if( ! ( mat.Z() > 0 ) ) {
+      if( mat.Z() <= 0 ) {
 	
         MaterialManager matMgr( _det.placement().volume() )  ;
         
@@ -636,7 +636,7 @@ namespace dd4hep {
       
       const IMaterial& mat = _volSurf.outerMaterial() ;
       
-      if( ! ( mat.Z() > 0 ) ) {
+      if( mat.Z() <= 0 ) {
 	
         MaterialManager matMgr( _det.placement().volume() ) ;
         

--- a/DDRec/src/Surface.cpp
+++ b/DDRec/src/Surface.cpp
@@ -18,7 +18,6 @@
 
 #include <cmath>
 #include <memory>
-#include <exception>
 
 #include "TGeoMatrix.h"
 #include "TGeoShape.h"
@@ -70,8 +69,8 @@ namespace dd4hep {
       return g ;
     }
 
-    const IMaterial&  VolSurfaceBase::innerMaterial() const{  return  _innerMat ;  }
-    const IMaterial&  VolSurfaceBase::outerMaterial() const { return  _outerMat  ; }
+    const IMaterial&  VolSurfaceBase::innerMaterial() const { return  _innerMat ; }
+    const IMaterial&  VolSurfaceBase::outerMaterial() const { return  _outerMat ; }
     double VolSurfaceBase::innerThickness() const { return _th_i ; }
     double VolSurfaceBase::outerThickness() const { return _th_o ; }
     
@@ -741,9 +740,8 @@ namespace dd4hep {
 
       //---- if the volSurface is not in the DetElement's volume, we need to mutliply the path to the volume to the
       // DetElements world transform
-      for( std::list<PlacedVolume>::iterator it = ++( pVList.begin() ) , n = pVList.end() ; it != n ; ++it ){
+      for( const auto pvol : pVList ){
 
-      	PlacedVolume pvol = *it ;
       	TGeoMatrix* m = pvol->GetMatrix();
       	// std::cout << "  +++ matrix for placed volume : " << std::endl ;
       	// m->Print() ;

--- a/DDRec/src/SurfaceHelper.cpp
+++ b/DDRec/src/SurfaceHelper.cpp
@@ -29,11 +29,6 @@ namespace dd4hep {
       initialize() ;
     }
     
-    SurfaceHelper::~SurfaceHelper(){
-      // nothing to do
-    }
-    
-    
     void SurfaceHelper::initialize() {
       
       // have to populate the volume manager once in order to have 
@@ -50,11 +45,9 @@ namespace dd4hep {
       
       while( ! daugs.empty() ) {
 	
-        for( std::list< DetElement >::iterator li=daugs.begin() ; li != daugs.end() ; ++li ){
-          DetElement dau = *li ;
-          DetElement::Children chMap = dau.children() ;
-          for ( DetElement::Children::const_iterator it=chMap.begin() ; it != chMap.end() ; ++it ){
-            DetElement de = (*it).second ;
+        for( const auto& dag : daugs ){
+          const DetElement::Children& chMap = dag.children() ;
+          for ( const auto& [_, de] : chMap ){
             gdaugs.push_back( de ) ;
           }  
         }
@@ -65,12 +58,8 @@ namespace dd4hep {
       
       //      std::cout << " **** SurfaceHelper::initialize() : # DetElements found  " << dets.size() << std::endl ;
       
-      for( std::list< DetElement >::iterator li=dets.begin() ; li != dets.end() ; ++li ) {
+      for( const auto& det : dets) {
 	
-        DetElement det = (*li) ;
-	
-
-
         // create surfaces
         DetectorSurfaces ds( det ) ;
 	

--- a/DDRec/src/SurfaceManager.cpp
+++ b/DDRec/src/SurfaceManager.cpp
@@ -35,12 +35,8 @@ namespace dd4hep {
       initialize(theDetector) ;
     }
     
-    SurfaceManager::~SurfaceManager(){
-      // nothing to do
-    }
     
-    
-    const SurfaceMap* SurfaceManager::map( const std::string name ) const {
+    const SurfaceMap* SurfaceManager::map( const std::string& name ) const {
 
       SurfaceMapsMap::const_iterator it = _map.find( name ) ;
 
@@ -49,36 +45,32 @@ namespace dd4hep {
         return & it->second ;
       }
 
-      return 0 ;
+      return nullptr ;
     }
 
     void SurfaceManager::initialize(const Detector& description) {
       
-      const std::vector<std::string>& types = description.detectorTypes() ;
+      for(const auto& type : description.detectorTypes()) {
 
-      for(unsigned i=0,N=types.size();i<N;++i){
+        const std::vector<DetElement>& dets = description.detectors( type ) ;
 
-        const std::vector<DetElement>& dets = description.detectors( types[i] ) ;  
+        for(const auto& det : dets) {
 
-        for(unsigned j=0,M=dets.size();j<M;++j){
+          const std::string& name = det.name() ;
 
-          std::string name = dets[j].name() ;
-
-          SurfaceHelper surfH( dets[j] ) ;
+          SurfaceHelper surfH( det ) ;
 	  
           const SurfaceList& detSL = surfH.surfaceList() ;
   
           // add an empty map for this detector in case there are no surfaces attached 
           _map.emplace(name , SurfaceMap());
 
-          for( SurfaceList::const_iterator it = detSL.begin() ; it != detSL.end() ; ++it ){
-            ISurface* surf =  *it ;
-	    
+          for( auto* surf : detSL ) {
             // enter surface into map for this detector
             _map[ name ].emplace(surf->id(), surf );
 
             // enter surface into map for detector type
-            _map[ types[i] ].emplace(surf->id(), surf );
+            _map[ type ].emplace(surf->id(), surf );
 
             // enter surface into world map 
             _map[ "world" ].emplace(surf->id(), surf );


### PR DESCRIPTION
BEGINRELEASENOTES
- Modernize code related to Surfaces and the SurfaceManager. Simplify for loops, define default destructors with `=default`, pass arguments by const reference when possible
- Make `DetectorSurfaces` not inherit from `DetElement` since it is not used nor needed

ENDRELEASENOTES