### PR TITLE
Add the pass-through of generator event information for EDM4hep

### DIFF
--- a/DDG4/edm4hep/EDM4hepFileReader.cpp
+++ b/DDG4/edm4hep/EDM4hepFileReader.cpp
@@ -230,7 +230,7 @@ namespace dd4hep::sim {
           const auto genParams = genEvtParameters[0];
           try {
             auto *ctx = context();
-            ctx->event().addExtension<edm4hep::GeneratorEventParameters>(new edm4hep::GeneratorEventParameters(genParams.clone()));
+            ctx->event().addExtension(new edm4hep::MutableGeneratorEventParameters(genParams.clone()));
           } catch (std::exception &) {}
         } else {
           printout(WARNING, "EDM4hepFileReader", "Multiple GeneratorEventParameters found in input file. Ignoring all but one!");

--- a/DDG4/edm4hep/EDM4hepFileReader.cpp
+++ b/DDG4/edm4hep/EDM4hepFileReader.cpp
@@ -226,13 +226,14 @@ namespace dd4hep::sim {
       // Attach the GeneratorEventParameters if they are available
       const auto &genEvtParameters = frame.get<edm4hep::GeneratorEventParametersCollection>(edm4hep::labels::GeneratorEventParameters);
       if (genEvtParameters.isValid()) {
-        if (genEvtParameters.size() == 1) {
+        if (genEvtParameters.size() >= 1) {
           const auto genParams = genEvtParameters[0];
           try {
             auto *ctx = context();
             ctx->event().addExtension(new edm4hep::MutableGeneratorEventParameters(genParams.clone()));
           } catch (std::exception &) {}
-        } else {
+        }
+        if (genEvtParameters.size() > 1) {
           printout(WARNING, "EDM4hepFileReader", "Multiple GeneratorEventParameters found in input file. Ignoring all but one!");
         }
       } else {

--- a/DDG4/edm4hep/EDM4hepFileReader.cpp
+++ b/DDG4/edm4hep/EDM4hepFileReader.cpp
@@ -234,7 +234,7 @@ namespace dd4hep::sim {
           } catch (std::exception &) {}
         }
         if (genEvtParameters.size() > 1) {
-          printout(WARNING, "EDM4hepFileReader", "Multiple GeneratorEventParameters found in input file. Ignoring all but one!");
+          printout(WARNING, "EDM4hepFileReader", "Multiple GeneratorEventParameters found in input file. Ignoring all but the first one!");
         }
       } else {
         printout(DEBUG, "EDM4hepFileReader", "No GeneratorEventParameters found in input file");

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -25,7 +25,6 @@
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
-#include <edm4hep/GeneratorEventParametersCollection.h>
 #include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/Constants.h>
 #if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 0)
@@ -33,6 +32,10 @@
 #else
   using edm4hep::labels::CellIDEncoding;
 #endif
+#if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 3)
+#include <edm4hep/GeneratorEventParametersCollection.h>
+#endif
+
 /// podio include files
 #include <podio/CollectionBase.h>
 #include <podio/podioVersion.h>
@@ -548,6 +551,7 @@ void Geant4Output2EDM4hep::saveEvent(OutputContext<G4Event>& ctxt)  {
 
   m_frame.put(std::move(header_collection), "EventHeader");
 
+#if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 3)
   // Attach the generator event parameters again if they are available
   auto* genEvtParams = context()->event().extension<edm4hep::GeneratorEventParameters>(false);
   if (genEvtParams) {
@@ -555,6 +559,7 @@ void Geant4Output2EDM4hep::saveEvent(OutputContext<G4Event>& ctxt)  {
     genEvtParamsColl.push_back(*genEvtParams);
     m_frame.put(std::move(genEvtParamsColl), edm4hep::labels::GeneratorEventParameters);
   }
+#endif
 
   saveEventParameters<int>(m_eventParametersInt);
   saveEventParameters<float>(m_eventParametersFloat);

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -553,7 +553,7 @@ void Geant4Output2EDM4hep::saveEvent(OutputContext<G4Event>& ctxt)  {
 
 #if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 3)
   // Attach the generator event parameters again if they are available
-  auto* genEvtParams = context()->event().extension<edm4hep::GeneratorEventParameters>(false);
+  auto* genEvtParams = context()->event().extension<edm4hep::MutableGeneratorEventParameters>(false);
   if (genEvtParams) {
     edm4hep::GeneratorEventParametersCollection genEvtParamsColl{};
     genEvtParamsColl.push_back(*genEvtParams);

--- a/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
+++ b/DDG4/edm4hep/Geant4Output2EDM4hep.cpp
@@ -25,6 +25,7 @@
 #include <edm4hep/SimTrackerHitCollection.h>
 #include <edm4hep/CaloHitContributionCollection.h>
 #include <edm4hep/SimCalorimeterHitCollection.h>
+#include <edm4hep/GeneratorEventParametersCollection.h>
 #include <edm4hep/EDM4hepVersion.h>
 #include <edm4hep/Constants.h>
 #if EDM4HEP_BUILD_VERSION < EDM4HEP_VERSION(0, 99, 0)
@@ -546,6 +547,15 @@ void Geant4Output2EDM4hep::saveEvent(OutputContext<G4Event>& ctxt)  {
   }
 
   m_frame.put(std::move(header_collection), "EventHeader");
+
+  // Attach the generator event parameters again if they are available
+  auto* genEvtParams = context()->event().extension<edm4hep::GeneratorEventParameters>(false);
+  if (genEvtParams) {
+    edm4hep::GeneratorEventParametersCollection genEvtParamsColl{};
+    genEvtParamsColl.push_back(*genEvtParams);
+    m_frame.put(std::move(genEvtParamsColl), edm4hep::labels::GeneratorEventParameters);
+  }
+
   saveEventParameters<int>(m_eventParametersInt);
   saveEventParameters<float>(m_eventParametersFloat);
   saveEventParameters<std::string>(m_eventParametersString);


### PR DESCRIPTION
BEGINRELEASENOTES
- EDM4hep Input / Output: Add the passing through of generator event information for EDM4hep, fixes #1373 

ENDRELEASENOTES

Keeping this as draft for now, until we have finalized all the details upstream, but I think those should be largely transparent for these changes.