### PR TITLE
Add a [[maybe_unused]] to prevent a warning in ConditionExampleObjects.cpp

### DIFF
--- a/examples/Conditions/src/ConditionExampleObjects.cpp
+++ b/examples/Conditions/src/ConditionExampleObjects.cpp
@@ -350,7 +350,8 @@ int ConditionsDataAccess::accessConditions(DetElement de, const std::vector<Cond
   ConditionKey key_derived3    (de,"derived_data/derived_3");
   ConditionKey key_derived4    (de,"derived_data/derived_4");
   ConditionKey key_derived5    (de,"derived_data/derived_5");
-  int result = 0, count = 0;
+  [[maybe_unused]] int result = 0;
+  int count = 0;
 
   // Let's go for the deltas....
   for( auto cond : conditions )  {


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a [[maybe_unused]] to prevent a warning in ConditionExampleObjects.cpp

ENDRELEASENOTES

This is the warning (Clang 20):

```
/DD4hep/examples/Conditions/src/ConditionExampleObjects.cpp:353:7: warning: variable 'result' set but not used [-Wunused-but-set-variable]
  353 |   int result = 0, count = 0;
```