### PR TITLE
Fix two compiler warnings about an unqualified move and an unused var

### DIFF
--- a/DDCAD/src/plugins/CADPlugins.cpp
+++ b/DDCAD/src/plugins/CADPlugins.cpp
@@ -77,7 +77,7 @@ static void* read_CAD_Volume(dd4hep::Detector& dsc, int argc, char** argv)   {
     except("CAD_Volume","+++ CAD file: %s does not contain any "
            "understandable tessellated volumes.", fname.c_str());
   }
-  auto* result = new std::vector<std::unique_ptr<TGeoVolume> >(move(volumes));
+  auto* result = new std::vector<std::unique_ptr<TGeoVolume> >(std::move(volumes));
   return result;
 }
 DECLARE_DD4HEP_CONSTRUCTOR(DD4hep_read_CAD_volumes,read_CAD_Volume)

--- a/DDCore/src/XML/XMLParsers.cpp
+++ b/DDCore/src/XML/XMLParsers.cpp
@@ -70,7 +70,6 @@ void dd4hep::xml::parse(xml_h e, Translation3D& tr)   {
 
 /// Convert alignment delta objects to Delta
 void dd4hep::xml::parse(xml_h e, Delta& delta)  {
-  Position pos;
   RotationZYX rot;
   Translation3D piv;
   xml_h  child_rot, child_pos, child_piv;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix two compiler warnings about an unqualified move and an unused var

ENDRELEASENOTES

With Clang 19:

```
  /home/runner/work/DD4hep/DD4hep/DDCAD/src/plugins/CADPlugins.cpp:80:64: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
     80 |   auto* result = new std::vector<std::unique_ptr<TGeoVolume> >(move(volumes));
        |                                                                ^
        |                                                                std::

   /home/runner/work/DD4hep/DD4hep/DDCore/src/XML/XMLParsers.cpp:73:12: warning: unused variable 'pos' [-Wunused-variable]
     73 |   Position pos;
     
```