### PR TITLE
Add the correct lib install dir to the plugin load path

### DIFF
--- a/cmake/thisdd4hep_package.sh.in
+++ b/cmake/thisdd4hep_package.sh.in
@@ -30,7 +30,7 @@ dd4hep_add_path    PYTHONPATH ${THIS}/@DD4HEP_PYTHON_INSTALL_DIR@;
 #----ROOT_INCLUDE_PATH--------------------------------------------------------
 dd4hep_add_path    ROOT_INCLUDE_PATH ${THIS}/include;
 #----LIBRARY_PATH-------------------------------------------------------------
-dd4hep_add_library_path ${THIS}/lib;
+dd4hep_add_library_path ${THIS}/@CMAKE_INSTALL_LIBDIR@
 # -- need to extend dynamic search path for all external libraries:
 if [ @External_LIBRARY_DIRS@ ]; then
     for lp in @External_LIBRARY_DIRS@; do


### PR DESCRIPTION
Otherwise dependent libraries will get a this<package>.sh setup script that will not pick up the plugins in all cases. E.g. when GNUInstallDirs is used in CMake, RedHat systems will put the libraries into lib64.



BEGINRELEASENOTES
- Generate the correct library install path into the `this<package>.sh` script

ENDRELEASENOTES