### PR TITLE
Fix a deprecation warning in EDM4hepFileReader.cpp

### DIFF
--- a/DDG4/edm4hep/EDM4hepFileReader.cpp
+++ b/DDG4/edm4hep/EDM4hepFileReader.cpp
@@ -191,10 +191,14 @@ namespace dd4hep::sim {
     podio::Frame frame = m_reader.readFrame("events", event_number);
     const auto& primaries = frame.get<edm4hep::MCParticleCollection>(m_collectionName);
     int eventNumber = event_number, runNumber = 0;
+#if PODIO_BUILD_VERSION >= PODIO_VERSION(1, 6, 0)
+    if (primaries.hasID()) {
+#else
     if (primaries.isValid()) {
+#endif
       //Read the event header collection and add it to the context as an extension
       const auto& eventHeaderCollection = frame.get<edm4hep::EventHeaderCollection>(m_eventHeaderCollectionName);
-      if(eventHeaderCollection.isValid() && eventHeaderCollection.size() == 1){
+      if(eventHeaderCollection.size() == 1){
         const auto& eh = eventHeaderCollection.at(0);
         eventNumber = eh.getEventNumber();
         runNumber = eh.getRunNumber();
@@ -224,8 +228,13 @@ namespace dd4hep::sim {
       }
 #if EDM4HEP_BUILD_VERSION >= EDM4HEP_VERSION(0, 99, 3)
       // Attach the GeneratorEventParameters if they are available
-      const auto &genEvtParameters = frame.get<edm4hep::GeneratorEventParametersCollection>(edm4hep::labels::GeneratorEventParameters);
+      const auto& genEvtParameters =
+          frame.get<edm4hep::GeneratorEventParametersCollection>(edm4hep::labels::GeneratorEventParameters);
+#if PODIO_BUILD_VERSION >= PODIO_VERSION(1, 6, 0)
+      if (genEvtParameters.hasID()) {
+#else
       if (genEvtParameters.isValid()) {
+#endif
         if (genEvtParameters.size() >= 1) {
           const auto genParams = genEvtParameters[0];
           try {


### PR DESCRIPTION
`isValid()` (a check if a collection was found in a file, because if not an empty one is returned) has been changed to `hasID()` in https://github.com/AIDASoft/podio/pull/860. Similar to what has been done in https://github.com/key4hep/EDM4hep/pull/453. In one place we can remove it since `size() == 1` implies `isValid()` or `hasID()`, otherwise the size would be 0.

BEGINRELEASENOTES

- Fix a deprecation warning in EDM4hepFileReader.cpp by changing `collection.isValid()` to `collection.hasID()`.

ENDRELEASENOTES