### PR TITLE
Add a --gdb argument to ddsim to attach gdb

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -823,30 +823,30 @@ class DD4hepSimulation(object):
     return generationInit
 
   def __attachGDB(self):
-        """Hook gdb to the current session. This is done by forking
-        the current process and replacing the parent with gdb, while
-        the child continues to run the program.
-        """
+    """Hook gdb to the current session. This is done by forking
+    the current process and replacing the parent with gdb, while
+    the child continues to run the program.
+    """
 
-        child_pid = os.fork()
+    child_pid = os.fork()
 
-        if child_pid == 0:
-            # Child process: runs the actual program
-            return
-        else:
-            # Parent process: becomes GDB
+    if child_pid == 0:
+        # Child process: runs the actual program
+        return
+    else:
+        # Parent process: becomes GDB
 
-            # Shells don't like '*' in args
-            args = [arg.replace("*", "\\*") for arg in sys.argv if arg != "--gdb"]
-            os.execvp(
+        # Shells don't like '*' in args
+        args = [arg.replace("*", "\\*") for arg in sys.argv if arg != "--gdb"]
+        os.execvp(
+            "gdb",
+            [
                 "gdb",
-                [
-                    "gdb",
-                    "-q",
-                    "-p",
-                    str(child_pid),
-                    "-ex",
-                    f"set args {' '.join(args)}",
+                "-q",
+                "-p",
+                str(child_pid),
+                "-ex",
+                f"set args {' '.join(args)}",
                 ],
             )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- ddsim: Add a `--gdb` argument to run ddsim inside gdb (debugger)

ENDRELEASENOTES
  
This is a convenient way of running with gdb. Given a command like:

```
ddsim --compactFile=$K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G -N=1 --gun.energy "10*GeV" --gun.particle 'mu-' --gun.multiplicity 10 --gun.distribution uniform --random.seed 123
```

This can be run through gdb by doing
```
gdb python -ex "set args $(which ddsim) --compactFile=... "
```
and changing the quotes in arguments like `"10*GeV"` to `\"10*GeV\"` or `'mu-'` to `\'mu-\'` that are in quotes. Instead, it's much easier to add `--gdb` at the end without touching the command.

Usage: The first time type `c` to continue the execution until the end (or stop to a breakpoint if set) and then `r` to restart from the beginning, preserving all the breakpoints and other temporary settings.

Here it is done after the python parsing of arguments is finished but it could be also be done later if a faster execution is needed.