### PR TITLE
Implement option to disable voxelization when closing the geometry

### DIFF
--- a/DDCore/include/DD4hep/Detector.h
+++ b/DDCore/include/DD4hep/Detector.h
@@ -112,7 +112,9 @@ namespace dd4hep {
     /// Initialize geometry
     virtual void init() = 0;
     /// Finalize the geometry
-    virtual void endDocument(bool close_geometry=true) = 0;
+    virtual void endDocument(bool close_geometry = true) = 0;
+    /// Finalize the geometry
+    virtual void endDocument(const char* option) = 0;
 
     /// Access the state of the geometry
     virtual State state()  const = 0;

--- a/DDCore/include/DD4hep/DetectorImp.h
+++ b/DDCore/include/DD4hep/DetectorImp.h
@@ -133,6 +133,8 @@ namespace dd4hep {
 
     /// Close the geometry
     virtual void endDocument(bool close_geometry)  override;
+    /// Finalize the geometry
+    virtual void endDocument(const char* option)  override;
 
     /// Add an extension object to the Detector instance
     virtual void* addUserExtension(unsigned long long int key, ExtensionEntry* entry)  override;

--- a/DDCore/src/plugins/Compact2Objects.cpp
+++ b/DDCore/src/plugins/Compact2Objects.cpp
@@ -1681,6 +1681,7 @@ template <> void Converter<DetElementInclude>::operator()(xml_h element) const {
 /// Main compact conversion entry point
 template <> void Converter<Compact>::operator()(xml_h element) const {
   static int num_calls = 0;
+  std::string close_option;
   char text[32];
 
   ++num_calls;
@@ -1704,6 +1705,9 @@ template <> void Converter<Compact>::operator()(xml_h element) const {
       close_document = steer.attr<bool>(_U(close));
     if ( steer.hasAttr(_U(reflect)) )
       build_reflections = steer.attr<bool>(_U(reflect));
+    if ( steer.hasAttr(_U(option))  )
+      close_option = steer.attr<std::string>(_U(option));
+
     for (xml_coll_t clr(steer, _U(clear)); clr; ++clr) {
       std::string nam = clr.hasAttr(_U(name)) ? clr.attr<std::string>(_U(name)) : std::string();
       if ( nam.substr(0,6) == "elemen" )   {
@@ -1788,7 +1792,8 @@ template <> void Converter<Compact>::operator()(xml_h element) const {
   if ( --num_calls == 0 && close_document )  {
     ::snprintf(text, sizeof(text), "%u", xml_h(element).checksum(0));
     description.addConstant(Constant("compact_checksum", text));
-    description.endDocument(close_geometry);
+    if( close_geometry ) close_option += "close";
+    description.endDocument(close_option.c_str());
   }
   if ( build_reflections )   {
     ReflectionBuilder rb(description);


### PR DESCRIPTION
BEGINRELEASENOTES
Badly designed, not well balanced geometries require lots of resources during the voxelization step when
closing the geometry. This can now be steered using an option tag in the steering element of the compact xml.

Example:
```
  <geometry close="true" option="nv"/>
or
  <geometry option="closenv"/>

or (close=true is the default)
  <geometry option="nv"/>
```
The options `nv` and `i` are directly routed to the call to `TGeoManager::CloseGeometry(option)`.
ENDRELEASENOTES