### PR TITLE
Fix the EDM4hep reader since frame.get throws if a collection is not found

### DIFF
--- a/DDG4/edm4hep/EDM4hepFileReader.cpp
+++ b/DDG4/edm4hep/EDM4hepFileReader.cpp
@@ -190,7 +190,7 @@ namespace dd4hep::sim {
     m_currEvent = event_number;
     podio::Frame frame = m_reader.readFrame("events", event_number);
     const auto& primaries = frame.get<edm4hep::MCParticleCollection>(m_collectionName);
-    const auto availableCollections = frame.getAvailableCollections();
+    const auto& availableCollections = frame.getAvailableCollections();
     int eventNumber = event_number, runNumber = 0;
 #if PODIO_BUILD_VERSION >= PODIO_VERSION(1, 6, 0)
     if (primaries.hasID()) {


### PR DESCRIPTION
BEGINRELEASENOTES
- EDM4hep reader: Prepare for podio frame.get to throw an exception if a collection is not found

ENDRELEASENOTES

Fix https://github.com/AIDASoft/DD4hep/issues/1529