### PR TITLE
Remove unused variable to prevent a compiler warning

### DIFF
--- a/examples/DDCMS/src/plugins/DDEcalEndcapAlgo.cpp
+++ b/examples/DDCMS/src/plugins/DDEcalEndcapAlgo.cpp
@@ -629,8 +629,6 @@ namespace {
       eeSCELog.placeVolume(eeSCALog, iSCType * 100 + 1, Position(dxy, dxy, dz));
       eeSCALog.placeVolume(eeSCILog, iSCType * 100 + 1, Position(xyIOff, xyIOff, zIOff));
 
-      DDTranslation croffset(0., 0., 0.);
-
       // Position crystals within parent supercrystal interior volume
       static const unsigned int ncol(5);
 


### PR DESCRIPTION
BEGINRELEASENOTES
- DDEcalEndcapAlgo: Remove unused variable to prevent a compiler warning

ENDRELEASENOTES

```
/DD4hep/examples/DDCMS/src/plugins/DDEcalEndcapAlgo.cpp:632:21: warning: unused variable 'croffset' [-Wunused-variable]
  632 |       DDTranslation croffset(0., 0., 0.);
      |                     ^~~~~~~~
1 warning generated.
```