### PR TITLE
Delay creating surfaces with the SurfaceManager plugin until it's needed

### DIFF
--- a/DDRec/include/DDRec/SurfaceManager.h
+++ b/DDRec/include/DDRec/SurfaceManager.h
@@ -41,17 +41,13 @@ namespace dd4hep {
       SurfaceManager(const Detector& theDetector);
 
       /// No default constructor
-#if defined(G__ROOT)
-      SurfaceManager() = default ;
-#else
       SurfaceManager() = delete ;
-#endif
       
       ~SurfaceManager() = default;
       SurfaceManager(const SurfaceManager&) = delete;
       SurfaceManager& operator=(const SurfaceManager&) = delete;
-      SurfaceManager(SurfaceManager&&) = default;
-      SurfaceManager& operator=(SurfaceManager&&) = default;
+      SurfaceManager(SurfaceManager&&) = delete;
+      SurfaceManager& operator=(SurfaceManager&&) = delete;
 
 
       /** Get the maps of all surfaces associated to the given detector or
@@ -68,9 +64,11 @@ namespace dd4hep {
 
 
       /// initialize all known surface maps
-      void initialize(const Detector& theDetector) ;
+      void initialize(const Detector& theDetector) const;
 
-      SurfaceMapsMap _map ;
+      mutable SurfaceMapsMap  _map{} ;
+      const Detector& _theDetector ;
+      mutable std::once_flag  _initializedFlag{} ;
     };
 
   } /* namespace rec */

--- a/DDRec/src/SurfaceManager.cpp
+++ b/DDRec/src/SurfaceManager.cpp
@@ -15,24 +15,26 @@
 #include "DDRec/SurfaceHelper.h"
 #include "DD4hep/VolumeManager.h"
 #include "DD4hep/Detector.h"
+#include "DD4hep/Printout.h"
 
 #include <sstream>
 
 namespace dd4hep {
   namespace rec {
 
-    SurfaceManager::SurfaceManager(const Detector& theDetector){
+    SurfaceManager::SurfaceManager(const Detector& theDetector) : _theDetector(theDetector) {
 
       // have to make sure the volume manager is populated once in order to have
       // the volumeIDs attached to the DetElements
 
       VolumeManager::getVolumeManager(theDetector);
 
-      initialize(theDetector) ;
     }
     
     
     const SurfaceMap* SurfaceManager::map( const std::string& name ) const {
+
+      std::call_once( _initializedFlag, &SurfaceManager::initialize, this, _theDetector ) ;
 
       SurfaceMapsMap::const_iterator it = _map.find( name ) ;
 
@@ -44,7 +46,7 @@ namespace dd4hep {
       return nullptr ;
     }
 
-    void SurfaceManager::initialize(const Detector& description) {
+    void SurfaceManager::initialize(const Detector& description) const {
       
       for(const auto& type : description.detectorTypes()) {
 
@@ -74,6 +76,8 @@ namespace dd4hep {
           }
         }
       }
+
+      printout(INFO,"SurfaceManager","%s" , description.extension<SurfaceManager>()->toString().c_str() );
 
     }
 

--- a/DDRec/src/plugins/createSurfaceManager.cpp
+++ b/DDRec/src/plugins/createSurfaceManager.cpp
@@ -40,10 +40,10 @@ namespace dd4hep{
     static long createSurfaceManager(Detector& description, int /*argc*/, char** /*argv*/) {
 
       printout(INFO,"InstallSurfaceManager","**** running plugin InstallSurfaceManager ! " );
+      printout(INFO,"InstallSurfaceManager","**** the map of surfaces will be created on first access ! " );
 
       description.addExtension<SurfaceManager>(  new SurfaceManager(description) ) ;
 
-      printout(INFO,"InstallSurfaceManager","%s" , description.extension<SurfaceManager>()->toString().c_str() );
 
       return 1;
     }


### PR DESCRIPTION
Currently, when this plugin is enabled in a detector xml file it will always be loaded, even when never used (for example, running ddsim). I propose to only create the surfaces and manager when the surfaces are actually used. For this, I'm making use of the single entrypoint for the SurfaceManager, `map()`, to create the maps there using `std::call_once` to make this also work in multithreaded contexts. This means, for example, running ddsim won't create these maps that can take some time depending on the detector (for example, for CLD_o2_v06).

With this change, the message with the keys and number of surface maps appears when it's created, instead of after building the detector. One change is that, because of the `std::once_flag` that is not copiable nor movable, the move constructor has to be deleted. I think however this class is not supposed to be moved, at least I haven't found any occurrences. There are two alternatives to make `SurfaceManager` movable:
- Define the move operators and create a `std::once_flag` in the new object (not trivially correct, since `std::once_flag` will always be "off" when created)
- Use a boolean and locks instead of `std::once_flag` and `std::use_flag` to control initialization, also the move operator would need to be locked.

Originally proposed in https://github.com/AIDASoft/DD4hep/pull/1304. But this is a different implementation that will create all the maps as soon as `map()` is called.

BEGINRELEASENOTES
- Delay creating surfaces with the SurfaceManager plugin until they are actually needed by getting the map of surfaces with `SurfaceManager::map()`

ENDRELEASENOTES

Maybe a parameter should be added to control whether it's delayed or not?