### PR TITLE
Remove unnecessary check

### DIFF
--- a/DDG4/edm4hep/EDM4hepFileReader.cpp
+++ b/DDG4/edm4hep/EDM4hepFileReader.cpp
@@ -228,24 +228,18 @@ namespace dd4hep::sim {
       if (std::find(availableCollections.begin(), availableCollections.end(), edm4hep::labels::GeneratorEventParameters) != availableCollections.end()) {
         const auto& genEvtParameters =
             frame.get<edm4hep::GeneratorEventParametersCollection>(edm4hep::labels::GeneratorEventParameters);
-#if PODIO_BUILD_VERSION >= PODIO_VERSION(1, 6, 0)
-        if (genEvtParameters.hasID()) {
-#else
-        if (genEvtParameters.isValid()) {
-#endif
-          if (genEvtParameters.size() >= 1) {
-            const auto genParams = genEvtParameters[0];
-            try {
-              auto *ctx = context();
-              ctx->event().addExtension(new edm4hep::MutableGeneratorEventParameters(genParams.clone()));
-            } catch (std::exception &) {}
-          }
-          if (genEvtParameters.size() > 1) {
-            printout(WARNING, "EDM4hepFileReader", "Multiple GeneratorEventParameters found in input file. Ignoring all but the first one!");
-          }
-        } else {
-          printout(DEBUG, "EDM4hepFileReader", "No GeneratorEventParameters found in input file");
+        if (genEvtParameters.size() >= 1) {
+          const auto genParams = genEvtParameters[0];
+          try {
+            auto *ctx = context();
+            ctx->event().addExtension(new edm4hep::MutableGeneratorEventParameters(genParams.clone()));
+          } catch (std::exception &) {}
         }
+        if (genEvtParameters.size() > 1) {
+          printout(WARNING, "EDM4hepFileReader", "Multiple GeneratorEventParameters found in input file. Ignoring all but the first one!");
+        }
+      } else {
+        printout(DEBUG, "EDM4hepFileReader", "No GeneratorEventParameters found in input file");
       }
 #endif
       printout(INFO,"EDM4hepFileReader","read collection %s from event %d in run %d ",


### PR DESCRIPTION
The check will never be false because we check if the collection is in the frame before we even enter here. If the collection is in the Frame it will also have an ID. Prior to AIDASoft/podio#828 this was necessary because we were creating empty collections if necessary without ID. After that we raise an exception, which is why the check with the available collections was introduced in the first place.



BEGINRELEASENOTES
- Remove an unnecessary check in reading EDM4hep files

ENDRELEASENOTES

Looks like the main issue for reading EDM4hep files with newer podio versions has already been solved in #1530. This is just a small unnecessary check that I found. I will make the PR that removes support for building with older versions of EDM4hep once we have v1.0 of that.