### PR TITLE
Use and cache ROOT_LIBRARY_PATH environment variable for plugins

### DIFF
--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -82,7 +82,7 @@ function(dd4hep_generate_rootmap library)
     set(ENV_VAR LD_LIBRARY_PATH)
   endif()
 
-  set(DD4HEP_LIBRARY_PATH "$ENV{${ENV_VAR}}")
+  set(_ld_path "$ENV{${ENV_VAR}}")
 
   # Pull ROOT library path from environment
   set(DD4HEP_ROOT_LIBRARY_PATH "$ENV{ROOT_LIBRARY_PATH}")
@@ -90,7 +90,7 @@ function(dd4hep_generate_rootmap library)
   string(JOIN ":" _ld_path
     "$<TARGET_FILE_DIR:${library}>"
     "$<TARGET_FILE_DIR:DD4hep::DD4hepGaudiPluginMgr>"
-    "${DD4HEP_LIBRARY_PATH}"
+    "${_ld_path}"
   )
   set(rootmapfile ${CMAKE_SHARED_MODULE_PREFIX}${library}.components)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- CMake: `add_dd4hep_plugin`: Preserve the `ROOT_LIBRARY_PATH` environment variable from the configuration stage to the build stage. This helps in cases where the configuration environment is not preserved.

ENDRELEASENOTES

See https://github.com/spack/spack-packages/pull/2875 : newer versions of ROOT require the `ROOT_LIBRARY_PATH` at runtime. Without this change, the plugin creation fails:
```
cd /Users/seth/Code/celeritas-temp/build/src/ddceler && /opt/homebrew/bin/cmake -E env DYLD_LIBRARY_PATH=/Users/seth/Code/celeritas-temp/build/lib:/opt/spack/var/spack/environments/celeritas/.spack-env/view/lib: /opt/spack/var/spack/environments/celeritas/.spack-env/view/bin/listcomponents_dd4hep -o libDDcelerRunAction.components libDDcelerRunAction.dylib
Error in <UnknownClass::FindDynamicLibrary>: libRIO[.so | .dll | .dylib | .sl | .dl | .a] does not exist in /Users/seth/Code/celeritas-temp/build/lib:/opt/spack/var/spack/environments/celeritas/.spack-env/view/lib::::.:/usr/local/lib:/usr/X11R6/lib:/usr/lib:/lib:/lib/x86_64-linux-gnu:/usr/local/lib64:/usr/lib64:/lib64:
Error in <UnknownClass::FindDynamicLibrary>: libCling[.so | .dll | .dylib | .sl | .dl | .a] does not exist in /Users/seth/Code/celeritas-temp/build/lib:/opt/spack/var/spack/environments/celeritas/.spack-env/view/lib::::.:/usr/local/lib:/usr/X11R6/lib:/usr/lib:/lib:/lib/x86_64-linux-gnu:/usr/local/lib64:/usr/lib64:/lib64:
Fatal in <TROOT::InitInterpreter>: cannot load symbol dlsym(RTLD_DEFAULT, CreateInterpreter): symbol not found
ninja: build stopped: subcommand failed.
```

The change to `add_custom_command`:
- Uses `VERBATIM` which is strongly recommended by cmake to avoid shell-specific interpretation
- Use `cmake -E {env}` to safely and consistently propagate environment variables rather than relying on shell parsing
- Will override build-time `ROOT_LIBRARY_PATH`/`(DY)LD_LIBRARY_PATH` environment with the configure-time environment values (previously `ROOT_LIBRARY_PATH` was left unchanged)