### PR TITLE
Use CMake cache variables for plugin-related commands

### DIFF
--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -84,15 +84,11 @@ function(dd4hep_generate_rootmap library)
 
   set(DD4HEP_${ENV_VAR} "$ENV{${ENV_VAR}}"
     CACHE STRING
-    "Set ${ENV_VAR} when adding plugins"
+    "Set ${ENV_VAR} when adding DD4hep plugins"
   )
-  if("$ENV{ROOT_LIBRARY_PATH}")
-    # Override path to required ROOT libraries from the environment
-    set(_default_root_lib_path "$ENV{ROOT_LIBRARY_PATH}")
-  endif()
-  set(DD4HEP_ROOT_LIBRARY_PATH "${_default_root_lib_path}"
+  set(DD4HEP_ROOT_LIBRARY_PATH "$ENV{ROOT_LIBRARY_PATH}"
     CACHE STRING
-    "Set ROOT_LIBRARY_PATH when adding plugins"
+    "Set ROOT_LIBRARY_PATH when adding DD4hep plugins"
   )
 
   string(JOIN ":" _ld_path


### PR DESCRIPTION
The `dd4hep_generate_rootmap` cmake command, used by `dd4hep_add_plugin`, is needed by DD4HEP and downstream libraries (e.g., Celeritas https://github.com/celeritas-project/celeritas/issues/1732) to generate plugins. CMake best practice is to use cache variables to make builds reproducible, so that reconfiguring with different environment variables does not affect the build file. (See discussion in https://github.com/AIDASoft/DD4hep/pull/1545#issuecomment-3714582796 .) This updates the call to `listcomponents` to reuse the environment variables from the original configuration, and it allows overrides of those variables via the CMakeCache.

BEGINRELEASENOTES
- CMake: `dd4hep_add_plugin`: Preserve `(LD|DYLD|ROOT)_LIBRARY_PATH` with `DD4HEP`-prefixed CMake variables to prevent environment changes from breaking builds when reconfiguring.

ENDRELEASENOTES