### PR TITLE
Make sure that the sensitive action pointer can be used before using it

### DIFF
--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -160,11 +160,9 @@ void Geant4ParticleHandler::mark(const G4Track* track)   {
   else // Assume by default "tracker"
     mask.set(G4PARTICLE_CREATED_TRACKER_HIT);
 
-  if ( !this->m_userHandlers.empty() )  {
+  if ( !this->m_userHandlers.empty() && sd ) {
     for( auto* h : this->m_userHandlers ) {
-      if ( sd ) {
-        h->mark_track(track, &m_currTrack, sd->sequence());
-      }
+      h->mark_track(track, &m_currTrack, sd->sequence());
     }
   }
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- In https://github.com/AIDASoft/DD4hep/pull/1555, `mark_track` is introduced and uses the `sd` pointer which may or may not be valid. This PR checks if the pointer is valid before using it.

ENDRELEASENOTES

https://github.com/AIDASoft/DD4hep/pull/1555 makes IDEA_o1_v03 simulations crash (see https://github.com/key4hep/k4geo/actions/runs/21236213514/job/61104707370). We should add a test with a setup similar to IDEA, but I'm not sure what is causing the `sd` pointer not to be valid, also I would prefer to have this merged sooner than later since a few things fail in our nightlies because of this. This is almost certainly happening because of the dual readout, as I've commented out all the other parts of IDEA for making it run a bit faster.

@BrieucF