### PR TITLE
Use Clang 19 instead of 16 in CI

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["dev4/x86_64-el9-clang16-opt"]
+        LCG: ["dev4/x86_64-el9-clang19-opt"]
     steps:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
@@ -21,7 +21,7 @@ jobs:
         release-platform: ${{ matrix.LCG }}
         run: |
           # clang-tidy does not work with the clang-wrapper, we setup the direct clang here
-          source /cvmfs/sft.cern.ch/lcg/contrib/clang/16/x86_64-el9/setup.sh
+          source /cvmfs/sft.cern.ch/lcg/contrib/clang/19/x86_64-el9/setup.sh
           mkdir build
           cd build
           unset CPATH

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,8 +28,8 @@ jobs:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-${{ matrix.LCG }}
         run: |
-          if [[ ${{ matrix.LCG }} =~ clang16 ]]; then
-            source /cvmfs/sft.cern.ch/lcg/contrib/clang/16/x86_64-el9/setup-wrapper.sh
+          if [[ ${{ matrix.LCG }} =~ clang19 ]]; then
+            source /cvmfs/sft.cern.ch/lcg/contrib/clang/19/x86_64-el9/setup-wrapper.sh
           fi
           mkdir build
           cd build
@@ -79,7 +79,7 @@ jobs:
           mkdir build
           cd build
           source ../../.github/scripts/common_cmake_opts.sh
-          if [[ ${{ matrix.LCG }} =~ gcc13|clang16 ]]; then
+          if [[ ${{ matrix.LCG }} =~ gcc13|gcc15|clang19 ]]; then
             cmake \
               $COMMON_EXAMPLES_CMAKE_OPTS \
               -DCMAKE_CXX_STANDARD=20 \


### PR DESCRIPTION
BEGINRELEASENOTES
- Use Clang 19 instead of 16 in CI, since these builds are going to be removed

ENDRELEASENOTES

Clang 16 builds seem not to work and are going to be removed, see https://its.cern.ch/jira/projects/SPI/issues/SPI-2955