### PR TITLE
replace compact.xsd location

### DIFF
--- a/DDTest/units.xml
+++ b/DDTest/units.xml
@@ -1,6 +1,6 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
+<lccdd xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0" 
     xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-    xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+    xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd">
 
     <info name="units_test"
 	  title="units"

--- a/examples/ClientTests/compact/FCCmachine/FCCee_DectDimensions.xml
+++ b/examples/ClientTests/compact/FCCmachine/FCCee_DectDimensions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+<lccdd xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0"
        xmlns:xs="http://www.w3.org/2001/XMLSchema"
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+       xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd">
 
   <info name="FCCDectDimensions"
 	title="master file with includes and world dimension"

--- a/examples/ClientTests/compact/FCCmachine/FCCee_DectMaster.xml
+++ b/examples/ClientTests/compact/FCCmachine/FCCee_DectMaster.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+<lccdd xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+  xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd">
 
   <info name="FCCDectMaster"
     title="FCCee Machine Elements geometry master file"

--- a/examples/ClientTests/compact/lhcbfull_plugins.xml
+++ b/examples/ClientTests/compact/lhcbfull_plugins.xml
@@ -1,6 +1,6 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
+<lccdd xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0" 
        xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+       xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd">
   <info name="lhcb_full"
         title="LHCb detector geometry imported from plain ROOT file"
         author="Markus Frank"

--- a/examples/DDCodex/compact/CODEX-b-alone.xml
+++ b/examples/DDCodex/compact/CODEX-b-alone.xml
@@ -1,6 +1,6 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
+<lccdd xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0" 
        xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+       xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd">
 
   <!-- Have the materials    -->
   <includes>

--- a/examples/DDCodex/compact/CODEX-b.xml
+++ b/examples/DDCodex/compact/CODEX-b.xml
@@ -1,6 +1,6 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
+<lccdd xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0" 
        xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+       xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd">
 <!--
   <includes>
     <gdmlFile  ref="elements.xml"/>

--- a/examples/DDDB/data/materials.xml
+++ b/examples/DDDB/data/materials.xml
@@ -1,6 +1,6 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" 
+<lccdd xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0" 
        xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+       xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd">
   <info name="lhcb_full"
         title="LHCb detector geometry"
         author="Markus Frank"

--- a/examples/RICH/compact/pfrich.xml
+++ b/examples/RICH/compact/pfrich.xml
@@ -1,7 +1,7 @@
 <lccdd 
-  xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+  xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd"
+  xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd"
   >
 
 <info

--- a/examples/SimpleDetector/compact/Simple_CLIC.xml
+++ b/examples/SimpleDetector/compact/Simple_CLIC.xml
@@ -1,6 +1,6 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+<lccdd xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0"
    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-   xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+   xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd">
 
     <info name="Simple_CLIC"
        title="CLIC Detector like example detector model"

--- a/examples/SimpleDetector/compact/Simple_ILD.xml
+++ b/examples/SimpleDetector/compact/Simple_ILD.xml
@@ -1,6 +1,6 @@
-<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+<lccdd xmlns:compact="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0"
    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-   xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+   xs:noNamespaceSchemaLocation="https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd">
 
     <info name="Simple_ILD"
        title="ILD Detector like example detector model"


### PR DESCRIPTION
BEGINRELEASENOTES
- Replace location of compact.xsd since the old location is no longer accessible: https://dd4hep.web.cern.ch/org/lcsim/schemas/compact/1.0/compact.xsd

ENDRELEASENOTES

https://github.com/slaclab/lcsim/blob/master/detector-framework/src/main/resources/org/lcsim/schemas/compact/1.0/compact.xsd

Thanks to @kjvbrt For pointing this out

I found the compact.xsd file here https://github.com/slaclab/lcsim/blob/master/detector-framework/src/main/resources/org/lcsim/schemas/compact/1.0/compact.xsd