### PR TITLE
#1544 add backward, far det types

### DIFF
--- a/DDCore/include/DD4hep/DetType.h
+++ b/DDCore/include/DD4hep/DetType.h
@@ -56,7 +56,9 @@ namespace dd4hep {
       SUPPORT         = 1 << 14,
       BEAMPIPE        = 1 << 15, 
       COIL            = 1 << 16,
-      AUXILIARY       = 1 << 17 
+      AUXILIARY       = 1 << 17,
+      BACKWARD        = 1 << 18,
+      FAR             = 1 << 19
    };
 
     /// default c'tor

--- a/DDDetectors/compact/detector_types.xml
+++ b/DDDetectors/compact/detector_types.xml
@@ -25,8 +25,8 @@
   <constant name="DetType_BEAMPIPE"        value =  " 0x8000 "/>
   <constant name="DetType_COIL"            value =  " 0x10000 "/>
   <constant name="DetType_AUXILIARY"       value =  " 0x20000 "/>
-  <!-- <constant name="DetType_bit_ 18 " value =  " 0x40000 "/> -->
-  <!-- <constant name="DetType_bit_ 19 " value =  " 0x80000 "/> -->
+  <constant name="DetType_BACKWARD"        value =  " 0x40000 "/>
+  <constant name="DetType_FAR"             value =  " 0x80000 "/>
   <!-- <constant name="DetType_bit_ 20 " value =  " 0x100000 "/> -->
   <!-- <constant name="DetType_bit_ 21 " value =  " 0x200000 "/> -->
   <!-- <constant name="DetType_bit_ 22 " value =  " 0x400000 "/> -->


### PR DESCRIPTION

BEGINRELEASENOTES

-  Add `BACKWARD`, `FAR` enums to `dd4hep::DetType`  (see #1544)

ENDRELEASENOTES