### PR TITLE
ParticleHandler: fix keepParticle logic

### DIFF
--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -627,11 +627,12 @@ int Geant4ParticleHandler::recombineParents()  {
     // or is set to NULL, the particle is ALWAYS removed
     //
     // Note: This may override all other decisions!
-    bool remove_me = defaultKeepParticle(*p);
+    bool remove_me = false;
     if ( !this->m_userHandlers.empty() )  {
-      remove_me = true;
       for( auto* h : this->m_userHandlers )
         remove_me |= h->keepParticle(*p);
+    } else {
+      remove_me = defaultKeepParticle(*p);
     }
 
     // Now look at the property mask of the particle


### PR DESCRIPTION

The logic introduced in https://github.com/AIDASoft/DD4hep/pull/1555 was not quite correct. 
remove_me would always be true if userParticle handlers were installed, since `true |= anything` is true for false or true. `keepParticle` is also not quite correctly named, since it rather is a dropParticle function.

BEGINRELEASENOTES
- Geant4ParticleHandler: fix logic to keep secondary particles. All non-primary particles were removed from the event record unless keepAllParticles was set. 

ENDRELEASENOTES