### PR TITLE
Fields/FieldTypes: performance related cleanups 

### DIFF
--- a/DDCore/include/DD4hep/Fields.h
+++ b/DDCore/include/DD4hep/Fields.h
@@ -213,9 +213,7 @@ namespace dd4hep {
     }
 
     /// Returns the 3 magnetic field components (x, y, z) if many components are present
-    void combinedMagnetic(const double* pos, double* field) const   {
-      combinedMagnetic(Position(pos[0], pos[1], pos[2]), field);
-    }
+    void combinedMagnetic(const double* pos, double* field) const;
 
     /// Returns the 3 electric field components (x, y, z).
     void electricField(const Position& pos, double* field) const;
@@ -245,14 +243,12 @@ namespace dd4hep {
     void magneticField(const Position& pos, double* field) const;
 
     /// Returns the 3  magnetic field components (x, y, z).
-    void magneticField(const double* pos, double* field) const   {
-      magneticField(Position(pos[0], pos[1], pos[2]), field);
-    }
+    void magneticField(const double* pos, double* field) const;
 
     /// Returns the 3 magnetic field components (x, y, z).
     void magneticField(const double* pos, Direction& field) const {
       double fld[3] = { 0e0, 0e0, 0e0 };
-      magneticField(Position(pos[0], pos[1], pos[2]), fld);
+      magneticField(pos, fld);
       field = { fld[0], fld[1], fld[2] };
     }
 

--- a/DDCore/src/FieldTypes.cpp
+++ b/DDCore/src/FieldTypes.cpp
@@ -56,10 +56,10 @@ void SolenoidField::fieldComponents(const double* pos, double* field) {
   double z = pos[2] ;
   //  std::cout << " field z=" << z << " maxZ=" << maxZ << " minZ = " << minZ << std::endl ;
   if( z > minZ && z < maxZ ){
-    double radius = std::sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
-    if (radius < innerRadius)
+    double radius2 = pos[0] * pos[0] + pos[1] * pos[1];
+    if (radius2 < innerRadius*innerRadius )
       field[2] += innerField;
-    else if (radius < outerRadius)
+    else if (radius2 < outerRadius*outerRadius )
       field[2] += outerField;
   }
 }
@@ -71,9 +71,9 @@ DipoleField::DipoleField() : zmax(INFINITY), zmin(-INFINITY), rmax(INFINITY) {
 
 /// Compute  the field components at a given location and add to given field
 void DipoleField::fieldComponents(const double* pos, double* field) {
-  double z = pos[2], r = std::sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
+  double z = pos[2], r2 = pos[0] * pos[0] + pos[1] * pos[1];
   // Check if z coordinate is within dipole z bounds.
-  if (z > zmin && z < zmax && r < rmax) {
+  if (z > zmin && z < zmax && r2 < rmax*rmax) {
     // Apply all coefficients to this z coordinate.
     double pp    = 1.0;
     double abs_z = fabs(z);

--- a/DDCore/src/Fields.cpp
+++ b/DDCore/src/Fields.cpp
@@ -169,6 +169,12 @@ void OverlayedField::combinedMagnetic(const Position& pos, double* field) const 
   calculate_combined_field(data<Object>()->magnetic_components, pos, field);
 }
 
+/// Returns the 3  magnetic field components (x, y, z).
+void OverlayedField::combinedMagnetic(const double *pos, double* field) const {
+  field[0] = field[1] = field[2] = 0.;
+  calculate_combined_field(data<Object>()->magnetic_components, pos, field);
+}
+
 /// Returns the 3 electric (val[0]-val[2]) and magnetic field components (val[3]-val[5]).
 void OverlayedField::electromagneticField(const Position& pos, double* field) const {
   Object* o = data<Object>();

--- a/DDCore/src/Fields.cpp
+++ b/DDCore/src/Fields.cpp
@@ -28,6 +28,11 @@ namespace {
   void calculate_combined_field(std::vector<CartesianField>& v, const Position& pos, double* field) {
     for (const auto& i : v ) i.value(pos, field);
   }
+
+  void calculate_combined_field(std::vector<CartesianField>& v, const double* pos, double* field) {
+    for (const auto& i : v ) i.value(pos, field);
+  }
+
 }
 
 /// Default constructor
@@ -62,7 +67,7 @@ void CartesianField::value(const Position& pos, Direction& field) const  {
   double fld[3] = {0e0, 0e0, 0e0};
   double position[3] = {pos.X(), pos.Y(), pos.Z()};
   data<Object>()->fieldComponents(position, fld);
-  field = Direction(fld[0], fld[1], fld[2]);
+  field += Direction(fld[0], fld[1], fld[2]);
 }
 
 /// Returns the 3 field components (x, y, z).
@@ -138,14 +143,15 @@ void OverlayedField::add(CartesianField field) {
 
 /// Returns the 3  magnetic field components (x, y, z).
 void OverlayedField::magneticField(const Position& pos, double* field) const   {
+  double position[3] = { pos.X(), pos.Y(), pos.Z() };
+  magneticField(position, field);
+}
+
+void OverlayedField::magneticField(const double* pos, double* field) const   {
   if ( isValid() )   {
     field[0] = field[1] = field[2] = 0.0;
     auto* obj = data<Object>();
-    CartesianField f = obj->magnetic;
-    if ( f.isValid() )
-      f.value(pos, field);
-    else
-      calculate_combined_field(obj->magnetic_components, pos, field);
+    calculate_combined_field(obj->magnetic_components, pos, field);
     return;
   }
   except("OverlayedField","add: Attempt to add an invalid field.");
@@ -166,7 +172,7 @@ void OverlayedField::combinedMagnetic(const Position& pos, double* field) const 
 /// Returns the 3 electric (val[0]-val[2]) and magnetic field components (val[3]-val[5]).
 void OverlayedField::electromagneticField(const Position& pos, double* field) const {
   Object* o = data<Object>();
-  field[0] = field[1] = field[2] = 0.;
+  field[0] = field[1] = field[2] = field[3] = field[4] = field[5] = 0.;
   calculate_combined_field(o->electric_components, pos, field);
   calculate_combined_field(o->magnetic_components, pos, field + 3);
 }


### PR DESCRIPTION
The time spent getting field values in the ILD detector configuration caught my eye.  These changes unfortunately do not make a large impact (seems virtual method overheads instead, but tbc)

Performance related updates
- avoid sqrts when not needed
- avoid unnecessary creation of Position objects when they are just taken apart again

Changes that would change results if methods were used (likely they are not)
- ```OverlayedField::electromagneticField``` did not initialize all field members properly. Added 
- Some ```CartesianField::value``` methods did not add the current field value to the existing one. Changed to be all consistent (I think)


BEGINRELEASENOTES
- Fields/FieldTypes: performance related cleanups 
ENDRELEASENOTES