### PR TITLE
Fix more memory leaks

### DIFF
--- a/DDCore/include/DD4hep/DetectorData.h
+++ b/DDCore/include/DD4hep/DetectorData.h
@@ -75,6 +75,7 @@ namespace dd4hep {
               printout(WARNING,"Detector",
                        "+++ Object '%s' is already defined. New value will be ignored",
                        n.c_str());
+              delete e.ptr();
             }
             return;
           }

--- a/DDCore/src/plugins/StandardPlugins.cpp
+++ b/DDCore/src/plugins/StandardPlugins.cpp
@@ -251,10 +251,11 @@ DECLARE_APPLY(DD4hep_Rint,run_interpreter)
  */
 static long root_ui(Detector& description, int /* argc */, char** /* argv */) {
   char cmd[256];
+  static dd4hep::detail::DD4hepUI s_ui(description);
   std::snprintf(cmd, sizeof(cmd),
-                "dd4hep::detail::DD4hepUI* gDD4hepUI = new "
-                "dd4hep::detail::DD4hepUI(*(dd4hep::Detector*)%p);",
-                (void*)&description);
+                "dd4hep::detail::DD4hepUI* gDD4hepUI = "
+                "(dd4hep::detail::DD4hepUI*)%p;",
+                (void*)&s_ui);
   gInterpreter->ProcessLine(cmd);
   printout(ALWAYS,"DD4hepUI",
            "Use the ROOT interpreter variable gDD4hepUI "

--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -108,6 +108,7 @@ function(dd4hep_generate_rootmap library)
                      ${DD4HEP_GENERATE_ROOTMAP_EXTRA_ENV}
                      "${ENV_VAR}=${_ld_path}"
                      "ROOT_LIBRARY_PATH=${DD4HEP_ROOT_LIBRARY_PATH}"
+                     "LSAN_OPTIONS=detect_leaks=0"
                      $<TARGET_FILE:DD4hep::listcomponents> -o ${rootmapfile} $<TARGET_FILE_NAME:${library}>
                      WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH}
                      COMMAND_EXPAND_LISTS


### PR DESCRIPTION
flagged by the leak sanitizer. Continuation of https://github.com/AIDASoft/DD4hep/pull/1586. These are a bit more complex.

BEGINRELEASENOTES
- `DetectorData.h`: fix a leak when defining multiple times the same constant. This is the case, for example, in the test `t_ClientTests_converter_vis_MagnetFields` where we have constants (like `world_side`) defined at the top level `MagnetFields.xml` and also in the included `SiDConstants.xml`. Because they are being put in a map, the second time the same constant appears emplacing will fail and there is a warning for that. However, that handle will never be deleted since it will never belong to the map.
- `DD4hep.cmake`: Allow listcomponents to run with the leak sanitizer during the build process since there are leaks coming from ROOT
- `StandardPlugins.cpp`: Make the `DD4hepUI` object static instead of allocating one with `new` that will never get deleted. Fixes the test `t_DDDigi_colored_noise`

ENDRELEASENOTES

For `DetectorData.h`, I can not call `e.destroy()` because it's const. Maybe it shouldn't be const?