### PR TITLE
feat: add Halton sequences support to isotrope generator

### DIFF
--- a/DDG4/include/DDG4/Geant4IsotropeGenerator.h
+++ b/DDG4/include/DDG4/Geant4IsotropeGenerator.h
@@ -17,13 +17,36 @@
 // Framework include files
 #include <DDG4/Geant4ParticleGenerator.h>
 
+// C/C++ include files
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+
 /// Namespace for the AIDA detector description toolkit
 namespace dd4hep {
 
   /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
   namespace sim {
+
+    // Forward declarations
+    class Geant4Random;
+
     /// Generate particles isotrop in space around origine (0,0,0)
     /**
+     *  Supports both standard PRNG-based sampling and Randomized Quasi-Monte Carlo
+     *  sampling via scrambled Halton sequences (Cranley-Patterson rotation).
+     *
+     *  When Halton mode is enabled (property "Halton" = true), the three sampling
+     *  dimensions use low-discrepancy Halton sequences in bases 2 (phi), 3 (theta),
+     *  and 5 (momentum), each additively scrambled by a per-dimension shift derived
+     *  from the property "HaltonSeed".  This provides superior phase-space coverage
+     *  relative to a PRNG while remaining reproducible and independent across jobs
+     *  (using different seeds or "HaltonOffset" values).
+     *
+     *  Note: the "ffbar" distribution is incompatible with Halton mode because its
+     *  acceptance-rejection loop cannot be driven by a fixed per-particle Halton point.
+     *
      *  \author  M.Frank
      *  \version 1.0
      *  \ingroup DD4HEP_SIMULATION
@@ -40,20 +63,42 @@ namespace dd4hep {
       double      m_thetaMin;
       /// Property: Maximal theta angular value
       double      m_thetaMax;
-      
+      /// Property: Enable scrambled Halton sequence sampling (RQMC mode)
+      bool        m_halton;
+      /// Property: Starting index in the Halton sequence (use for parallel-job partitioning)
+      uint64_t    m_haltonOffset;
+      /// Current Halton sequence index (incremented per generated particle)
+      mutable uint64_t m_haltonIndex;
+      /// Per-dimension additive scramble shifts in [0,1), sampled from Geant4Random on first use
+      mutable std::array<double,3> m_haltonShift;
+      /// Ensures initHalton() runs exactly once across all events
+      mutable std::once_flag m_haltonOnce;
+
+      /// Initialize Cranley-Patterson shifts using @a rnd; set m_haltonIndex = m_haltonOffset
+      void initHalton(Geant4Random& rnd) const;
+      /// Compute the radical inverse of @a index in the given @a base (standard Halton value)
+      static double haltonValue(uint64_t index, int base);
+      /// Return the scrambled Halton sample for dimension @a dim (0=phi,1=theta,2=momentum)
+      double haltonScrambled(uint64_t index, unsigned int dim) const;
+      /// Build and return a per-particle sampler: either PRNG or Halton, depending on m_halton.
+      /// For Halton mode, advances m_haltonIndex by one.
+      std::function<double(unsigned int)> makeSampler(Geant4Random& rnd) const;
+      /// Sample momentum from [m_momentumMin, m_momentumMax] using a pre-computed [0,1) value @a h
+      void sampleMomentum(double h, double& momentum) const;
+
       /// Particle modification. Caller presets defaults to: ( direction = m_direction,  momentum = [m_momentumMin, m_momentumMax])
       /** Use this function to implement isotrop guns, multiple guns etc. 
           User must return a UNIT vector, which gets scaled with momentum.
       */
       virtual void getParticleDirection(int num, ROOT::Math::XYZVector& direction, double& momentum) const  override;
-      /// e+e- --> ffbar particle distribution ~ 1 + cos^2(theta)
+      /// e+e- --> ffbar particle distribution ~ 1 + cos^2(theta) (PRNG only; incompatible with Halton)
       void getParticleDirectionFFbar(int num, ROOT::Math::XYZVector& direction, double& momentum) const;
-      /// e+e- --> ffbar particle distribution ~ 1 + cos^2(theta)
-      void getParticleDirectionEta(int num, ROOT::Math::XYZVector& direction, double& momentum) const;
+      /// Flat pseudorapidity (eta) distribution
+      void getParticleDirectionEta(int num, const std::function<double(unsigned int)>& sample, ROOT::Math::XYZVector& direction, double& momentum) const;
       /// Particle distribution ~ cos(theta)
-      void getParticleDirectionCosTheta(int num, ROOT::Math::XYZVector& direction, double& momentum) const;
+      void getParticleDirectionCosTheta(int num, const std::function<double(unsigned int)>& sample, ROOT::Math::XYZVector& direction, double& momentum) const;
       /// Uniform particle distribution
-      void getParticleDirectionUniform(int num, ROOT::Math::XYZVector& direction, double& momentum) const;
+      void getParticleDirectionUniform(int num, const std::function<double(unsigned int)>& sample, ROOT::Math::XYZVector& direction, double& momentum) const;
 
     public:
       /// Inhibit default constructor

--- a/DDG4/include/DDG4/Geant4IsotropeGenerator.h
+++ b/DDG4/include/DDG4/Geant4IsotropeGenerator.h
@@ -40,7 +40,7 @@ namespace dd4hep {
      *  When Halton mode is enabled (property "Halton" = true), the three sampling
      *  dimensions use low-discrepancy Halton sequences in bases 2 (phi), 3 (theta),
      *  and 5 (momentum), each additively scrambled by a per-dimension shift derived
-     *  from the property "HaltonSeed".  This provides superior phase-space coverage
+     *  from the Geant4Random seed.  This provides superior phase-space coverage
      *  relative to a PRNG while remaining reproducible and independent across jobs
      *  (using different seeds or "HaltonOffset" values).
      *

--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -4,6 +4,7 @@ from DDSim.Helper.ConfigHelper import ConfigHelper
 from g4units import GeV
 from math import atan, exp
 import logging
+import textwrap
 
 logger = logging.getLogger(__name__)
 
@@ -39,18 +40,27 @@ class Gun(ConfigHelper):
                           "If not None, it will overwrite the setting of momentumMin and momentumMax"}
     self.energy = None
 
-    self._halton_EXTRA = {'help': "Use scrambled Halton sequence (RQMC) for particle gun sampling.\n\n"
-                          "Replaces the standard PRNG with a low-discrepancy sequence that gives\n"
-                          "superior phase-space coverage. The scrambling shifts are seeded from\n"
-                          "the simulation's Geant4Random engine (controlled by --random.seed).\n\n"
-                          "Note: the standard 1/sqrt(N) error estimate assumes i.i.d. samples and\n"
-                          "does NOT apply here. To estimate statistical errors, run M independent\n"
-                          "replications with different random seeds and use the spread across runs.\n\n"
-                          "Incompatible with distribution='ffbar': acceptance-rejection sampling\n"
-                          "cannot be driven by a fixed per-particle Halton point."}
+    self._halton_EXTRA = {'help': textwrap.dedent("""\
+            Use scrambled Halton sequence (RQMC) for particle gun sampling.
+
+            Replaces the standard PRNG with a low-discrepancy sequence that gives
+            superior phase-space coverage. The scrambling shifts are seeded from
+            the simulation's Geant4Random engine (controlled by --random.seed).
+            
+            Note: the standard 1/sqrt(N) error estimate assumes independent and
+            identically distributed (i.i.d.) samples and does NOT apply here.
+            To estimate statistical errors, run M independent replications with
+            different random seeds and use the spread across runs.
+            
+            Incompatible with distribution='ffbar': acceptance-rejection sampling
+            cannot be driven by a fixed per-particle Halton point.
+            """)}
     self.halton = False
-    self._haltonOffset_EXTRA = {'help': "Starting index in the Halton sequence.\n\n"
-                                "Set to k*N*m for parallel jobs (job k, N events, multiplicity m)."}
+    self._haltonOffset_EXTRA = {'help': textwrap.dedent("""\
+            Starting index in the Halton sequence.
+
+            Set to k*N*m for parallel jobs (job k, N events, multiplicity m).
+            """)}
     self.haltonOffset = 0
 
     self._distribution_EXTRA = {'choices': ['uniform', 'cos(theta)',

--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -46,12 +46,12 @@ class Gun(ConfigHelper):
             Replaces the standard PRNG with a low-discrepancy sequence that gives
             superior phase-space coverage. The scrambling shifts are seeded from
             the simulation's Geant4Random engine (controlled by --random.seed).
-            
+
             Note: the standard 1/sqrt(N) error estimate assumes independent and
             identically distributed (i.i.d.) samples and does NOT apply here.
             To estimate statistical errors, run M independent replications with
             different random seeds and use the spread across runs.
-            
+
             Incompatible with distribution='ffbar': acceptance-rejection sampling
             cannot be driven by a fixed per-particle Halton point.
             """)}

--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -50,7 +50,7 @@ class Gun(ConfigHelper):
                           "cannot be driven by a fixed per-particle Halton point."}
     self.halton = False
     self._haltonOffset_EXTRA = {'help': "Starting index in the Halton sequence.\n\n"
-                                "Set to k*N for parallel-job partitioning (job k, N events each)."}
+                                "Set to k*N*m for parallel jobs (job k, N events, multiplicity m)."}
     self.haltonOffset = 0
 
     self._distribution_EXTRA = {'choices': ['uniform', 'cos(theta)',

--- a/DDG4/python/DDSim/Helper/Gun.py
+++ b/DDG4/python/DDSim/Helper/Gun.py
@@ -39,6 +39,20 @@ class Gun(ConfigHelper):
                           "If not None, it will overwrite the setting of momentumMin and momentumMax"}
     self.energy = None
 
+    self._halton_EXTRA = {'help': "Use scrambled Halton sequence (RQMC) for particle gun sampling.\n\n"
+                          "Replaces the standard PRNG with a low-discrepancy sequence that gives\n"
+                          "superior phase-space coverage. The scrambling shifts are seeded from\n"
+                          "the simulation's Geant4Random engine (controlled by --random.seed).\n\n"
+                          "Note: the standard 1/sqrt(N) error estimate assumes i.i.d. samples and\n"
+                          "does NOT apply here. To estimate statistical errors, run M independent\n"
+                          "replications with different random seeds and use the spread across runs.\n\n"
+                          "Incompatible with distribution='ffbar': acceptance-rejection sampling\n"
+                          "cannot be driven by a fixed per-particle Halton point."}
+    self.halton = False
+    self._haltonOffset_EXTRA = {'help': "Starting index in the Halton sequence.\n\n"
+                                "Set to k*N for parallel-job partitioning (job k, N events each)."}
+    self.haltonOffset = 0
+
     self._distribution_EXTRA = {'choices': ['uniform', 'cos(theta)',
                                             'eta', 'pseudorapidity',
                                             'ffbar']}  # (1+cos^2 theta)
@@ -153,6 +167,9 @@ class Gun(ConfigHelper):
       # this avoids issues if momentumMin is None because of previous default
       ddg4Gun.MomentumMin = self.momentumMin if self.momentumMin else 0.0
       ddg4Gun.MomentumMax = self.momentumMax
+      if self.halton:
+        ddg4Gun.Halton = True
+        ddg4Gun.HaltonOffset = int(self.haltonOffset)
     except Exception as e:  # pylint: disable=W0703
       logger.error("parsing gun options:\n%s\nException: %s " % (self, e))
       exit(1)

--- a/DDG4/src/Geant4IsotropeGenerator.cpp
+++ b/DDG4/src/Geant4IsotropeGenerator.cpp
@@ -29,6 +29,10 @@ Geant4IsotropeGenerator::Geant4IsotropeGenerator(Geant4Context* ctxt, const std:
   declareProperty("ThetaMin", m_thetaMin = 0.0);
   declareProperty("ThetaMax", m_thetaMax = M_PI);
   declareProperty("Distribution", m_distribution = "uniform" );
+  declareProperty("Halton", m_halton = false);
+  declareProperty("HaltonOffset", m_haltonOffset = 0ULL);
+  m_haltonIndex = 0;
+  m_haltonShift = {0.0, 0.0, 0.0};
 }
 
 /// Default destructor
@@ -36,57 +40,94 @@ Geant4IsotropeGenerator::~Geant4IsotropeGenerator() {
   InstanceCount::decrement(this);
 }
 
-/// Uniform particle distribution
-void Geant4IsotropeGenerator::getParticleDirectionUniform(int, ROOT::Math::XYZVector& direction, double& momentum) const   {
-  Geant4Event&  evt = context()->event();
-  Geant4Random& rnd = evt.random();
-  double phi   = m_phiMin+(m_phiMax-m_phiMin)*rnd.rndm();
-  double theta = m_thetaMin+(m_thetaMax-m_thetaMin)*rnd.rndm();
-  double x1 = std::sin(theta)*std::cos(phi);
-  double x2 = std::sin(theta)*std::sin(phi);
-  double x3 = std::cos(theta);
+/// Initialize Cranley-Patterson shifts using rnd; set m_haltonIndex = m_haltonOffset
+void Geant4IsotropeGenerator::initHalton(Geant4Random& rnd) const  {
+  for (auto& s : m_haltonShift) s = rnd.rndm();
+  m_haltonIndex = m_haltonOffset;
+}
 
-  direction.SetXYZ(x1,x2,x3);
-  getParticleMomentumUniform(momentum);
+/// Compute the radical inverse of index in the given base (Halton value in [0,1))
+double Geant4IsotropeGenerator::haltonValue(uint64_t index, int base)  {
+  uint64_t num   = 0;
+  uint64_t denom = 1;
+  while ( index > 0 )  {
+    denom *= base;
+    num    = num * base + (index % base);
+    index /= base;
+  }
+  return static_cast<double>(num) / static_cast<double>(denom);
+}
+
+/// Cranley-Patterson scrambled Halton sample for dimension dim (0=phi, 1=theta, 2=momentum)
+double Geant4IsotropeGenerator::haltonScrambled(uint64_t index, unsigned int dim) const  {
+  static constexpr std::array<int,3> bases = {2, 3, 5};
+  if ( dim >= bases.size() )  {
+    except("haltonScrambled: dimension %u out of range [0,%zu].", dim, bases.size()-1);
+  }
+  return std::fmod(haltonValue(index, bases[dim]) + m_haltonShift[dim], 1.0);
+}
+
+/// Build a per-particle sampler: PRNG or Halton depending on m_halton
+std::function<double(unsigned int)> Geant4IsotropeGenerator::makeSampler(Geant4Random& rnd) const  {
+  if ( m_halton )  {
+    std::call_once(m_haltonOnce, &Geant4IsotropeGenerator::initHalton, this, std::ref(rnd));
+    uint64_t idx = m_haltonIndex++;
+    return [this, idx](unsigned int dim) { return haltonScrambled(idx, dim); };
+  }
+  return [&rnd](unsigned int) { return rnd.rndm(); };
+}
+
+/// Sample momentum from [m_momentumMin, m_momentumMax] using a pre-computed [0,1) value h
+void Geant4IsotropeGenerator::sampleMomentum(double h, double& momentum) const  {
+  if ( m_energy != -1 )  {
+    momentum = m_energy;
+    return;
+  }
+  if ( m_momentumMax < m_momentumMin )
+    momentum = m_momentumMin + (momentum - m_momentumMin) * h;
+  else
+    momentum = m_momentumMin + (m_momentumMax - m_momentumMin) * h;
+}
+
+/// Uniform particle distribution
+void Geant4IsotropeGenerator::getParticleDirectionUniform(int, const std::function<double(unsigned int)>& sample,
+                                                          ROOT::Math::XYZVector& direction, double& momentum) const  {
+  double phi   = m_phiMin   + (m_phiMax   - m_phiMin)   * sample(0);
+  double theta = m_thetaMin + (m_thetaMax - m_thetaMin) * sample(1);
+  direction.SetXYZ(std::sin(theta)*std::cos(phi), std::sin(theta)*std::sin(phi), std::cos(theta));
+  sampleMomentum(sample(2), momentum);
 }
 
 /// Particle distribution ~ cos(theta)
-void Geant4IsotropeGenerator::getParticleDirectionCosTheta(int, ROOT::Math::XYZVector& direction, double& momentum) const   {
-  Geant4Event&  evt = context()->event();
-  Geant4Random& rnd = evt.random();
-  double phi       = m_phiMin+(m_phiMax-m_phiMin)*rnd.rndm();
-  double cos_theta = std::cos(m_thetaMin)+(std::cos(m_thetaMax)-std::cos(m_thetaMin))*rnd.rndm();
-  double sin_theta = std::sqrt(1.0-cos_theta*cos_theta);
-  double x1 = sin_theta*std::cos(phi);
-  double x2 = sin_theta*std::sin(phi);
-  double x3 = cos_theta;
-
-  direction.SetXYZ(x1,x2,x3);
-  getParticleMomentumUniform(momentum);
+void Geant4IsotropeGenerator::getParticleDirectionCosTheta(int, const std::function<double(unsigned int)>& sample,
+                                                           ROOT::Math::XYZVector& direction, double& momentum) const  {
+  double phi       = m_phiMin + (m_phiMax - m_phiMin) * sample(0);
+  double cos_theta = std::cos(m_thetaMin) + (std::cos(m_thetaMax) - std::cos(m_thetaMin)) * sample(1);
+  double sin_theta = std::sqrt(1.0 - cos_theta*cos_theta);
+  direction.SetXYZ(sin_theta*std::cos(phi), sin_theta*std::sin(phi), cos_theta);
+  sampleMomentum(sample(2), momentum);
 }
 
 /// Particle distribution flat in eta (pseudo rapidity)
-void Geant4IsotropeGenerator::getParticleDirectionEta(int, ROOT::Math::XYZVector& direction, double& momentum) const   {
+void Geant4IsotropeGenerator::getParticleDirectionEta(int, const std::function<double(unsigned int)>& sample,
+                                                      ROOT::Math::XYZVector& direction, double& momentum) const  {
   struct Distribution {
     static double eta(double x)  { return -1.0*std::log(std::tan(x/2.0)); }
   };
-  Geant4Event&  evt = context()->event();
-  Geant4Random& rnd = evt.random();
-  // See https://en.wikipedia.org/wiki/Pseudorapidity
   const double dmin = std::numeric_limits<double>::epsilon();
-  double phi        = m_phiMin+(m_phiMax-m_phiMin)*rnd.rndm();
-  double eta_max    = Distribution::eta(m_thetaMin>dmin ? m_thetaMin : dmin);
-  double eta_min    = Distribution::eta(m_thetaMax>(M_PI-dmin) ? M_PI-dmin : m_thetaMax);
-  double eta        = eta_min + (eta_max-eta_min)*rnd.rndm();
+  double phi        = m_phiMin + (m_phiMax - m_phiMin) * sample(0);
+  double eta_max    = Distribution::eta(m_thetaMin > dmin ? m_thetaMin : dmin);
+  double eta_min    = Distribution::eta(m_thetaMax > (M_PI - dmin) ? M_PI - dmin : m_thetaMax);
+  double eta        = eta_min + (eta_max - eta_min) * sample(1);
   double x1         = std::cos(phi);
   double x2         = std::sin(phi);
   double x3         = std::sinh(eta);
   double r          = std::sqrt(1.0+x3*x3);
   direction.SetXYZ(x1/r,x2/r,x3/r);
-  getParticleMomentumUniform(momentum);
+  sampleMomentum(sample(2), momentum);
 }
 
-/// e+e- --> ffbar particle distribution ~ 1 + cos^2(theta)
+/// e+e- --> ffbar particle distribution ~ 1 + cos^2(theta) (PRNG only; incompatible with Halton)
 void Geant4IsotropeGenerator::getParticleDirectionFFbar(int, ROOT::Math::XYZVector& direction, double& momentum) const   {
   struct Distribution {
     static double ffbar(double x)  { double c = std::cos(x); return 1 + c*c; }
@@ -103,13 +144,9 @@ void Geant4IsotropeGenerator::getParticleDirectionFFbar(int, ROOT::Math::XYZVect
   while(1)  {
     double dice  = rnd.rndm()*vmax;
     double theta = m_thetaMin+(m_thetaMax-m_thetaMin)*rnd.rndm();
-    double dist  = Distribution::ffbar(theta);
-    if ( dice <= dist )   {
-      double x1 = std::sin(theta)*std::cos(phi);
-      double x2 = std::sin(theta)*std::sin(phi);
-      double x3 = std::cos(theta);
-      direction.SetXYZ(x1,x2,x3);
-      getParticleMomentumUniform(momentum);
+    if ( dice <= Distribution::ffbar(theta) )  {
+      direction.SetXYZ(std::sin(theta)*std::cos(phi), std::sin(theta)*std::sin(phi), std::cos(theta));
+      sampleMomentum(rnd.rndm(), momentum);
       return;
     }
   }
@@ -117,20 +154,28 @@ void Geant4IsotropeGenerator::getParticleDirectionFFbar(int, ROOT::Math::XYZVect
 
 /// Particle modification. Caller presets defaults to: ( direction = m_direction, momentum = [mMin, mMax])
 void Geant4IsotropeGenerator::getParticleDirection(int num, ROOT::Math::XYZVector& direction, double& momentum) const   {
+  if ( m_halton && ::toupper(m_distribution[0]) == 'F' )  {
+    except("Halton mode is incompatible with the 'ffbar' distribution: "
+           "acceptance-rejection cannot be driven by a fixed per-particle Halton point. "
+           "Use distribution='uniform', 'cos(theta)', or 'eta' with Halton mode.");
+  }
+  Geant4Event&  evt    = context()->event();
+  Geant4Random& rnd    = evt.random();
+  auto          sample = makeSampler(rnd);
   switch(::toupper(m_distribution[0]))  {
   case 'C':  // cos(theta)
-    return getParticleDirectionCosTheta(num, direction, momentum);
+    return getParticleDirectionCosTheta(num, sample, direction, momentum);
   case 'F':  // ffbar: ~ 1 + cos^2(theta)
     return getParticleDirectionFFbar(num, direction, momentum);
   case 'E':  // eta, rapidity, pseudorapidity
   case 'P':
   case 'R':
-    return getParticleDirectionEta(num, direction, momentum);
+    return getParticleDirectionEta(num, sample, direction, momentum);
   case 'U':  // uniform
-    return getParticleDirectionUniform(num, direction, momentum);
+    return getParticleDirectionUniform(num, sample, direction, momentum);
   default:
     break;
   }
-  except("Unknown distribution densitiy: %s. Cannot generate primaries.",
+  except("Unknown distribution density: %s. Cannot generate primaries.",
          m_distribution.c_str());
 }


### PR DESCRIPTION
Halton sequences are low-discrepancy sequences that fill phase space with faster variance reduction (1/N) than standard uniform point picking with PRNGs (1/sqrt(N)). It's not cheating statistics since you lose the Poisson statistical properties between two consecutive events. This technique is often referred to as RQMC, randomized quasi-Monte Carlo.

This adds scrambled Halton sequence support to the isotrope generators (where inter-event statistics are not considered since they don't represent real experimental running conditions). The scrambling uses Cranley-Patterson rotation, which is sufficient to remove correlations in three dimensional phase space sampling.

The sequences are scrambled with the random seed, so different runs with different seeds will produce different sequences. This also then allows statistical treatment to determine the errors on aggregate quantities (see note in ddsim help).

The various distributions are modified to take a sampler function that can either use PRNG or Halton sequences. For FFbar this is not possible since it uses an accept/reject algorithm that only works for PRNG.

Additional implementation notes:
- `getParticleMomentumUniform` needed to get the sample passed to it, so it was renamed to `sampleMomentum`. That leaves parent `Geant4ParticleGenerator::getParticleMomentumUniform` without any use or re-implementation in DD4hep, I think.
- `haltonValue` is written to use a pure integer loop with conversion to double only on return.

Since a picture (from wikipedia) is worth 1000 words:

| PRNG | RQMC |
|----------|-----------|
|<img width="250" height="250" alt="image" src="https://github.com/user-attachments/assets/ef133330-1cd5-4ff6-87c0-8e83eaa58e61" /> | <img width="250" height="250" alt="image" src="https://github.com/user-attachments/assets/9e461fa7-193e-4639-9fd0-e7c735241ee6" /> |

BEGINRELEASENOTES
- add Halton sequences support to isotrope generator

ENDRELEASENOTES