### PR TITLE
Remove unused template function calling non existing function.

### DIFF
--- a/DDCore/include/DD4hep/Shapes.h
+++ b/DDCore/include/DD4hep/Shapes.h
@@ -950,11 +950,6 @@ namespace dd4hep {
                 double zneg, double zpos, int nsegments, double totphi)
     {  this->make(nam, twist_angle, rmin, rmax, zneg, zpos, nsegments, totphi);  }
 
-    /// Constructor to create a new identified tube object with attribute initialization
-    template <typename A, typename B, typename DZ>
-    TwistedTube(const std::string& nam, const A& a, const B& b, const DZ& dz)
-    {  this->make(nam, _toDouble(a), _toDouble(b), _toDouble(dz));   }
-
     /// Move Assignment operator
     TwistedTube& operator=(TwistedTube&& copy) = default;
     /// Copy Assignment operator


### PR DESCRIPTION
Remove unused template function calling non existing function.

This function is causing a build error when trying to compile with nvcc < 13.2. It works fine with other compilers (eg. gcc, clang) because the template function is never instantiated, so the compiler should be ignoring it. This is a bug in nvcc which doesn't ignore it and throws a compilation error. This issue is fixed in nvcc 13.2 but is present in all prior versions.

As part of the Gaudi-Allen convergence work we want to be able to compile, or at least parse DD4HEP headers with nvcc (for the host part).

FYI @sponce 

BEGINRELEASENOTES

* Shapes.h: Remove unused template function calling non existing function. (fix nvcc build)

ENDRELEASENOTES