### PR TITLE
Fix undefined behaviour in the BitFieldCoder

### DIFF
--- a/DDCore/src/segmentations/BitFieldCoder.cpp
+++ b/DDCore/src/segmentations/BitFieldCoder.cpp
@@ -49,7 +49,7 @@ namespace dd4hep{
         _maxVal =  ( 1LL << ( _width - 1 ) ) - 1 ;
       
       } else {
-        _maxVal = 0x0001<<_width  ;
+        _maxVal = 1LL << _width ;
       }
     }
   


### PR DESCRIPTION
BEGINRELEASENOTES
- BitFieldCoder: Fix undefined behaviour if width is 32 (or greater) and the bitfield is unsigned. Then `1 << width` is undefined behaviour.

ENDRELEASENOTES

Note that above 1LL is being used for the signed branch.