### PR TITLE
Update the checkout action since v4 uses a deprecated version of node

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         LCG: ["dev4/x86_64-el9-clang19-opt"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v3
       with:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'AIDASoft/DD4hep'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v3
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ jobs:
               "dev3/x86_64-el9-clang19-opt",
               "dev3/x86_64-el9-gcc15-dbg"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v5
       with:
@@ -118,7 +118,7 @@ jobs:
       matrix:
         view-path: ["/cvmfs/sw-nightlies.hsf.org/key4hep/"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v5
       with:
@@ -182,7 +182,7 @@ jobs:
       matrix:
         LCG: ["LCG_107a/x86_64-el9-gcc13-opt"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v5
       with:
@@ -211,7 +211,7 @@ jobs:
       matrix:
         LCG: ["dev3/x86_64-el9-gcc13-opt"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v5
       with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Brew install
       run: |
         brew install root boost ninja

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         LCG: ["dev4/x86_64-el9-gcc13-opt"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v3
       with:


### PR DESCRIPTION
BEGINRELEASENOTES
- CI: Update the checkout action since v4 uses a deprecated version of Node.js

ENDRELEASENOTES

Warnings are emitted in CI runs because of this.