### PR TITLE
Remove checks for nullptrs before deleting, since deleting is a no-op

### DIFF
--- a/DDCore/include/Parsers/Primitives.h
+++ b/DDCore/include/Parsers/Primitives.h
@@ -331,14 +331,12 @@ namespace dd4hep {
     }
     /// Helper to delete objects from heap and reset the pointer. Saves many many lines of code
     template <typename T> inline void deletePtr(T*& ptr) {
-      if (0 != ptr)
-        delete ptr;
+      delete ptr;
       ptr = 0;
     }
     /// Helper to delete objects from heap and reset the pointer. Saves many many lines of code
     template <typename T> inline void deleteObject(T* ptr) {
-      if (0 != ptr)
-        delete ptr;
+      delete ptr;
     }
     /// Helper to delete objects from heap and reset the pointer
     template <typename T> inline void destroyObject(T*& ptr) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove checks for nullptrs before deleting, since deleting nullptr is a no-op

ENDRELEASENOTES