### PR TITLE
Make EventSeeder run before primary generation

### DIFF
--- a/DDG4/include/DDG4/Geant4GeneratorAction.h
+++ b/DDG4/include/DDG4/Geant4GeneratorAction.h
@@ -116,6 +116,8 @@ namespace dd4hep {
     protected:
       /// Callback sequence to generate primary particles
       CallbackSequence m_calls;
+      /// Callback sequence before generate primary particles
+      CallbackSequence m_calls_at_begin;
       /// The list of action objects to be called
       Actors<Geant4GeneratorAction> m_actors;
       
@@ -137,6 +139,12 @@ namespace dd4hep {
       void call(Q* p, void (T::*f)(G4Event*)) {
         m_calls.add(p, f);
       }
+      /// Register callback to happen before primary particle. Types Q and T must be polymorph!
+      template <typename Q, typename T>
+      void callAtBegin(Q* p, void (T::*f)(const G4Event*)) {
+        m_calls_at_begin.add(p, f);
+      }
+
       /// Add an actor responding to all callbacks. Sequence takes ownership.
       void adopt(Geant4GeneratorAction* action);
       /// Callback to generate primary particles

--- a/DDG4/plugins/Geant4EventSeed.cpp
+++ b/DDG4/plugins/Geant4EventSeed.cpp
@@ -38,6 +38,7 @@ Geant4EventSeed::Geant4EventSeed(Geant4Context* c, const std::string& typ) : Gea
 									     m_initialised(false)
 {
   Geant4Action::runAction().callAtBegin(this,&Geant4EventSeed::begin);
+  Geant4Action::generatorAction().call(this,&Geant4EventSeed::setSeedForPrimaries);
   Geant4Action::eventAction().callAtBegin(this,&Geant4EventSeed::beginEvent);
   InstanceCount::increment(this);
 }
@@ -79,6 +80,12 @@ void Geant4EventSeed::beginEvent(const G4Event* evt) {
     rndm->showStatus();
   }
 
+}
+
+/// begin-of-event callback
+void Geant4EventSeed::setSeedForPrimaries(G4Event* evt) {
+  dd4hep::printout(dd4hep::INFO, m_type, "At generatePrimaries");
+  beginEvent(evt);
 }
 
 DECLARE_GEANT4ACTION(Geant4EventSeed)

--- a/DDG4/plugins/Geant4EventSeed.cpp
+++ b/DDG4/plugins/Geant4EventSeed.cpp
@@ -18,6 +18,7 @@
 #include <DD4hep/InstanceCount.h>
 #include <DD4hep/Printout.h>
 
+#include <DDG4/EventParameters.h>
 #include <DDG4/Geant4EventAction.h>
 #include <DDG4/Geant4StackingAction.h>
 #include <DDG4/Geant4Random.h>
@@ -41,7 +42,7 @@ Geant4EventSeed::Geant4EventSeed(Geant4Context* c, const std::string& typ) : Gea
 									     m_initialised(false)
 {
   Geant4Action::runAction().callAtBegin(this,&Geant4EventSeed::begin);
-  Geant4Action::generatorAction().call(this,&Geant4EventSeed::setSeedForPrimaries);
+  Geant4Action::generatorAction().callAtBegin(this,&Geant4EventSeed::setSeedForPrimaries);
   Geant4Action::eventAction().callAtBegin(this,&Geant4EventSeed::beginEvent);
   // Re-seed after GeneratePrimaries so file-based generators' SetEventID is visible.
   Geant4Action::stackingAction().callAtPrepare(this,&Geant4EventSeed::prepareEvent);
@@ -69,47 +70,58 @@ void Geant4EventSeed::begin(const G4Run* run) {
 
 /// begin-of-event callback
 void Geant4EventSeed::beginEvent(const G4Event* evt) {
-
-  Geant4Random *rndm = Geant4Random::instance();
-  Geant4Event& ddevt = context()->event();
-
-  unsigned int eventID = evt->GetEventID();
-  unsigned int newSeed = hash( m_initialSeed, eventID, m_runID );
-
-  dd4hep::printout( dd4hep::INFO, m_type,
-		    "At beginEvent: eventID=%u, runID=%u initialSeed=%u, newSeed=%u" ,
-		    evt->GetEventID(),  m_runID, m_initialSeed, newSeed );
-
-  rndm->setSeed( newSeed );
-
-  if ( dd4hep::printLevel() <= dd4hep::DEBUG ) {
-    rndm->showStatus();
-  }
-
+  dd4hep::printout(dd4hep::INFO, m_type, "EventSeed:: At beginEvent");
+  setSeed(evt, true);
 }
 
 /// prepare-stacking callback: re-seed after GeneratePrimaries using the final event ID
 void Geant4EventSeed::prepareEvent(G4StackManager* /* stackMgr */) {
-
+  dd4hep::printout(dd4hep::INFO, m_type, "EventSeed:: At prepareEvent");
   const G4Event* evt = G4EventManager::GetEventManager()->GetConstCurrentEvent();
-  if ( !evt ) return;
-
-  Geant4Random *rndm = Geant4Random::instance();
-
-  unsigned int eventID = evt->GetEventID();
-  unsigned int newSeed = hash( m_initialSeed, eventID, m_runID );
-
-  dd4hep::printout( dd4hep::INFO, m_type,
-		    "At prepareEvent: eventID=%u, runID=%u initialSeed=%u, newSeed=%u",
-		    eventID, m_runID, m_initialSeed, newSeed );
-
-  rndm->setSeed( newSeed );
+  setSeed(evt, true);
 }
 
 /// begin-of-event callback
-void Geant4EventSeed::setSeedForPrimaries(G4Event* evt) {
-  dd4hep::printout(dd4hep::INFO, m_type, "At generatePrimaries");
-  beginEvent(evt);
+void Geant4EventSeed::setSeedForPrimaries(const G4Event* evt) {
+  dd4hep::printout(dd4hep::INFO, m_type, "EventSeed:: At generatePrimaries");
+  // since this is before we read input files we cannot expect parameters to be present
+  setSeed(evt, false);
+}
+
+/// general function for setting the seed, called by other callbacks
+void Geant4EventSeed::setSeed(const G4Event* evt, bool checkForEventParameters=true) {
+
+  Geant4Random *rndm = Geant4Random::instance();
+
+  //Trying to use event id from the Geant4 event, unless we have it also in the EventParameters
+  unsigned int eventID = evt->GetEventID();
+
+  if(checkForEventParameters) {
+    //Get EventParameters from the context
+    EventParameters* parameters = context()->event().extension<EventParameters>(false);
+    if(parameters) {
+      eventID = parameters->eventNumber();
+      m_runID = parameters->runNumber();
+      dd4hep::printout(dd4hep::INFO, m_type,
+                       "EventSeed::setSeed: Found eventParameters: eventID=%u, runID=%u",
+                       eventID, m_runID);
+    } else {
+      dd4hep::printout(dd4hep::DEBUG, m_type,
+                       "EventSeed::setSeed: Did not find eventParameters");
+    }
+  }
+
+  unsigned int newSeed = hash( m_initialSeed, eventID, m_runID );
+  dd4hep::printout(dd4hep::INFO, m_type,
+                   "EventSeed::setSeed: eventID=%u, runID=%u initialSeed=%u, newSeed=%u",
+                   eventID, m_runID, m_initialSeed, newSeed );
+
+  rndm->setSeed(newSeed);
+
+  if (dd4hep::printLevel() <= dd4hep::DEBUG) {
+    rndm->showStatus();
+  }
+
 }
 
 DECLARE_GEANT4ACTION(Geant4EventSeed)

--- a/DDG4/plugins/Geant4EventSeed.cpp
+++ b/DDG4/plugins/Geant4EventSeed.cpp
@@ -43,9 +43,8 @@ Geant4EventSeed::Geant4EventSeed(Geant4Context* c, const std::string& typ) : Gea
 {
   Geant4Action::runAction().callAtBegin(this,&Geant4EventSeed::begin);
   Geant4Action::generatorAction().callAtBegin(this,&Geant4EventSeed::setSeedForPrimaries);
-  Geant4Action::eventAction().callAtBegin(this,&Geant4EventSeed::beginEvent);
   // Re-seed after GeneratePrimaries so file-based generators' SetEventID is visible.
-  Geant4Action::stackingAction().callAtPrepare(this,&Geant4EventSeed::prepareEvent);
+  Geant4Action::eventAction().callAtBegin(this,&Geant4EventSeed::beginEvent);
   InstanceCount::increment(this);
 }
 
@@ -71,13 +70,6 @@ void Geant4EventSeed::begin(const G4Run* run) {
 /// begin-of-event callback
 void Geant4EventSeed::beginEvent(const G4Event* evt) {
   dd4hep::printout(dd4hep::INFO, m_type, "EventSeed:: At beginEvent");
-  setSeed(evt, true);
-}
-
-/// prepare-stacking callback: re-seed after GeneratePrimaries using the final event ID
-void Geant4EventSeed::prepareEvent(G4StackManager* /* stackMgr */) {
-  dd4hep::printout(dd4hep::INFO, m_type, "EventSeed:: At prepareEvent");
-  const G4Event* evt = G4EventManager::GetEventManager()->GetConstCurrentEvent();
   setSeed(evt, true);
 }
 

--- a/DDG4/plugins/Geant4EventSeed.cpp
+++ b/DDG4/plugins/Geant4EventSeed.cpp
@@ -41,6 +41,7 @@ Geant4EventSeed::Geant4EventSeed(Geant4Context* c, const std::string& typ) : Gea
 									     m_initialised(false)
 {
   Geant4Action::runAction().callAtBegin(this,&Geant4EventSeed::begin);
+  Geant4Action::generatorAction().call(this,&Geant4EventSeed::setSeedForPrimaries);
   Geant4Action::eventAction().callAtBegin(this,&Geant4EventSeed::beginEvent);
   // Re-seed after GeneratePrimaries so file-based generators' SetEventID is visible.
   Geant4Action::stackingAction().callAtPrepare(this,&Geant4EventSeed::prepareEvent);
@@ -102,7 +103,12 @@ void Geant4EventSeed::prepareEvent(G4StackManager* /* stackMgr */) {
 		    eventID, m_runID, m_initialSeed, newSeed );
 
   rndm->setSeed( newSeed );
+}
 
+/// begin-of-event callback
+void Geant4EventSeed::setSeedForPrimaries(G4Event* evt) {
+  dd4hep::printout(dd4hep::INFO, m_type, "At generatePrimaries");
+  beginEvent(evt);
 }
 
 DECLARE_GEANT4ACTION(Geant4EventSeed)

--- a/DDG4/plugins/Geant4EventSeed.cpp
+++ b/DDG4/plugins/Geant4EventSeed.cpp
@@ -69,13 +69,13 @@ void Geant4EventSeed::begin(const G4Run* run) {
 
 /// begin-of-event callback
 void Geant4EventSeed::beginEvent(const G4Event* evt) {
-  dd4hep::printout(dd4hep::INFO, m_type, "EventSeed:: At beginEvent");
+  dd4hep::printout(dd4hep::DEBUG, m_type, "EventSeed:: At beginEvent");
   setSeed(evt, true);
 }
 
 /// begin-of-event callback
 void Geant4EventSeed::setSeedForPrimaries(const G4Event* evt) {
-  dd4hep::printout(dd4hep::INFO, m_type, "EventSeed:: At generatePrimaries");
+  dd4hep::printout(dd4hep::DEBUG, m_type, "EventSeed:: At generatePrimaries");
   // since this is before we read input files we cannot expect parameters to be present
   setSeed(evt, false);
 }
@@ -94,7 +94,7 @@ void Geant4EventSeed::setSeed(const G4Event* evt, bool checkForEventParameters=t
     if(parameters) {
       eventID = parameters->eventNumber();
       m_runID = parameters->runNumber();
-      dd4hep::printout(dd4hep::INFO, m_type,
+      dd4hep::printout(dd4hep::DEBUG, m_type,
                        "EventSeed::setSeed: Found eventParameters: eventID=%u, runID=%u",
                        eventID, m_runID);
     } else {

--- a/DDG4/plugins/Geant4EventSeed.cpp
+++ b/DDG4/plugins/Geant4EventSeed.cpp
@@ -71,6 +71,7 @@ void Geant4EventSeed::begin(const G4Run* run) {
 void Geant4EventSeed::beginEvent(const G4Event* evt) {
 
   Geant4Random *rndm = Geant4Random::instance();
+  Geant4Event& ddevt = context()->event();
 
   unsigned int eventID = evt->GetEventID();
   unsigned int newSeed = hash( m_initialSeed, eventID, m_runID );

--- a/DDG4/plugins/Geant4EventSeed.h
+++ b/DDG4/plugins/Geant4EventSeed.h
@@ -15,6 +15,7 @@
 
 // Framework include files
 #include <DDG4/Geant4RunAction.h>
+#include <DDG4/Geant4GeneratorAction.h>
 
 
 
@@ -56,6 +57,8 @@ namespace dd4hep {
       void begin(const G4Run*);
       /// begin-of-event callback
       void beginEvent(const G4Event*);
+      /// generatePrimaries callback
+      void setSeedForPrimaries(G4Event*);
     };
 
     /*

--- a/DDG4/plugins/Geant4EventSeed.h
+++ b/DDG4/plugins/Geant4EventSeed.h
@@ -63,7 +63,9 @@ namespace dd4hep {
       /// prepare-stacking callback: re-seeds after GeneratePrimaries using the final event ID
       void prepareEvent(G4StackManager*);
       /// generatePrimaries callback
-      void setSeedForPrimaries(G4Event*);
+      void setSeedForPrimaries(const G4Event*);
+      /// set the seed function, called from other callbacks)
+      void setSeed(const G4Event*, bool checkForParameters);
     };
 
     /*

--- a/DDG4/plugins/Geant4EventSeed.h
+++ b/DDG4/plugins/Geant4EventSeed.h
@@ -15,6 +15,7 @@
 
 // Framework include files
 #include <DDG4/Geant4RunAction.h>
+#include <DDG4/Geant4GeneratorAction.h>
 
 // Forward declarations
 class G4StackManager;
@@ -61,6 +62,8 @@ namespace dd4hep {
       void beginEvent(const G4Event*);
       /// prepare-stacking callback: re-seeds after GeneratePrimaries using the final event ID
       void prepareEvent(G4StackManager*);
+      /// generatePrimaries callback
+      void setSeedForPrimaries(G4Event*);
     };
 
     /*

--- a/DDG4/src/Geant4GeneratorAction.cpp
+++ b/DDG4/src/Geant4GeneratorAction.cpp
@@ -121,8 +121,8 @@ void Geant4GeneratorActionSequence::adopt(Geant4GeneratorAction* action) {
 /// Generator callback
 void Geant4GeneratorActionSequence::operator()(G4Event* event) {
   if ( context()->kernel().processEvents() )  {
-    m_actors(&Geant4GeneratorAction::operator(), event);
     m_calls(event);
+    m_actors(&Geant4GeneratorAction::operator(), event);
     return;
   }
   throw DD4hep_Stop_Processing();

--- a/DDG4/src/Geant4GeneratorAction.cpp
+++ b/DDG4/src/Geant4GeneratorAction.cpp
@@ -87,6 +87,7 @@ Geant4GeneratorActionSequence::Geant4GeneratorActionSequence(Geant4Context* ctxt
 Geant4GeneratorActionSequence::~Geant4GeneratorActionSequence() {
   m_actors(&Geant4GeneratorAction::release);
   m_actors.clear();
+  m_calls_at_begin.clear();
   m_calls.clear();
   InstanceCount::decrement(this);
 }
@@ -121,8 +122,9 @@ void Geant4GeneratorActionSequence::adopt(Geant4GeneratorAction* action) {
 /// Generator callback
 void Geant4GeneratorActionSequence::operator()(G4Event* event) {
   if ( context()->kernel().processEvents() )  {
-    m_calls(event);
+    m_calls_at_begin(event);
     m_actors(&Geant4GeneratorAction::operator(), event);
+    m_calls(event);
     return;
   }
   throw DD4hep_Stop_Processing();


### PR DESCRIPTION
If I understand correctly, the callback order from GeneratePrimaries and beginOfEvent is controlled by Geant4?

So this first registers the eventSeeder to be called by the generate primary call, and then because it is registered as a call, and not "adopted" as a sequence by our GeneratePrimaries code, I change the order in which calls and sequences are called. I have no idea if that will have bad side effects... And one should expect calls to come after sequences?

Since "adopt" claims ownership of the sequence, I didn't want to pass the eventSeeder into it.

BEGINRELEASENOTES
- GeneratorAction: add `callAtBegin`  callback to add callbacks that happen before generating primaries
- EventSeeder: get a call before the primary particles are generated, fixes #1604 
- EventSeeder: add reading the event and runnumber from the EventParameters that might be filled by Generator input files.

ENDRELEASENOTES