### PR TITLE
Improve material properties. Introduce Geant4-custom properties

### DIFF
--- a/DDCore/include/DD4hep/Objects.h
+++ b/DDCore/include/DD4hep/Objects.h
@@ -301,14 +301,22 @@ namespace dd4hep {
     double intLength() const;
     /// Access the fraction of an element within the material
     double fraction(Atom atom) const;
-    /// Access to tabular properties of the material
-    Property property(const char* name)  const;
-    /// Access to tabular properties of the material
-    Property property(const std::string& name)  const;
+    /// Access the number of properties attached to the material (if any)
+    std::size_t numProperties()  const;
+    /// Access to tabular properties of the material by index
+    Property    property(std::size_t index)  const;
+    /// Access to tabular properties of the material by name
+    Property    property(const char* name)  const;
+    /// Access to tabular properties of the material by name
+    Property    property(const std::string& name)  const;
     /// Access string property value from the material table
     std::string propertyRef(const std::string& name, const std::string& default_value="");
+    /// Access the number of const properties attached to the material (if any)
+    std::size_t numConstProperties()  const;
+    /// Access to const properties of the material by index
+    double      constProperty(std::size_t index)  const;
     /// Access to tabular properties of the material
-    double constProperty(const std::string& name)  const;
+    double      constProperty(const std::string& name)  const;
     /// Access string property value from the material table
     std::string constPropertyRef(const std::string& name, const std::string& default_value="");
   };

--- a/DDCore/include/DD4hep/PropertyTable.h
+++ b/DDCore/include/DD4hep/PropertyTable.h
@@ -52,9 +52,18 @@ namespace dd4hep {
                   size_t             num_rows,
                   size_t             num_cols);
 
-    /// Assignment operator
-    PropertyTable& operator=(const PropertyTable& m) = default;
+    /// Assignment from object copy
+    PropertyTable& operator=(const PropertyTable& e) = default;
+    /// Assignment from object copy
+    PropertyTable& operator=(PropertyTable&& e) = default;
+    /// Assignment from object pointer
+    PropertyTable& operator=(Object* matrix);
+    /// Access property title
+    const char* title()  const;
+    /// Number of rows in the property table
+    std::size_t numRows()  const;
+    /// Number of colums in the property table
+    std::size_t numColumns()  const;
   };
-
 }      // End namespace dd4hep
 #endif // DD4HEP_PROPERTYTABLE_H

--- a/DDCore/src/Objects.cpp
+++ b/DDCore/src/Objects.cpp
@@ -254,8 +254,18 @@ double Material::fraction(Atom atom) const    {
   return tot>1e-20 ? frac/tot : 0.0;
 }
 
+/// Access the number of properties attached to the material (if any)
+std::size_t Material::numProperties()  const  {
+  return access()->GetMaterial()->GetNproperties();
+}
+
+/// Access to tabular properties of the material by index
+Material::Property Material::property(std::size_t index)  const  {
+  return access()->GetMaterial()->GetProperty(index);
+}
+
 /// Access to tabular properties of the optical surface
-Material::Property Material::property(const char* nam)  const    {
+Material::Property Material::property(const char* nam)  const  {
   return access()->GetMaterial()->GetProperty(nam);
 }
 
@@ -272,11 +282,25 @@ std::string Material::propertyRef(const std::string& name, const std::string& de
   return default_value;
 }
 
+/// Access the number of properties attached to the material (if any)
+std::size_t Material::numConstProperties()  const  {
+  return access()->GetMaterial()->GetNconstProperties();
+}
+
+/// Access to const properties of the material by index
+double Material::constProperty(std::size_t index)  const  {
+  Bool_t err = kFALSE;
+  const auto* mat  = access()->GetMaterial();
+  double value = mat->GetConstProperty(index, &err);
+  if ( err != kTRUE ) return value;
+  throw std::runtime_error("Attempt to access non existing material const property with index: "+std::to_string(index));
+}
+
 /// Access to tabular properties of the optical surface
 double Material::constProperty(const std::string& nam)  const   {
   Bool_t err = kFALSE;
-  auto* o = access()->GetMaterial();
-  double value = o->GetConstProperty(nam.c_str(), &err);
+  auto*  mat = access()->GetMaterial();
+  double value = mat->GetConstProperty(nam.c_str(), &err);
   if ( err != kTRUE ) return value;
   throw std::runtime_error("Attempt to access non existing material const property: "+nam);
 }

--- a/DDCore/src/PropertyTable.cpp
+++ b/DDCore/src/PropertyTable.cpp
@@ -36,3 +36,25 @@ PropertyTable::PropertyTable(Detector&     description,
   table->SetTitle(property_name.c_str());
   description.manager().AddGDMLMatrix(m_element=table.release());
 }
+
+/// Assignment from object pointer
+PropertyTable& PropertyTable::operator=(Object* matrix)  {
+  this->m_element = matrix;
+  return *this;
+}
+
+/// Access property title
+const char* PropertyTable::title()  const  {
+  return access()->GetTitle();
+}
+
+/// Number of rows in the property table
+std::size_t PropertyTable::numRows()  const  {
+  return access()->GetRows();
+}
+
+/// Number of colums in the property table
+std::size_t PropertyTable::numColumns()  const  {
+  return access()->GetCols();
+}
+

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -86,6 +86,7 @@ using namespace dd4hep;
 namespace {
 
   static constexpr const double CM_2_MM = (CLHEP::centimeter/dd4hep::centimeter);
+  static constexpr const char* GEANT4_TAG_CUSTOM = "Geant4-custom";
   static constexpr const char* GEANT4_TAG_IGNORE = "Geant4-ignore";
   static constexpr const char* GEANT4_TAG_PLUGIN = "Geant4-plugin";
   static constexpr const char* GEANT4_TAG_BIRKSCONSTANT    = "BirksConstant";
@@ -414,36 +415,48 @@ void* Geant4Converter::handleMaterial(const std::string& name, Material medium) 
     G4MaterialPropertiesTable* tab = 0;
     TListIter propIt(&material->GetProperties());
     for(TObject* obj=propIt.Next(); obj; obj = propIt.Next())  {
-      std::string       exc_str;
+      std::string  exc_str;
+      bool         custom_property = false;
       TNamed*      named  = (TNamed*)obj;
       TGDMLMatrix* matrix = info.manager->GetGDMLMatrix(named->GetTitle());
       const char*  cptr   = ::strstr(matrix->GetName(), GEANT4_TAG_IGNORE);
-      if ( nullptr != cptr )  {
+      if( nullptr != cptr )  {
         printout(INFO,name,"++ Ignore property %s [%s]. Not Suitable for Geant4.",
                  matrix->GetName(), matrix->GetTitle());
         continue;
       }
       cptr = ::strstr(matrix->GetTitle(), GEANT4_TAG_IGNORE);
-      if ( nullptr != cptr )  {
+      if( nullptr != cptr )  {
         printout(INFO,name,"++ Ignore property %s [%s]. Not Suitable for Geant4.",
                  matrix->GetName(), matrix->GetTitle());
         continue;
       }
+      cptr   = ::strstr(matrix->GetName(), GEANT4_TAG_CUSTOM);
+      if( nullptr != cptr )  {
+        custom_property = true;
+      }
+      cptr = ::strstr(matrix->GetTitle(), GEANT4_TAG_CUSTOM);
+      if( nullptr != cptr )  {
+        custom_property = true;
+      }
+
       Geant4GeometryInfo::PropertyVector* v =
         (Geant4GeometryInfo::PropertyVector*)handleMaterialProperties(matrix);
-      if ( nullptr == v )  {
+      if( nullptr == v )  {
         except("Geant4Converter", "++ FAILED to create G4 material %s [Cannot convert property:%s]",
                material->GetName(), named->GetName());
       }
-      if ( nullptr == tab )  {
+      if( nullptr == tab )  {
         tab = new G4MaterialPropertiesTable();
         mat->SetMaterialPropertiesTable(tab);
       }
       int idx = -1;
       try  {
-        const auto& pn = tab->GetMaterialPropertyNames();
-        if( std::find(std::begin(pn), std::end(pn), named->GetName()) != pn.end() )  {
-          idx = tab->GetPropertyIndex(named->GetName());
+        if( !custom_property )  {
+          const auto& pn = tab->GetMaterialPropertyNames();
+          if( std::find(std::begin(pn), std::end(pn), named->GetName()) != pn.end() )  {
+            idx = tab->GetPropertyIndex(named->GetName());
+          }
         }
       }
       catch(const std::exception& e)   {
@@ -453,23 +466,26 @@ void* Geant4Converter::handleMaterial(const std::string& name, Material medium) 
       catch(...)   {
         idx = -1;
       }
-      if ( idx < 0 )   {
+      if ( idx < 0 && !custom_property )  {
         printout(ERROR, "Geant4Converter",
                  "++ UNKNOWN Geant4 Property: %-20s %s [IGNORED]",
                  exc_str.c_str(), named->GetName());
         continue;
       }
       // We need to convert the property from TGeo units to Geant4 units
-      auto conv = g4PropertyConversion(idx);
       std::vector<double> bins(v->bins), vals(v->values);
-      for(std::size_t i=0, count=bins.size(); i<count; ++i)
-        bins[i] *= conv.first, vals[i] *= conv.second;
-
+      std::pair<double, double> conv = { 1e0, 1e0 };
+      if( !custom_property )  {
+        conv = g4PropertyConversion(idx);
+        for(std::size_t i=0, count=bins.size(); i<count; ++i)
+          bins[i] *= conv.first, vals[i] *= conv.second;
+      }
       G4MaterialPropertyVector* vec =
         new G4MaterialPropertyVector(&bins[0], &vals[0], bins.size());
-      tab->AddProperty(named->GetName(), vec);
-      printout(lvl, name, "++      Property: %-20s [%ld x %ld] -> %s ",
-               named->GetName(), matrix->GetRows(), matrix->GetCols(), named->GetTitle());
+      tab->AddProperty(named->GetName(), vec, custom_property);
+      printout(lvl, name, "++      %sProperty: %-20s [%ld x %ld] -> %s ",
+               custom_property ? "CUSTOM " : "", named->GetName(),
+               matrix->GetRows(), matrix->GetCols(), named->GetTitle());
       for(std::size_t i=0, count=v->bins.size(); i<count; ++i)
         printout(lvl, name, "  Geant4: %s %8.3g [MeV]  TGeo: %8.3g [GeV] Conversion: %8.3g",
                  named->GetName(), bins[i], v->bins[i], conv.first);
@@ -479,53 +495,62 @@ void* Geant4Converter::handleMaterial(const std::string& name, Material medium) 
     TListIter cpropIt(&material->GetConstProperties());
     for(TObject* obj=cpropIt.Next(); obj; obj = cpropIt.Next())  {
       std::string  exc_str;
-      Bool_t     err = kFALSE;
-      TNamed*  named = (TNamed*)obj;
+      Bool_t  err = kFALSE;
+      TNamed* named = (TNamed*)obj;
+      bool    custom_property = false;
 
       const char*  cptr = ::strstr(named->GetName(), GEANT4_TAG_IGNORE);
-      if ( nullptr != cptr )   {
+      if( nullptr != cptr )   {
         printout(INFO, name, "++ Ignore CONST property %s [%s].",
                  named->GetName(), named->GetTitle());
         continue;
       }
       cptr = ::strstr(named->GetTitle(), GEANT4_TAG_IGNORE);
-      if ( nullptr != cptr )   {
+      if( nullptr != cptr )  {
         printout(INFO, name,"++ Ignore CONST property %s [%s].",
                  named->GetName(), named->GetTitle());
         continue;
       }
       cptr = ::strstr(named->GetName(), GEANT4_TAG_PLUGIN);
-      if ( nullptr != cptr )   {
+      if( nullptr != cptr )  {
         printout(INFO, name, "++ Ignore CONST property %s [%s]  --> Plugin.",
                  named->GetName(), named->GetTitle());
         plugin_name = named->GetTitle();
         continue;
       }
       cptr = ::strstr(named->GetName(), GEANT4_TAG_BIRKSCONSTANT);
-      if ( nullptr != cptr )   {
+      if( nullptr != cptr )  {
         err = kFALSE;
         value = material->GetConstProperty(GEANT4_TAG_BIRKSCONSTANT,&err);
         if ( err == kFALSE ) ionisation_birks_constant = value * (CLHEP::mm/CLHEP::MeV)/(units::mm/units::MeV);
         continue;
       }
       cptr = ::strstr(named->GetName(), GEANT4_TAG_MEE);
-      if ( nullptr != cptr )   {
+      if( nullptr != cptr )  {
         err = kFALSE;
         value = material->GetConstProperty(GEANT4_TAG_MEE, &err);
         if ( err == kFALSE ) ionisation_mee = value * (CLHEP::MeV/units::MeV);
         continue;
       }
       cptr = ::strstr(named->GetName(), GEANT4_TAG_ENE_PER_ION_PAIR);
-      if ( nullptr != cptr )   {
+      if( nullptr != cptr )  {
         err = kFALSE;
         value = material->GetConstProperty(GEANT4_TAG_ENE_PER_ION_PAIR,&err);
         if ( err == kFALSE ) ionisation_ene_per_ion_pair = value * (CLHEP::MeV/units::MeV);
         continue;
       }
+      cptr = ::strstr(named->GetName(), GEANT4_TAG_CUSTOM);
+      if ( nullptr != cptr )  {
+        custom_property = true;
+      }
+      cptr = ::strstr(named->GetTitle(), GEANT4_TAG_CUSTOM);
+      if ( nullptr != cptr )  {
+        custom_property = true;
+      }
 
       err = kFALSE;
       value = info.manager->GetProperty(named->GetTitle(), &err);
-      if ( err != kFALSE )   {
+      if ( err != kFALSE )  {
         except(name,
                "++ FAILED to create G4 material %s [Cannot convert const property: %s]",
                material->GetName(), named->GetName());
@@ -536,9 +561,11 @@ void* Geant4Converter::handleMaterial(const std::string& name, Material medium) 
       }
       int idx = -1;
       try   {
-        const auto& pn = tab->GetMaterialConstPropertyNames();
-        if( std::find(std::begin(pn), std::end(pn), named->GetName()) != pn.end() )  {
-          idx = tab->GetConstPropertyIndex(named->GetName());
+        if( !custom_property )  {
+          const auto& pn = tab->GetMaterialConstPropertyNames();
+          if( std::find(std::begin(pn), std::end(pn), named->GetName()) != pn.end() )  {
+            idx = tab->GetConstPropertyIndex(named->GetName());
+          }
         }
       }
       catch(const std::exception& e)   {
@@ -548,16 +575,20 @@ void* Geant4Converter::handleMaterial(const std::string& name, Material medium) 
       catch(...)   {
         idx = -1;
       }
-      if ( idx < 0 )   {
+      if ( idx < 0 && !custom_property )  {
         printout(ERROR, name,
                  "++ UNKNOWN Geant4 CONST Property: %-20s %s [IGNORED]",
                  exc_str.c_str(), named->GetName());
         continue;
       }
       // We need to convert the property from TGeo units to Geant4 units
-      double conv = g4ConstPropertyConversion(idx);
-      printout(lvl, name, "++      CONST Property: %-20s %g ", named->GetName(), value);
-      tab->AddConstProperty(named->GetName(), value * conv);
+      if ( !custom_property )  {
+        double conv = g4ConstPropertyConversion(idx);
+        value = value * conv;
+      }
+      printout(lvl, name, "++      %sCONST Property: %-20s %g ",
+               custom_property ? "CUSTOM " : "", named->GetName(), value);
+      tab->AddConstProperty(named->GetName(), value);
     }
     //
     // Set Birk's constant if it was supplied in the material table of the TGeoMaterial

--- a/examples/ClientTests/src/MaterialTester_geo.cpp
+++ b/examples/ClientTests/src/MaterialTester_geo.cpp
@@ -14,6 +14,7 @@
 // Framework include files
 #include <DD4hep/DetFactoryHelper.h>
 #include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/PropertyTable.h>
 #include <DD4hep/Printout.h>
 
 // ROOT include file
@@ -45,8 +46,8 @@ static Ref_t create_element(Detector& description, xml_h xml_det, SensitiveDetec
     Material mat = description.material(c.nameStr());
     TGeoMaterial* material = mat->GetMaterial();
     printout(INFO,det_name,"+++ Material:%s [%p, %p] Z=%6.2f A=%6.2f D=%9.4f [g/cm3]",
-             material->GetName(), mat.ptr(), material, material->GetZ(),
-             material->GetA(), material->GetDensity());
+             mat.name(), mat.ptr(), material, mat.Z(), mat.A(),
+             material->GetDensity());
     
     printout(INFO,det_name,"+++          Radiation Length:%9.4f [cm] Interaction length:%9.4f [cm] Mixture:%s",
              material->GetRadLen()/TGeant4Unit::mm*units::cm, material->GetIntLen()/TGeant4Unit::mm*units::cm,
@@ -61,43 +62,44 @@ static Ref_t create_element(Detector& description, xml_h xml_det, SensitiveDetec
       printout(INFO,det_name,"+++          ELT[%02d]: %s Z=%3d N=%3d N_eff=%7.2f A=%6.2f Weight=%9.4f ",
                i, e->GetName(), e->Z(), e->N(), e->Neff(), e->A(), w);
       if ( material->IsMixture() )   {
-        TGeoMixture* mix = (TGeoMixture*)material;
-        Int_t* nmix = mix->GetNmixt();
+        auto*     mix  = (TGeoMixture*)material;
+        Int_t*    nmix = mix->GetNmixt();
         Double_t* wmix = mix->GetWmixt();
         printout(INFO,det_name,"+++                   Zmix:%7.3f Nmix:%3d Amix:%7.3f Wmix:%7.3f",
                  mix->GetZmixt()[i],nmix ? nmix[i] : -1,
                  mix->GetAmixt()[i],wmix ? wmix[i] : -1e0);
       }
     }
-    if ( material->GetNproperties() > 0 )    {
+    if ( mat.numProperties() > 0 )    {
       printout(INFO,det_name,"+++          Properties: %d", material->GetNproperties());
-      for(Int_t i=0, n=material->GetNproperties(); i<n; ++i)  {
-        TGDMLMatrix* matrix = material->GetProperty(i);
+      for(std::size_t i=0, n=mat.numProperties(); i<n; ++i)  {
+        PropertyTable matrix(mat.property(i));
         printout(INFO,det_name,"+++                   \"%s\" [%s] rows:%d cols:%d",
-                 matrix->GetName(), matrix->GetTitle(), matrix->GetRows(), matrix->GetCols());
+                 matrix.name(), matrix.title(), matrix.numRows(), matrix.numColumns());
         matrix->Print();
       }
       printout(INFO,det_name,"+++          Properties by NAME:");
-      for(Int_t i=0, n=material->GetNproperties(); i<n; ++i)  {
+      for(Int_t i=0, n=mat.numProperties(); i<n; ++i)  {
         const auto* name = material->GetProperties().At(i)->GetName();
-        const auto* matrix = material->GetProperty(name);
+        //const auto* name = mat.property(i)->GetName();
+        PropertyTable matrix(mat.property(name));
         printout(INFO,det_name,"+++                   \"%s\" [%s,%s] cols: %d rows: %d", name,
-                 matrix->GetName(), matrix->GetTitle(), matrix->GetCols(), matrix->GetRows());
+                 matrix.name(), matrix.title(), matrix.numColumns(), matrix.numRows());
       }
     }
-    if ( material->GetNconstProperties() > 0 )    {
+    if ( mat.numConstProperties() > 0 )    {
       printout(INFO,det_name,"+++          CONST Properties: %d", material->GetNconstProperties());
       const TList& all = material->GetConstProperties();
-      for(Int_t i=0, n=material->GetNconstProperties(); i<n; ++i)  {
+      for(Int_t i=0, n=mat.numConstProperties(); i<n; ++i)  {
         const TNamed* prop  = (const TNamed*)all.At(i);
-        double        value = material->GetConstProperty(i);
+        double        value = mat.constProperty(i);
         printout(INFO,det_name,"+++                   \"%s\" [%s] value: %f",
                  prop->GetName(), prop->GetTitle(), value);
       }
       printout(INFO,det_name,"+++          CONST Properties by NAME:");
-      for(Int_t i=0, n=material->GetNconstProperties(); i<n; ++i)  {
-        const auto* name  = material->GetConstProperties().At(i)->GetName();
-        double      value = material->GetConstProperty(name);
+      for(Int_t i=0, n=mat.numConstProperties(); i<n; ++i)  {
+        const char* name  = ((const TNamed*)all.At(i))->GetName();
+        double      value = mat.constProperty(name);
         printout(INFO,det_name,"+++                   \"%s\"  value: %f", name, value);
       }
     }

--- a/examples/OpticalSurfaces/compact/ReadMaterialProperties.xml
+++ b/examples/OpticalSurfaces/compact/ReadMaterialProperties.xml
@@ -213,6 +213,15 @@
               2.177*eV 
               2.216*eV 
     "/>
+
+    <matrix name= "Water__Custom" option="Geant4-custom" coldim="1" values="  
+              1*GeV
+              2*GeV 
+              3*GeV 
+              4*GeV 
+              5*GeV 
+              6*GeV 
+    "/>
   </properties>
 
   <includes>
@@ -222,6 +231,7 @@
   <properties>
     <constant name="Birk__Water|Geant4-ignore" value="12.345678"/>
     <constant name="Water__Mine|Geant4-ignore" value="87.654321"/>
+    <constant name="SubdetectorProperty|Geant4-custom" value="1234567"/>
   </properties>
 
   <materials>
@@ -248,9 +258,12 @@
       <property name="SLOWCOMPONENT" ref="SLOWCOMPONENT__0x123aff00"/>
       <!-- Properties ignored by Geant4 -->
       <property name="Property_of_mine" ref="Water__SpecialMine"/>
+      <property name="Property_custom"  ref="Water__Custom"/>
       <constant name="BirksConstant"    ref="Birk__Water|Geant4-ignore"/>
       <!-- Constants  ignored by Geant4 -->
       <constant name="Constant_of_mine" ref="Water__Mine|Geant4-ignore"/>
+      <!-- Custom constants properties passed to Geant4, but not udsed by Geant4 -->
+      <constant name="ConstantProperty_custom" ref="SubdetectorProperty|Geant4-custom"/>
     </material>
   </materials>
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Improve the interface to access material properties from materials if used:
```
    /// Access the number of properties attached to the material (if any)
    std::size_t numProperties()  const;
    /// Access to tabular properties of the material by index
    Property    property(std::size_t index)  const;
    /// Access to tabular properties of the material by name
    Property    property(const char* name)  const;
    /// Access to tabular properties of the material by name
    Property    property(const std::string& name)  const;
    /// Access string property value from the material table
    std::string propertyRef(const std::string& name, const std::string& default_value="");
    /// Access the number of const properties attached to the material (if any)
    std::size_t numConstProperties()  const;
    /// Access to const properties of the material by index
    double      constProperty(std::size_t index)  const;
    /// Access to tabular properties of the material
    double      constProperty(const std::string& name)  const;
    /// Access string property value from the material table
    std::string constPropertyRef(const std::string& name, const std::string& default_value="");
```
See for examples the area: examples/ClientTests/src/MaterialTester_geo.cpp

- In Geant4 special tags are used if the properties should be treated in a special way by Geant4:
  (see examples/OpticalSurfaces/compact/ReadMaterialProperties.xml)
  -- the tag `Geant4-ignore` hides the material property entirely from the Geant4 materials
  -- the tag `Geant4-custom` injects the property into the  Geant4 material. It may be used in user code 
     and accessed from regular Geant4 materials.
  -- the tag `Geant4-plugin` hides the property from Geant4 and allows the usage inside Geant4 plugins.

Users are e.g. RICH reconstruction and Channeling experiments. [Request from W,Pokorski]

ENDRELEASENOTES