### PR TITLE
Allow passing `batch` as runType for G4Gun and G4GPS

### DIFF
--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -750,7 +750,7 @@ class DD4hepSimulation(object):
     if self.runType == "batch":
       if not self.numberOfEvents:
         self._errorMessages.append("ERROR: Batch mode requested, but did not set number of events")
-      if not (self.inputFiles or self.enableGun or self.inputConfig.userInputPlugin):
+      if not (self.inputFiles or self.enableGun or self.enableG4Gun or self.enableG4GPS or self.inputConfig.userInputPlugin):
         self._errorMessages.append("ERROR: Batch mode requested, but did not set inputFile(s), gun, or userInputPlugin")
 
     if self.inputFiles and (self.enableG4Gun or self.enableG4GPS):


### PR DESCRIPTION
BEGINRELEASENOTES
- ddsim: Allow passing `batch` as runType for G4Gun and G4GPS

ENDRELEASENOTES

Taken from https://github.com/AIDASoft/DD4hep/pull/1240 to get it sooner and simplify that PR.