### PR TITLE
Avoid triggering infinite recursion with DDG4

### DIFF
--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -167,8 +167,6 @@ def _getKernelProperty(self, name):
     return _evalProperty(ret.data)
   elif hasattr(self.get(), name):
     return _evalProperty(getattr(self.get(), name))
-  elif hasattr(self, name):
-    return _evalProperty(getattr(self, name))
   msg = 'Geant4Kernel::GetProperty [Unhandled]: Cannot access Kernel.' + name
   raise KeyError(msg)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Avoid triggering infinite recursion with DDG4 in Python

ENDRELEASENOTES

The recursion goes as follows:
1. `kernel.SomeName` → not found by normal lookup → Python calls `__getattr__` = `_getKernelProperty`
2. Property map lookup fails, `hasattr(self.get(), name)` is False
3. `hasattr(self, name)` tries to look up name on self → not found → Python calls `__getattr__` again → step 2 → ...

Reproducer:
``` python

    import sys, DDG4
    k = DDG4.Kernel()
    sys.setrecursionlimit(80)
    try:
        _ = k.DoesNotExist
    except RecursionError:
        print('RecursionError: bug triggered')
    except KeyError as e:
        print('Clean KeyError (fix in place):', e)
```
(without the fix, the `RecursionError` path is taken, with the fix it's the `KeyError` path).

Taken from https://github.com/AIDASoft/DD4hep/pull/1240.