### PR TITLE
feat: add support for python geometry plugins

### DIFF
--- a/DDCore/python/dd4hep_geo_plugin.py
+++ b/DDCore/python/dd4hep_geo_plugin.py
@@ -1,0 +1,190 @@
+# ==========================================================================
+#  AIDA Detector description implementation
+# --------------------------------------------------------------------------
+# Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+# All rights reserved.
+#
+# For the licensing terms see $DD4hepINSTALL/LICENSE.
+# For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+#
+# ==========================================================================
+#
+# dd4hep_geo_plugin.py — helpers for Python-based DD4hep geometry plugins.
+#
+# Usage in a geometry plugin module:
+#   from dd4hep_geo_plugin import *
+#
+# Provides:
+#   - DD4hep header and cppyy initialisation (idempotent)
+#   - C++ helper namespace `dd4hep_geo_plugin` with safe wrappers for XML
+#     attribute access and xml_coll_t iteration
+#   - Python wrapper functions: _handle, _collValid, _hasAttr, _getAttrBool
+#   - Convenience type aliases covering common DD4hep geometry types
+#
+# Background — three cppyy limitations that require workarounds:
+#
+# 1. dd4hep::xml::Element::hasAttr / attr<T> accept const XmlChar* (= const
+#    char16_t* with the Xerces-C backend).  cppyy cannot auto-convert a Python
+#    str to char16_t*, so direct calls raise TypeError.  The C++ helpers below
+#    accept const char* and convert via dd4hep::xml::Strng_t.
+#
+# 2. xml_coll_t inherits from Collection_t but cppyy does NOT map its
+#    operator bool() to Python __bool__, so `while coll:` loops forever and
+#    eventually segfaults on a NULL pointer.  Use _collValid(coll) instead.
+#
+# 3. xml_coll_t's constructor expects a Handle_t but cppyy will not
+#    auto-upcast xml_det_t / xml_comp_t even though C++ would.  Use
+#    _handle(el) to perform the cast explicitly.
+#
+# ==========================================================================
+
+import cppyy
+from ROOT import gInterpreter, TMath  # noqa: F401  (re-exported via __all__)
+
+# ---------------------------------------------------------------------------
+# Load DD4hep headers into cppyy (idempotent — safe to call multiple times)
+# ---------------------------------------------------------------------------
+gInterpreter.ProcessLine('#include "DD4hep/DetFactoryHelper.h"')
+
+# ---------------------------------------------------------------------------
+# Thin C++ helpers in namespace dd4hep_geo_plugin
+# ---------------------------------------------------------------------------
+cppyy.cppdef(r"""
+#include "DD4hep/DetFactoryHelper.h"
+#ifndef DD4HEP_GEO_PLUGIN_HELPERS_DEFINED
+#define DD4HEP_GEO_PLUGIN_HELPERS_DEFINED
+namespace dd4hep_geo_plugin {
+  /// Test for a named attribute; accepts plain C string (avoids char16_t* conversion).
+  inline bool hasAttr(dd4hep::xml::Element el, const char* name) {
+    return el.hasAttr(dd4hep::xml::Strng_t(name));
+  }
+  /// Read a named attribute as std::string.
+  inline std::string getAttrStr(dd4hep::xml::Element el, const char* name) {
+    return el.attr<std::string>(dd4hep::xml::Strng_t(name));
+  }
+  /// Read a named attribute as double (DD4hep unit-aware).
+  inline double getAttrDbl(dd4hep::xml::Element el, const char* name) {
+    return el.attr<double>(dd4hep::xml::Strng_t(name));
+  }
+  /// Read a named attribute as bool.
+  inline bool getAttrBool(dd4hep::xml::Element el, const char* name) {
+    return el.attr<bool>(dd4hep::xml::Strng_t(name));
+  }
+  /// Return true if the xml_coll_t iterator is still valid.
+  /// Use instead of operator bool(), which cppyy does not map to __bool__.
+  inline bool collValid(const dd4hep::xml::Collection_t& c) {
+    return static_cast<bool>(c);
+  }
+}
+#endif // DD4HEP_GEO_PLUGIN_HELPERS_DEFINED
+""")
+
+
+# ---------------------------------------------------------------------------
+# Python wrapper functions
+# ---------------------------------------------------------------------------
+
+def _handle(el):
+    """Cast any xml Element type to Handle_t.
+
+    Required because cppyy does not auto-upcast xml_det_t / xml_comp_t to
+    Handle_t even though C++ would do so implicitly.  xml_coll_t's constructor
+    expects a Handle_t, so pass _handle(el) instead of el directly.
+    """
+    return cppyy.gbl.dd4hep.xml.Handle_t(el.ptr())
+
+
+def _collValid(c) -> bool:
+    """Return True if an xml_coll_t iterator is still valid.
+
+    Never write ``while c:`` — cppyy maps Python __bool__ to the default
+    object truthiness (always True), not to C++ operator bool(). Use
+    ``while _collValid(c):`` instead to avoid an infinite loop and segfault.
+    """
+    return cppyy.gbl.dd4hep_geo_plugin.collValid(c)
+
+
+def _hasAttr(el, name: str) -> bool:
+    """Return True if the XML element has the named attribute."""
+    return cppyy.gbl.dd4hep_geo_plugin.hasAttr(el, name)
+
+
+def _getAttrStr(el, name: str) -> str:
+    """Return the named XML attribute as a string."""
+    return cppyy.gbl.dd4hep_geo_plugin.getAttrStr(el, name)
+
+
+def _getAttrDbl(el, name: str) -> float:
+    """Return the named XML attribute as a double (DD4hep unit-aware)."""
+    return cppyy.gbl.dd4hep_geo_plugin.getAttrDbl(el, name)
+
+
+def _getAttrBool(el, name: str) -> bool:
+    """Return the named XML attribute as a bool."""
+    return cppyy.gbl.dd4hep_geo_plugin.getAttrBool(el, name)
+
+
+# ---------------------------------------------------------------------------
+# DD4hep type aliases
+# ---------------------------------------------------------------------------
+_dd4hep = cppyy.gbl.dd4hep
+
+# -- Core detector / volume types
+Assembly     = _dd4hep.Assembly
+DetElement   = _dd4hep.DetElement
+PlacedVolume = _dd4hep.PlacedVolume
+Volume       = _dd4hep.Volume
+
+# -- Transforms and positions
+Position     = _dd4hep.Position
+Transform3D  = _dd4hep.Transform3D
+Translation3D = _dd4hep.Translation3D
+Rotation3D   = _dd4hep.Rotation3D
+RotationX    = _dd4hep.RotationX
+RotationY    = _dd4hep.RotationY
+RotationZ    = _dd4hep.RotationZ
+RotationZYX  = _dd4hep.RotationZYX
+
+# -- Shapes (common subset sufficient for most detector geometry)
+Box              = _dd4hep.Box
+Tube             = _dd4hep.Tube
+CutTube          = _dd4hep.CutTube
+Cone             = _dd4hep.Cone
+ConeSegment      = _dd4hep.ConeSegment
+Sphere           = _dd4hep.Sphere
+Torus            = _dd4hep.Torus
+Polycone         = _dd4hep.Polycone
+Trapezoid        = _dd4hep.Trapezoid
+SubtractionSolid = _dd4hep.SubtractionSolid
+UnionSolid       = _dd4hep.UnionSolid
+IntersectionSolid = _dd4hep.IntersectionSolid
+
+# -- XML handle types used in detector factory functions
+_U        = _dd4hep.xml.Strng_t       # equivalent of the C++ _U("tag") macro
+_toString = _dd4hep.xml._toString     # equivalent of the C++ _toString(n, "fmt") macro
+
+xml_det_t  = cppyy.gbl.xml_det_t
+xml_coll_t = cppyy.gbl.xml_coll_t
+xml_comp_t = cppyy.gbl.xml_comp_t
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+__all__ = [
+    # ROOT helper
+    "TMath",
+    # Python wrapper functions
+    "_handle", "_collValid",
+    "_hasAttr", "_getAttrStr", "_getAttrDbl", "_getAttrBool",
+    # Core types
+    "Assembly", "DetElement", "PlacedVolume", "Volume",
+    # Transforms
+    "Position", "Transform3D", "Translation3D",
+    "Rotation3D", "RotationX", "RotationY", "RotationZ", "RotationZYX",
+    # Shapes
+    "Box", "Tube", "CutTube", "Cone", "ConeSegment",
+    "Sphere", "Torus", "Polycone", "Trapezoid",
+    "SubtractionSolid", "UnionSolid", "IntersectionSolid",
+    # XML helpers
+    "_U", "_toString", "xml_det_t", "xml_coll_t", "xml_comp_t",
+]

--- a/DDCore/python/dd4hep_geo_plugin.py
+++ b/DDCore/python/dd4hep_geo_plugin.py
@@ -130,40 +130,40 @@ def _getAttrBool(el, name: str) -> bool:
 _dd4hep = cppyy.gbl.dd4hep
 
 # -- Core detector / volume types
-Assembly     = _dd4hep.Assembly
-DetElement   = _dd4hep.DetElement
+Assembly = _dd4hep.Assembly
+DetElement = _dd4hep.DetElement
 PlacedVolume = _dd4hep.PlacedVolume
-Volume       = _dd4hep.Volume
+Volume = _dd4hep.Volume
 
 # -- Transforms and positions
-Position     = _dd4hep.Position
-Transform3D  = _dd4hep.Transform3D
+Position = _dd4hep.Position
+Transform3D = _dd4hep.Transform3D
 Translation3D = _dd4hep.Translation3D
-Rotation3D   = _dd4hep.Rotation3D
-RotationX    = _dd4hep.RotationX
-RotationY    = _dd4hep.RotationY
-RotationZ    = _dd4hep.RotationZ
-RotationZYX  = _dd4hep.RotationZYX
+Rotation3D = _dd4hep.Rotation3D
+RotationX = _dd4hep.RotationX
+RotationY = _dd4hep.RotationY
+RotationZ = _dd4hep.RotationZ
+RotationZYX = _dd4hep.RotationZYX
 
 # -- Shapes (common subset sufficient for most detector geometry)
-Box              = _dd4hep.Box
-Tube             = _dd4hep.Tube
-CutTube          = _dd4hep.CutTube
-Cone             = _dd4hep.Cone
-ConeSegment      = _dd4hep.ConeSegment
-Sphere           = _dd4hep.Sphere
-Torus            = _dd4hep.Torus
-Polycone         = _dd4hep.Polycone
-Trapezoid        = _dd4hep.Trapezoid
+Box = _dd4hep.Box
+Tube = _dd4hep.Tube
+CutTube = _dd4hep.CutTube
+Cone = _dd4hep.Cone
+ConeSegment = _dd4hep.ConeSegment
+Sphere = _dd4hep.Sphere
+Torus = _dd4hep.Torus
+Polycone = _dd4hep.Polycone
+Trapezoid = _dd4hep.Trapezoid
 SubtractionSolid = _dd4hep.SubtractionSolid
-UnionSolid       = _dd4hep.UnionSolid
+UnionSolid = _dd4hep.UnionSolid
 IntersectionSolid = _dd4hep.IntersectionSolid
 
 # -- XML handle types used in detector factory functions
-_U        = _dd4hep.xml.Strng_t       # equivalent of the C++ _U("tag") macro
+_U = _dd4hep.xml.Strng_t       # equivalent of the C++ _U("tag") macro
 _toString = _dd4hep.xml._toString     # equivalent of the C++ _toString(n, "fmt") macro
 
-xml_det_t  = cppyy.gbl.xml_det_t
+xml_det_t = cppyy.gbl.xml_det_t
 xml_coll_t = cppyy.gbl.xml_coll_t
 xml_comp_t = cppyy.gbl.xml_comp_t
 
@@ -187,4 +187,4 @@ __all__ = [
     "SubtractionSolid", "UnionSolid", "IntersectionSolid",
     # XML helpers
     "_U", "_toString", "xml_det_t", "xml_coll_t", "xml_comp_t",
-]
+    ]

--- a/DDCore/src/python/PythonPlugin.cpp
+++ b/DDCore/src/python/PythonPlugin.cpp
@@ -12,11 +12,17 @@
 //==========================================================================
 
 // Framework include files
+#include <DD4hep/DetFactoryHelper.h>
 #include <DD4hep/Factories.h>
 #include <DD4hep/Printout.h>
 
 // ROOT includes
 #include <TPython.h>
+
+// C++ includes
+#include <cstdlib>
+#include <regex>
+#include <sstream>
 
 using namespace std;
 using namespace dd4hep;
@@ -109,6 +115,138 @@ namespace  {
     except("DD4hep_Python","+++ No commands file name given.");
     return 0;
   }
+
+  // ---------------------------------------------------------------------------
+  // DD4hep_PythonDetector — delegate geometry construction to a Python function.
+  //
+  // Compact XML usage:
+  //   <detector id="X_ID" name="X" type="DD4hep_PythonDetector"
+  //             module="my_package.barrel_geo"
+  //             function="create_detector"
+  //             readout="XHits"
+  //             pythonpath="/path/to/package">  <!-- ${ENV_VAR} expanded -->
+  //     ...
+  //   </detector>
+  //
+  // The Python function must have the signature:
+  //   def create_detector(description, xml_element, sens) -> dd4hep.DetElement
+  //
+  // C++ objects are passed as addresses (integers); reconstruct them in Python
+  // using cppyy.bind_object(addr, typename).  The dd4hep_geo_plugin helper
+  // module (shipped with DD4hep) handles this automatically.
+  // ---------------------------------------------------------------------------
+
+  /// Expand ${VAR} and $VAR patterns using std::getenv.
+  static std::string expand_env(const std::string& input) {
+    static const std::regex env_re(R"(\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*))");
+    std::string result;
+    result.reserve(input.size());
+    auto it  = std::sregex_iterator(input.begin(), input.end(), env_re);
+    auto end = std::sregex_iterator();
+    std::size_t last_pos = 0;
+    for (; it != end; ++it) {
+      const auto& m = *it;
+      result.append(input, last_pos, m.position() - last_pos);
+      const std::string var = m[1].matched ? m[1].str() : m[2].str();
+      const char* val = std::getenv(var.c_str());
+      if (val) result.append(val);
+      last_pos = m.position() + m.length();
+    }
+    result.append(input, last_pos, std::string::npos);
+    return result;
+  }
+
+  /// Escape a C++ string into a Python single-quoted string literal.
+  /// Handles backslashes, quotes, newlines, and non-printable bytes.
+  static std::string py_str(const std::string& value) {
+    std::string result = "'";
+    for (unsigned char c : value) {
+      switch (c) {
+        case '\\': result += "\\\\"; break;
+        case '\'': result += "\\'";  break;
+        case '\n': result += "\\n";  break;
+        case '\r': result += "\\r";  break;
+        case '\t': result += "\\t";  break;
+        default:
+          if (c < 0x20 || c == 0x7f) {
+            char buf[8];
+            snprintf(buf, sizeof(buf), "\\x%02x", c);
+            result += buf;
+          } else {
+            result += static_cast<char>(c);
+          }
+      }
+    }
+    result += "'";
+    return result;
+  }
+
+  /// DetElement returned from Python; swapped back to C++ via SwapWithObjAtAddr.
+  static DetElement s_python_detector_result;
+
+  /**
+   *  Factory: DD4hep_PythonDetector
+   *
+   *  Reads `module`, `function`, and optionally `pythonpath` from the XML
+   *  <detector> element, then calls the specified Python function to build the
+   *  geometry.  The returned DetElement is transferred back to C++ via
+   *  ROOT::Internal::SwapWithObjAtAddr.
+   *
+   *  \author  DD4hep developers
+   */
+  Ref_t create_python_detector(Detector& description, xml_h e, SensitiveDetector sens) {
+    xml_det_t x_det(e);
+    const std::string factory_name = "DD4hep_PythonDetector";
+
+    auto get_attr = [&](const char* name) {
+      return x_det.attr<std::string>(dd4hep::xml::Strng_t(name));
+    };
+    auto has_attr = [&](const char* name) {
+      return x_det.hasAttr(dd4hep::xml::Strng_t(name));
+    };
+
+    const std::string mod  = get_attr("module");
+    const std::string func = get_attr("function");
+    const std::string pypath = has_attr("pythonpath")
+                                 ? expand_env(get_attr("pythonpath")) : "";
+
+    printout(DEBUG, factory_name,
+             "+++ Loading Python module '%s', function '%s'", mod.c_str(), func.c_str());
+
+    // Addresses of the C++ objects, passed as integers to Python.
+    const std::uintptr_t desc_addr = reinterpret_cast<std::uintptr_t>(&description);
+    const std::uintptr_t xml_addr  = reinterpret_cast<std::uintptr_t>(static_cast<xml_h*>(&e));
+    const std::uintptr_t sens_addr = reinterpret_cast<std::uintptr_t>(&sens);
+    const std::uintptr_t res_addr  = reinterpret_cast<std::uintptr_t>(&s_python_detector_result);
+
+    std::ostringstream script;
+    // Prepend pythonpath to sys.path when specified.
+    if (!pypath.empty()) {
+      script << "import sys\n"
+             << "if " << py_str(pypath) << " not in sys.path:\n"
+             << "    sys.path.insert(0, " << py_str(pypath) << ")\n";
+    }
+    script << "import importlib, cppyy\n"
+           << "_dd4hep_py_mod = importlib.import_module(" << py_str(mod) << ")\n"
+           << "_dd4hep_py_desc = cppyy.bind_object(" << desc_addr << ", 'dd4hep::Detector')\n"
+           << "_dd4hep_py_xml  = cppyy.bind_object(" << xml_addr  << ", 'dd4hep::xml::Handle_t')\n"
+           << "_dd4hep_py_sens = cppyy.bind_object(" << sens_addr << ", 'dd4hep::SensitiveDetector')\n"
+           << "try:\n"
+           << "    _dd4hep_py_det = getattr(_dd4hep_py_mod, " << py_str(func) << ")"
+           << "(_dd4hep_py_desc, _dd4hep_py_xml, _dd4hep_py_sens)\n"
+           << "except Exception:\n"
+           << "    import traceback; traceback.print_exc()\n"
+           << "    raise\n"
+           << "cppyy.gbl.ROOT.Internal.SwapWithObjAtAddr['dd4hep::DetElement']"
+           << "(_dd4hep_py_det, " << res_addr << ")\n";
+
+    if (!TPython::Exec(script.str().c_str())) {
+      except(factory_name, "+++ Python function %s.%s failed", mod.c_str(), func.c_str());
+    }
+    return s_python_detector_result;
+  }
 }
 
 DECLARE_APPLY(DD4hep_Python,call_python)
+DECLARE_DETELEMENT(DD4hep_PythonDetector,create_python_detector)
+

--- a/DDCore/src/python/PythonPlugin.cpp
+++ b/DDCore/src/python/PythonPlugin.cpp
@@ -17,6 +17,7 @@
 #include <DD4hep/Printout.h>
 
 // ROOT includes
+#include <RVersion.h>
 #include <TPython.h>
 
 // C++ includes
@@ -237,8 +238,13 @@ namespace  {
            << "except Exception:\n"
            << "    import traceback; traceback.print_exc()\n"
            << "    raise\n"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,34,0)
            << "cppyy.gbl.ROOT.Internal.SwapWithObjAtAddr['dd4hep::DetElement']"
            << "(_dd4hep_py_det, " << res_addr << ")\n";
+#else
+           << "_dd4hep_py_res = cppyy.bind_object(" << res_addr << ", 'dd4hep::DetElement')\n"
+           << "cppyy.gbl.std.swap(_dd4hep_py_det, _dd4hep_py_res)\n";
+#endif
 
     if (!TPython::Exec(script.str().c_str())) {
       except(factory_name, "+++ Python function %s.%s failed", mod.c_str(), func.c_str());

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -49,7 +49,7 @@ install(TARGETS testLoad RUNTIME DESTINATION bin)
 #
 #
 set(ClientTestsEx_INSTALL ${CMAKE_INSTALL_PREFIX}/examples/ClientTests)
-dd4hep_install_dir( compact scripts ref eve DESTINATION ${ClientTestsEx_INSTALL} )
+dd4hep_install_dir( compact scripts python ref eve DESTINATION ${ClientTestsEx_INSTALL} )
 #--------------------------------------------------------------------------
 
 #--------------------------------------------------------------------------
@@ -333,6 +333,21 @@ foreach (test Assemblies BoxTrafos CaloEndcapReflection IronCylinder LheD_tracke
       REGEX_PASS " Handled [1-9][0-9]* volumes" )
   endforeach(type)
 endforeach()
+#
+#
+# Test DD4hep_PythonDetector: a Python port of the IronCylinder geometry.
+# DD4hep_PythonDetector is only available when DDPythonPlugins is built,
+# which requires ROOT to include Python/TPython support.
+if(TARGET ROOT::ROOTTPython)
+  dd4hep_add_test_reg( ClientTests_volume_materials_IronCylinder_python
+    COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_ClientTests.sh"
+    EXEC_ARGS  geoPluginRun -print WARNING -volmgr -destroy
+               -input file:${ClientTestsEx_INSTALL}/compact/IronCylinder_python.xml
+               -plugin DD4hep_VolumeDump -materials
+    REGEX_PASS "\\+\\+\\+ Checked [1-9][0-9]* materials in volume placements.   0 are BAD."
+    REGEX_FAIL "Exception"
+    REGEX_FAIL "FAILED" )
+endif(TARGET ROOT::ROOTTPython)
 #
 #
 # Note:

--- a/examples/ClientTests/compact/IronCylinder_python.xml
+++ b/examples/ClientTests/compact/IronCylinder_python.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd>
+<!-- #==========================================================================
+     #  AIDA Detector description implementation 
+     #==========================================================================
+     # Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+     # All rights reserved.
+     #
+     # For the licensing terms see $DD4hepINSTALL/LICENSE.
+     # For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+     #
+     #==========================================================================
+     #
+     # IronCylinder_python.xml
+     #
+     # Mirrors IronCylinder.xml but uses the DD4hep_PythonDetector factory to
+     # delegate geometry construction to IronCylinder_python_geo.py. This
+     # exercises the python-geo-plugin in DDCore/src/python/PythonPlugin.cpp.
+     #
+     #==========================================================================
+-->
+
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/materials.xml"/>
+  </includes>
+
+  <define>
+    <constant name="world_size" value="30*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+    <constant name="HcalBarrel_rmin" value="300*cm"/>
+    <constant name="HcalBarrel_rmax" value="500*cm"/>
+    <constant name="HcalBarrel_zmax" value="600*cm"/>
+  </define>
+
+  <display>
+    <vis name="Invisible" showDaughters="false" visible="false"/>
+    <vis name="InvisibleWithChildren" showDaughters="true" visible="false"/>
+    <vis name="VisibleGreen" alpha="1.0" r="0.0" g="1.0" b="0.0" drawingStyle="solid" lineStyle="solid" showDaughters="true" visible="true"/>
+  </display>
+
+  <limits>
+    <limitset name="cal_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+  </limits>
+
+  <detectors>
+    <detector id="1" name="HcalBarrel"
+              type="DD4hep_PythonDetector"
+              module="IronCylinder_python_geo"
+              function="create_detector"
+              pythonpath="${DD4hepExamplesINSTALL}/examples/ClientTests/python"
+              readout="HcalBarrelHits" vis="VisibleGreen" limits="cal_limits">
+      <comment>Iron cylinder calorimeter built by the Python geometry plugin.</comment>
+      <dimensions rmin="HcalBarrel_rmin" rmax="HcalBarrel_rmax" z="HcalBarrel_zmax" phiBins="64"/>
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="HcalBarrelHits">
+      <id>system:8,barrel:3,module:7,layer:5,slice:10,eta:10,phi:5</id>
+    </readout>
+  </readouts>
+
+  <fields>
+    <field name="GlobalSolenoid" type="solenoid"
+           inner_field="5.0*tesla"
+           outer_field="-1.5*tesla"
+           zmax="2*m"
+           outer_radius="3*m">
+    </field>
+  </fields>
+
+</lccdd>

--- a/examples/ClientTests/python/IronCylinder_python_geo.py
+++ b/examples/ClientTests/python/IronCylinder_python_geo.py
@@ -1,0 +1,79 @@
+# ==========================================================================
+#  AIDA Detector description implementation
+# --------------------------------------------------------------------------
+# Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+# All rights reserved.
+#
+# For the licensing terms see $DD4hepINSTALL/LICENSE.
+# For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+#
+# ==========================================================================
+#
+# IronCylinder_python_geo.py — Python port of IronCylinder_geo.cpp.
+#
+# Demonstrates the DD4hep_PythonDetector factory:
+#   - Reads detector dimensions from the compact XML.
+#   - Builds an iron tube sensitive calorimeter volume.
+#   - Places it inside the world volume.
+#
+# ==========================================================================
+
+from dd4hep_geo_plugin import Assembly, DetElement, Tube, Volume, TMath, xml_det_t
+
+
+def create_detector(description, xml_h, sens):
+    """Build an iron cylindrical calorimeter.
+
+    Parameters
+    ----------
+    description : dd4hep.Detector
+        The top-level detector description object.
+    xml_h : dd4hep.xml.Handle_t
+        Handle to the ``<detector>`` XML element.
+    sens : dd4hep.SensitiveDetector
+        Sensitive detector assigned to this sub-detector.
+
+    Returns
+    -------
+    dd4hep.DetElement
+        The fully placed detector element.
+    """
+    x_det = xml_det_t(xml_h)
+    name = x_det.nameStr()
+
+    d_det = DetElement(name, x_det.id())
+
+    # Read dimensions from the compact XML.
+    x_dim = x_det.dimensions()
+    inner_r = x_dim.rmin()
+    outer_r = x_dim.rmax()
+    z_half = x_dim.z() / 2.0
+
+    # Envelope assembly volume.
+    calo_vol = Assembly(name + "_envelope")
+    calo_vol.setAttributes(description,
+                           x_det.regionStr(),
+                           x_det.limitsStr(),
+                           x_det.visStr())
+
+    # Sensitive iron tube.
+    tub = Tube(inner_r, outer_r, z_half, 0.0, TMath.TwoPi())
+    tub_vol = Volume(name + "_tube", tub,
+                     description.material("Iron"))
+    calo_vol.placeVolume(tub_vol).addPhysVolID("module", 1)
+
+    sens.setType("calorimeter")
+    tub_vol.setSensitiveDetector(sens)
+    d_det.setAttributes(description, tub_vol,
+                        x_det.regionStr(),
+                        x_det.limitsStr(),
+                        x_det.visStr())
+
+    # Place the envelope inside the world / mother volume.
+    mother = description.pickMotherVolume(d_det)
+    calo_plv = mother.placeVolume(calo_vol)
+    calo_plv.addPhysVolID("system", x_det.id())
+    calo_plv.addPhysVolID("barrel", 0)
+    d_det.setPlacement(calo_plv)
+
+    return d_det


### PR DESCRIPTION
This PR adds a `DECLARE_DETELEMENT` plugin `DD4hep_PythonDetector` that delegates geometry construction to a Python function specified by module/function/pythonpath XML attributes. This enables geometry to be distributed as pure Python packages without any per-project C++ compilation.

This PR also adds `DDCore/python/dd4hep_geo_plugin.py` providing the cppyy workarounds and type aliases needed by plugin authors (to be imported with `from dd4hep_geo_plugin import *`).

This PR also ports the IronCylinder example (the simplest I could find) from a C++ example to a minimal Python example, and includes it as a test.

BEGINRELEASENOTES
-  feat: add support for python geometry plugins

ENDRELEASENOTES

Note: This is for discussion; as I understand it from discussion with @jmcarcell there may be more computational intensive stuff done in the geometry plugins in FCC so this may impact initialization time in production and may add a translation step in project transition from prototype to production. In the case of EIC we have a challenge where incoming workforce is generally more familiar with python and this address that.