### PR TITLE
fix: correct off-by-one error in dd4hep::detail::update_hash64(std::string)

### DIFF
--- a/DDCore/src/Primitives.cpp
+++ b/DDCore/src/Primitives.cpp
@@ -208,9 +208,7 @@ unsigned long long int dd4hep::detail::update_hash64(unsigned long long int hash
 /// 64 bit hash update function
 unsigned long long int dd4hep::detail::update_hash64(unsigned long long int hash, const void* key, std::size_t len)  {
   const unsigned char* str = (const unsigned char*)key;
-  if ( len > 0 )  {
-    for ( ; --len; ++str) hash = FNV1a_64::doByte(hash, *str);
-  }
+  for ( ; len--; ++str) hash = FNV1a_64::doByte(hash, *str);
   return hash;
 }
 

--- a/DDCore/src/Primitives.cpp
+++ b/DDCore/src/Primitives.cpp
@@ -208,7 +208,7 @@ unsigned long long int dd4hep::detail::update_hash64(unsigned long long int hash
 /// 64 bit hash update function
 unsigned long long int dd4hep::detail::update_hash64(unsigned long long int hash, const void* key, std::size_t len)  {
   const unsigned char* str = (const unsigned char*)key;
-  for ( ; len--; ++str) hash = FNV1a_64::doByte(hash, *str);
+  for (std::size_t i = 0; i < len; ++i) hash = FNV1a_64::doByte(hash, str[i]);
   return hash;
 }
 

--- a/DDCore/src/Primitives.cpp
+++ b/DDCore/src/Primitives.cpp
@@ -17,6 +17,7 @@
 #include <DD4hep/Printout.h>
 
 // C/C++ include files
+#include <cstddef>
 #include <cstring>
 
 #if defined(__linux) || defined(__APPLE__) || defined(__powerpc64__)

--- a/examples/CLICSiD/CMakeLists.txt
+++ b/examples/CLICSiD/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 dd4hep_add_test_reg( CLICSiD_check_checksum_EcalBarrel
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  geoPluginRun -input ${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -plugin DD4hepDetectorChecksum -readout -detector EcalBarrel
-  REGEX_PASS "Combined hash code                      ec2a9dbb0aeccacc  \\(10375 sub-codes\\)"
+  REGEX_PASS "Combined hash code                      6ad14133ce43a48f  \\(10375 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
@@ -141,7 +141,7 @@ dd4hep_add_test_reg( CLICSiD_check_checksum_EcalBarrel
 dd4hep_add_test_reg( CLICSiD_check_checksum_full
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  geoPluginRun -input ${DD4hep_ROOT}/DDDetectors/compact/SiD.xml -plugin DD4hepDetectorChecksum -readout 
-  REGEX_PASS "Combined hash code                      a2e90886360b3b75  \\(3395674 sub-codes\\)"
+  REGEX_PASS "Combined hash code                      2147984ea0779b88  \\(3395674 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #

--- a/examples/ClientTests/CMakeLists.txt
+++ b/examples/ClientTests/CMakeLists.txt
@@ -405,7 +405,7 @@ dd4hep_add_test_reg( MiniTel_check_checksum_Minitel3
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/MiniTelGenerate.xml
   	      -plugin DD4hepDetectorChecksum -readout -detector Minitel3
-  REGEX_PASS "Combined hash code                      22de2a78a15abd64  \\(54 sub-codes\\)"
+  REGEX_PASS "Combined hash code                      5373250faed5e515  \\(54 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
@@ -414,7 +414,7 @@ dd4hep_add_test_reg( MiniTel_check_checksum_full
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/MiniTelGenerate.xml
   	      -plugin DD4hepDetectorChecksum -readout
-  REGEX_PASS "Combined hash code                      cbcafd06b9ee34c1  \\(207 sub-codes\\)"
+  REGEX_PASS "Combined hash code                      e0b451e964100859  \\(207 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
@@ -423,7 +423,7 @@ dd4hep_add_test_reg( Check_Shape_Tessellated_check_checksum
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/Check_Shape_Tessellated.xml
   	      -plugin DD4hepDetectorChecksum
-  REGEX_PASS "Combined hash code                      13a268b6718de7a8  \\(13 sub-codes\\)"
+  REGEX_PASS "Combined hash code                      716a174589b62a5c  \\(13 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #
@@ -432,7 +432,7 @@ dd4hep_add_test_reg( Check_Shape_Tessellated_check_checksum_with_meshes
   COMMAND    "${CMAKE_INSTALL_PREFIX}/bin/run_test_CLICSiD.sh"
   EXEC_ARGS  geoPluginRun -input ${ClientTestsEx_INSTALL}/compact/Check_Shape_Tessellated.xml
   	      -plugin DD4hepDetectorChecksum -meshes -precision 3
-  REGEX_PASS "Combined hash code                      1fc84f1c2d93fd80  \\(13 sub-codes\\)"
+  REGEX_PASS "Combined hash code                      8372633493ec703a  \\(13 sub-codes\\)"
   REGEX_FAIL "Exception;EXCEPTION;ERROR"
 )
 #


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed a bug which caused update_hash64 to ignore last character of a std::string. This results in a change to geometry hash values.
ENDRELEASENOTES

before:
```c++
root [0] #include <DD4hep/Primitives.h>
root [1] dd4hep::detail::hash64(std::string("aaa"))
(unsigned long long) 620444549055354551
root [2] dd4hep::detail::hash64(std::string("aab"))
(unsigned long long) 620444549055354551
root [3] dd4hep::detail::hash64("aab")
(unsigned long long) 16653391238245862383
```
after:
```c++
root [0] #include <DD4hep/Primitives.h>
root [1] dd4hep::detail::hash64(std::string("aab"))
(unsigned long long) 16653391238245862383
root [2] dd4hep::detail::hash64(std::string("aaa"))
(unsigned long long) 16653392337757490594
```