### PR TITLE
Refactor Geant4Output2ROOT

### DIFF
--- a/DDG4/include/DDG4/Geant4Output2ROOT.h
+++ b/DDG4/include/DDG4/Geant4Output2ROOT.h
@@ -16,6 +16,8 @@
 // Framework include files
 #include <DDG4/Geant4OutputAction.h>
 
+#include <memory>
+
 class TFile;
 class TTree;
 class TBranch;
@@ -36,16 +38,16 @@ namespace dd4hep {
      */
     class Geant4Output2ROOT: public Geant4OutputAction {
     protected:
-      typedef std::map<std::string, TBranch*> Branches;
-      typedef std::map<std::string, TTree*> Sections;
+      using Branches = std::map<std::string, TBranch*>;
+      using Sections = std::map<std::string, TTree*>;
       /// Known file sections
       Sections m_sections;
       /// Branches in the event tree
       Branches m_branches;
       /// Reference to the ROOT file to open
-      TFile* m_file;
-      /// Reference to the event data tree
-      TTree* m_tree;
+      std::unique_ptr<TFile> m_file;
+      /// Reference to the event data tree (owned by m_file)
+      TTree* m_tree = nullptr;
       /// File sequence number
       int    m_fseqNunmber  { 0 };
       /// Property: name of the event tree
@@ -55,31 +57,31 @@ namespace dd4hep {
       /// Property: vector with disabled collections
       bool  m_disableParticles = false;
       /// Property: Flag if Monte-Carlo truth should be followed and checked
-      bool m_handleMCTruth;
+      bool m_handleMCTruth = true;
       /// Property: Flag if Monte-Carlo truth should be followed and checked
-      bool m_filesByRun;
-      
+      bool m_filesByRun = false;
+
     public:
       /// Standard constructor
       Geant4Output2ROOT(Geant4Context* context, const std::string& nam);
       /// Default destructor
-      virtual ~Geant4Output2ROOT();
+      ~Geant4Output2ROOT() override;
       /// Create/access tree by name for non collection user data
-      TTree* section(const std::string& nam);
+      [[nodiscard]] TTree* section(const std::string& nam);
       /// Fill single EVENT branch entry (Geant4 collection data)
       int fill(const std::string& nam, const ComponentCast& type, void* ptr);
 
       /// Close current output file
       virtual void closeOutput();
       /// Callback to store the Geant4 run information
-      virtual void beginRun(const G4Run* run)  override;
+      void beginRun(const G4Run* run)  override;
       /// Callback to store each Geant4 hit collection
-      virtual void saveCollection(OutputContext<G4Event>& ctxt, G4VHitsCollection* collection)  override;
+      void saveCollection(OutputContext<G4Event>& ctxt, G4VHitsCollection* collection)  override;
       /// Callback to store the Geant4 event
-      virtual void saveEvent(OutputContext<G4Event>& ctxt)  override;
+      void saveEvent(OutputContext<G4Event>& ctxt)  override;
 
       /// Commit data at end of filling procedure
-      virtual void commit(OutputContext<G4Event>& ctxt)  override;
+      void commit(OutputContext<G4Event>& ctxt)  override;
     };
 
   }    // End namespace sim

--- a/DDG4/include/DDG4/Geant4Output2ROOT.h
+++ b/DDG4/include/DDG4/Geant4Output2ROOT.h
@@ -48,8 +48,6 @@ namespace dd4hep {
       std::unique_ptr<TFile> m_file;
       /// Reference to the event data tree (owned by m_file)
       TTree* m_tree = nullptr;
-      /// File sequence number
-      int    m_fseqNunmber  { 0 };
       /// Property: name of the event tree
       std::string m_section;
       /// Property: vector with disabled collections
@@ -58,7 +56,7 @@ namespace dd4hep {
       bool  m_disableParticles = false;
       /// Property: Flag if Monte-Carlo truth should be followed and checked
       bool m_handleMCTruth = true;
-      /// Property: Flag if Monte-Carlo truth should be followed and checked
+      /// Property: Flag to create a new output file for each run
       bool m_filesByRun = false;
 
     public:
@@ -67,7 +65,7 @@ namespace dd4hep {
       /// Default destructor
       ~Geant4Output2ROOT() override;
       /// Create/access tree by name for non collection user data
-      [[nodiscard]] TTree* section(const std::string& nam);
+      TTree* section(const std::string& nam);
       /// Fill single EVENT branch entry (Geant4 collection data)
       int fill(const std::string& nam, const ComponentCast& type, void* ptr);
 

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -54,7 +54,7 @@ void Geant4Output2ROOT::closeOutput()   {
   if (!m_file) return;
   TDirectory::TContext ctxt(m_file.get());
   info("+++ Closing ROOT output file %s", m_file->GetName());
-  m_sections.erase(m_section);
+  m_sections.clear();
   m_branches.clear();
   m_tree->Write();
   m_file->Close();
@@ -184,18 +184,18 @@ void Geant4Output2ROOT::saveEvent(OutputContext<G4Event>& /* ctxt */) {
 /// Callback to store each Geant4 hit collection
 void Geant4Output2ROOT::saveCollection(OutputContext<G4Event>& /* ctxt */, G4VHitsCollection* collection) {
   auto* coll = dynamic_cast<Geant4HitCollection*>(collection);
+  if (!coll) return;
   const std::string hc_nam = collection->GetName();
   for(const auto& n : m_disabledCollections)  {
     if ( n == hc_nam )   {
       return;
     }
   }
-  if (!coll) return;
-  std::vector<void*> hits;
-  coll->getHitsUnchecked(hits);
   const size_t nhits = coll->GetSize();
+  std::vector<void*> hits;
+  hits.reserve(nhits);
+  coll->getHitsUnchecked(hits);
   if ( m_handleMCTruth && m_truth && nhits > 0 )   {
-    hits.reserve(nhits);
     try  {
       for(size_t i=0; i<nhits; ++i)   {
         Geant4HitData* h = coll->hit(i);

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -13,7 +13,6 @@
 
 // Framework include files
 #include <DD4hep/Printout.h>
-#include <DD4hep/Primitives.h>
 #include <DD4hep/InstanceCount.h>
 #include <DDG4/Geant4HitCollection.h>
 #include <DDG4/Geant4Output2ROOT.h>
@@ -36,12 +35,12 @@ using namespace dd4hep::sim;
 
 /// Standard constructor
 Geant4Output2ROOT::Geant4Output2ROOT(Geant4Context* ctxt, const std::string& nam)
-  : Geant4OutputAction(ctxt, nam), m_file(nullptr), m_tree(nullptr) {
+  : Geant4OutputAction(ctxt, nam) {
   declareProperty("Section",              m_section = "EVENT");
-  declareProperty("HandleMCTruth",        m_handleMCTruth = true);
+  declareProperty("HandleMCTruth",        m_handleMCTruth);
   declareProperty("DisabledCollections",  m_disabledCollections);
   declareProperty("DisableParticles",     m_disableParticles);
-  declareProperty("FilesByRun",           m_filesByRun = false);
+  declareProperty("FilesByRun",           m_filesByRun);
   InstanceCount::increment(this);
 }
 
@@ -53,30 +52,27 @@ Geant4Output2ROOT::~Geant4Output2ROOT() {
 
 /// Close current output file
 void Geant4Output2ROOT::closeOutput()   {
-  if (m_file) {
-    TDirectory::TContext ctxt(m_file);
-    Sections::iterator i = m_sections.find(m_section);
-    info("+++ Closing ROOT output file %s", m_file->GetName());
-    if ( i != m_sections.end() )
-      m_sections.erase(i);
-    m_branches.clear();
-    m_tree->Write();
-    m_file->Close();
-    m_tree = nullptr;
-    detail::deletePtr (m_file);
-  }
+  if (!m_file) return;
+  TDirectory::TContext ctxt(m_file.get());
+  info("+++ Closing ROOT output file %s", m_file->GetName());
+  m_sections.erase(m_section);
+  m_branches.clear();
+  m_tree->Write();
+  m_file->Close();
+  m_tree = nullptr;
+  m_file.reset();
 }
 
 /// Create/access tree by name
 TTree* Geant4Output2ROOT::section(const std::string& nam) {
-  Sections::const_iterator i = m_sections.find(nam);
+  auto i = m_sections.find(nam);
   if (i == m_sections.end()) {
-    TDirectory::TContext ctxt(m_file);
+    TDirectory::TContext ctxt(m_file.get());
     TTree* t = new TTree(nam.c_str(), ("Geant4 " + nam + " information").c_str());
     m_sections.emplace(nam, t);
     return t;
   }
-  return (*i).second;
+  return i->second;
 }
 
 /// Callback to store the Geant4 run information
@@ -84,9 +80,8 @@ void Geant4Output2ROOT::beginRun(const G4Run* run) {
   std::string fname = m_output;
   if ( m_filesByRun )    {
     size_t idx = m_output.rfind(".");
-    if ( m_file )  {
+    if ( m_file )
       closeOutput();
-    }
     fname  = m_output.substr(0, idx);
     fname += _toString(run->GetRunID(), ".run%08d");
     if ( idx != std::string::npos )
@@ -105,10 +100,9 @@ void Geant4Output2ROOT::beginRun(const G4Run* run) {
       except("Failed to create ROOT output file:'%s'", fname.c_str());
     }
     if (file->IsZombie()) {
-      detail::deletePtr (m_file);
       except("Failed to open ROOT output file:'%s'", fname.c_str());
     }
-    m_file = file.release();
+    m_file = std::move(file);
     m_tree = section(m_section);
   }
   Geant4OutputAction::beginRun(run);
@@ -116,59 +110,52 @@ void Geant4Output2ROOT::beginRun(const G4Run* run) {
 
 /// Fill single EVENT branch entry (Geant4 collection data)
 int Geant4Output2ROOT::fill(const std::string& nam, const ComponentCast& type, void* ptr) {
-  if (m_file) {
-    TBranch* b = 0;
-    Branches::const_iterator i = m_branches.find(nam);
-    if (i == m_branches.end()) {
-      const std::type_info& typ = type.type();
-      TClass* cl = TBuffer::GetClass(typ);
-      if (cl) {
-        b = m_tree->Branch(nam.c_str(), cl->GetName(), (void*) 0);
-        b->SetAutoDelete(false);
-        m_branches.emplace(nam, b);
-      }
-      else {
-        throw std::runtime_error("No ROOT TClass object available for object type:" + typeName(typ));
-      }
+  if (!m_file) return 0;
+  TBranch* b = nullptr;
+  auto i = m_branches.find(nam);
+  if (i == m_branches.end()) {
+    const std::type_info& typ = type.type();
+    if (auto* cl = TBuffer::GetClass(typ)) {
+      b = m_tree->Branch(nam.c_str(), cl->GetName(), static_cast<void*>(nullptr));
+      b->SetAutoDelete(false);
+      m_branches.emplace(nam, b);
     }
     else {
-      b = (*i).second;
+      throw std::runtime_error("No ROOT TClass object available for object type:" + typeName(typ));
     }
-    Long64_t evt = b->GetEntries(), nevt = b->GetTree()->GetEntries(), num = nevt - evt;
-    if (nevt > evt) {
-      b->SetAddress(0);
-      while (num > 0) {
-        b->Fill();
-        --num;
-      }
-    }
-    b->SetAddress(&ptr);
-    int nbytes = b->Fill();
-    if (nbytes < 0) {
-      throw std::runtime_error("Failed to write ROOT collection:" + nam + "!");
-    }
-    return nbytes;
   }
-  return 0;
+  else {
+    b = i->second;
+  }
+  const Long64_t evt  = b->GetEntries();
+  const Long64_t nevt = b->GetTree()->GetEntries();
+  if (nevt > evt) {
+    b->SetAddress(nullptr);
+    for (Long64_t num = nevt - evt; num > 0; --num)
+      b->Fill();
+  }
+  b->SetAddress(&ptr);
+  const int nbytes = b->Fill();
+  if (nbytes < 0) {
+    throw std::runtime_error("Failed to write ROOT collection:" + nam + "!");
+  }
+  return nbytes;
 }
 
 /// Commit data at end of filling procedure
 void Geant4Output2ROOT::commit(OutputContext<G4Event>& ctxt) {
   if (m_file) {
-    TObjArray* a = m_tree->GetListOfBranches();
-    Long64_t evt = m_tree->GetEntries() + 1;
-    Int_t nb = a->GetEntriesFast();
+    auto* a = m_tree->GetListOfBranches();
+    const Long64_t evt = m_tree->GetEntries() + 1;
+    const Int_t nb = a->GetEntriesFast();
     /// Fill NULL pointers to all branches, which have less entries than the Event branch
     for (Int_t i = 0; i < nb; ++i) {
-      TBranch* br_ptr = (TBranch*) a->UncheckedAt(i);
-      Long64_t br_evt = br_ptr->GetEntries();
+      auto* br_ptr = static_cast<TBranch*>(a->UncheckedAt(i));
+      const Long64_t br_evt = br_ptr->GetEntries();
       if (br_evt < evt) {
-        Long64_t num = evt - br_evt;
-        br_ptr->SetAddress(0);
-        while (num > 0) {
+        br_ptr->SetAddress(nullptr);
+        for (Long64_t num = evt - br_evt; num > 0; --num)
           br_ptr->Fill();
-          --num;
-        }
       }
     }
     m_tree->SetEntries(evt);
@@ -178,66 +165,56 @@ void Geant4Output2ROOT::commit(OutputContext<G4Event>& ctxt) {
 
 /// Callback to store the Geant4 event
 void Geant4Output2ROOT::saveEvent(OutputContext<G4Event>& /* ctxt */) {
-  if ( !m_disableParticles )  {
-    Geant4ParticleMap* parts = context()->event().extension<Geant4ParticleMap>();
-    if ( parts )   {
-      typedef Geant4HitWrapper::HitManipulator Manip;
-      typedef Geant4ParticleMap::ParticleMap ParticleMap;
-      Manip* manipulator = Geant4HitWrapper::manipulator<Geant4Particle>();
-      G4ParticleTable* table = G4ParticleTable::GetParticleTable();
-      const ParticleMap& pm = parts->particles();
-      std::vector<void*> particles;
-      particles.reserve(pm.size());
-      for ( const auto& i : pm )   {
-        auto* p = i.second;
-        G4ParticleDefinition* def = table->FindParticle(p->pdgID);
-        p->charge = int(3.0 * (def ? def->GetPDGCharge() : -1.0)); // Assume e-/pi-
-        particles.emplace_back((ParticleMap::mapped_type*)p);
-      }
-      fill("MCParticles",manipulator->vec_type,&particles);
-    }
+  if (m_disableParticles) return;
+  auto* parts = context()->event().extension<Geant4ParticleMap>();
+  if (!parts) return;
+  using Manip = Geant4HitWrapper::HitManipulator;
+  using ParticleMap = Geant4ParticleMap::ParticleMap;
+  Manip* manipulator = Geant4HitWrapper::manipulator<Geant4Particle>();
+  G4ParticleTable* table = G4ParticleTable::GetParticleTable();
+  const ParticleMap& pm = parts->particles();
+  std::vector<void*> particles;
+  particles.reserve(pm.size());
+  for ( const auto& i : pm )   {
+    auto* p = i.second;
+    G4ParticleDefinition* def = table->FindParticle(p->pdgID);
+    p->charge = static_cast<char>(3.0 * (def ? def->GetPDGCharge() : -1.0)); // Assume e-/pi-
+    particles.emplace_back(p);
   }
+  fill("MCParticles",manipulator->vec_type,&particles);
 }
 
 /// Callback to store each Geant4 hit collection
 void Geant4Output2ROOT::saveCollection(OutputContext<G4Event>& /* ctxt */, G4VHitsCollection* collection) {
-  Geant4HitCollection* coll = dynamic_cast<Geant4HitCollection*>(collection);
-  std::string hc_nam = collection->GetName();
+  auto* coll = dynamic_cast<Geant4HitCollection*>(collection);
+  const std::string hc_nam = collection->GetName();
   for(const auto& n : m_disabledCollections)  {
     if ( n == hc_nam )   {
       return;
     }
   }
-  if (coll) {
-    std::vector<void*> hits;
-    coll->getHitsUnchecked(hits);
-    size_t nhits = coll->GetSize();
-    if ( m_handleMCTruth && m_truth && nhits > 0 )   {
-      hits.reserve(nhits);
-      try  {
-        for(size_t i=0; i<nhits; ++i)   {
-          Geant4HitData* h = coll->hit(i);
-          Geant4Tracker::Hit* trk_hit = dynamic_cast<Geant4Tracker::Hit*>(h);
-          if ( 0 != trk_hit )   {
-            Geant4HitData::Contribution& t = trk_hit->truth;
-            int trackID = t.trackID;
-            t.trackID = m_truth->particleID(trackID);
-          }
-          Geant4Calorimeter::Hit* cal_hit = dynamic_cast<Geant4Calorimeter::Hit*>(h);
-          if ( 0 != cal_hit )   {
-            Geant4HitData::Contributions& c = cal_hit->truth;
-            for(Geant4HitData::Contributions::iterator j=c.begin(); j!=c.end(); ++j)  {
-              Geant4HitData::Contribution& t = *j;
-              int trackID = t.trackID;
-              t.trackID = m_truth->particleID(trackID);
-            }
-          }
+  if (!coll) return;
+  std::vector<void*> hits;
+  coll->getHitsUnchecked(hits);
+  const size_t nhits = coll->GetSize();
+  if ( m_handleMCTruth && m_truth && nhits > 0 )   {
+    hits.reserve(nhits);
+    try  {
+      for(size_t i=0; i<nhits; ++i)   {
+        Geant4HitData* h = coll->hit(i);
+        if (auto* trk_hit = dynamic_cast<Geant4Tracker::Hit*>(h))   {
+          Geant4HitData::Contribution& t = trk_hit->truth;
+          t.trackID = m_truth->particleID(t.trackID);
+        }
+        if (auto* cal_hit = dynamic_cast<Geant4Calorimeter::Hit*>(h))   {
+          for(auto& t : cal_hit->truth)
+            t.trackID = m_truth->particleID(t.trackID);
         }
       }
-      catch(...)   {
-        error("+++ Exception while saving collection %s.",hc_nam.c_str());
-      }
     }
-    fill(hc_nam, coll->vector_type(), &hits);
+    catch(...)   {
+      error("+++ Exception while saving collection %s.",hc_nam.c_str());
+    }
   }
+  fill(hc_nam, coll->vector_type(), &hits);
 }

--- a/DDG4/src/Geant4Output2ROOT.cpp
+++ b/DDG4/src/Geant4Output2ROOT.cpp
@@ -30,7 +30,6 @@
 #include <TBranch.h>
 #include <TSystem.h>
 
-
 using namespace dd4hep::sim;
 
 /// Standard constructor
@@ -168,11 +167,9 @@ void Geant4Output2ROOT::saveEvent(OutputContext<G4Event>& /* ctxt */) {
   if (m_disableParticles) return;
   auto* parts = context()->event().extension<Geant4ParticleMap>();
   if (!parts) return;
-  using Manip = Geant4HitWrapper::HitManipulator;
-  using ParticleMap = Geant4ParticleMap::ParticleMap;
-  Manip* manipulator = Geant4HitWrapper::manipulator<Geant4Particle>();
+  Geant4HitWrapper::HitManipulator* manipulator = Geant4HitWrapper::manipulator<Geant4Particle>();
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
-  const ParticleMap& pm = parts->particles();
+  const Geant4ParticleMap::ParticleMap pm = parts->particles();
   std::vector<void*> particles;
   particles.reserve(pm.size());
   for ( const auto& i : pm )   {


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `std::unique_ptr` when possible, return earlier to unindent big blocks and simplify when possible.

ENDRELEASENOTES

In preparation for https://github.com/AIDASoft/DD4hep/pull/1240, a few changes need to be done in `Geant4Output2ROOT` so it's a good time to do this.

In addition, I think assignments like this one were a bug: https://github.com/AIDASoft/DD4hep/blob/13d881a61f948a7b7a6501aa3617f6a7a84778b5/DDG4/src/Geant4Output2ROOT.cpp#L41

I have checked a few histograms and the output is the same before and after this change.