### PR TITLE
feat: add DD4HEP_GENERATE_ROOTMAP_EXTRA_ENV hook to dd4hep_generate_rootmap

### DIFF
--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -73,6 +73,9 @@ endfunction()
 # dd4hep_generate_rootmap(library)
 #
 # Create the .components file needed by the plug-in system.
+#
+# Setting DD4HEP_GENERATE_ROOTMAP_EXTRA_ENV before calling allows callers to inject environment
+# variables (such as LD_PRELOAD) into the listcomponents subprocess.
 #---------------------------------------------------------------------------------------------------
 function(dd4hep_generate_rootmap library)
 

--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -102,9 +102,9 @@ function(dd4hep_generate_rootmap library)
                      DEPENDS ${library}
                      VERBATIM COMMAND
                      "${CMAKE_COMMAND}" -E env
+                     ${DD4HEP_GENERATE_ROOTMAP_EXTRA_ENV}
                      "${ENV_VAR}=${_ld_path}"
                      "ROOT_LIBRARY_PATH=${DD4HEP_ROOT_LIBRARY_PATH}"
-                     ${DD4HEP_GENERATE_ROOTMAP_EXTRA_ENV}
                      $<TARGET_FILE:DD4hep::listcomponents> -o ${rootmapfile} $<TARGET_FILE_NAME:${library}>
                      WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH}
                      COMMAND_EXPAND_LISTS

--- a/cmake/DD4hep.cmake
+++ b/cmake/DD4hep.cmake
@@ -104,8 +104,10 @@ function(dd4hep_generate_rootmap library)
                      "${CMAKE_COMMAND}" -E env
                      "${ENV_VAR}=${_ld_path}"
                      "ROOT_LIBRARY_PATH=${DD4HEP_ROOT_LIBRARY_PATH}"
+                     ${DD4HEP_GENERATE_ROOTMAP_EXTRA_ENV}
                      $<TARGET_FILE:DD4hep::listcomponents> -o ${rootmapfile} $<TARGET_FILE_NAME:${library}>
                      WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH}
+                     COMMAND_EXPAND_LISTS
                      )
 
   add_custom_target(Components_${library} ALL DEPENDS ${rootmapfile})


### PR DESCRIPTION
In test builds of plugins with UBSAN or ASAN, we typically run into complications with the `listcomponents` subprocess since it fails to find e.g. `libasan.so`.

This PR allows callers to inject extra environment variables (such as `LD_PRELOAD`) into the `listcomponents` subprocess by setting `DD4HEP_GENERATE_ROOTMAP_EXTRA_ENV` before calling `dd4hep_add_plugin`.  The variable is empty by default so existing users are unaffected. `COMMAND_EXPAND_LISTS` is added so a CMake list in the variable is correctly word-split at build time (and hence not quoted).

BEGINRELEASENOTES
- feat: add DD4HEP_GENERATE_ROOTMAP_EXTRA_ENV hook to dd4hep_generate_rootmap

ENDRELEASENOTES