### PR TITLE
Include type unsigned long long for macOS in GrammarTypes

### DIFF
--- a/DDCore/src/GrammarTypes.cpp
+++ b/DDCore/src/GrammarTypes.cpp
@@ -51,6 +51,7 @@ DD4HEP_DEFINE_PARSER_GRAMMAR_U_CONT(long long)
 DD4HEP_DEFINE_PARSER_GRAMMAR_CONT_VL(unsigned long,eval_item)
 #ifdef __APPLE__
 DD4HEP_DEFINE_PARSER_GRAMMAR(long long,eval_item)
+DD4HEP_DEFINE_PARSER_GRAMMAR(unsigned long long,eval_item)
 #endif
 #endif   //  DD4HEP_HAVE_ALL_PARSERS
 


### PR DESCRIPTION


BEGINRELEASENOTES

- Include type `unsigned long long` for macOS in GrammarTypes.cpp, Fixes #1637 

ENDRELEASENOTES