### PR TITLE
feat: add plugin for G4HepEm vectorized EM physics

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,9 +65,12 @@ jobs:
               -DCMAKE_CXX_STANDARD=17 \
               ..
           fi
-          if [[ ${{ matrix.LCG }} =~ dev3 ]]; then
+          if [[ ${{ matrix.LCG }} =~ dev[34] ]]; then
             echo "::group::CMakeConfig 2"
-            cmake -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON ..
+            cmake \
+              -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON \
+              -DDD4HEP_USE_G4HEPEM=ON \
+              ..
           fi
           # Make sure DD4hep can be built with an older version of EDM4hep, 0.10.5 for LCG_106
           if [[ ${{ matrix.LCG }} =~ 106 ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ option(DD4HEP_USE_GEANT4_UNITS  "Build using Geant4 units throughout"           
 option(DD4HEP_USE_EDM4HEP       "Build edm4hep extensions"                      OFF)
 option(DD4HEP_USE_HEPMC3        "Build hepmc3 extensions"                       OFF)
 option(DD4HEP_USE_TBB           "Build features that require TBB"               OFF)
+option(DD4HEP_USE_G4HEPEM       "Build G4HepEm EM tracking physics plugin"      OFF)
 option(DD4HEP_LOAD_ASSIMP       "Download and build ASSIMP from github"         OFF)
 option(DD4HEP_DISABLE_PACKAGES  "Selectively disable DD4HEP sub-packages [Separate multiples by space]"  OFF)
 option(BUILD_TESTING            "Enable and build tests"                        ON)
@@ -217,6 +218,9 @@ if(DD4HEP_USE_TBB)
   find_package(TBB REQUIRED CONFIG)
 endif()
 
+if(DD4HEP_USE_G4HEPEM)
+  find_package(G4HepEm REQUIRED)
+endif()
 
 ######################
 # Set compiler flags #

--- a/DDG4/CMakeLists.txt
+++ b/DDG4/CMakeLists.txt
@@ -163,6 +163,19 @@ IF(DD4HEP_USE_HEPMC3)
   SET(DD4HEP_USE_HEPMC3 ON)
 ENDIF()
 
+#---------------------------  G4HepEm plugin  ----------------------------------------
+IF(TARGET G4HepEm::g4HepEm)
+  dd4hep_print("|++> G4HepEm found, building DDG4HepEm plugin")
+  dd4hep_add_plugin(DDG4HepEm
+    SOURCES g4hepem/Geant4HepEmTrackingPhysics.cpp
+    USES    DD4hep::DDG4 G4HepEm::g4HepEm
+    )
+  set_target_properties(DDG4HepEm PROPERTIES VERSION ${DD4hep_VERSION} SOVERSION ${DD4hep_SOVERSION})
+  install(TARGETS DDG4HepEm EXPORT DD4hep
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION bin)
+ENDIF()
+
 #
 #---------------------------  DDRec dependent Plugins  -----------------------------
 #This does not compile at the moment

--- a/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
+++ b/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
@@ -1,0 +1,144 @@
+//==========================================================================
+//  AIDA Detector description implementation
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+//==========================================================================
+
+/** \addtogroup Geant4PhysicsConstructor
+ *
+ * @{
+ * \package Geant4HepEmTrackingPhysics
+ * \brief PhysicsConstructor enabling G4HepEm vectorised EM tracking for e-/e+/gamma
+ *
+ * This plugin replaces the Geant4 stepping loop for electrons, positrons and
+ * photons with the G4HepEmTrackingManager, which provides vectorised EM physics
+ * using SIMD intrinsics (AVX2/AVX-512).  Hadronic physics from the base physics
+ * list (e.g. FTFP_BERT) is unaffected: G4VTrackingManager::SetTrackingManager()
+ * takes priority over the standard process manager for the three EM particles,
+ * while all other particles continue to use the default stepping loop.
+ *
+ * Woodcock tracking for photons can be enabled per G4Region via the
+ * WoodcockRegions property.  Woodcock tracking allows photons to bypass
+ * fine-grained geometry navigation (e.g. individual fibres in a ScFi
+ * calorimeter) by sampling interactions against a majorant cross-section.
+ *
+ * Usage in a ddsim/npsim steering file:
+ * \code{.py}
+ *   SIM.physics.list = "FTFP_BERT"
+ *
+ *   def setupHepEm(kernel):
+ *     from DDG4 import PhysicsList
+ *     seq = kernel.physicsList()
+ *     hepem = PhysicsList(kernel, 'Geant4HepEmTrackingPhysics/HepEmPhysics')
+ *     hepem.WoodcockRegions = ['EcalBarrelRegion']
+ *     hepem.enableUI()
+ *     seq.adopt(hepem)
+ *
+ *   SIM.physics.setupUserPhysics(setupHepEm)
+ * \endcode
+ *
+ * The DDG4HepEm plugin library must be in LD_LIBRARY_PATH.
+ *
+ * @}
+ */
+
+#ifndef DDG4_GEANT4HEPEMTRACKINGPHYSICS_H
+#define DDG4_GEANT4HEPEMTRACKINGPHYSICS_H 1
+
+/// Framework include files
+#include <DDG4/Geant4PhysicsList.h>
+
+/// Geant4 include files
+#include <G4Electron.hh>
+#include <G4Gamma.hh>
+#include <G4Positron.hh>
+#include <G4VUserPhysicsList.hh>
+
+/// G4HepEm include files
+#include <G4HepEmConfig.hh>
+#include <G4HepEmTrackingManager.hh>
+
+/// C++ include files
+#include <string>
+#include <vector>
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    /// DDG4 physics constructor that installs the G4HepEm vectorised EM tracking manager
+    /**
+     * Replaces the Geant4 stepping loop for e-, e+ and gamma with
+     * G4HepEmTrackingManager, providing SIMD-vectorised EM physics.
+     * A single tracking manager instance is shared among the three particle
+     * types, which is the standard G4HepEm usage pattern.
+     *
+     * \author  W. Deconinck
+     * \version 1.0
+     * \ingroup DD4HEP_SIMULATION
+     */
+    class Geant4HepEmTrackingPhysics : public Geant4PhysicsList {
+    protected:
+      /// Define standard assignments and constructors
+      DDG4_DEFINE_ACTION_CONSTRUCTORS(Geant4HepEmTrackingPhysics);
+
+      /// G4Region names in which Woodcock tracking is activated for photons
+      std::vector<std::string> m_woodcockRegions;
+
+    public:
+      /// Standard constructor
+      Geant4HepEmTrackingPhysics(Geant4Context* context, const std::string& nam)
+        : Geant4PhysicsList(context, nam) {
+        declareProperty("WoodcockRegions", m_woodcockRegions);
+      }
+
+      /// Default destructor
+      virtual ~Geant4HepEmTrackingPhysics() = default;
+
+      /// Callback to install the G4HepEmTrackingManager on e-, e+ and gamma
+      /**
+       * Called from within G4VPhysicsConstructor::ConstructProcess() by the DDG4
+       * action sequence, after ConstructParticle() has been executed.
+       */
+      virtual void constructProcesses(G4VUserPhysicsList* /* physics_list */) override {
+        auto* tm = new G4HepEmTrackingManager();
+
+        for (const auto& region : m_woodcockRegions) {
+          info("+++ Enabling Woodcock photon tracking in G4Region: %s", region.c_str());
+          tm->GetConfig()->SetWoodcockTrackingRegion(region);
+        }
+
+        // Warn if another custom tracking manager is already installed —
+        // SetTrackingManager() is exclusive and will silently replace it.
+        auto warnIfConflict = [&](G4ParticleDefinition* particle) {
+          if (particle->GetTrackingManager() != nullptr) {
+            warning("+++ Replacing existing tracking manager for %s with G4HepEmTrackingManager",
+                    particle->GetParticleName().c_str());
+          }
+        };
+        warnIfConflict(G4Electron::Definition());
+        warnIfConflict(G4Positron::Definition());
+        warnIfConflict(G4Gamma::Definition());
+
+        G4Electron::Definition()->SetTrackingManager(tm);
+        G4Positron::Definition()->SetTrackingManager(tm);
+        G4Gamma::Definition()   ->SetTrackingManager(tm);
+
+        info("+++ Installed G4HepEmTrackingManager for e-/e+/gamma");
+      }
+    };
+  }  // namespace sim
+}  // namespace dd4hep
+
+#endif  // DDG4_GEANT4HEPEMTRACKINGPHYSICS_H
+
+#include <DDG4/Factories.h>
+using namespace dd4hep::sim;
+DECLARE_GEANT4ACTION(Geant4HepEmTrackingPhysics)

--- a/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
+++ b/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
@@ -77,8 +77,14 @@ namespace dd4hep {
     /**
      * Replaces the Geant4 stepping loop for e-, e+ and gamma with
      * G4HepEmTrackingManager, providing SIMD-vectorised EM physics.
-     * A single tracking manager instance is shared among the three particle
-     * types, which is the standard G4HepEm usage pattern.
+     *
+     * A single G4HepEmTrackingManager instance is created per call to
+     * constructProcesses() and registered with all three particle types
+     * (e-, e+, gamma).  This is the canonical G4HepEm usage pattern:
+     * G4HepEmTrackingManager::HandOverOneTrack() dispatches internally on
+     * particle type, so one shared instance handles all three species.
+     *
+     * Geant4 owns and deletes the tracking manager.
      *
      * \author  W. Deconinck
      * \version 1.0
@@ -106,8 +112,17 @@ namespace dd4hep {
       /**
        * Called from within G4VPhysicsConstructor::ConstructProcess() by the DDG4
        * action sequence, after ConstructParticle() has been executed.
+       *
+       * Creates one G4HepEmTrackingManager and registers it with all three EM
+       * particle types.  Ownership is transferred to Geant4: the pointer is
+       * stored (non-owning) inside each particle's TLS data slot, and
+       * G4VUserPhysicsList::RemoveTrackingManager() will delete it at thread /
+       * run teardown.
        */
       virtual void constructProcesses(G4VUserPhysicsList* /* physics_list */) override {
+        // Allocate one tracking manager for this thread.  G4HepEmTrackingManager
+        // handles e-/e+/gamma internally by dispatching on particle type, so one
+        // shared instance per thread suffices.  Ownership lies with Geant4.
         auto* tm = new G4HepEmTrackingManager();
 
         for (const auto& region : m_woodcockRegions) {


### PR DESCRIPTION
This PR adds a physics list plugin for the G4HepEm vectorized EM physics (without use of AdePT, on CPU).

Tested on the EIC/ePIC geometry with:
```py
  SIM.physics.list = "FTFP_BERT"
  
  # Ensure that G4HepEm vectorized EM physics is always loaded
  def setupHepEm(kernel):
    from DDG4 import PhysicsList
    seq = kernel.physicsList()
    hepem = PhysicsList(kernel, 'Geant4HepEmTrackingPhysics/HepEmPhysics')
    hepem.enableUI()
    seq.adopt(hepem)

  SIM.physics.setupUserPhysics(setupHepEm)
```

BEGINRELEASENOTES
- feat: add plugin for G4HepEm vectorized EM physics

ENDRELEASENOTES