### PR TITLE
DDG4: fix uncaught OSError raised by getpass.getuser() in Python 3.13

### DIFF
--- a/DDG4/python/DDSim/Helper/Meta.py
+++ b/DDG4/python/DDSim/Helper/Meta.py
@@ -108,7 +108,7 @@ class Meta(ConfigHelper):
     import getpass
     try:
         runHeader["User"] = getpass.getuser()
-    except KeyError:
+    except (KeyError, OSError):
         runHeader["User"] = str(os.getuid())
 
     return runHeader


### PR DESCRIPTION
From https://docs.python.org/3/whatsnew/3.13.html:
> An [OSError](https://docs.python.org/3/library/exceptions.html#OSError) is now raised by [getpass.getuser()](https://docs.python.org/3/library/getpass.html#getpass.getuser) for any failure to retrieve a username, instead of [ImportError](https://docs.python.org/3/library/exceptions.html#ImportError) on non-Unix platforms or [KeyError](https://docs.python.org/3/library/exceptions.html#KeyError) on Unix platforms where the password database is empty.

BEGINRELEASENOTES
- Updated DDG4 user discovery to be compatible with Python 3.13

ENDRELEASENOTES