### PR TITLE
Use Clang 22 instead of 19 in CI, soon unsupported

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["dev4/x86_64-el9-clang19-opt"]
+        LCG: ["dev4/x86_64-el9-clang22-opt"]
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
     - uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
               "dev4/x86_64-el9-gcc13-opt",
               "dev4/x86_64-ubuntu2404-gcc13-opt",
               "dev3/x86_64-el9-gcc13-opt",
-              "dev3/x86_64-el9-clang19-opt",
+              "dev3/x86_64-el9-clang22-opt",
               "dev3/x86_64-el9-gcc15-dbg"]
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -34,8 +34,8 @@ jobs:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-${{ matrix.LCG }}
         run: |
-          if [[ ${{ matrix.LCG }} =~ clang19 ]]; then
-            source /cvmfs/sft.cern.ch/lcg/contrib/clang/19/x86_64-el9/setup-wrapper.sh
+          if [[ ${{ matrix.LCG }} =~ clang22 ]]; then
+            source /cvmfs/sft.cern.ch/lcg/contrib/clang/22/x86_64-el9/setup-wrapper.sh
           fi
           mkdir build
           cd build
@@ -43,19 +43,19 @@ jobs:
           echo "::group::CMakeConfig"
           # Common CMake options
           source ../.github/scripts/common_cmake_opts.sh
-          if [[ ${{ matrix.LCG }} =~ gcc13|clang19 ]]; then
-            echo "::group::CMakeConfig C++20"
-            cmake \
-              $COMMON_CMAKE_OPTS \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_CXX_STANDARD=20 \
-              ..
-          elif [[ ${{ matrix.LCG }} =~ gcc15 ]]; then
+          if [[ ${{ matrix.LCG }} =~ gcc15|clang22 ]]; then
             echo "::group::CMakeConfig C++23"
             cmake \
               $COMMON_CMAKE_OPTS \
-              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_CXX_STANDARD=23 \
+              ..
+          elif [[ ${{ matrix.LCG }} =~ gcc13 ]]; then
+            echo "::group::CMakeConfig C++20"
+            cmake \
+              $COMMON_CMAKE_OPTS \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_CXX_STANDARD=20 \
               ..
           else
             echo "::group::CMakeConfig C++17"
@@ -85,7 +85,12 @@ jobs:
           mkdir build
           cd build
           source ../../.github/scripts/common_cmake_opts.sh
-          if [[ ${{ matrix.LCG }} =~ gcc13|gcc15|clang19 ]]; then
+          if [[ ${{ matrix.LCG }} =~ gcc15|clang22 ]]; then
+            cmake \
+              $COMMON_EXAMPLES_CMAKE_OPTS \
+              -DCMAKE_CXX_STANDARD=23 \
+              ..
+          elif [[ ${{ matrix.LCG }} =~ gcc13 ]]; then
             cmake \
               $COMMON_EXAMPLES_CMAKE_OPTS \
               -DCMAKE_CXX_STANDARD=20 \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,14 +47,14 @@ jobs:
             echo "::group::CMakeConfig C++23"
             cmake \
               $COMMON_CMAKE_OPTS \
-              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_BUILD_TYPE=Debug \
               -DCMAKE_CXX_STANDARD=23 \
               ..
           elif [[ ${{ matrix.LCG }} =~ gcc13 ]]; then
             echo "::group::CMakeConfig C++20"
             cmake \
               $COMMON_CMAKE_OPTS \
-              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_CXX_STANDARD=20 \
               ..
           else

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,12 +43,19 @@ jobs:
           echo "::group::CMakeConfig"
           # Common CMake options
           source ../.github/scripts/common_cmake_opts.sh
-          if [[ ${{ matrix.LCG }} =~ gcc15|clang22 ]]; then
+          if [[ ${{ matrix.LCG }} =~ gcc15 ]]; then
             echo "::group::CMakeConfig C++23"
             cmake \
               $COMMON_CMAKE_OPTS \
               -DCMAKE_BUILD_TYPE=Debug \
               -DCMAKE_CXX_STANDARD=23 \
+              ..
+          elif [[ ${{ matrix.LCG }} =~ clang22 ]]; then
+            echo "::group::CMakeConfig C++23"
+            cmake \
+              $COMMON_CMAKE_OPTS \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_CXX_STANDARD=20 \
               ..
           elif [[ ${{ matrix.LCG }} =~ gcc13 ]]; then
             echo "::group::CMakeConfig C++20"


### PR DESCRIPTION
BEGINRELEASENOTES
- Use Clang 22 instead of 19 in CI, soon unsupported

ENDRELEASENOTES