### PR TITLE
feat: add region selection for G4HepEm plugin

### DIFF
--- a/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
+++ b/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
@@ -147,6 +147,11 @@ namespace dd4hep {
         }
 
         void trackWithGeant4(G4Track* track) {
+          // We are inside a custom G4VTrackingManager::HandOverOneTrack() path here,
+          // but with track hand-off to Geant4 after all (since not in a HepEm region).
+          // In this path, G4EventManager does not execute its normal post-ProcessOneTrack()
+          // switch (see G4EventManager::DoProcessing, switch(istop) in the non-custom branch),
+          // so we must mirror that track-status/secondary/trajectory handling here.
           auto* eventManager = G4EventManager::GetEventManager();
           auto* trackManager = eventManager->GetTrackingManager();
           auto* stackManager = eventManager->GetStackManager();

--- a/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
+++ b/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
@@ -153,12 +153,12 @@ namespace dd4hep {
 
           trackManager->ProcessOneTrack(track);
 
-          G4TrackStatus istop = track->GetTrackStatus();
+          G4TrackStatus track_status = track->GetTrackStatus();
           G4VTrajectory* trajectory =
               trackManager->GetStoreTrajectory() == 0 ? nullptr : trackManager->GimmeTrajectory();
           G4TrackVector* secondaries = trackManager->GimmeSecondaries();
 
-          switch (istop) {
+          switch (track_status) {
           case fStopButAlive:
           case fSuspend:
           case fSuspendAndWait:

--- a/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
+++ b/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
@@ -22,10 +22,16 @@
  * takes priority over the standard process manager for the three EM particles,
  * while all other particles continue to use the default stepping loop.
  *
+ * HepEm can be restricted to selected G4Region names via the HepEmRegions
+ * property. If HepEmRegions is empty (default), HepEm applies in all regions.
+ *
  * Woodcock tracking for photons can be enabled per G4Region via the
  * WoodcockRegions property.  Woodcock tracking allows photons to bypass
  * fine-grained geometry navigation (e.g. individual fibres in a ScFi
  * calorimeter) by sampling interactions against a majorant cross-section.
+ * When HepEmRegions is non-empty, WoodcockRegions is applied only to the
+ * intersection with HepEmRegions; non-overlapping Woodcock regions are ignored
+ * with a warning.
  *
  * Usage in a ddsim/npsim steering file:
  * \code{.py}
@@ -35,7 +41,9 @@
  *     from DDG4 import PhysicsList
  *     seq = kernel.physicsList()
  *     hepem = PhysicsList(kernel, 'Geant4HepEmTrackingPhysics/HepEmPhysics')
- *     hepem.WoodcockRegions = ['EcalBarrelRegion']
+ *     hepem.HepEmRegions = ['EcalBarrelScFiLayerRegion']
+ *     hepem.VerboseLevel = 1
+ *     hepem.WoodcockRegions = ['EcalBarrelScFiLayerRegion']
  *     hepem.enableUI()
  *     seq.adopt(hepem)
  *
@@ -55,8 +63,11 @@
 
 /// Geant4 include files
 #include <G4Electron.hh>
+#include <G4EventManager.hh>
 #include <G4Gamma.hh>
 #include <G4Positron.hh>
+#include <G4RegionStore.hh>
+#include <G4TrackStatus.hh>
 #include <G4VUserPhysicsList.hh>
 
 /// G4HepEm include files
@@ -64,7 +75,10 @@
 #include <G4HepEmTrackingManager.hh>
 
 /// C++ include files
+#include <memory>
 #include <string>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 /// Namespace for the AIDA detector description toolkit
@@ -72,6 +86,123 @@ namespace dd4hep {
 
   /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
   namespace sim {
+
+    namespace {
+
+      /// Tracking manager wrapper that applies HepEm only in selected regions.
+      class Geant4RegionSelectiveHepEmTrackingManager : public G4VTrackingManager {
+      public:
+        Geant4RegionSelectiveHepEmTrackingManager(bool trackInAllRegions,
+                                                  std::unordered_set<G4int> hepEmRegionIDs,
+                                                  G4int verbose)
+          : fTrackInAllRegions(trackInAllRegions)
+          , fHepEmRegionIDs(std::move(hepEmRegionIDs))
+          , fHepEmTrackingManager(new G4HepEmTrackingManager(verbose)) {}
+
+        virtual ~Geant4RegionSelectiveHepEmTrackingManager() = default;
+
+        G4HepEmConfig* GetConfig() { return fHepEmTrackingManager->GetConfig(); }
+
+        void BuildPhysicsTable(const G4ParticleDefinition& part) override {
+          fHepEmTrackingManager->BuildPhysicsTable(part);
+        }
+
+        void PreparePhysicsTable(const G4ParticleDefinition& part) override {
+          fHepEmTrackingManager->PreparePhysicsTable(part);
+        }
+
+        void FlushEvent() override {
+          fHepEmTrackingManager->FlushEvent();
+        }
+
+        void HandOverOneTrack(G4Track* aTrack) override {
+          if (useHepEm(aTrack)) {
+            fHepEmTrackingManager->HandOverOneTrack(aTrack);
+            return;
+          }
+          trackWithGeant4(aTrack);
+        }
+
+      private:
+        bool useHepEm(const G4Track* aTrack) const {
+          if (fTrackInAllRegions) {
+            return true;
+          }
+          const G4VPhysicalVolume* volume = aTrack->GetVolume();
+          if (volume == nullptr && aTrack->GetTouchableHandle()) {
+            volume = aTrack->GetTouchableHandle()->GetVolume();
+          }
+          if (volume == nullptr) {
+            return false;
+          }
+          const G4LogicalVolume* logical = volume->GetLogicalVolume();
+          if (logical == nullptr) {
+            return false;
+          }
+          const G4Region* region = logical->GetRegion();
+          if (region == nullptr) {
+            return false;
+          }
+          return fHepEmRegionIDs.find(region->GetInstanceID()) != fHepEmRegionIDs.end();
+        }
+
+        void trackWithGeant4(G4Track* track) {
+          auto* eventManager = G4EventManager::GetEventManager();
+          auto* trackManager = eventManager->GetTrackingManager();
+          auto* stackManager = eventManager->GetStackManager();
+
+          trackManager->ProcessOneTrack(track);
+
+          G4TrackStatus istop = track->GetTrackStatus();
+          G4VTrajectory* trajectory =
+              trackManager->GetStoreTrajectory() == 0 ? nullptr : trackManager->GimmeTrajectory();
+          G4TrackVector* secondaries = trackManager->GimmeSecondaries();
+
+          switch (istop) {
+          case fStopButAlive:
+          case fSuspend:
+          case fSuspendAndWait:
+            stackManager->PushOneTrack(track, trajectory);
+            trajectory = nullptr;
+            eventManager->StackTracks(secondaries);
+            break;
+          case fPostponeToNextEvent:
+            stackManager->PushOneTrack(track);
+            eventManager->StackTracks(secondaries);
+            delete trajectory;
+            break;
+          case fStopAndKill:
+            eventManager->StackTracks(secondaries);
+            delete trajectory;
+            delete track;
+            break;
+          case fKillTrackAndSecondaries:
+            if (secondaries != nullptr) {
+              for (auto& secondary : *secondaries) {
+                delete secondary;
+              }
+              secondaries->clear();
+            }
+            delete trajectory;
+            delete track;
+            break;
+          default:
+            G4cerr << "+++ Geant4RegionSelectiveHepEmTrackingManager: unexpected track status from "
+                      "G4TrackingManager, killing track."
+                   << G4endl;
+            eventManager->StackTracks(secondaries);
+            delete trajectory;
+            delete track;
+            break;
+          }
+        }
+
+        bool fTrackInAllRegions;
+        std::unordered_set<G4int> fHepEmRegionIDs;
+        std::unique_ptr<G4HepEmTrackingManager> fHepEmTrackingManager;
+      };
+
+    }  // namespace
 
     /// DDG4 physics constructor that installs the G4HepEm vectorised EM tracking manager
     /**
@@ -97,12 +228,18 @@ namespace dd4hep {
 
       /// G4Region names in which Woodcock tracking is activated for photons
       std::vector<std::string> m_woodcockRegions;
+      /// G4Region names in which HepEm tracking manager is activated
+      std::vector<std::string> m_hepEmRegions;
+      /// Verbosity forwarded to the underlying G4HepEmTrackingManager
+      G4int m_verbosity;
 
     public:
       /// Standard constructor
       Geant4HepEmTrackingPhysics(Geant4Context* context, const std::string& nam)
         : Geant4PhysicsList(context, nam) {
         declareProperty("WoodcockRegions", m_woodcockRegions);
+        declareProperty("HepEmRegions", m_hepEmRegions);
+        declareProperty("VerboseLevel", m_verbosity = 0);
       }
 
       /// Default destructor
@@ -120,14 +257,47 @@ namespace dd4hep {
        * run teardown.
        */
       virtual void constructProcesses(G4VUserPhysicsList* /* physics_list */) override {
-        // Allocate one tracking manager for this thread.  G4HepEmTrackingManager
-        // handles e-/e+/gamma internally by dispatching on particle type, so one
-        // shared instance per thread suffices.  Ownership lies with Geant4.
-        auto* tm = new G4HepEmTrackingManager();
+        const bool trackInAllRegions = m_hepEmRegions.empty();
+        std::unordered_set<G4int> hepEmRegionIDs;
+        if (trackInAllRegions) {
+          info("+++ HepEm region selection: all regions");
+        } else {
+          for (const auto& regionName : m_hepEmRegions) {
+            G4Region* region = G4RegionStore::GetInstance()->GetRegion(regionName, false);
+            if (region == nullptr) {
+              warning("+++ HepEm region not found in G4RegionStore: %s", regionName.c_str());
+              continue;
+            }
+            hepEmRegionIDs.insert(region->GetInstanceID());
+            info("+++ HepEm enabled in G4Region: %s", regionName.c_str());
+          }
+          if (hepEmRegionIDs.empty()) {
+            warning("+++ No valid HepEmRegions were resolved; HepEm tracking will be disabled.");
+          }
+        }
+        const std::unordered_set<G4int> resolvedHepEmRegionIDs = hepEmRegionIDs;
 
+        auto* tm =
+            new Geant4RegionSelectiveHepEmTrackingManager(trackInAllRegions, std::move(hepEmRegionIDs), m_verbosity);
+
+        G4int configuredWoodcockRegions = 0;
         for (const auto& region : m_woodcockRegions) {
+          G4Region* woodcockRegion = G4RegionStore::GetInstance()->GetRegion(region, false);
+          if (woodcockRegion == nullptr) {
+            warning("+++ Woodcock region not found in G4RegionStore: %s", region.c_str());
+            continue;
+          }
+          if (!trackInAllRegions
+              && resolvedHepEmRegionIDs.find(woodcockRegion->GetInstanceID()) == resolvedHepEmRegionIDs.end()) {
+            warning("+++ Ignoring Woodcock region '%s': region is outside HepEmRegions selection", region.c_str());
+            continue;
+          }
           info("+++ Enabling Woodcock photon tracking in G4Region: %s", region.c_str());
           tm->GetConfig()->SetWoodcockTrackingRegion(region);
+          ++configuredWoodcockRegions;
+        }
+        if (!trackInAllRegions && !m_woodcockRegions.empty() && configuredWoodcockRegions == 0) {
+          warning("+++ No WoodcockRegions remain after applying HepEmRegions intersection.");
         }
 
         // Warn if another custom tracking manager is already installed —

--- a/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
+++ b/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
@@ -95,29 +95,29 @@ namespace dd4hep {
         Geant4RegionSelectiveHepEmTrackingManager(bool trackInAllRegions,
                                                   std::unordered_set<G4int> hepEmRegionIDs,
                                                   G4int verbose)
-          : fTrackInAllRegions(trackInAllRegions)
-          , fHepEmRegionIDs(std::move(hepEmRegionIDs))
-          , fHepEmTrackingManager(new G4HepEmTrackingManager(verbose)) {}
+          : m_trackInAllRegions(trackInAllRegions)
+          , m_hepEmRegionIDs(std::move(hepEmRegionIDs))
+          , m_hepEmTrackingManager(new G4HepEmTrackingManager(verbose)) {}
 
         virtual ~Geant4RegionSelectiveHepEmTrackingManager() = default;
 
-        G4HepEmConfig* GetConfig() { return fHepEmTrackingManager->GetConfig(); }
+        G4HepEmConfig* GetConfig() { return m_hepEmTrackingManager->GetConfig(); }
 
         void BuildPhysicsTable(const G4ParticleDefinition& part) override {
-          fHepEmTrackingManager->BuildPhysicsTable(part);
+          m_hepEmTrackingManager->BuildPhysicsTable(part);
         }
 
         void PreparePhysicsTable(const G4ParticleDefinition& part) override {
-          fHepEmTrackingManager->PreparePhysicsTable(part);
+          m_hepEmTrackingManager->PreparePhysicsTable(part);
         }
 
         void FlushEvent() override {
-          fHepEmTrackingManager->FlushEvent();
+          m_hepEmTrackingManager->FlushEvent();
         }
 
         void HandOverOneTrack(G4Track* aTrack) override {
           if (useHepEm(aTrack)) {
-            fHepEmTrackingManager->HandOverOneTrack(aTrack);
+            m_hepEmTrackingManager->HandOverOneTrack(aTrack);
             return;
           }
           trackWithGeant4(aTrack);
@@ -125,7 +125,7 @@ namespace dd4hep {
 
       private:
         bool useHepEm(const G4Track* aTrack) const {
-          if (fTrackInAllRegions) {
+          if (m_trackInAllRegions) {
             return true;
           }
           const G4VPhysicalVolume* volume = aTrack->GetVolume();
@@ -143,7 +143,7 @@ namespace dd4hep {
           if (region == nullptr) {
             return false;
           }
-          return fHepEmRegionIDs.find(region->GetInstanceID()) != fHepEmRegionIDs.end();
+          return m_hepEmRegionIDs.find(region->GetInstanceID()) != m_hepEmRegionIDs.end();
         }
 
         void trackWithGeant4(G4Track* track) {
@@ -197,9 +197,9 @@ namespace dd4hep {
           }
         }
 
-        bool fTrackInAllRegions;
-        std::unordered_set<G4int> fHepEmRegionIDs;
-        std::unique_ptr<G4HepEmTrackingManager> fHepEmTrackingManager;
+        bool m_trackInAllRegions;
+        std::unordered_set<G4int> m_hepEmRegionIDs;
+        std::unique_ptr<G4HepEmTrackingManager> m_hepEmTrackingManager;
       };
 
     }  // namespace

--- a/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
+++ b/DDG4/g4hepem/Geant4HepEmTrackingPhysics.cpp
@@ -23,8 +23,8 @@
  * while all other particles continue to use the default stepping loop.
  *
  * HepEm can be restricted to selected G4Region names via the HepEmRegions
- * property. If HepEmRegions is empty (default), HepEm applies in all regions.
- *
+ * property. If HepEmRegions is empty (default), HepEm applies in all regions; if
+ * non-empty but no regions are resolved, HepEm tracking is disabled (with a warning).
  * Woodcock tracking for photons can be enabled per G4Region via the
  * WoodcockRegions property.  Woodcock tracking allows photons to bypass
  * fine-grained geometry navigation (e.g. individual fibres in a ScFi


### PR DESCRIPTION
In using the G4HepEm plugin, we encountered a usability concern, namely that the G4Cerenkov process in our RICH detectors is also disabled for electrons (and positrons). This is a show stopper for us.

In this PR we add region selection to the G4HepEm plugin, by specifying the property HepEmRegions. A thin tracking manager wrapper is added before the G4HepEmTrackingManager to do the actual region selection.

Care is taken to avoid that WoodcockRegions and HepEmRegions are disjoint sets (i.e. warn the user when this is the case).

Note: we have to implement our own trackWithGeant4 since with a custom G4VTrackingManager this abstract base class does not cascade through to existing G4TrackingManager.

BEGINRELEASENOTES
- feat: add region selection for G4HepEm plugin

ENDRELEASENOTES