### PR TITLE
Speed up getting the magnetic field and the solenoid one in particular

### DIFF
--- a/DDCore/include/DD4hep/Fields.h
+++ b/DDCore/include/DD4hep/Fields.h
@@ -244,10 +244,8 @@ namespace dd4hep {
     /// Returns the 3  magnetic field components (x, y, z).
     void magneticField(const Position& pos, double* field) const;
 
-    /// Returns the 3  magnetic field components (x, y, z).
-    void magneticField(const double* pos, double* field) const   {
-      magneticField(Position(pos[0], pos[1], pos[2]), field);
-    }
+    /// Returns the 3 magnetic field components (x, y, z).
+    void magneticField(const double* pos, double* field) const;
 
     /// Returns the 3 magnetic field components (x, y, z).
     void magneticField(const double* pos, Direction& field) const {

--- a/DDCore/src/FieldTypes.cpp
+++ b/DDCore/src/FieldTypes.cpp
@@ -59,10 +59,10 @@ void SolenoidField::fieldComponents(const double* pos, double* field) {
   double z = pos[2] ;
   //  std::cout << " field z=" << z << " maxZ=" << maxZ << " minZ = " << minZ << std::endl ;
   if( z > minZ && z < maxZ ){
-    double radius = std::sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
-    if (radius < innerRadius)
+    const double radius2 = pos[0] * pos[0] + pos[1] * pos[1];
+    if (radius2 < innerRadius * innerRadius)
       field[2] += innerField;
-    else if (radius < outerRadius)
+    else if (radius2 < outerRadius * outerRadius)
       field[2] += outerField;
   }
 }

--- a/DDCore/src/Fields.cpp
+++ b/DDCore/src/Fields.cpp
@@ -28,6 +28,9 @@ namespace {
   void calculate_combined_field(std::vector<CartesianField>& v, const Position& pos, double* field) {
     for (const auto& i : v ) i.value(pos, field);
   }
+  void calculate_combined_field(std::vector<CartesianField>& v, const double* pos, double* field) {
+    for (const auto& i : v ) i.value(pos, field);
+  }
 }
 
 /// Default constructor
@@ -138,6 +141,12 @@ void OverlayedField::add(CartesianField field) {
 
 /// Returns the 3  magnetic field components (x, y, z).
 void OverlayedField::magneticField(const Position& pos, double* field) const   {
+  const double position[3] = {pos.X(), pos.Y(), pos.Z()};
+  magneticField(position, field);
+}
+
+/// Returns the 3 magnetic field components (x, y, z).
+void OverlayedField::magneticField(const double* pos, double* field) const   {
   if ( isValid() )   {
     field[0] = field[1] = field[2] = 0.0;
     auto* obj = data<Object>();

--- a/DDG4/src/Geant4Field.cpp
+++ b/DDG4/src/Geant4Field.cpp
@@ -24,8 +24,8 @@ G4bool Geant4Field::DoesFieldChangeEnergy() const {
 }
 
 void Geant4Field::GetFieldValue(const double pos[4], double *field) const {
-  static const double fac1 = units::mm/CLHEP::mm;
-  static const double fac2 = CLHEP::tesla/units::tesla;
+  static constexpr double fac1 = units::mm/CLHEP::mm;
+  static constexpr double fac2 = CLHEP::tesla/units::tesla;
   double p[3] = {pos[0]*fac1, pos[1]*fac1, pos[2]*fac1}; // Convert from CLHEP units to tgeo units
   field[0] = field[1] = field[2] = 0.0;                  // Reset field vector
   m_field.magneticField(p, field);


### PR DESCRIPTION
Originally in https://github.com/AIDASoft/DD4hep/pull/1587 (the first two changes below), with some benchmarks using SiD. Maybe other parts of https://github.com/AIDASoft/DD4hep/pull/1587 can also be useful. On performance there seems to be only one removal of `std::sqrt` for `DipoleField` and a check `isValid()` (probably without a large impact).

BEGINRELEASENOTES
- In `FieldTypes.cpp`, for the `SolenoidField`, use the square of the radius to compare to avoid calling `std::sqrt` many times. Saving the squares of the `innerRadius` and `outerRadius` seems not to change much. 
- In `Fields.h` and `Fields.cpp`, the calls to `magneticField` go through the `double *` overload, then the `Position` (`ROOT::Math::XYZVector`) overload, and then represented back to an array of doubles. The change is to make the `double *` overload be the main function, and the `Position` overload call this one instead of the opposite. The `double *` overload is the one called from `Geant4Field::GetFieldValue`: https://github.com/AIDASoft/DD4hep/blob/master/DDG4/src/Geant4Field.cpp#L31
- Use `static constexpr` with unit factors in `Geant4Field.cpp` (like it is done both in DD4hep and CLHEP units).

ENDRELEASENOTES

Both the first and second changes have a measurable impact:

```
# DD4hep master
$ ddsim --compactFile DDDetectors/compact/SiD.xml --runType batch --numberOfEvents 100 --enableGun --gun.particle e- --gun.energy '20*GeV' --outputFile /tmp/sid-gun.root  --random.seed 12345 
Wall time: 37.52
Per event: 0.371 s
# Do not use std::sqrt
$ ddsim --compactFile DDDetectors/compact/SiD.xml --runType batch --numberOfEvents 100 --enableGun --gun.particle e- --gun.energy '20*GeV' --outputFile /tmp/sid-gun.root  --random.seed 12345 
Wall time: 35.90
Per event: 0.355 s
# Do not use std::sqrt and don't create a `ROOT::Math::XYZVector` through the `double *` overload
$ ddsim --compactFile DDDetectors/compact/SiD.xml --runType batch --numberOfEvents 100 --enableGun --gun.particle e- --gun.energy '20*GeV' --outputFile /tmp/sid-gun.root  --random.seed 12345 
Wall time: 35.14
Per event: 0.347 s
```

I repeated the runs a few times and they are always ordered like this