### PR TITLE
Use double for smartless since Geant4 also uses double

### DIFF
--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -646,6 +646,7 @@ namespace dd4hep {
     bool isAssembly()   const;
 
     /// Set the smartless option for G4 voxelization. Returns previous value
+    double setSmartlessValue(double value);
     /// access the smartless option for G4 voxelization
     double smartlessValue()  const;
     

--- a/DDCore/include/DD4hep/Volumes.h
+++ b/DDCore/include/DD4hep/Volumes.h
@@ -321,7 +321,7 @@ namespace dd4hep {
     /// Reference to properties
     TList* properties  { nullptr };
     /// Geant4 optimization flag: Smartless
-    unsigned char       smartLess  = 0xFF;  // MUST match Volume::NO_SMARTLESS_OPTIMIZATION
+    double              smartLess  = 0xFF;  // MUST match Volume::NO_SMARTLESS_OPTIMIZATION
 
     /// Default destructor
     virtual ~VolumeExtension();
@@ -646,9 +646,8 @@ namespace dd4hep {
     bool isAssembly()   const;
 
     /// Set the smartless option for G4 voxelization. Returns previous value
-    unsigned char setSmartlessValue(unsigned char value);
     /// access the smartless option for G4 voxelization
-    unsigned char smartlessValue()  const;
+    double smartlessValue()  const;
     
     /// Set the volume's option value
     const Volume& setOption(const std::string& opt) const;

--- a/DDCore/src/Volumes.cpp
+++ b/DDCore/src/Volumes.cpp
@@ -725,15 +725,15 @@ bool Volume::isAssembly()   const   {
 }    
 
 /// Set the smartless option for G4 voxelization. Returns previous value
-unsigned char Volume::setSmartlessValue(unsigned char new_value)  {
+double Volume::setSmartlessValue(double new_value)  {
   Object* obj = _data(*this);
-  unsigned char tmp = obj->smartLess;
+  double tmp = obj->smartLess;
   obj->smartLess = new_value;
   return tmp;
 }
 
 /// access the smartless option for G4 voxelization
-unsigned char Volume::smartlessValue()  const  {
+double Volume::smartlessValue()  const  {
   return _data(*this)->smartLess;
 }
 

--- a/DDG4/examples/SiDSim.py
+++ b/DDG4/examples/SiDSim.py
@@ -54,7 +54,7 @@ def run():
   kernel.loadGeometry(str("file:" + install_dir + "/DDDetectors/compact/SiD.xml"))
 
   if args.smartless:
-    description.worldVolume().setSmartlessValue(int(args.smartless))
+    description.worldVolume().setSmartlessValue(float(args.smartless))
   DDG4.importConstants(description)
 
   geant4 = DDG4.Geant4(kernel, tracker='Geant4TrackerCombineAction')

--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -841,11 +841,11 @@ void* Geant4Converter::handleVolume(const std::string& name, const TGeoVolume* v
     }
     PrintLevel plevel = (debugVolumes||debugRegions||debugLimits) ? ALWAYS : outputLevel;
     /// Set smartless optimization
-    unsigned char smart_less_value = _v.smartlessValue();
+    double smart_less_value = _v.smartlessValue();
     if( smart_less_value != Volume::NO_SMARTLESS_OPTIMIZATION )  {
       printout(ALWAYS, "Geant4Converter",
-               "++ Volume %s Set Smartless value to %d",
-               vnam, int(smart_less_value));
+               "++ Volume %s Set Smartless value to %g",
+               vnam, smart_less_value);
       g4vol->SetSmartless( smart_less_value );
     }
     /// Assign limits if necessary

--- a/examples/ClientTests/src/DriftChamber_geo.cpp
+++ b/examples/ClientTests/src/DriftChamber_geo.cpp
@@ -56,8 +56,8 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
 
   /// The Geant4 voxelization change must be applied to the parent volume
   if ( x_dim.hasAttr(_U(option)) )  {
-    int value = x_dim.attr<int>(_U(option));
-    printout(ALWAYS, "DriftChamber", "+++ Setting smartlessValue to %d for %s",
+    double value = x_dim.attr<double>(_U(option));
+    printout(ALWAYS, "DriftChamber", "+++ Setting smartlessValue to %g for %s",
              value, sdet_vol.name());
     sdet_vol.setSmartlessValue(value);
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Use double for smartless since Geant4 also uses double, see https://github.com/Geant4/geant4/blob/f3d5293d384757b8a228a099898b2b87cfa4023c/source/geometry/management/include/G4LogicalVolume.icc#L207.

ENDRELEASENOTES

This should be backwards compatible since you can always represent an unsigned char in a double and viceversa takes the integer part.

Pointed out by @atolosadelgado 