### PR TITLE
DetectorSensitives: assign sensitive detector to reflected object if …

### DIFF
--- a/DDG4/plugins/Geant4DetectorSensitivesConstruction.cpp
+++ b/DDG4/plugins/Geant4DetectorSensitivesConstruction.cpp
@@ -12,6 +12,9 @@
 //
 //==========================================================================
 
+#include "G4ReflectionFactory.hh"
+#include "G4LogicalVolume.hh"
+
 // Framework include files
 #include <DDG4/Geant4DetectorConstruction.h>
 
@@ -80,6 +83,7 @@ Geant4DetectorSensitivesConstruction::~Geant4DetectorSensitivesConstruction() {
 
 /// Sensitive detector construction callback. Called at "ConstructSDandField()"
 void Geant4DetectorSensitivesConstruction::constructSensitives(Geant4DetectorConstructionContext* ctxt)   {
+  G4ReflectionFactory* reflFactory = G4ReflectionFactory::Instance();
   Geant4GeometryInfo* p = Geant4Mapping::instance().ptr();
   const Geant4Kernel& kernel = context()->kernel();
   const auto&         types  = kernel.sensitiveDetectorTypes();
@@ -97,6 +101,11 @@ void Geant4DetectorSensitivesConstruction::constructSensitives(Geant4DetectorCon
                nam.c_str(), typ.c_str());
       }
       ctxt->setSensitiveDetector(g4v, g4sd);
+      //logical volume has a reflected counterpart
+      if(reflFactory->IsConstituent(g4v)) {
+        auto* g4refl = reflFactory->GetReflectedLV(g4v);
+        ctxt->setSensitiveDetector(g4refl, g4sd);
+      }
     }
   }
   print("+++ Handled %ld sensitive detectors.",p->sensitives.size());


### PR DESCRIPTION
…the logical volume was sensitive

BEGINRELEASENOTES
- DDG4: DetectorSensitives: assign sensitive detector to reflected object if the original logical volume was sensitive, fixes #1650 

ENDRELEASENOTES

So the G4ReflectionFactory

https://github.com/AIDASoft/DD4hep/blob/8e15ffeef91c2674a0d1bbd158949c4397c3d3de/DDG4/src/Geant4Converter.cpp#L1164-L1170

Creates a new G4LogicalVolume (...+"_refl"), but we only assign the sensitive detector to the original logical volume. And here in that conversion we have not yet assigned the sensitive detector to the logical volume, so we cannot just copy it over from the original LogicalVolume.

@MarkusFrankATcernch : is there a more sensible way of doing this without checking the reflectionfactory for all entries? Although that maybe is a small number of reflected logical volumes, so the overhead is small?