### PR TITLE
Fix a compiler warning in Geant4Converter.cpp

### DIFF
--- a/DDG4/src/Geant4Converter.cpp
+++ b/DDG4/src/Geant4Converter.cpp
@@ -841,8 +841,8 @@ void* Geant4Converter::handleVolume(const std::string& name, const TGeoVolume* v
     }
     PrintLevel plevel = (debugVolumes||debugRegions||debugLimits) ? ALWAYS : outputLevel;
     /// Set smartless optimization
-    double smart_less_value = _v.smartlessValue();
-    if( smart_less_value != Volume::NO_SMARTLESS_OPTIMIZATION )  {
+    auto smart_less_value = _v.smartlessValue();
+    if (smart_less_value != static_cast<decltype(smart_less_value)>(Volume::NO_SMARTLESS_OPTIMIZATION)) {
       printout(ALWAYS, "Geant4Converter",
                "++ Volume %s Set Smartless value to %g",
                vnam, smart_less_value);


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a compiler warning comparing a `double` to an enum 

ENDRELEASENOTES

The warning (Clang 22):
```
/DD4hep/DDG4/src/Geant4Converter.cpp:845:26 warning: comparison of floating-point type 'double' with enumeration type 'dd4hep::Volume::g4_optimizations' is deprecated [-Wdeprecated-enum-float-conversion].
  845 |     if( smart_less_value != Volume::NO_SMARTLESS_OPTIMIZATION )  {
      |         ~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```