### PR TITLE
Removed .py extension from the g4PolarAngleScan help text

### DIFF
--- a/DDG4/python/bin/g4PolarAngleScan.py
+++ b/DDG4/python/bin/g4PolarAngleScan.py
@@ -50,7 +50,7 @@ parser = argparse.ArgumentParser(
         by Poissonian fluctuations. Mitigated by the script slightly by using Halton sequence for gun.
 
         Example:
-          g4PolarAngleScan.py \\
+          g4PolarAngleScan \\
               -c myDetector.xml \\
               -o materialScan.root \\
               --angleDef theta --minValue 10 --maxValue 170 -b 2 \\


### PR DESCRIPTION

BEGINRELEASENOTES
- `g4PolarAngleScan` documentation update

ENDRELEASENOTES

A colleague notified me that the help text contains the `.py` extension for running the `g4PolarAngleScan` command, which should not be there.
