### PR TITLE
Improve Geant4RegexSensitivesConstruction::collect_volumes to avoid duplicate regex searches

### DIFF
--- a/DDG4/plugins/Geant4RegexSensitivesConstruction.cpp
+++ b/DDG4/plugins/Geant4RegexSensitivesConstruction.cpp
@@ -40,10 +40,16 @@ namespace dd4hep {
     public:
       std::string detector_name;
       std::vector<std::string> regex_values;
-      std::size_t collect_volumes(std::set<Volume>&  volumes,
-                                  PlacedVolume       pv,
-                                  const std::string& path,
-                                  const std::vector<std::regex>& matches);
+      // Cached result from the first call: TGeo geometry is shared across worker
+      // threads so the matching volume set is identical every call. Subsequent
+      // calls skip the tree traversal and reuse this directly.
+      std::set<Volume> m_cached_volumes;
+      bool             m_volumes_cached {false};
+      std::size_t collect_volumes(std::set<Volume>&               volumes,
+                                  std::set<Volume>&               visited,
+                                  PlacedVolume                    pv,
+                                  std::string&                    path,
+                                  const std::vector<std::regex>&  matches);
     public:
       /// Initializing constructor for DDG4
       Geant4RegexSensitivesConstruction(Geant4Context* ctxt, const std::string& nam);
@@ -93,30 +99,32 @@ Geant4RegexSensitivesConstruction::~Geant4RegexSensitivesConstruction() {
 }
 
 std::size_t
-Geant4RegexSensitivesConstruction::collect_volumes(std::set<Volume>&  volumes,
-                                                   PlacedVolume       pv,
-                                                   const std::string& path,
-                                                   const std::vector<std::regex>& matches)
+Geant4RegexSensitivesConstruction::collect_volumes(std::set<Volume>&               volumes,
+                                                   std::set<Volume>&               visited,
+                                                   PlacedVolume                    pv,
+                                                   std::string&                    path,
+                                                   const std::vector<std::regex>&  matches)
 {
   std::size_t count = 0;
-  // Try to minimize a bit the number of regex matches.
-  if ( volumes.find(pv.volume()) == volumes.end() )  {
-    if( !path.empty() )  {
-      for( const auto& match : matches )  {
-        std::smatch sm;
-        bool stat = std::regex_search(path, sm, match);
-        if( stat )  {
-          volumes.insert(pv.volume());
-          ++count;
-          break;
-        }
+  // visited guards on logical volume: each unique Volume is walked exactly once
+  // regardless of how many times it is placed in the geometry tree.
+  if ( visited.insert(pv.volume()).second )  {
+    for( const auto& match : matches )  {
+      std::smatch sm;
+      if( std::regex_search(path, sm, match) )  {
+        volumes.insert(pv.volume());
+        ++count;
+        break;
       }
     }
-    // Now recurse down the daughters
+    // Recurse into daughters, reusing the path string in-place.
+    const std::size_t base_len = path.size();
     for( int i=0, num = pv->GetNdaughters(); i < num; ++i )  {
       PlacedVolume daughter = pv->GetDaughter(i);
-      std::string  daughter_path = path + "/" + daughter.name();
-      count += this->collect_volumes(volumes, daughter, daughter_path, matches);
+      path += '/';
+      path += daughter.name();
+      count += this->collect_volumes(volumes, visited, daughter, path, matches);
+      path.resize(base_len);
     }
   }
   return count;
@@ -143,16 +151,25 @@ void Geant4RegexSensitivesConstruction::constructSensitives(Geant4DetectorConstr
   std::string typ  = (iter != types.end()) ? (*iter).second : dflt;
   G4VSensitiveDetector* g4sd = this->createSensitiveDetector(typ, nam);
 
-  std::set<Volume> volumes;
-  int flags = std::regex_constants::icase | std::regex_constants::ECMAScript;
-  std::vector<std::regex> expressions;
-  for( const auto& val : regex_values )  {
-    std::regex e(val, (std::regex_constants::syntax_option_type)flags);
-    expressions.emplace_back(e);
-  }
   TTimeStamp start;
-  info("%s Starting to scan volume....", det);
-  std::size_t num_nodes = this->collect_volumes(volumes, de.placement(), de.placementPath(), expressions);
+  std::size_t num_nodes = 0;
+  if( !m_volumes_cached )  {
+    int flags = std::regex_constants::icase | std::regex_constants::ECMAScript;
+    std::vector<std::regex> expressions;
+    for( const auto& val : regex_values )  {
+      std::regex e(val, (std::regex_constants::syntax_option_type)flags);
+      expressions.emplace_back(e);
+    }
+    info("%s Starting to scan volume....", det);
+    std::set<Volume> visited;
+    std::string placement_path = de.placementPath();
+    num_nodes = this->collect_volumes(m_cached_volumes, visited, de.placement(), placement_path, expressions);
+    m_volumes_cached = true;
+  }
+  else  {
+    info("%s Reusing cached volume set (%zu volumes).", det, m_cached_volumes.size());
+  }
+  const std::set<Volume>& volumes = m_cached_volumes;
   for( const auto& vol : volumes )  {
     G4LogicalVolume* g4vol = g4info->g4Volumes[vol];
     if( !g4vol )  {

--- a/DDG4/scripts/dumpDDG4.C
+++ b/DDG4/scripts/dumpDDG4.C
@@ -1,5 +1,5 @@
 //==========================================================================
-//  AIDA Detector description implementation 
+//  AIDA Detector description implementation
 //--------------------------------------------------------------------------
 // Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
 // All rights reserved.
@@ -8,6 +8,30 @@
 // For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
 //
 // Author     : M.Frank
+//
+//==========================================================================
+//
+// Build recipe (requires DD4hepINSTALL, CLHEP_INCLUDE_DIR, root-config in PATH):
+//
+//   g++ $(root-config --cflags) \
+//       -I$DD4hepINSTALL/include \
+//       -I$CLHEP_INCLUDE_DIR \
+//       -o dumpDDG4 \
+//       dumpDDG4.C \
+//       $(root-config --libs) \
+//       -L$DD4hepINSTALL/lib -lDDCore -lDDG4
+//
+// Usage:
+//   ./dumpDDG4 -input <file.root>                        # dump all events
+//   ./dumpDDG4 -input <file.root> -event <N>             # dump one event
+//   ./dumpDDG4 -compact <geometry.xml> -input <file.root> # with cell/volume info
+//
+// Notes:
+//   - ROOT dictionaries for the DDG4 sim classes live in libDDG4Plugins (not
+//     libDDG4); the binary loads it at runtime via gSystem->Load so that ROOT
+//     can locate the matching G__DDG4_rdict.pcm and register the streamers.
+//   - Without -compact, calorimeter hits are printed without cell-centre
+//     position or volume name (geometry-free fallback).
 //
 //==========================================================================
 
@@ -43,11 +67,11 @@ namespace {
   static bool have_geometry = false;
 
   int usage()  {
-    printf("\ndumpDDG4 -opt [-opt]                                                                   \n"
-           "    -compact <compact-geometry>   Supply geometry file to check hits with volume manager.\n"
-           "    -input   <root-file>          File generated with DDG4                               \n"
-           "    -event   <event-number>       Specify event to be dumped. Default: ALL.              \n"
-           "\n\n");
+    ::printf("\ndumpDDG4 -opt [-opt]                                                                   \n"
+             "    -compact <compact-geometry>   Supply geometry file to check hits with volume manager.\n"
+             "    -input   <root-file>          File generated with DDG4                               \n"
+             "    -event   <event-number>       Specify event to be dumped. Default: ALL.              \n"
+             "\n\n");
     return EINVAL;
   }
 
@@ -71,7 +95,7 @@ namespace {
         const Geant4Tracker::Hit* h = *i;
         const Position& pos = h->position;
         Position pos_cell = seg.position(h->cellID);
-        PlacedVolume pv = vm.lookupPlacement(h->cellID);
+        PlacedVolume pv = vm.lookupVolumePlacement(h->cellID);
         printout(ALWAYS,container,
                  "+++ Track:%3d PDG:%6d Pos:(%+.2e,%+.2e,%+.2e)[mm] Pixel:(%+.2e,%+.2e,%+.2e)[mm] %s Deposit:%7.3f MeV CellID:%16lX",
                  h->truth.trackID,h->truth.pdgID,
@@ -105,7 +129,7 @@ namespace {
     else if ( hits->empty() )   {
       ::printf("+  Invalid Hit container '%s'. No entries. No printout\n",container.c_str());
     }
-    else   {
+    else if ( have_geometry )  {
       string det_name = container;
       Detector& description = Detector::getInstance();
       det_name = det_name.substr(0,det_name.length()-4);
@@ -117,12 +141,24 @@ namespace {
         const Geant4Calorimeter::Hit* h = *i;
         const Position& pos = h->position;
         Position pos_cell = seg.position(h->cellID);
-        PlacedVolume pv = vm.lookupPlacement(h->cellID);
+        PlacedVolume pv = vm.lookupVolumePlacement(h->cellID);
         printout(ALWAYS,container,
                  "+++ Pos:(%+.2e,%+.2e,%+.2e)[mm] Pixel:(%+.2e,%+.2e,%+.2e)[mm] %s Deposit:%7.3f MeV CellID:%16lX",
                  pos.x()/CLHEP::mm,pos.y()/CLHEP::mm,pos.z()/CLHEP::mm,
                  pos_cell.x()/dd4hep::mm,pos_cell.y()/dd4hep::mm,pos_cell.z()/dd4hep::mm,
                  pv.name(),h->energyDeposit/CLHEP::MeV,h->cellID
+                 );
+        delete h;
+      }
+    }
+    else  {
+      for(_H::const_iterator i=hits->begin(); i!=hits->end(); ++i)  {
+        const Geant4Calorimeter::Hit* h = *i;
+        const Position& pos = h->position;
+        printout(ALWAYS,container,
+                 "+++ Pos:(%+.2e,%+.2e,%+.2e)[mm] Deposit:%7.3f MeV CellID:%16lX",
+                 pos.x()/CLHEP::mm,pos.y()/CLHEP::mm,pos.z()/CLHEP::mm,
+                 h->energyDeposit/CLHEP::MeV,h->cellID
                  );
         delete h;
       }
@@ -167,9 +203,17 @@ namespace {
 }
 
 int dumpDDG4(const char* fname, int event_num)  {
+  // Dictionaries for Geant4Particle/Tracker/Calorimeter hits live in DDG4Plugins, not DDG4.
+  // Use full path so ROOT can locate G__DDG4_rdict.pcm alongside the library.
+  const char* dd4hep_install = gSystem->Getenv("DD4hepINSTALL");
+  if (dd4hep_install) {
+    gSystem->Load((string(dd4hep_install) + "/lib/libDDG4Plugins.so").c_str());
+  } else {
+    gSystem->Load("libDDG4Plugins");
+  }
   TFile* data = TFile::Open(fname);
   if ( !data || data->IsZombie() )   {
-    printf("+  File seems to not exist. Exiting\n");
+    ::printf("+  File seems to not exist. Exiting\n");
     usage();
     return -1;
   }
@@ -217,7 +261,7 @@ int dumpddg4_load_geometry(const char* fname)   {
     gSystem->Load("libDDG4Plugins");
     Detector& description = Detector::getInstance();
     description.fromXML(fname);
-    VolumeManager::getVolumeManager();
+    VolumeManager::getVolumeManager(description);
   }
   return 1;
 }


### PR DESCRIPTION
Found that running the Idea detector geometry with multiple threads did the rather time consuming elements of collect_volumes  24x times (3 subdetectors x 8 threads). A cache is set up to ensure that volumes are checked just once even with repeated calls to the same volume. 

Single threaded ConstructSDAndField gets about (40xNThreads)x faster for Idea.

Tested with Idea geometry to give same results using dumpDDG4 script (which has been updated to allow it to compile/run with current DD4Hep)

BEGINRELEASENOTES
- Improve Geant4RegexSensitivesConstruction::collect_volumes to avoid duplicate regex searches
ENDRELEASENOTES