### PR TITLE
feat: honor DD4HEP_LIBRARY_PATH for plugin search

### DIFF
--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -31,11 +31,6 @@ def loadDDG4():
 
   import platform
   import os
-  if platform.system() == "Darwin":
-    gSystem.SetDynamicPath(os.environ['DD4HEP_LIBRARY_PATH'])
-    os.environ['DYLD_LIBRARY_PATH'] = os.pathsep.join([os.environ['DD4HEP_LIBRARY_PATH'],
-                                                       os.environ.get('DYLD_LIBRARY_PATH', '')]).strip(os.pathsep)
-
   result = gSystem.Load("libDDG4Plugins")
   if result < 0:
     raise Exception('DDG4.py: Failed to load the DDG4 library libDDG4Plugins: ' + gSystem.GetErrorStr())

--- a/DDG4/python/DDG4.py
+++ b/DDG4/python/DDG4.py
@@ -29,8 +29,6 @@ def loadDDG4():
     gSystem.Load("libglapi")
     ROOT.gErrorIgnoreLevel = orgLevel
 
-  import platform
-  import os
   result = gSystem.Load("libDDG4Plugins")
   if result < 0:
     raise Exception('DDG4.py: Failed to load the DDG4 library libDDG4Plugins: ' + gSystem.GetErrorStr())

--- a/GaudiPluginService/src/PluginServiceV1.cpp
+++ b/GaudiPluginService/src/PluginServiceV1.cpp
@@ -155,8 +155,14 @@ namespace Gaudi {
           const char* envVar = "LD_LIBRARY_PATH";
           const char  sep    = ':';
 #endif
-          char* search_path = ::getenv( envVar );
-          logger().debug( std::string( "searching factories in " ) + envVar );
+          char* search_path = ::getenv( "DD4HEP_LIBRARY_PATH" );
+          if ( !search_path ) {
+            // Fall back to system-specific library path
+            search_path = ::getenv( envVar );
+            if ( search_path ) logger().debug( std::string( "searching factories in " ) + envVar );
+          } else {
+            logger().debug( "searching factories in DD4HEP_LIBRARY_PATH" );
+          }
           std::string path = search_path ? std::string(search_path) : "/usr/lib64:/usr/lib:/usr/local/lib";
           std::string::size_type pos    = 0;
           std::string::size_type newpos = 0;

--- a/GaudiPluginService/src/PluginServiceV2.cpp
+++ b/GaudiPluginService/src/PluginServiceV2.cpp
@@ -150,13 +150,19 @@ namespace Gaudi {
           std::smatch matches;
 
           std::string search_path;
-          const char* envPtr = std::getenv( envVar.c_str() );
+          const char* envPtr = std::getenv( "DD4HEP_LIBRARY_PATH" );
+          if ( !envPtr ) {
+            // Fall back to system-specific library path
+            envPtr = std::getenv( envVar.c_str() );
+            if ( envPtr ) logger().debug("searching factories in " + envVar);
+          } else {
+            logger().debug("searching factories in DD4HEP_LIBRARY_PATH");
+          }
           search_path = envPtr ? envPtr : "/usr/lib64:/usr/lib:/usr/local/lib";
           if ( search_path.empty() ) {
             return;
           }
 
-          logger().debug("searching factories in " + envVar);
           logger().debug("searching factories in " + search_path);
 
           std::vector<std::string> directories;

--- a/cmake/thisdd4hep.sh
+++ b/cmake/thisdd4hep.sh
@@ -114,8 +114,6 @@ dd4hep_add_path ROOT_INCLUDE_PATH ${THIS}/include;
 if [ @APPLE@ ];
 then
     export DD4HEP_LIBRARY_PATH=${DYLD_LIBRARY_PATH};
-else
-    export DD4HEP_LIBRARY_PATH=${LD_LIBRARY_PATH};
 fi;
 #-----------------------------------------------------------------------------
 #

--- a/cmake/thisdd4hep_only.sh
+++ b/cmake/thisdd4hep_only.sh
@@ -79,8 +79,6 @@ dd4hep_add_path ROOT_INCLUDE_PATH ${THIS}/include;
 if [ @APPLE@ ];
 then
     export DD4HEP_LIBRARY_PATH=${DYLD_LIBRARY_PATH};
-else
-    export DD4HEP_LIBRARY_PATH=${LD_LIBRARY_PATH};
 fi;
 #-----------------------------------------------------------------------------
 #


### PR DESCRIPTION
Plugins are currently searched for in (DY)LD_LIBRARY_PATH or PATH, depending on the system. These are environment variables with many uses beyond DD4hep and in some cases you may not want to add DD4hep plugins to them (or the directory which contains the plugins, which could be a lot more generic).

By introducing a dedicated DD4hep-only variable `DD4HEP_LIBRARY_PATH`, those who wish to keep their plugins away from other programs can now do so.

Backwards compatibility: if you do not define `DD4HEP_LIBRARY_PATH`, the previous system-specific variables are used. When both are defined, `DD4HEP_LIBRARY_PATH` has priority and must contain all necessary plugins. If you have plugins that rely on finding other e.g. system libraries, and you are not using rpath linking, then you may need to experiment a bit but likely only need the plugin directory in `DD4HEP_LIBRARY_PATH` (I don't have a test case for this).

This follows the modern ROOT approach, where `ROOT_LIBRARY_PATH` is now available.

BEGINRELEASENOTES
- feat: honor DD4HEP_LIBRARY_PATH for plugin search

ENDRELEASENOTES