### PR TITLE
remove redundant calculations from i_collect and scanPhysicalVolume 

### DIFF
--- a/DDCore/src/GeoHandler.cpp
+++ b/DDCore/src/GeoHandler.cpp
@@ -147,6 +147,13 @@ detail::GeoHandler& detail::GeoHandler::i_collect(const TGeoNode* /* parent */,
                                                   const TGeoNode*    current,
                                                   int level, Region rg, LimitSet ls)
 {
+  /// Early-exit if this node has already been collected at this level.
+  /// Daughters of a TGeoVolume are the same TGeoNode pointers for every placement of
+  /// that volume; without this guard the subtree would be traversed once per placement
+  /// (N times for a volume placed N times) with all but the first producing no output.
+  if ( !(*m_set_data)[level].emplace(current).second )
+    return *this;
+
   TGeoVolume* vol    = current->GetVolume();
   TObjArray*  nodes  = vol->GetNodes();
   Volume      volume = vol;
@@ -163,11 +170,7 @@ detail::GeoHandler& detail::GeoHandler::i_collect(const TGeoNode* /* parent */,
       volume.setLimitSet(limits);
     }
   }
-  /// Collect the hierarchy of placements
-  /// perform lookup using std::set::emplace (faster than std::find for very large number of volumes)
-  if ( (*m_set_data)[level].emplace(current).second ) {
-    (*m_data)[level].push_back(current);
-  }
+  (*m_data)[level].push_back(current);
   int num = nodes ? nodes->GetEntriesFast() : 0;
   for (int i = 0; i < num; ++i)
     i_collect(current, (TGeoNode*)nodes->At(i), level + 1, region, limits);

--- a/DDCore/src/VolumeManager.cpp
+++ b/DDCore/src/VolumeManager.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <sstream>
 #include <iomanip>
+#include <unordered_map>
 
 using namespace dd4hep;
 using namespace dd4hep::detail;
@@ -52,6 +53,8 @@ namespace dd4hep {
       VolumeManager      m_volManager;
       /// Set of already added entries
       std::set<VolumeID> m_entries;
+      /// Cache: does a TGeoVolume subtree contain any sensitive volume?
+      std::unordered_map<TGeoVolume*, bool> m_has_sensitive;
       /// Debug flag
       bool               m_debug    = false;
       /// Node counter
@@ -67,6 +70,19 @@ namespace dd4hep {
 
       /// Access node count
       size_t numNodes()  const  {   return m_numNodes;  }
+
+      /// Returns true if vol or any descendant is a sensitive volume (result is cached).
+      bool hasSensitiveContent(TGeoVolume* vol) {
+        auto [it, inserted] = m_has_sensitive.emplace(vol, false);
+        if ( !inserted ) return it->second;
+        if ( Volume(vol).isSensitive() ) return it->second = true;
+        for ( Int_t i = 0, n = vol->GetNdaughters(); i < n; ++i ) {
+          TGeoNode* dau = vol->GetNode(i);
+          if ( PlacedVolume(dau).data() && hasSensitiveContent(dau->GetVolume()) )
+            return it->second = true;
+        }
+        return false;
+      }
 
       /// Populate the Volume manager
       void populate(DetElement e) {
@@ -135,23 +151,25 @@ namespace dd4hep {
             TGeoNode* daughter = node->GetDaughter(idau);
             PlacedVolume placement(daughter);
             if ( placement.data() ) {
-              PlacedVolume pv_dau(daughter);
-              DetElement   de_dau;
-              /// Check if this particular volume is the placement of one of the
-              /// children of this detector element. If the daughter placement is also
-              /// a detector child, then we must reset the node chain.
-              for( const auto& de : e.children() )  {
-                if ( de.second.placement().ptr() == daughter )  {
-                  de_dau = de.second;
-                  break;
+              if ( hasSensitiveContent(daughter->GetVolume()) ) {
+                PlacedVolume pv_dau(daughter);
+                DetElement   de_dau;
+                /// Check if this particular volume is the placement of one of the
+                /// children of this detector element. If the daughter placement is also
+                /// a detector child, then we must reset the node chain.
+                for( const auto& de : e.children() )  {
+                  if ( de.second.placement().ptr() == daughter )  {
+                    de_dau = de.second;
+                    break;
+                  }
                 }
-              }
-              if ( de_dau.isValid() ) {
-                Chain dau_chain;
-                count += scanPhysicalVolume(parent, de_dau, pv_dau, vol_encoding, sd, dau_chain);
-              }
-              else {
-                count += scanPhysicalVolume(parent, e, pv_dau, vol_encoding, sd, chain);
+                if ( de_dau.isValid() ) {
+                  Chain dau_chain;
+                  count += scanPhysicalVolume(parent, de_dau, pv_dau, vol_encoding, sd, dau_chain);
+                }
+                else {
+                  count += scanPhysicalVolume(parent, e, pv_dau, vol_encoding, sd, chain);
+                }
               }
             }
             else  {

--- a/DDG4/include/DDG4/Geant4Particle.h
+++ b/DDG4/include/DDG4/Geant4Particle.h
@@ -26,6 +26,7 @@ class G4VProcess;
 // C/C++ include files
 #include <set>
 #include <map>
+#include <unordered_map>
 #include <vector>
 #include <memory>
 
@@ -338,8 +339,8 @@ namespace dd4hep {
     class Geant4ParticleMap  {
     public:
       typedef Geant4Particle          Particle;
-      typedef std::map<int,Particle*> ParticleMap;
-      typedef std::map<int,int>       TrackEquivalents;
+      typedef std::map<int,Particle*>         ParticleMap;
+      typedef std::unordered_map<int,int>    TrackEquivalents;
       /// Mapping of particles of this event
       ParticleMap particleMap; //! not persistent
       /// Map associating the G4Track identifiers with identifiers of existing MCParticles

--- a/DDG4/src/Geant4ParticleHandler.cpp
+++ b/DDG4/src/Geant4ParticleHandler.cpp
@@ -425,15 +425,27 @@ void Geant4ParticleHandler::end(const G4Track* track)   {
     int pid = m_currTrack.g4Parent;
     m_equivalentTracks[g4_id] = pid;
     // Need to find the last stored particle and OR this particle's mask
-    // with the mask of the last stored particle
+    // with the mask of the last stored particle.
+    // Walk up the equivalent-track chain to find the nearest kept ancestor.
     auto iend = m_equivalentTracks.end(), iequiv=m_equivalentTracks.end();
+    const int start_pid = pid;
     ParticleMap::iterator ip;
     for(ip=m_particleMap.find(pid); ip == m_particleMap.end(); ip=m_particleMap.find(pid))  {
       if (iequiv=m_equivalentTracks.find(pid); iequiv == iend) break;  // ERROR
       pid = (*iequiv).second;
     }
-    if ( ip != m_particleMap.end() )
+    // Path compression: point all intermediate entries directly to the root pid,
+    // so future walks from nearby tracks are O(1) instead of O(chain length).
+    if ( ip != m_particleMap.end() )  {
+      for(int compress=start_pid; compress != pid; )  {
+        auto it = m_equivalentTracks.find(compress);
+        if(it == iend) break;
+        int next = it->second;
+        it->second = pid;
+        compress = next;
+      }
       (*ip).second->reason |= track_reason;
+    }
     else
       ph.dumpWithVertex(outputLevel()+3,name(),"FATAL: No real particle parent present");
   }

--- a/DDG4/src/Geant4VolumeManager.cpp
+++ b/DDG4/src/Geant4VolumeManager.cpp
@@ -31,6 +31,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -91,6 +92,8 @@ namespace  {
     Geant4GeometryInfo& m_geo;
     /// Debug flag for population
     long                m_debug { 0 };
+    /// Per-volume cache: does this volume's subtree contain any dd4hep-sensitive volumes?
+    std::unordered_map<TGeoVolume*, bool> m_has_sensitive;
     
     /// Default constructor
     Populator(const Detector& description, Geant4GeometryInfo& g, long dbg)
@@ -126,7 +129,7 @@ namespace  {
           PlacedVolume::VolIDs ids;
           m_entries.clear();
           chain.emplace_back(m_detDesc.world().placement().ptr());
-          scanPhysicalVolume(pv.ptr(), std::move(ids), sd, chain);
+          scanPhysicalVolume(pv.ptr(), ids, sd, chain);
           continue;
         }
         printout(WARNING, "Geant4VolumeManager",
@@ -143,13 +146,28 @@ namespace  {
       m_entries.clear();
     }
 
+    /// Returns true if vol or any dd4hep-instrumented descendant is sensitive.
+    /// Result is cached per-volume so each volume is checked at most once.
+    bool hasSensitiveContent(TGeoVolume* vol) {
+      auto [it, inserted] = m_has_sensitive.emplace(vol, false);
+      if ( !inserted ) return it->second;
+      if ( Volume(vol).isSensitive() ) return it->second = true;
+      for ( Int_t i = 0, n = vol->GetNdaughters(); i < n; ++i ) {
+        TGeoNode* dau = vol->GetNode(i);
+        if ( PlacedVolume(dau).data() && hasSensitiveContent(dau->GetVolume()) )
+          return it->second = true;
+      }
+      return false;
+    }
+
     /// Scan a single physical volume and look for sensitive elements below
-    void scanPhysicalVolume(const TGeoNode* node, PlacedVolume::VolIDs ids, SensitiveDetector& sd, Chain& chain) {
+    void scanPhysicalVolume(const TGeoNode* node, PlacedVolume::VolIDs& ids, SensitiveDetector& sd, Chain& chain) {
       PlacedVolume pv = node;
       Volume       vol = pv.volume();
-      PlacedVolume::VolIDs pv_ids = pv.volIDs();
+      const PlacedVolume::VolIDs& pv_ids = pv.volIDs();
 
       chain.emplace_back(node);
+      const std::size_t ids_save = ids.size();
       ids.PlacedVolume::VolIDs::Base::insert(ids.end(), pv_ids.begin(), pv_ids.end());
       if( vol.isSensitive() )  {
         sd = vol.sensitiveDetector();
@@ -165,10 +183,11 @@ namespace  {
       for( Int_t idau = 0, ndau = node->GetNdaughters(); idau < ndau; ++idau )  {
         TGeoNode* daughter = node->GetDaughter(idau);
         PlacedVolume placement(daughter);
-        if( placement.data() ) {
+        if( placement.data() && hasSensitiveContent(daughter->GetVolume()) ) {
           scanPhysicalVolume(daughter, ids, sd, chain);
         }
       }
+      ids.resize(ids_save);
       chain.pop_back();
     }
 


### PR DESCRIPTION
Found that considerable time for idea geometry was going into 

::Populator::scanPhysicalVolume
dd4hep::detail::VolumeManager_Populator::scanPhysicalVolume
dd4hep::detail::GeoHandler::i_collect

This PR reduces that considerably by removing duplicate calculations by caching some results.


BEGINRELEASENOTES
- remove redundant calculations from i_collect and scanPhysicalVolume 
ENDRELEASENOTES