### PR TITLE
DDG4: catch primaries outside the world volume

### DIFF
--- a/DDG4/include/DDG4/Geant4PrimaryHandler.h
+++ b/DDG4/include/DDG4/Geant4PrimaryHandler.h
@@ -45,6 +45,8 @@ namespace dd4hep {
       /// for these particles the decay time is chosen by Geant4 according to the lifetime configured instead of what is
       /// assigned in the MC generator
       std::set<int> m_decayByGeant = {};
+      /// drop primaries outside the world instead of aborting
+      bool m_skipParticlesOutsideWorldVolume = false;
 
       std::string toString() const {
         std::stringstream str;
@@ -54,6 +56,7 @@ namespace dd4hep {
         for (int i: m_zeroTimePDGs) { str << i << ", "; }
         str << "\nDecayByGeant: ";
         for (int i: m_decayByGeant) { str << i << ", "; }
+        str << "\nSkipParticlesOutsideWorldVolume: " << (m_skipParticlesOutsideWorldVolume ? "true" : "false");
         return str.str();
       }
     };

--- a/DDG4/include/DDG4/Geant4PrimaryHandler.h
+++ b/DDG4/include/DDG4/Geant4PrimaryHandler.h
@@ -56,7 +56,7 @@ namespace dd4hep {
         for (int i: m_zeroTimePDGs) { str << i << ", "; }
         str << "\nDecayByGeant: ";
         for (int i: m_decayByGeant) { str << i << ", "; }
-        str << "\nSkipParticlesOutsideWorldVolume: " << (m_skipParticlesOutsideWorldVolume ? "true" : "false");
+        str << "\nSkipParticlesOutsideWorldVolume: " << std::boolalpha << m_skipParticlesOutsideWorldVolume;
         return str.str();
       }
     };

--- a/DDG4/python/DDSim/DD4hepSimulation.py
+++ b/DDG4/python/DDSim/DD4hepSimulation.py
@@ -927,6 +927,7 @@ class DD4hepSimulation(object):
       gen.RejectPDGs = ConfigHelper.makeString(self.physics.rejectPDGs)
       gen.ZeroTimePDGs = ConfigHelper.makeString(self.physics.zeroTimePDGs)
       gen.DecayByGeant = ConfigHelper.makeString(self.physics.decayByGeant)
+      gen.SkipParticlesOutsideWorldVolume = self.physics.skipParticlesOutsideWorldVolume
       gen.enableUI()
       if output_level is not None:
         gen.OutputLevel = output_level

--- a/DDG4/python/DDSim/Helper/Physics.py
+++ b/DDG4/python/DDSim/Helper/Physics.py
@@ -48,6 +48,10 @@ class Physics(ConfigHelper):
     self._alternativeDecayStatuses = set()
     self._alternativeStableStatuses = set()
     self._userFunctions = []
+    self._skipParticlesOutsideWorldVolume_EXTRA = {
+        "help": "Drop primary particles that start outside the world volume."
+                " By default such particles abort the run, because Geant4 cannot track them"}
+    self.skipParticlesOutsideWorldVolume = False
     self._closeProperties()
     Physics.__doc__ += "\n\n" + self.setupUserPhysics.__doc__
 

--- a/DDG4/src/Geant4InputHandling.cpp
+++ b/DDG4/src/Geant4InputHandling.cpp
@@ -26,6 +26,11 @@
 #include <G4PrimaryVertex.hh>
 #include <G4PrimaryParticle.hh>
 #include <G4ParticleDefinition.hh>
+#include <G4TransportationManager.hh>
+#include <G4Navigator.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4LogicalVolume.hh>
+#include <G4VSolid.hh>
 
 // C/C++ include files
 #include <stdexcept>
@@ -482,6 +487,19 @@ getRelevant(std::set<int>& visited,
   return res;
 }
 
+namespace {
+
+  /// Point inside the world volume; unknown world accepts
+  bool insideWorldVolume(const G4ThreeVector& point)   {
+    auto* transportation = G4TransportationManager::GetTransportationManager();
+    auto* navigator      = transportation ? transportation->GetNavigatorForTracking() : nullptr;
+    auto* world          = navigator ? navigator->GetWorldVolume() : nullptr;
+    auto* logical        = world ? world->GetLogicalVolume() : nullptr;
+    G4VSolid* solid      = logical ? logical->GetSolid() : nullptr;
+    return solid ? (solid->Inside(point) != kOutside) : true;
+  }
+}
+
 /// Generate all primary vertices corresponding to the merged interaction
 int dd4hep::sim::generatePrimaries(const Geant4Action* caller,
                                    const Geant4Context* context,
@@ -512,6 +530,17 @@ int dd4hep::sim::generatePrimaries(const Geant4Action* caller,
       for( Geant4Vertex* v : (*i).second ){
 
         int num_part = 0;
+        if ( !insideWorldVolume(G4ThreeVector(v->x, v->y, v->z)) )   {
+          if ( primaryConfig.m_skipParticlesOutsideWorldVolume )   {
+            caller->warning("+++ Dropping primary vertex at (%+.2e,%+.2e,%+.2e) [mm]: outside the world volume",
+                            v->x/CLHEP::mm, v->y/CLHEP::mm, v->z/CLHEP::mm);
+            continue;
+          }
+          caller->except("Primary vertex at (%+.2e,%+.2e,%+.2e) [mm] is outside the world volume. "
+                         "Geant4 cannot track particles starting there. Enlarge the world volume, or set "
+                         "SkipParticlesOutsideWorldVolume=True to drop such vertices instead.",
+                         v->x/CLHEP::mm, v->y/CLHEP::mm, v->z/CLHEP::mm);
+        }
         G4PrimaryVertex* v4 = new G4PrimaryVertex(v->x,v->y,v->z,v->time);
         event->AddPrimaryVertex(v4);
         caller->print("+++++ G4PrimaryVertex at (%+.2e,%+.2e,%+.2e) [mm] %+.2e [ns]",

--- a/DDG4/src/Geant4InputHandling.cpp
+++ b/DDG4/src/Geant4InputHandling.cpp
@@ -26,8 +26,6 @@
 #include <G4PrimaryVertex.hh>
 #include <G4PrimaryParticle.hh>
 #include <G4ParticleDefinition.hh>
-#include <G4TransportationManager.hh>
-#include <G4Navigator.hh>
 #include <G4VPhysicalVolume.hh>
 #include <G4LogicalVolume.hh>
 #include <G4VSolid.hh>
@@ -490,12 +488,9 @@ getRelevant(std::set<int>& visited,
 namespace {
 
   /// Point inside the world volume; unknown world accepts
-  bool insideWorldVolume(const G4ThreeVector& point)   {
-    auto* transportation = G4TransportationManager::GetTransportationManager();
-    auto* navigator      = transportation ? transportation->GetNavigatorForTracking() : nullptr;
-    auto* world          = navigator ? navigator->GetWorldVolume() : nullptr;
-    auto* logical        = world ? world->GetLogicalVolume() : nullptr;
-    G4VSolid* solid      = logical ? logical->GetSolid() : nullptr;
+  bool insideWorldVolume(const G4VPhysicalVolume* world, const G4ThreeVector& point)   {
+    auto* logical   = world ? world->GetLogicalVolume() : nullptr;
+    G4VSolid* solid = logical ? logical->GetSolid() : nullptr;
     return solid ? (solid->Inside(point) != kOutside) : true;
   }
 }
@@ -530,7 +525,7 @@ int dd4hep::sim::generatePrimaries(const Geant4Action* caller,
       for( Geant4Vertex* v : (*i).second ){
 
         int num_part = 0;
-        if ( !insideWorldVolume(G4ThreeVector(v->x, v->y, v->z)) )   {
+        if ( !insideWorldVolume(context->world(), G4ThreeVector(v->x, v->y, v->z)) )   {
           if ( primaryConfig.m_skipParticlesOutsideWorldVolume )   {
             caller->warning("+++ Dropping primary vertex at (%+.2e,%+.2e,%+.2e) [mm]: outside the world volume",
                             v->x/CLHEP::mm, v->y/CLHEP::mm, v->z/CLHEP::mm);

--- a/DDG4/src/Geant4PrimaryHandler.cpp
+++ b/DDG4/src/Geant4PrimaryHandler.cpp
@@ -27,6 +27,7 @@ Geant4PrimaryHandler::Geant4PrimaryHandler(Geant4Context* ctxt, const std::strin
   declareProperty("RejectPDGs", m_primaryConfig.m_rejectPDGs);
   declareProperty("ZeroTimePDGs", m_primaryConfig.m_zeroTimePDGs);
   declareProperty("DecayByGeant", m_primaryConfig.m_decayByGeant);
+  declareProperty("SkipParticlesOutsideWorldVolume", m_primaryConfig.m_skipParticlesOutsideWorldVolume);
 }
 
 /// Default destructor


### PR DESCRIPTION
Fixes #1635.

BEGINRELEASENOTES

- ddsim: add flag `--physics.skipParticlesOutsideWorldVolume` to drop particles on a primary vertex outside the world volume with a warning, otherwise abort the run since Geant4 will end with an exception otherwise.

ENDRELEASENOTES