### PR TITLE
fix(EventSeed): do not leak the run number from EventParameters between events

### DIFF
--- a/DDG4/plugins/Geant4EventSeed.cpp
+++ b/DDG4/plugins/Geant4EventSeed.cpp
@@ -81,32 +81,48 @@ void Geant4EventSeed::setSeedForPrimaries(const G4Event* evt) {
 }
 
 /// general function for setting the seed, called by other callbacks
-void Geant4EventSeed::setSeed(const G4Event* evt, bool checkForEventParameters=true) {
+void Geant4EventSeed::setSeed(const G4Event* evt, bool checkForEventParameters) {
 
   Geant4Random *rndm = Geant4Random::instance();
 
-  //Trying to use event id from the Geant4 event, unless we have it also in the EventParameters
+  //Trying to use event and run id from the Geant4 event, unless we have them also in the EventParameters
+  //Both are kept local: m_runID is owned by the begin-of-run callback and must not be overwritten here,
+  //otherwise the value would leak into the calls that asked not to look at the EventParameters
   unsigned int eventID = evt->GetEventID();
+  unsigned int runID   = m_runID;
 
   if(checkForEventParameters) {
     //Get EventParameters from the context
     EventParameters* parameters = context()->event().extension<EventParameters>(false);
     if(parameters) {
-      eventID = parameters->eventNumber();
-      m_runID = parameters->runNumber();
+      //Unset numbers are negative in the EventParameters, keep the Geant4 values in that case
+      if(parameters->eventNumber() < 0) {
+        dd4hep::printout(dd4hep::DEBUG, m_type,
+                         "EventSeed::setSeed: eventParameters have unset eventNumber=%d, keeping eventID=%u",
+                         parameters->eventNumber(), eventID);
+      } else {
+        eventID = parameters->eventNumber();
+      }
+      if(parameters->runNumber() < 0) {
+        dd4hep::printout(dd4hep::DEBUG, m_type,
+                         "EventSeed::setSeed: eventParameters have unset runNumber=%d, keeping runID=%u",
+                         parameters->runNumber(), runID);
+      } else {
+        runID = parameters->runNumber();
+      }
       dd4hep::printout(dd4hep::DEBUG, m_type,
                        "EventSeed::setSeed: Found eventParameters: eventID=%u, runID=%u",
-                       eventID, m_runID);
+                       eventID, runID);
     } else {
       dd4hep::printout(dd4hep::DEBUG, m_type,
                        "EventSeed::setSeed: Did not find eventParameters");
     }
   }
 
-  unsigned int newSeed = hash( m_initialSeed, eventID, m_runID );
+  unsigned int newSeed = hash( m_initialSeed, eventID, runID );
   dd4hep::printout(dd4hep::INFO, m_type,
                    "EventSeed::setSeed: eventID=%u, runID=%u initialSeed=%u, newSeed=%u",
-                   eventID, m_runID, m_initialSeed, newSeed );
+                   eventID, runID, m_initialSeed, newSeed );
 
   rndm->setSeed(newSeed);
 

--- a/DDG4/plugins/Geant4EventSeed.h
+++ b/DDG4/plugins/Geant4EventSeed.h
@@ -65,7 +65,7 @@ namespace dd4hep {
       /// generatePrimaries callback
       void setSeedForPrimaries(const G4Event*);
       /// set the seed function, called from other callbacks)
-      void setSeed(const G4Event*, bool checkForParameters);
+      void setSeed(const G4Event*, bool checkForParameters = true);
     };
 
     /*


### PR DESCRIPTION
## Summary

This fixes an issue in `Geant4EventSeed` where the run number read from `EventParameters` could leak into the next event.

Since #1617 the event seeder is called twice per event: once before primary generation, where the input file has not been read yet and `EventParameters` are intentionally ignored, and again at begin-of-event, where the event and run numbers from the input can be used.

The problem was that the run number from `EventParameters` was assigned to `m_runID`. This is the same member that stores the Geant4 run ID, so after processing one event the input run number was still there when the pre-primary seeding call for the next event happened.

This PR keeps the run number from `EventParameters` local to the current call instead. `m_runID` is only set from the `G4Run` in the begin-of-run callback.

It also handles unset event/run numbers in `EventParameters`. These default to `-1`, which previously ended up as `4294967295` after being assigned to an unsigned integer and was then used in the seed hash.

BEGINRELEASENOTES

- `Geant4EventSeed`: do not leak the run number read from `EventParameters` into subsequent events.
- `Geant4EventSeed`: ignore unset (negative) event and run numbers from `EventParameters` and keep the Geant4 values instead.

ENDRELEASENOTES

## Before / after

Using a HepMC3 input with:

```text
--random.seed 42 --random.enableEventSeed
````

Before:

```text
EventSeed::setSeed: eventID=0, runID=0          initialSeed=42, newSeed=1328797229
EventSeed::setSeed: eventID=0, runID=4294967295 initialSeed=42, newSeed=3270455385
EventSeed::setSeed: eventID=1, runID=4294967295 initialSeed=42, newSeed=3258479401
EventSeed::setSeed: eventID=1, runID=4294967295 initialSeed=42, newSeed=3258479401
```

The first call uses the correct Geant4 run ID. The second call finds `runNumber=-1` in the `EventParameters`, which gets converted to `4294967295` and stored in `m_runID`. The pre-primary call for the next event then reuses this value.

After:

```text
EventSeed::setSeed: eventID=0, runID=0 initialSeed=42, newSeed=1328797229
EventSeed::setSeed: eventID=0, runID=0 initialSeed=42, newSeed=1328797229
EventSeed::setSeed: eventID=1, runID=0 initialSeed=42, newSeed=901388549
EventSeed::setSeed: eventID=1, runID=0 initialSeed=42, newSeed=901388549
```

The Geant4 run ID now stays unchanged.

This is also relevant if the input contains a valid run number. For example, an input run number of `77` should be used for the begin-of-event seed of that event, but should not become the run number used by the pre-primary call of the next event.

The two calls within one event are not necessarily expected to give the same seed. For example with `--skipNEvents`, the begin-of-event call can use the event number from the input while the pre-primary call uses the Geant4 event ID. This is the behaviour introduced in #1617 and is unchanged here.