### PR TITLE
fix(Geant4UIManager): do not skip BeamOn when PreRunCommands are set

### DIFF
--- a/DDG4/include/DDG4/Geant4UIManager.h
+++ b/DDG4/include/DDG4/Geant4UIManager.h
@@ -64,6 +64,8 @@ namespace dd4hep {
       std::vector<std::string> m_initializeCommands;
       /// Property: List of commands to be executed when the Geant4Kernel gets terminated
       std::vector<std::string> m_terminateCommands;
+      /// Property: Legacy list of commands controlling the run execution themselves
+      std::vector<std::string> m_commands;
       /// Property: List of commands to be executed BEFORE running
       std::vector<std::string> m_preRunCommands;
       /// Property: List of commands to be executed AFTER running

--- a/DDG4/include/DDG4/Geant4UIManager.h
+++ b/DDG4/include/DDG4/Geant4UIManager.h
@@ -64,7 +64,7 @@ namespace dd4hep {
       std::vector<std::string> m_initializeCommands;
       /// Property: List of commands to be executed when the Geant4Kernel gets terminated
       std::vector<std::string> m_terminateCommands;
-      /// Property: Legacy list of commands controlling the run execution themselves
+      /// Property: List of commands steering the run execution themselves (e.g. /run/beamOn)
       std::vector<std::string> m_commands;
       /// Property: List of commands to be executed BEFORE running
       std::vector<std::string> m_preRunCommands;

--- a/DDG4/src/Geant4UIManager.cpp
+++ b/DDG4/src/Geant4UIManager.cpp
@@ -228,6 +228,17 @@ void Geant4UIManager::start() {
   G4UImanager* mgr = G4UImanager::GetUIpointer();
   bool executed_statements = false;
 
+  /// Execute the chained post-run command statements
+  auto post_run_commands = [this, mgr]()   {
+    for(const auto& c : this->m_postRunCommands)  {
+      info("++ Executing post-run statement: %s",c.c_str());
+      G4int ret = mgr->ApplyCommand(c.c_str());
+      if ( ret != 0 )  {
+        except("Failed to execute command: %s",c.c_str());
+      }
+    }
+  };
+
   /// Start visualization
   if ( m_haveVis || !m_visSetup.empty() ) {
     m_vis = startVis();
@@ -258,20 +269,11 @@ void Geant4UIManager::start() {
     if ( ret != 0 )  {
       except("Failed to execute command: %s",c.c_str());
     }
-    executed_statements = true;
   }
   /// Start UI session if present
   if ( m_haveUI && m_ui )   {
     m_ui->SessionStart();
-    /// Execute the chained post-run command statements
-    for(const auto& c : m_postRunCommands)  {
-      info("++ Executing post-run statement: %s",c.c_str());
-      G4int ret = mgr->ApplyCommand(c.c_str());
-      if ( ret != 0 )  {
-        except("Failed to execute command: %s",c.c_str());
-      }
-      executed_statements = true;
-    }
+    post_run_commands();
     return;
   }
   else if ( m_haveUI )   {
@@ -279,14 +281,7 @@ void Geant4UIManager::start() {
     return;
   }
   else if ( executed_statements )  {
-    /// Execute the chained post-run command statements
-    for(const auto& c : m_postRunCommands)  {
-      info("++ Executing post-run statement: %s",c.c_str());
-      G4int ret = mgr->ApplyCommand(c.c_str());
-      if ( ret != 0 )  {
-        except("Failed to execute command: %s",c.c_str());
-      }
-    }
+    post_run_commands();
     return;
   }
 
@@ -301,6 +296,7 @@ void Geant4UIManager::start() {
     info("++ End of file reached, ending run...");
     context()->kernel().runManager().RunTermination();
   }
+  post_run_commands();
 }
 
 /// Stop and release resources

--- a/DDG4/src/Geant4UIManager.cpp
+++ b/DDG4/src/Geant4UIManager.cpp
@@ -49,7 +49,7 @@ Geant4UIManager::Geant4UIManager(Geant4Context* ctxt, const std::string& nam)
   declareProperty("ConfigureCommands",  m_configureCommands);
   declareProperty("InitializeCommands", m_initializeCommands);
   declareProperty("TerminateCommands",  m_terminateCommands);
-  declareProperty("Commands",           m_preRunCommands);
+  declareProperty("Commands",           m_commands);
   declareProperty("PreRunCommands",     m_preRunCommands);
   declareProperty("PostRunCommands",    m_postRunCommands);
   declareProperty("HaveVIS",            m_haveVis=false);
@@ -262,13 +262,26 @@ void Geant4UIManager::start() {
     mgr->ApplyCommand(make_cmd(m.c_str()));
     executed_statements = true;
   }
-  /// Execute the chained pre-run command statements
+  /// Execute the chained pre-run command statements.
+  /// These configure the run. They do not replace it and hence do NOT
+  /// set executed_statements: the automatic batch run below still happens.
   for(const auto& c : m_preRunCommands)  {
     info("++ Executing pre-run statement: %s",c.c_str());
     G4int ret = mgr->ApplyCommand(c.c_str());
     if ( ret != 0 )  {
       except("Failed to execute command: %s",c.c_str());
     }
+  }
+  /// Execute the legacy chained command statements.
+  /// These are assumed to steer the execution themselves (e.g. by calling
+  /// /run/beamOn) and hence suppress the automatic batch run below.
+  for(const auto& c : m_commands)  {
+    info("++ Executing command statement: %s",c.c_str());
+    G4int ret = mgr->ApplyCommand(c.c_str());
+    if ( ret != 0 )  {
+      except("Failed to execute command: %s",c.c_str());
+    }
+    executed_statements = true;
   }
   /// Start UI session if present
   if ( m_haveUI && m_ui )   {

--- a/DDG4/src/Geant4UIManager.cpp
+++ b/DDG4/src/Geant4UIManager.cpp
@@ -272,7 +272,7 @@ void Geant4UIManager::start() {
       except("Failed to execute command: %s",c.c_str());
     }
   }
-  /// Execute the legacy chained command statements.
+  /// Execute the chained command statements.
   /// These are assumed to steer the execution themselves (e.g. by calling
   /// /run/beamOn) and hence suppress the automatic batch run below.
   for(const auto& c : m_commands)  {


### PR DESCRIPTION
BEGINRELEASENOTES

- Geant4UIManager: fix `PreRunCommands` preventing the normal batch `BeamOn` call.
- Geant4UIManager: separate `PreRunCommands` from the `Commands` property.
- Geant4UIManager: execute `PostRunCommands` after the automatic batch run.

ENDRELEASENOTES


## Summary

PreRunCommands are intended to configure Geant4 immediately before starting a run. However, they currently share the same internal storage as the Commands property. Since Commands historically assumes that the supplied commands control the run themselves, setting any PreRunCommands also prevents the normal batch `BeamOn` from happening.

This separates the two properties while keeping the existing behaviour of Commands for backwards compatibility. `PreRunCommands` are now executed before the normal batch run without suppressing it, while `Commands` continue to suppress the automatic `BeamOn`. `PostRunCommands` are also executed after the automatic batch run.