### PR TITLE
Add cvmfs/LCG-based macOS workflow

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -28,13 +28,19 @@ jobs:
         ninja
 
   default:
-    runs-on: macos-15
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["LCG_110/arm64-mac15-clang170-opt",
-              "dev3/arm64-mac15-clang170-opt",
-              "dev4/arm64-mac15-clang170-opt"]
+        include:
+        - os: macos-26
+          LCG: "LCG_110/arm64-mac26-clang170-opt"
+        - os: macos-15
+          LCG: "LCG_110/arm64-mac15-clang170-opt"
+        - os: macos-15
+          LCG: "dev3/arm64-mac15-clang170-opt"
+        - os: macos-15
+          LCG: "dev4/arm64-mac15-clang170-opt"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
     - uses: cvmfs-contrib/github-action-cvmfs@ea996d5ba388b05d4b97f07569d677eac442f20a

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -54,7 +54,6 @@ jobs:
           mkdir build
           cd build
           unset CPATH
-          echo "::group::CMakeConfig"
           # Common CMake options
           source ../.github/scripts/common_cmake_opts.sh
           echo "::group::CMakeConfig C++20"
@@ -63,19 +62,23 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_STANDARD=20 \
             ..
+          echo "::endgroup::"
           if [[ ${{ matrix.LCG }} =~ dev[34] ]]; then
             echo "::group::CMakeConfig 2"
             cmake \
               -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON \
               -DDD4HEP_USE_G4HEPEM=ON \
               ..
+            echo "::endgroup::"
           fi
           echo "::group::Compile"
           ninja install
           ccache -s
-          . ../bin/thisdd4hep.sh
+          echo "::endgroup::"
           echo "::group::Test"
+          . ../bin/thisdd4hep.sh
           ctest --output-on-failure -j"$(getconf _NPROCESSORS_ONLN)" --output-junit TestResults_1.xml
+          echo "::endgroup::"
           echo "::group::CMakeExamples"
           cd ../examples/
           mkdir build
@@ -85,11 +88,14 @@ jobs:
             $=COMMON_EXAMPLES_CMAKE_OPTS \
             -DCMAKE_CXX_STANDARD=20 \
             ..
+          echo "::endgroup::"
           echo "::group::CompileExamples"
           ninja install
           ccache -s
+          echo "::endgroup::"
           echo "::group::TestExamples"
           ctest --output-on-failure -j"$(getconf _NPROCESSORS_ONLN)" --output-junit TestResults_2.xml
+          echo "::endgroup::"
     - name: Prepare Artifact Name
       if: success() || failure()
       run: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -53,7 +53,7 @@ jobs:
           source ../.github/scripts/common_cmake_opts.sh
           echo "::group::CMakeConfig C++20"
           cmake \
-            $COMMON_CMAKE_OPTS \
+            ($COMMON_CMAKE_OPTS) \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_STANDARD=20 \
             ..
@@ -76,7 +76,7 @@ jobs:
           cd build
           source ../../.github/scripts/common_cmake_opts.sh
           cmake \
-            $COMMON_EXAMPLES_CMAKE_OPTS \
+            ($COMMON_EXAMPLES_CMAKE_OPTS) \
             -DCMAKE_CXX_STANDARD=20 \
             ..
           echo "::group::CompileExamples"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -38,7 +38,13 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
     - uses: cvmfs-contrib/github-action-cvmfs@ea996d5ba388b05d4b97f07569d677eac442f20a
-    - run: |
+      with:
+        cvmfs_repositories: sft.cern.ch,sft-nightlies.cern.ch,geant4.cern.ch
+    - uses: aidasoft/run-lcg-view@d8db17c61216548c9192889942d46ff2d7c3a3b6
+      with:
+        release-platform: ${{ matrix.LCG }}
+        ccache-key: ccache-${{ matrix.LCG }}
+        run: |
           mkdir build
           cd build
           unset CPATH

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -26,3 +26,73 @@ jobs:
         cd build
         cmake -GNinja -DDD4HEP_USE_GEANT4=OFF -DBoost_NO_BOOST_CMAKE=ON -DDD4HEP_USE_LCIO=OFF -DBUILD_TESTING=ON -DDD4HEP_USE_XERCESC=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DDD4HEP_RELAX_PYVER=ON ..
         ninja
+
+  default:
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        LCG: ["LCG_110/arm64-mac15-clang170-opt",
+              "dev3/arm64-mac15-clang170-opt",
+              "dev4/arm64-mac15-clang170-opt"]
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+    - uses: cvmfs-contrib/github-action-cvmfs@ea996d5ba388b05d4b97f07569d677eac442f20a
+    - uses: aidasoft/run-lcg-view@d8db17c61216548c9192889942d46ff2d7c3a3b6
+      with:
+        release-platform: ${{ matrix.LCG }}
+        ccache-key: ccache-${{ matrix.LCG }}
+        run: |
+          mkdir build
+          cd build
+          unset CPATH
+          echo "::group::CMakeConfig"
+          # Common CMake options
+          source ../.github/scripts/common_cmake_opts.sh
+          echo "::group::CMakeConfig C++20"
+          cmake \
+            $COMMON_CMAKE_OPTS \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_STANDARD=20 \
+            ..
+          if [[ ${{ matrix.LCG }} =~ dev[34] ]]; then
+            echo "::group::CMakeConfig 2"
+            cmake \
+              -DDD4HEP_HEPMC3_COMPRESSION_SUPPORT=ON \
+              -DDD4HEP_USE_G4HEPEM=ON \
+              ..
+          fi
+          echo "::group::Compile"
+          ninja install
+          ccache -s
+          . ../bin/thisdd4hep.sh
+          echo "::group::Test"
+          ctest --output-on-failure -j"$(getconf _NPROCESSORS_ONLN)" --output-junit TestResults_1.xml
+          echo "::group::CMakeExamples"
+          cd ../examples/
+          mkdir build
+          cd build
+          source ../../.github/scripts/common_cmake_opts.sh
+          cmake \
+            $COMMON_EXAMPLES_CMAKE_OPTS \
+            -DCMAKE_CXX_STANDARD=20 \
+            ..
+          echo "::group::CompileExamples"
+          ninja install
+          ccache -s
+          echo "::group::TestExamples"
+          ctest --output-on-failure -j"$(getconf _NPROCESSORS_ONLN)" --output-junit TestResults_2.xml
+    - name: Prepare Artifact Name
+      if: success() || failure()
+      run: |
+          artifact_name="${{ matrix.LCG }}"
+          artifact_name=$(echo -n "${artifact_name}" | sed -e 's@/@@g')
+          echo "ARTIFACT_NAME=${artifact_name}" >> $GITHUB_ENV
+    - name: Upload test results
+      if: success() || failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: Test Results ${{ env.ARTIFACT_NAME }}
+        path: |
+           /home/runner/work/DD4hep/DD4hep/build/TestResults_1.xml
+           /home/runner/work/DD4hep/DD4hep/examples/build/TestResults_2.xml

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -102,5 +102,5 @@ jobs:
       with:
         name: Test Results ${{ env.ARTIFACT_NAME }}
         path: |
-           /home/runner/work/DD4hep/DD4hep/build/TestResults_1.xml
-           /home/runner/work/DD4hep/DD4hep/examples/build/TestResults_2.xml
+           /Users/runner/work/DD4hep/DD4hep/build/TestResults_1.xml
+           /Users/runner/work/DD4hep/DD4hep/examples/build/TestResults_2.xml

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -43,7 +43,7 @@ jobs:
           LCG: "dev4/arm64-mac15-clang170-opt"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-    - uses: cvmfs-contrib/github-action-cvmfs@ea996d5ba388b05d4b97f07569d677eac442f20a
+    - uses: cvmfs-contrib/github-action-cvmfs@72f2a8d366043978d6aebee154bc9ed321c2f2a8
       with:
         cvmfs_repositories: sft.cern.ch,sft-nightlies.cern.ch,geant4.cern.ch
     - uses: aidasoft/run-lcg-view@d8db17c61216548c9192889942d46ff2d7c3a3b6

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -51,6 +51,7 @@ jobs:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-${{ matrix.LCG }}
         run: |
+          ulimit -n 8192
           mkdir build
           cd build
           unset CPATH

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -102,5 +102,5 @@ jobs:
       with:
         name: Test Results ${{ env.ARTIFACT_NAME }}
         path: |
-           /Users/runner/work/DD4hep/DD4hep/build/TestResults_1.xml
-           /Users/runner/work/DD4hep/DD4hep/examples/build/TestResults_2.xml
+           ${{ github.workspace }}/build/TestResults_1.xml
+           ${{ github.workspace }}/examples/build/TestResults_2.xml

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -53,7 +53,7 @@ jobs:
           source ../.github/scripts/common_cmake_opts.sh
           echo "::group::CMakeConfig C++20"
           cmake \
-            ($COMMON_CMAKE_OPTS) \
+            $=COMMON_CMAKE_OPTS \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_STANDARD=20 \
             ..
@@ -76,7 +76,7 @@ jobs:
           cd build
           source ../../.github/scripts/common_cmake_opts.sh
           cmake \
-            ($COMMON_EXAMPLES_CMAKE_OPTS) \
+            $=COMMON_EXAMPLES_CMAKE_OPTS \
             -DCMAKE_CXX_STANDARD=20 \
             ..
           echo "::group::CompileExamples"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -38,11 +38,7 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
     - uses: cvmfs-contrib/github-action-cvmfs@ea996d5ba388b05d4b97f07569d677eac442f20a
-    - uses: aidasoft/run-lcg-view@d8db17c61216548c9192889942d46ff2d7c3a3b6
-      with:
-        release-platform: ${{ matrix.LCG }}
-        ccache-key: ccache-${{ matrix.LCG }}
-        run: |
+    - run: |
           mkdir build
           cd build
           unset CPATH


### PR DESCRIPTION
Needs:
- [x] https://github.com/AIDASoft/DD4hep/pull/1673

This pull request adds a new `default` job matrix to the `.github/workflows/mac.yml` workflow to enhance macOS testing coverage and artifact handling. The main focus is on expanding CI support for multiple macOS and LCG configurations, improving build and test automation, and ensuring test results are uploaded for each configuration.

**CI/CD workflow improvements:**

* Added a new `default` job matrix in `.github/workflows/mac.yml` to run builds and tests across multiple macOS versions and LCG configurations (`macos-26`, `macos-15` with various LCG releases).
* Configured the workflow to use `cvmfs-contrib/github-action-cvmfs` and `aidasoft/run-lcg-view` actions for environment setup and dependency management across all matrix jobs.
* Automated building and testing of both the main project and its examples with C++20, including conditional configuration for specific LCG `dev3` and `dev4` releases.
* Implemented steps to prepare unique artifact names per matrix job and upload test result XML files as artifacts, aiding in test result tracking and debugging.

BEGINRELEASENOTES
- Add cvmfs/LCG-based macOS workflow

ENDRELEASENOTES