### PR TITLE
fix: rename RETURN template type to avoid macro clash on macOS-15

### DIFF
--- a/DDG4/include/DDG4/Python/Geant4PythonCall.h
+++ b/DDG4/include/DDG4/Python/Geant4PythonCall.h
@@ -45,13 +45,13 @@ namespace dd4hep {
       bool isValid()  const {  return m_callable != 0;  }
 
       /// Execute command in the python interpreter.
-      template <typename RETURN> RETURN execute() const;
+      template <typename ReturnType> ReturnType execute() const;
 
       /// Execute command in the python interpreter.
-      template <typename RETURN> RETURN execute(PyObject* callable) const;
+      template <typename ReturnType> ReturnType execute(PyObject* callable) const;
 
       /// Execute command in the python interpreter.
-      template <typename RETURN> RETURN execute(PyObject* callable, PyObject* args) const;
+      template <typename ReturnType> ReturnType execute(PyObject* callable, PyObject* args) const;
 
       /// Set the callback structures for callbacks with arguments
       void set(PyObject* callable, PyObject* args);

--- a/DDG4/src/python/Geant4PythonCall.cpp
+++ b/DDG4/src/python/Geant4PythonCall.cpp
@@ -49,24 +49,24 @@ void Geant4PythonCall::set(PyObject* callable)   {
 namespace dd4hep { namespace sim {
 
     /// Execute command in the python interpreter.
-    template <typename RETURN> RETURN Geant4PythonCall::execute() const   {
+    template <typename ReturnType> ReturnType Geant4PythonCall::execute() const   {
       DDPython::GILState state(0);
       TPyReturn ret(DDPython::instance().callC(m_callable, m_arguments));
-      return (RETURN)ret;
+      return (ReturnType)ret;
     }
 
     /// Execute command in the python interpreter.
-    template <typename RETURN> RETURN Geant4PythonCall::execute(PyObject* method) const   {
+    template <typename ReturnType> ReturnType Geant4PythonCall::execute(PyObject* method) const   {
       DDPython::GILState state(0);
       TPyReturn ret(DDPython::instance().callC(method,0));
-      return (RETURN)ret;
+      return (ReturnType)ret;
     }
 
     /// Execute command in the python interpreter.
-    template <typename RETURN> RETURN Geant4PythonCall::execute(PyObject* method, PyObject* args) const   {
+    template <typename ReturnType> ReturnType Geant4PythonCall::execute(PyObject* method, PyObject* args) const   {
       DDPython::GILState state(0);
       TPyReturn ret(DDPython::instance().callC(method,args));
-      return (RETURN)ret;
+      return (ReturnType)ret;
     }
 #define INSTANTIATE(X)                                                  \
     template X Geant4PythonCall::execute<X>() const;                      \


### PR DESCRIPTION
This PR renames the template type `RETURN` in Geant4PythonCall to `ReturnType` to avoid a macro clash with MacOSX.sdk/usr/include/sys/tty.h on macOS-15. See https://github.com/AIDASoft/DD4hep/actions/runs/34041679557/job/101509518698?pr=1672#step:4:2276.

BEGINRELEASENOTES
- fix: rename RETURN template type to avoid macro clash on macOS-15

ENDRELEASENOTES